### PR TITLE
claude: add pr-create, pr-description, docs-sync, and pr-review skills

### DIFF
--- a/.claude/skills/docs-sync/SKILL.md
+++ b/.claude/skills/docs-sync/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: docs-sync
+description: Checks whether code changes require documentation updates and applies only the necessary documentation changes. Use when preparing a PR, reviewing branch readiness, or verifying that docs stay aligned with implementation.
+---
+
+When syncing documentation with code changes, follow this workflow:
+
+1. Identify the scope of the change.
+   - Determine the correct base branch.
+   - Do not assume it is always `master`; use the PR base branch or repository default branch when available.
+   - Review the change set with:
+     - `git diff --stat <base>...HEAD`
+     - `git diff <base>...HEAD`
+
+2. Determine whether documentation changes are actually needed.
+   Update documentation only if the code changes affect one or more of these:
+
+   - Setup or installation steps
+   - Usage instructions
+   - Configuration or environment variables
+   - Inputs, outputs, or interfaces
+   - Examples or commands
+   - Architecture or workflow behavior
+   - Operational runbooks or troubleshooting steps
+   - Team or agent instructions
+   - Constraints, assumptions, or supported paths
+
+3. Do not force documentation changes when they are not justified.
+   Documentation updates are usually not needed for:
+   - Internal refactors with unchanged behavior
+   - Naming cleanup with no user or developer impact
+   - Pure formatting or linting changes
+   - Tests-only changes, unless they change how contributors should work
+   - Non-meaningful code movement with no workflow impact
+
+4. Check the right documentation targets.
+   Review and update only the files that match the change:
+
+   - `README.md`
+     - For setup, usage, configuration, examples, commands, and user-facing behavior
+
+   - `CLAUDE.md`
+     - For repository instructions, coding workflow, agent behavior, team conventions, or execution rules
+
+   - Other docs, runbooks, or notes
+     - For architecture, operations, troubleshooting, deployment, migrations, or project-specific guidance
+
+5. Prefer minimal, accurate updates.
+   - Do not rewrite entire documentation sections if a focused edit is enough.
+   - Preserve the current tone and structure of the document.
+   - Keep examples, commands, and paths accurate and copy-paste safe.
+   - Remove outdated instructions when replacing them with new ones.
+
+6. Cross-check code against docs, not just docs against code.
+   Look for:
+   - Commands that no longer match reality
+   - Missing new flags, parameters, files, or steps
+   - Old file names, paths, or branch names
+   - Docs describing behavior that changed
+   - Missing caveats, rollout notes, or operational warnings
+
+7. If no documentation changes are needed, say so explicitly.
+   Do not invent documentation edits just to satisfy the workflow.
+
+8. If documentation changes are needed, produce a clear summary in this format:
+
+## Documentation Impact
+One to three sentences explaining whether docs needed updating and why.
+
+## Files to Update
+- List the documentation files that should change
+- State `None` if no documentation changes are needed
+
+## Required Updates
+- Summarize the exact documentation changes needed
+- Keep this reviewer-focused and actionable
+
+## Notes
+- Mention anything reviewers or maintainers should verify
+- State `None` if there are no extra notes
+
+9. If editing documentation directly:
+   - Make the smallest useful change that keeps docs aligned with implementation
+   - Ensure examples and instructions reflect the current code
+   - Avoid speculative wording
+   - Keep documentation concise and easy to scan
+
+10. Special rules for `README.md`
+   Update `README.md` only when the branch changes:
+   - project setup
+   - installation
+   - usage
+   - configuration
+   - common commands
+   - examples
+   - behavior visible to users or contributors
+
+11. Special rules for `CLAUDE.md`
+   Update `CLAUDE.md` only when the branch changes:
+   - repository workflow
+   - coding or review conventions
+   - project-specific agent instructions
+   - required execution steps
+   - documentation or delivery expectations
+
+12. Final output should always make one of these outcomes clear:
+   - No documentation changes needed
+   - Documentation updates recommended
+   - Documentation updates required before merge

