### PR TITLE
db: enable RLS and define public-read policies for civic data tables

### DIFF
--- a/data/migrations/001_init.sql
+++ b/data/migrations/001_init.sql
@@ -63,3 +63,30 @@ CREATE TABLE IF NOT EXISTS document_chunks (
 CREATE INDEX IF NOT EXISTS idx_chunks_embedding
     ON document_chunks USING ivfflat (embedding vector_cosine_ops)
     WITH (lists = 100);
+
+-- ---------------------------------------------------------------------------
+-- Row-Level Security
+-- Affects direct Supabase REST API access only — psycopg2 (superuser role)
+-- bypasses RLS entirely, so the FastAPI app is unaffected.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE deputies        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE votes           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vote_positions  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE document_chunks ENABLE ROW LEVEL SECURITY;
+
+-- Public read on civic data (AN open data — already public by design)
+DROP POLICY IF EXISTS "public_read_deputies"       ON deputies;
+DROP POLICY IF EXISTS "public_read_votes"          ON votes;
+DROP POLICY IF EXISTS "public_read_vote_positions" ON vote_positions;
+
+CREATE POLICY "public_read_deputies"
+    ON deputies FOR SELECT USING (true);
+
+CREATE POLICY "public_read_votes"
+    ON votes FOR SELECT USING (true);
+
+CREATE POLICY "public_read_vote_positions"
+    ON vote_positions FOR SELECT USING (true);
+
+-- document_chunks: no public policy — anon gets nothing (embeddings are internal)


### PR DESCRIPTION
## What
Enable Row-Level Security on all four core tables and define public-read policies for the three civic data tables (`deputies`, `votes`, `vote_positions`).

## Why
Supabase exposes a direct REST API (PostgREST) that bypasses application-level auth. Without RLS, anonymous clients hitting the Supabase URL directly could read or—once write endpoints exist—mutate any row. Enabling RLS locks down direct access to an explicit allowlist of policies while leaving the FastAPI app (which connects as a superuser via psycopg2) completely unaffected.

## Changes
- `data/migrations/001_init.sql`: appended RLS block
  - `ALTER TABLE … ENABLE ROW LEVEL SECURITY` on all four tables
  - `CREATE POLICY "public_read_*" … USING (true)` for `deputies`, `votes`, `vote_positions` — mirrors the open-data nature of AN data
  - `document_chunks` intentionally gets no policy: anonymous callers receive nothing (embeddings are internal)
  - `DROP POLICY IF EXISTS` guards make the migration idempotent (safe to re-run)

## Testing
- Migration is idempotent — `DROP POLICY IF EXISTS` + `CREATE TABLE IF NOT EXISTS` pattern already in place
- FastAPI app unaffected: psycopg2 connects as superuser, which bypasses RLS by design
- Manual validation: apply migration against Supabase and confirm anon key can `SELECT` from `deputies`/`votes`/`vote_positions` but gets 0 rows from `document_chunks`

## Risks / Notes
- RLS applies to Supabase REST access only — the Railway-hosted FastAPI is unaffected
- `document_chunks` has no read policy by design; if a public semantic-search endpoint is added later, a policy will be needed
- No write policies are defined yet — any future insert/update path via Supabase REST will be blocked by default (safe default)

## Breaking Changes
None — superuser connections (FastAPI / ingestion scripts) bypass RLS entirely