--- a/.claude/skills/pr-create/SKILL.md
+++ b/.claude/skills/pr-create/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: pr-create
+description: Creates or updates a pull request using reviewer-friendly best practices. Use when opening a PR, updating an existing PR, or when the user asks to prepare a pull request.
+---
+
+When handling a pull request, follow this workflow:
+
+1. Detect whether a PR already exists for the current branch.
+   - If no PR exists, prepare to create one.
+   - If a PR already exists, update the existing PR instead of creating a new one.
+   - Only suggest creating a new PR if the branch purpose changed substantially, the base branch is wrong, or the user explicitly asks for a separate PR.
+
+2. Identify the correct base branch.
+   - Prefer the PR base branch if one already exists.
+   - Otherwise use the repository default branch or the intended target branch.
+   - Do not assume it is always `master`.
+
+3. Review the branch before creating or updating the PR.
+   - Run `git diff --stat <base>...HEAD` for a concise summary.
+   - Run `git diff <base>...HEAD` to inspect the full change set.
+   - Review recent commits if needed to better understand intent and scope.
+
+4. Validate branch quality before proceeding.
+   - Check that the branch has one coherent purpose.
+   - Flag unrelated changes, debug code, temporary comments, generated noise, or accidental edits.
+   - Confirm whether tests, documentation, configuration, migrations, or changelog updates are needed.
+   - If the branch is too broad or mixed, recommend splitting it before creating or heavily revising the PR.
+
+5. Prepare a strong PR title.
+   - Use a clear, specific, action-oriented title.
+   - Prefer the format:
+     - `<area>: <change>`
+   - Examples:
+     - `airflow: add retry handling for trustpair ingestion`
+     - `dbt: standardize casting in cognos employee details model`
+   - Avoid vague titles like `updates`, `fixes`, or `changes`.
+
+6. Prepare the PR description in `notes/pr_<sanitized-branch-name>.md`
+   - Replace `/` with `_`
+   - Use lowercase
+   - Keep the name concise and filesystem-safe
+
+7. Use this PR description structure:
+
+## What
+One or two sentences describing what this PR changes.
+
+## Why
+Explain the problem, context, or reason the change is needed.
+
+## Changes
+- Group related changes together
+- Summarize meaningful implementation changes
+- Mention deleted, renamed, or moved files when relevant
+- Focus on reviewer-relevant changes, not raw diff noise
+
+## Testing
+- List automated tests run
+- List manual validation steps
+- If not tested, say so explicitly
+
+## Risks / Notes
+- Mention rollout concerns, edge cases, follow-ups, or reviewer attention points
+
+## Breaking Changes
+- State `None` if there are no breaking changes
+- Otherwise explain the impact clearly
+
+8. If a PR already exists:
+   - Read the existing PR title and description first
+   - Compare them against the current diff
+   - Update only the parts that are no longer accurate or are missing
+   - Preserve useful reviewer context that is still valid
+   - Do not rewrite a good PR description unnecessarily
+
+9. Check whether documentation should be updated.
+   - Update `README.md` only if setup, usage, configuration, examples, or user-facing behavior changed
+   - Update `CLAUDE.md` only if repo instructions, workflow rules, or agent guidance changed
+   - Do not update documentation unless the code changes justify it
+
+10. Apply a reviewer-first quality bar.
+   - Make the PR easy to review quickly
+   - Highlight the main purpose, important changes, testing, and risks
+   - Keep the title and description concise, accurate, and easy to scan
+
+11. Do not guess silently when context is missing.
+   - State what is unknown
+   - Ask for confirmation only when necessary
+   - Otherwise use the branch diff and repository context to produce the strongest possible draft
+
+12. Final deliverables:
+   - A proposed or updated PR title
+   - A PR description saved in `notes/pr_<sanitized-branch-name>.md`
+   - A short reviewer summary explaining what to review first

--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -6,7 +6,8 @@ description: Writes pull request descriptions. Use when creating a PR, writing a
 When writing a PR description:
 
 1. Run `git diff master...HEAD` to see all changes on this branch
-2. Write a description following this format in the notes folder and use pr_nameofbranch.md as aname of file:
+2. Update the README.md file to include the changes also the CLAUDE.md file if needed.
+3. Write a description following this format in the notes folder and use pr_nameofbranch.md as aname of file:
 
 ## What
 One sentence explaining what this PR does.

--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -1,21 +1,59 @@
 ---
 name: pr-description
-description: Writes pull request descriptions. Use when creating a PR, writing a PR, or when the user asks to summarize changes for a pull request.
+description: Writes high-quality pull request descriptions. Use when creating a PR, summarizing branch changes, or when the user asks for a PR description.
 ---
 
 When writing a PR description:
 
-1. Run `git diff master...HEAD` to see all changes on this branch
-2. Update the README.md file to include the changes also the CLAUDE.md file if needed.
-3. Write a description following this format in the notes folder and use pr_nameofbranch.md as aname of file:
+1. Identify the correct base branch before diffing.
+   - Prefer the PR base branch if known.
+   - Otherwise use the repository default branch.
+   - Do not assume it is always `master`.
+
+2. Review the change set before writing.
+   - Run `git diff <base>...HEAD` to inspect all branch changes.
+   - Run `git diff --stat <base>...HEAD` for a concise summary.
+   - Review commit messages if helpful to understand intent.
+
+3. Check whether documentation needs updating.
+   - Update `README.md` only if user-facing behavior, setup, usage, configuration, or examples changed.
+   - Update `CLAUDE.md` only if workflow instructions, repo conventions, or agent guidance changed.
+   - Do not modify documentation unless the changes actually require it.
+
+4. Write the PR description in `notes/` using this filename format:
+   - `pr_<sanitized-branch-name>.md`
+   - Replace `/` with `_`
+   - Use lowercase
+   - Keep the name concise and filesystem-safe
+
+5. Use this structure:
 
 ## What
-One sentence explaining what this PR does.
+One or two sentences explaining what this PR changes.
 
 ## Why
-Brief context on why this change is needed
+Brief context on the problem, goal, or motivation behind the change.
 
 ## Changes
-- Bullet points of specific changes made
+- Summarize the important code, config, test, and documentation changes
 - Group related changes together
-- Mention any files deleted or renamed
+- Mention deleted, renamed, or restructured files when relevant
+- Focus on meaningful changes, not every small diff detail
+
+## Testing
+- List how the change was validated
+- Mention tests added/updated, manual checks, or why no testing was needed
+
+## Risks / Notes
+- Mention edge cases, rollout concerns, follow-ups, or anything reviewers should pay attention to
+
+## Breaking Changes
+- State `None` if there are no breaking changes
+- Otherwise describe the impact clearly
+
+6. Keep the description concise but useful.
+   - Prefer clarity over exhaustiveness
+   - Avoid repeating raw diff output
+   - Write for reviewers, not for the author
+
+7. If the branch changes are unclear or mixed, first infer the main objective of the PR and organize the description around that objective.

--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: pr-description
+description: Writes pull request descriptions. Use when creating a PR, writing a PR, or when the user asks to summarize changes for a pull request.
+---
+
+When writing a PR description:
+
+1. Run `git diff master...HEAD` to see all changes on this branch
+2. Write a description following this format in the notes folder and use pr_nameofbranch.md as aname of file:
+
+## What
+One sentence explaining what this PR does.
+
+## Why
+Brief context on why this change is needed
+
+## Changes
+- Bullet points of specific changes made
+- Group related changes together
+- Mention any files deleted or renamed

--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -3,6 +3,8 @@ name: pr-description
 description: Writes high-quality pull request descriptions. Use when creating a PR, summarizing branch changes, or when the user asks for a PR description.
 ---
 
+This skill writes the PR description body only. For the full PR creation workflow (opening, updating, saving to `notes/`), use the `pr-create` skill instead.
+
 When writing a PR description:
 
 1. Identify the correct base branch before diffing.
@@ -20,13 +22,7 @@ When writing a PR description:
    - Update `CLAUDE.md` only if workflow instructions, repo conventions, or agent guidance changed.
    - Do not modify documentation unless the changes actually require it.
 
-4. Write the PR description in `notes/` using this filename format:
-   - `pr_<sanitized-branch-name>.md`
-   - Replace `/` with `_`
-   - Use lowercase
-   - Keep the name concise and filesystem-safe
-
-5. Use this structure:
+4. Use this structure:
 
 ## What
 One or two sentences explaining what this PR changes.
@@ -51,9 +47,9 @@ Brief context on the problem, goal, or motivation behind the change.
 - State `None` if there are no breaking changes
 - Otherwise describe the impact clearly
 
-6. Keep the description concise but useful.
+5. Keep the description concise but useful.
    - Prefer clarity over exhaustiveness
    - Avoid repeating raw diff output
    - Write for reviewers, not for the author
 
-7. If the branch changes are unclear or mixed, first infer the main objective of the PR and organize the description around that objective.
+6. If the branch changes are unclear or mixed, first infer the main objective of the PR and organize the description around that objective.

--- a/.claude/skills/pr-review-fix/SKILL.md
+++ b/.claude/skills/pr-review-fix/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: pr-review-fix
+description: Applies fixes to a pull request based on an existing PR review comment. Use when the user asks to address PR review feedback, fix a PR from review comments, or update a branch based on PR feedback.
+---
+
+When fixing a pull request from review feedback, follow this workflow:
+
+1. Start from the actual PR review comment.
+   - Read the PR comment carefully before making any changes.
+   - Extract only the explicitly requested fixes.
+   - If there is no review comment, or no clear fix request is available, stop and say that you need the PR comment or a clear list of what to fix.
+
+2. Only act on these categories by default:
+   - Must Fix
+   - Should Fix
+
+3. Must Fix items are mandatory.
+   - Always address all explicit Must Fix items.
+   - Do not skip them unless the user explicitly tells you not to, or the request is impossible or incorrect.
+   - If a Must Fix item cannot be implemented safely, explain why clearly.
+
+4. Should Fix items should also be addressed.
+   - Apply explicit Should Fix items as part of the update.
+   - Treat them as in scope unless the user says otherwise.
+
+5. Nice to Have items are out of scope by default.
+   - Do not implement Nice to Have suggestions unless the user explicitly asks for them in the prompt.
+   - Do not silently include optional cleanup, refactors, or polish work just because it seems beneficial.
+
+6. Do not invent extra work.
+   - Do not add unrelated refactors.
+   - Do not make opportunistic cleanup changes.
+   - Do not broaden the PR scope beyond the review feedback.
+   - Keep the branch focused on the requested review fixes.
+
+7. Review the relevant code before editing.
+   - Understand the intent of the original PR.
+   - Inspect only the files needed to implement the requested fixes.
+   - Preserve the PR’s purpose and avoid changing behavior outside the requested scope.
+
+8. Apply the fixes carefully.
+   - Make the smallest useful changes that fully resolve the requested feedback.
+   - Prefer targeted edits over broad rewrites.
+   - Maintain consistency with the repository’s existing patterns and conventions.
+
+9. Validate the fixes.
+   - Run relevant tests, checks, or validation steps when possible.
+   - If no validation is possible, say so explicitly.
+   - If a fix changes behavior, verify that the requested issue is actually resolved.
+
+10. Check whether the PR description or docs need updating.
+   - Update the PR description only if the implemented fixes materially change the current PR summary.
+   - Update documentation only if the requested fixes affect setup, usage, configuration, workflow, or documented behavior.
+   - Do not update docs for unrelated reasons.
+
+11. Summarize the applied fixes in this format:
+
+## Fixed
+- List all Must Fix items that were addressed
+- List all Should Fix items that were addressed
+
+## Not Fixed
+- List any requested item that could not be implemented
+- Explain why clearly
+- Write `None` if everything in scope was addressed
+
+## Validation
+- List tests, checks, or manual validation performed
+- If none, state that explicitly
+
+## Notes
+- Mention whether the PR description or docs were updated
+- Mention any follow-up the reviewer or author should know
+- Write `None` if there is nothing extra to note
+
+12. If there is no clear review feedback to act on, respond with:
+   - a concise statement that you need the PR review comment or a clear list of fixes before making changes
+
+13. Final behavior:
+   - Read the review comment
+   - Fix all explicit Must Fix items
+   - Fix all explicit Should Fix items
+   - Ignore Nice to Have items unless explicitly requested in the prompt
+   - Keep the changes narrow, relevant, and review-driven

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -122,7 +122,7 @@ One of:
    - Explicitly recommend splitting unrelated work
    - Call out accidental edits, debug code, commented-out code, temporary files, or generated noise
 
-12. Optimize for helpfulness.
-   - Write feedback the author can act on immediately
-   - Be direct, concise, and constructive
-   - Prioritize the issues that matter most for correctness, safety, and review speed
+12. Final behavior:
+   - Review the PR
+   - Generate the structured review comment
+   - Post that review comment directly on the pull request

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: pr-review
+description: Reviews a branch or pull request like a careful reviewer before or during code review. Use when the user asks for a PR review, review readiness check, or wants feedback before merging.
+---
+
+When reviewing a pull request or branch, follow this workflow:
+
+1. Identify the review target.
+   - Prefer the existing PR if one exists.
+   - Otherwise review the current branch against the intended base branch.
+   - Do not assume the base branch is always `master`; use the PR base branch or repository default branch when available.
+
+2. Review the actual change set.
+   - Run `git diff --stat <base>...HEAD` for a high-level summary.
+   - Run `git diff <base>...HEAD` for the full changes.
+   - Review recent commits if they help explain the change history or intent.
+
+3. Understand the purpose of the change before judging details.
+   - Infer the main objective of the PR.
+   - Identify whether the implementation matches the stated or implied goal.
+   - If the scope is unclear, say so explicitly.
+
+4. Review with a reviewer-first lens.
+   Evaluate the PR for:
+
+   - Correctness
+     - Does the implementation appear to solve the intended problem?
+     - Are there obvious logic errors, broken assumptions, or incomplete paths?
+
+   - Scope
+     - Is the PR focused on one coherent purpose?
+     - Are there unrelated changes mixed in?
+
+   - Readability
+     - Is the code understandable and reasonably structured?
+     - Are naming, comments, and organization clear?
+
+   - Maintainability
+     - Does the change introduce avoidable complexity?
+     - Are there duplicated patterns, hardcoded values, or brittle logic?
+
+   - Safety
+     - Are there migration, deployment, rollback, data, or config risks?
+     - Are there edge cases that could fail in production?
+
+   - Testing
+     - Are tests present where needed?
+     - Are manual validation steps or automated checks sufficient?
+     - Call out missing tests clearly.
+
+   - Documentation
+     - Should `README.md`, internal docs, runbooks, or `CLAUDE.md` be updated?
+     - Do not require docs changes unless the code changes justify them.
+
+5. Distinguish issue severity.
+   Categorize findings as:
+
+   - Must fix
+     - Likely bug, broken behavior, unsafe change, or serious gap before merge
+
+   - Should fix
+     - Important quality, maintainability, or clarity issue that should ideally be addressed before merge
+
+   - Nice to have
+     - Non-blocking suggestion, cleanup, or polish
+
+6. Be precise and evidence-based.
+   - Reference concrete files, patterns, or behaviors when possible.
+   - Do not make vague comments like "this looks bad" or "maybe improve this".
+   - Explain why something is risky, confusing, or incorrect.
+
+7. Avoid low-value review noise.
+   - Do not comment on purely stylistic preferences unless they affect readability or conflict with project conventions.
+   - Do not restate what the code already says without adding insight.
+   - Focus on the highest-signal review feedback first.
+
+8. Flag review readiness.
+   Conclude with one of:
+   - Ready to merge
+   - Ready with minor changes
+   - Needs changes before merge
+   - Scope should be reduced or split
+
+9. Produce the review in this format:
+
+## Summary
+Two to four sentences summarizing what the PR does and the overall review outcome.
+
+## Must Fix
+- Blocking issues that should be resolved before merge
+- State `None` if there are no blocking issues
+
+## Should Fix
+- Important non-blocking improvements
+- State `None` if there are no important improvements
+
+## Nice to Have
+- Optional improvements or follow-ups
+- State `None` if there are no optional suggestions
+
+## Testing / Validation Gaps
+- Missing or weak validation
+- State `None` if validation looks sufficient
+
+## Documentation / Reviewer Notes
+- Needed docs changes, rollout notes, or areas reviewers should pay attention to
+- State `None` if nothing special is needed
+
+## Verdict
+One of:
+- Ready to merge
+- Ready with minor changes
+- Needs changes before merge
+- Scope should be reduced or split
+
+10. If an existing PR description is available, compare it against the diff.
+   - Check whether the PR description accurately reflects the implementation.
+   - Call out mismatches between the description and the actual changes.
+   - Note when the PR title or description should be updated.
+
+11. If the branch is messy or mixed:
+   - Explicitly recommend splitting unrelated work
+   - Call out accidental edits, debug code, commented-out code, temporary files, or generated noise
+
+12. Optimize for helpfulness.
+   - Write feedback the author can act on immediately
+   - Be direct, concise, and constructive
+   - Prioritize the issues that matter most for correctness, safety, and review speed

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -125,4 +125,4 @@ One of:
 12. Final behavior:
    - Review the PR
    - Generate the structured review comment
-   - Post that review comment directly on the pull request
+   - Post that review comment directly on the pull request using the `mcp__github__pull_request_review_write` tool with `method: create` and `event: COMMENT`. If the MCP tool is unavailable, fall back to `gh pr review <number> --comment -b '<review>'`.


### PR DESCRIPTION
## What
Add four reusable Claude Code skills — `pr-create`, `pr-description`, `docs-sync`, and `pr-review` — that standardize how pull requests are created, described, reviewed, and kept in sync with project documentation.

## Why
Without a shared workflow, PR titles were vague, descriptions missed key sections (testing, risks, breaking changes), and there was no consistent review process. These skills encode a reviewer-first standard so every PR from this repo follows the same quality bar without relying on memory or convention.

## Changes
- Added `.claude/skills/pr-create/SKILL.md` — full end-to-end skill: detects existing PRs, picks the correct base branch, validates branch quality, generates a title and description, and saves output to `notes/pr_<branch>.md`
- Added `.claude/skills/pr-description/SKILL.md` — focused skill for writing PR description bodies only; same structure (What / Why / Changes / Testing / Risks / Breaking Changes), with a rule to update README and CLAUDE.md only when the code changes justify it. For the full PR creation workflow, use `pr-create` instead.
- Added `.claude/skills/docs-sync/SKILL.md` — skill for checking whether code changes require documentation updates; reviews the diff and applies only the necessary changes to `README.md` or `CLAUDE.md`, with explicit rules for when docs should and should not be updated
- Added `.claude/skills/pr-review/SKILL.md` — skill for reviewing a branch or PR with a structured reviewer-first workflow; produces a categorized review (Must Fix / Should Fix / Nice to Have / Testing Gaps / Verdict) and posts it directly to the PR via the `mcp__github__pull_request_review_write` tool

## Testing
- All four skills manually invoked on this branch to validate their output
- No automated tests (skills are markdown instructions, not executable code)

## Risks / Notes
- Skills are advisory — Claude follows them as prompts, not enforced contracts
- `pr-create` supersedes `pr-description` for the full PR workflow; both are kept since `pr-description` remains useful as a standalone description-writer
- `pr-review` posts directly to GitHub via `mcp__github__pull_request_review_write`; ensure the GitHub MCP tool is configured before invoking

## Breaking Changes
None