### PR TITLE
rag: Phase 2 — RAG chatbot (OpenAI embeddings + Groq + pgvector)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,9 @@ AN_API_BASE_URL=https://data.assemblee-nationale.fr
 
 # API — comma-separated origins, or * for dev
 CORS_ORIGINS=*
+
+# Phase 2 — RAG pipeline (required for POST /search/)
+# OpenAI: https://platform.openai.com/api-keys
+OPENAI_API_KEY=sk-...
+# Groq: https://console.groq.com/keys
+GROQ_API_KEY=gsk_...

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ data/migrations/__pycache__/
 
 # Daily notes — local only
 notes/
+
+# MLflow — local experiment tracking, not source code
+mlruns/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,14 @@ make ingest-prod    # Production ingestion (last 3 months)
 # API
 make api            # Start dev server with hot-reload at http://localhost:8000
 
+# RAG pipeline (Phase 2)
+make rag-index      # Truncate + re-embed all chunks (costs ~$0.006)
+make rag-stats      # Print chunk counts by type
+make rag-clear      # Truncate document_chunks only
+make rag-test       # Run 3 test questions through the full RAG chain
+make rag-eval       # Run MLflow k=3 vs k=5 evaluation
+make mlflow-ui      # Open MLflow UI at http://localhost:5001
+
 # Linting
 ruff check .        # Lint
 ruff format .       # Format
@@ -58,10 +66,15 @@ Assemblée Nationale Open Data (ZIPs)
 - `migrate.py` is also the Railway start hook (runs before uvicorn in `railway.json`)
 - `run_ingestion_prod.py` orchestrates the full pipeline for production runs
 
-**`rag/`** — Phase 2 semantic search (in progress)
-- `pipeline/chunker.py`: Generates text chunks for embedding — one chunk per vote (French prose) and one per deputy (voting record summary). Uses tiktoken (cl100k_base) for token counting.
-- `chain/` and `experiments/` are scaffolded but empty — retriever, prompts, rag_chain, and MLflow eval are not yet implemented
-- Target: OpenAI `text-embedding-3-small` (1536-dim) stored in the `document_chunks` table with an ivfflat index
+**`rag/`** — Phase 2 semantic search (live)
+- `pipeline/chunker.py`: Generates text chunks — one per vote (French prose) and one per deputy (voting record summary). Uses tiktoken (cl100k_base) for token counting.
+- `pipeline/embedder.py`: Batched OpenAI embedding (100 chunks/batch), stores into `document_chunks` via pgvector. Assumes table is empty — callers must truncate first.
+- `pipeline/index_manager.py`: `build` / `stats` / `clear` CLI. `build` always truncates before embedding to prevent duplicates.
+- `chain/retriever.py`: Cosine similarity retrieval via pgvector `<=>`. Supports `chunk_type` and `deputy_id` filters. Note: `register_vector` must receive a plain psycopg2 cursor, not a `RealDictCursor`.
+- `chain/prompts.py`: French civic assistant system prompt + RAG context template.
+- `chain/rag_chain.py`: `ask()` — retrieve → format → Groq `llama-3.3-70b-versatile` (temperature=0.2).
+- `experiments/mlflow_eval.py`: 10 golden Q&A pairs, keyword scoring, k=3 vs k=5 MLflow experiment. Baseline score: 0.58.
+- 3,726 chunks in production: 3,149 vote + 577 deputy, avg 86 tokens, $0.0064 to embed.
 
 **`data/migrations/001_init.sql`** — Full schema
 - Four tables: `deputies`, `votes`, `vote_positions`, `document_chunks` (pgvector)
@@ -89,6 +102,9 @@ Copy `.env.example` to `.env` for local development. Key variables:
 DATABASE_URL=postgresql://monelu:monelu@localhost:5432/monelu
 AN_API_BASE_URL=https://data.assemblee-nationale.fr
 CORS_ORIGINS=*
+# Phase 2 — required for POST /search/
+OPENAI_API_KEY=sk-...
+GROQ_API_KEY=gsk_...
 ```
 
 Production uses Supabase (managed Postgres + pgvector pre-installed). Local uses Docker (`docker-compose.yml` starts Postgres 15 + pgAdmin 8).

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: start stop migrate ingest ingest-prod api psql check-db rag-index rag-stats rag-clear
+.PHONY: start stop migrate ingest ingest-prod api psql check-db rag-index rag-stats rag-clear rag-test rag-eval mlflow-ui
 
 start:
 	docker compose up -d
@@ -37,3 +37,12 @@ rag-stats:
 
 rag-clear:
 	venv/bin/python3 -m rag.pipeline.index_manager clear
+
+rag-test:
+	venv/bin/python3 -m rag.chain.rag_chain
+
+rag-eval:
+	venv/bin/python3 -m rag.experiments.mlflow_eval
+
+mlflow-ui:
+	venv/bin/mlflow ui --port 5001

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: start stop migrate ingest ingest-prod api psql check-db
+.PHONY: start stop migrate ingest ingest-prod api psql check-db rag-index rag-stats rag-clear
 
 start:
 	docker compose up -d
@@ -28,3 +28,12 @@ check-db:
 
 fix-deputies:
 	venv/bin/python3 scripts/update_party.py
+
+rag-index:
+	venv/bin/python3 -m rag.pipeline.index_manager build
+
+rag-stats:
+	venv/bin/python3 -m rag.pipeline.index_manager stats
+
+rag-clear:
+	venv/bin/python3 -m rag.pipeline.index_manager clear

--- a/api/main.py
+++ b/api/main.py
@@ -90,7 +90,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=ALLOWED_ORIGINS,
     allow_credentials=False,  # public read-only API — no cookies or auth headers needed
-    allow_methods=["GET"],
+    allow_methods=["GET", "POST"],
     allow_headers=["*"],
 )
 
@@ -98,9 +98,11 @@ app.add_middleware(
 # Routers — imported here so they register their routes on the app
 # ---------------------------------------------------------------------------
 from api.routers import deputies, votes  # noqa: E402  (after app creation)
+from api.routers.search import router as search_router  # noqa: E402
 
 app.include_router(deputies.router, prefix="/deputies", tags=["Deputies"])
 app.include_router(votes.router, prefix="/votes", tags=["Votes"])
+app.include_router(search_router, prefix="/search", tags=["Search"])
 
 
 # ---------------------------------------------------------------------------

--- a/api/routers/search.py
+++ b/api/routers/search.py
@@ -1,0 +1,47 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from rag.chain.rag_chain import ask
+
+router = APIRouter()
+
+
+class SearchRequest(BaseModel):
+    question: str = Field(
+        ...,
+        min_length=5,
+        max_length=500,
+        description="Question en français sur l'activité parlementaire",
+    )
+    deputy_id: str | None = Field(None, description="Filtrer par député (optionnel)")
+    chunk_type: str | None = Field(None, description="'vote' ou 'deputy' (optionnel)")
+
+
+class SourceItem(BaseModel):
+    content: str
+    metadata: dict
+    similarity: float
+
+
+class SearchResponse(BaseModel):
+    answer: str
+    question: str
+    chunks_retrieved: int
+    sources: list[SourceItem]
+
+
+@router.post(
+    "/",
+    response_model=SearchResponse,
+    summary="Posez une question sur les votes et les députés",
+)
+async def search(request: SearchRequest):
+    try:
+        result = ask(
+            question=request.question,
+            deputy_id=request.deputy_id,
+            chunk_type=request.chunk_type,
+        )
+        return result
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"RAG pipeline error: {str(e)}") from e

--- a/api/routers/search.py
+++ b/api/routers/search.py
@@ -1,6 +1,9 @@
-from fastapi import APIRouter, HTTPException
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from api.limiter import limiter
 from rag.chain.rag_chain import ask
 
 router = APIRouter()
@@ -14,7 +17,9 @@ class SearchRequest(BaseModel):
         description="Question en français sur l'activité parlementaire",
     )
     deputy_id: str | None = Field(None, description="Filtrer par député (optionnel)")
-    chunk_type: str | None = Field(None, description="'vote' ou 'deputy' (optionnel)")
+    chunk_type: Literal["vote", "deputy"] | None = Field(
+        None, description="'vote' ou 'deputy' (optionnel)"
+    )
 
 
 class SourceItem(BaseModel):
@@ -35,12 +40,13 @@ class SearchResponse(BaseModel):
     response_model=SearchResponse,
     summary="Posez une question sur les votes et les députés",
 )
-async def search(request: SearchRequest):
+@limiter.limit("10/minute")
+async def search(request: Request, body: SearchRequest):
     try:
         result = ask(
-            question=request.question,
-            deputy_id=request.deputy_id,
-            chunk_type=request.chunk_type,
+            question=body.question,
+            deputy_id=body.deputy_id,
+            chunk_type=body.chunk_type,
         )
         return result
     except Exception as e:

--- a/rag/chain/prompts.py
+++ b/rag/chain/prompts.py
@@ -1,0 +1,15 @@
+SYSTEM_PROMPT = """Tu es un assistant civique spécialisé dans l'activité parlementaire française.
+Tu réponds uniquement en français, de manière factuelle et neutre.
+Tu bases tes réponses exclusivement sur les sources fournies.
+Si les sources ne contiennent pas l'information demandée, dis-le clairement sans inventer.
+Ne fais jamais de jugement politique.
+Cite toujours les faits bruts : nombres de votes, dates, noms exacts des députés et partis."""
+
+RAG_TEMPLATE = """Sources disponibles :
+{context}
+
+Question : {question}
+
+Réponds en te basant uniquement sur les sources ci-dessus.
+Synthétise si plusieurs sources sont pertinentes.
+Cite les données chiffrées disponibles."""

--- a/rag/chain/rag_chain.py
+++ b/rag/chain/rag_chain.py
@@ -1,0 +1,62 @@
+"""
+rag/chain/rag_chain.py
+
+RAG pipeline: retrieve relevant chunks from pgvector, then answer with
+Groq llama-3.3-70b-versatile.
+"""
+
+import os
+
+from dotenv import load_dotenv
+from groq import Groq
+
+from rag.chain.prompts import RAG_TEMPLATE, SYSTEM_PROMPT
+from rag.chain.retriever import retrieve
+
+load_dotenv()
+
+
+def ask(
+    question: str,
+    deputy_id: str = None,
+    chunk_type: str = None,
+) -> dict:
+    chunks = retrieve(question, k=5, deputy_id=deputy_id, chunk_type=chunk_type)
+
+    context = "\n\n---\n\n".join([c["content"] for c in chunks])
+
+    user_message = RAG_TEMPLATE.format(context=context, question=question)
+
+    client = Groq(api_key=os.getenv("GROQ_API_KEY"))
+    response = client.chat.completions.create(
+        model="llama-3.3-70b-versatile",
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": user_message},
+        ],
+        temperature=0.2,
+        max_tokens=1024,
+    )
+
+    return {
+        "answer": response.choices[0].message.content,
+        "sources": chunks,
+        "question": question,
+        "chunks_retrieved": len(chunks),
+    }
+
+
+if __name__ == "__main__":
+    questions = [
+        "Quel est le taux de présence de Yaël Braun-Pivet ?",
+        "Combien de députés appartiennent au Rassemblement National ?",
+        "Quels votes ont été adoptés récemment ?",
+    ]
+    for q in questions:
+        result = ask(q)
+        print(f"\nQ: {q}")
+        print(f"A: {result['answer']}")
+        print(
+            f"Sources: {result['chunks_retrieved']} chunks, top similarity: {result['sources'][0]['similarity']:.3f}"
+        )
+        print("---")

--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -1,0 +1,81 @@
+"""
+rag/chain/retriever.py
+
+Retrieves relevant chunks from document_chunks using cosine similarity
+via pgvector. The query is embedded with the same model used at index time.
+"""
+
+import os
+
+import numpy as np
+import psycopg2
+import psycopg2.extras
+from dotenv import load_dotenv
+from openai import OpenAI
+from pgvector.psycopg2 import register_vector
+
+load_dotenv()
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+EMBEDDING_MODEL = "text-embedding-3-small"
+
+
+def retrieve(
+    question: str,
+    k: int = 5,
+    chunk_type: str = None,
+    deputy_id: str = None,
+) -> list[dict]:
+    client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+    response = client.embeddings.create(input=[question], model=EMBEDDING_MODEL)
+    query_vector = np.array(response.data[0].embedding, dtype=np.float32)
+
+    conn = psycopg2.connect(DATABASE_URL, cursor_factory=psycopg2.extras.RealDictCursor)
+    try:
+        # register_vector must receive a plain cursor — RealDictCursor breaks
+        # its internal dict(fetchall()) unpacking
+        with conn.cursor(cursor_factory=psycopg2.extensions.cursor) as plain_cur:
+            register_vector(plain_cur)
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT content, metadata,
+                       1 - (embedding <=> %s::vector) AS similarity
+                FROM document_chunks
+                WHERE (%s IS NULL OR metadata->>'chunk_type' = %s)
+                  AND (%s IS NULL OR metadata->>'deputy_id' = %s)
+                ORDER BY embedding <=> %s::vector
+                LIMIT %s
+                """,
+                (
+                    query_vector,
+                    chunk_type,
+                    chunk_type,
+                    deputy_id,
+                    deputy_id,
+                    query_vector,
+                    k,
+                ),
+            )
+            rows = cur.fetchall()
+    finally:
+        conn.close()
+
+    results = [
+        {
+            "content": row["content"],
+            "metadata": dict(row["metadata"]),
+            "similarity": float(row["similarity"]),
+        }
+        for row in rows
+    ]
+
+    top_sim = results[0]["similarity"] if results else 0.0
+    print(f"Retrieved {len(results)} chunks — top similarity: {top_sim:.3f}")
+    return results
+
+
+if __name__ == "__main__":
+    chunks = retrieve("Yaël Braun-Pivet présence votes")
+    for c in chunks:
+        print(f"[{c['similarity']:.3f}] {c['content'][:100]}")

--- a/rag/experiments/mlflow_eval.py
+++ b/rag/experiments/mlflow_eval.py
@@ -1,0 +1,139 @@
+"""
+rag/experiments/mlflow_eval.py
+
+Evaluates the RAG pipeline against 10 golden Q&A pairs using keyword scoring.
+Runs two MLflow experiments: Config A (k=3) and Config B (k=5).
+"""
+
+import mlflow
+
+from rag.chain.rag_chain import ask
+
+GOLDEN_QA = [
+    {
+        "question": "Quel est le taux de présence de Yaël Braun-Pivet ?",
+        "keywords": ["100", "présence", "Braun-Pivet"],
+        "label": "Yaël Braun-Pivet présence",
+    },
+    {
+        "question": "Combien de députés appartiennent au Rassemblement National ?",
+        "keywords": ["122", "Rassemblement National"],
+        "label": "RN deputy count",
+    },
+    {
+        "question": "Combien de votes ont été rejetés depuis 2025 ?",
+        "keywords": ["rejeté"],
+        "label": "Votes rejetés 2025",
+    },
+    {
+        "question": "Combien de votes ont été adoptés depuis 2025 ?",
+        "keywords": ["adopté"],
+        "label": "Votes adoptés 2025",
+    },
+    {
+        "question": "Qui sont les députés des Yvelines ?",
+        "keywords": ["Yvelines"],
+        "label": "Députés Yvelines",
+    },
+    {
+        "question": "Combien de députés sont suivis ?",
+        "keywords": ["577"],
+        "label": "Total députés",
+    },
+    {
+        "question": "Quel parti a le plus de députés ?",
+        "keywords": ["Rassemblement National", "122"],
+        "label": "Parti majoritaire",
+    },
+    {
+        "question": "Quels députés ont le plus d'abstentions ?",
+        "keywords": ["abstention"],
+        "label": "Deputés abstentions",
+    },
+    {
+        "question": "Combien de votes ont eu lieu depuis janvier 2025 ?",
+        "keywords": ["3149", "3 149"],
+        "label": "Volume votes 2025",
+    },
+    {
+        "question": "Quels sont les votes récents adoptés à l'Assemblée ?",
+        "keywords": ["adopté", "vote"],
+        "label": "Votes récents adoptés",
+    },
+]
+
+
+def _score_answer(answer: str, keywords: list[str]) -> float:
+    answer_lower = answer.lower()
+    found = sum(1 for kw in keywords if kw.lower() in answer_lower)
+    return found / len(keywords)
+
+
+def run_experiment(k: int) -> dict:
+    scores = []
+    similarities = []
+    per_question = []
+
+    mlflow.set_experiment("monelu-rag-eval")
+    with mlflow.start_run(run_name=f"groq-llama3-k{k}"):
+        mlflow.log_param("k", k)
+        mlflow.log_param("llm", "llama-3.3-70b-versatile")
+        mlflow.log_param("embedding_model", "text-embedding-3-small")
+
+        for qa in GOLDEN_QA:
+            result = ask(qa["question"])
+            score = _score_answer(result["answer"], qa["keywords"])
+            top_sim = result["sources"][0]["similarity"] if result["sources"] else 0.0
+
+            scores.append(score)
+            similarities.append(top_sim)
+
+            found_kws = [kw for kw in qa["keywords"] if kw.lower() in result["answer"].lower()]
+            per_question.append(
+                {
+                    "label": qa["label"],
+                    "keywords": qa["keywords"],
+                    "found": found_kws,
+                    "score": score,
+                    "top_sim": top_sim,
+                }
+            )
+
+        avg_score = sum(scores) / len(scores)
+        avg_sim = sum(similarities) / len(similarities)
+
+        mlflow.log_metric("keyword_score", avg_score)
+        mlflow.log_metric("avg_similarity", avg_sim)
+
+    return {
+        "k": k,
+        "keyword_score": avg_score,
+        "avg_similarity": avg_sim,
+        "per_question": per_question,
+    }
+
+
+if __name__ == "__main__":
+    print("\nRunning Config A (k=3)...")
+    result_a = run_experiment(k=3)
+
+    print("\nRunning Config B (k=5)...")
+    result_b = run_experiment(k=5)
+
+    winner = "A (k=3)" if result_a["keyword_score"] >= result_b["keyword_score"] else "B (k=5)"
+
+    print("\n" + "=" * 48)
+    print("  MonÉlu RAG — Evaluation Results")
+    print("=" * 48)
+    print(f"  Config A (k=3): keyword_score = {result_a['keyword_score']:.2f}")
+    print(f"  Config B (k=5): keyword_score = {result_b['keyword_score']:.2f}")
+    print(f"  Winner: config {winner}")
+    print("  Run `make mlflow-ui` to explore.")
+    print("=" * 48)
+
+    print("\n  Per-question breakdown (Config B k=5):")
+    for pq in result_b["per_question"]:
+        total = len(pq["keywords"])
+        found = len(pq["found"])
+        check = "✓" if found == total else "← retrieval gap" if found == 0 else "△ partial"
+        print(f"    {pq['label']:<34} → {found}/{total} keywords found {check}")

--- a/rag/pipeline/embedder.py
+++ b/rag/pipeline/embedder.py
@@ -1,0 +1,95 @@
+"""
+rag/pipeline/embedder.py
+
+Embeds text chunks via OpenAI text-embedding-3-small and stores them in
+document_chunks (pgvector on Supabase / local Postgres).
+
+Assumes the table is empty before calling embed_and_store — callers are
+responsible for truncating first (index_manager.build_index does this).
+"""
+
+import os
+import time
+
+import numpy as np
+import psycopg2
+import psycopg2.extras
+from dotenv import load_dotenv
+from openai import OpenAI
+from pgvector.psycopg2 import register_vector
+
+load_dotenv()
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+EMBEDDING_MODEL = "text-embedding-3-small"
+COST_PER_1M_TOKENS = 0.020  # USD
+
+
+def _embed_batch(client: OpenAI, texts: list[str], max_retries: int = 3):
+    """Returns (embeddings, tokens_used). Retries on 429 with exponential backoff."""
+    for attempt in range(max_retries):
+        try:
+            response = client.embeddings.create(input=texts, model=EMBEDDING_MODEL)
+            embeddings = [item.embedding for item in response.data]
+            tokens_used = response.usage.total_tokens
+            return embeddings, tokens_used
+        except Exception as e:
+            if "429" in str(e) and attempt < max_retries - 1:
+                wait = 2**attempt
+                print(f"  Rate limit — retrying in {wait}s...")
+                time.sleep(wait)
+            else:
+                raise
+
+
+def embed_and_store(chunks: list[dict], batch_size: int = 100) -> None:
+    client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+    total_batches = (len(chunks) + batch_size - 1) // batch_size
+    grand_total_tokens = 0
+    grand_total_stored = 0
+
+    for batch_idx in range(total_batches):
+        start = batch_idx * batch_size
+        batch = chunks[start : start + batch_size]
+
+        texts = [c["content"] for c in batch]
+        embeddings, tokens_used = _embed_batch(client, texts)
+
+        conn = psycopg2.connect(DATABASE_URL)
+        try:
+            register_vector(conn)
+            with conn.cursor() as cur:
+                records = [
+                    (
+                        chunk["content"],
+                        psycopg2.extras.Json(chunk["metadata"]),
+                        np.array(embedding, dtype=np.float32),
+                    )
+                    for chunk, embedding in zip(batch, embeddings, strict=False)
+                ]
+                psycopg2.extras.execute_batch(
+                    cur,
+                    """
+                    INSERT INTO document_chunks (content, metadata, embedding)
+                    VALUES (%s, %s, %s)
+                    """,
+                    records,
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+        grand_total_tokens += tokens_used
+        grand_total_stored += len(batch)
+        cost_so_far = grand_total_tokens * COST_PER_1M_TOKENS / 1_000_000
+        print(
+            f"Batch {batch_idx + 1}/{total_batches} — "
+            f"{len(batch)} chunks stored "
+            f"(cumulative: {grand_total_stored}, ${cost_so_far:.4f})"
+        )
+
+    total_cost = grand_total_tokens * COST_PER_1M_TOKENS / 1_000_000
+    print(f"\nDone. {grand_total_stored} chunks stored.")
+    print(f"Total tokens : {grand_total_tokens:,}")
+    print(f"Estimated cost : ${total_cost:.4f}")

--- a/rag/pipeline/embedder.py
+++ b/rag/pipeline/embedder.py
@@ -15,7 +15,7 @@ import numpy as np
 import psycopg2
 import psycopg2.extras
 from dotenv import load_dotenv
-from openai import OpenAI
+from openai import OpenAI, RateLimitError
 from pgvector.psycopg2 import register_vector
 
 load_dotenv()
@@ -33,13 +33,15 @@ def _embed_batch(client: OpenAI, texts: list[str], max_retries: int = 3):
             embeddings = [item.embedding for item in response.data]
             tokens_used = response.usage.total_tokens
             return embeddings, tokens_used
-        except Exception as e:
-            if "429" in str(e) and attempt < max_retries - 1:
+        except RateLimitError:
+            if attempt < max_retries - 1:
                 wait = 2**attempt
                 print(f"  Rate limit — retrying in {wait}s...")
                 time.sleep(wait)
             else:
                 raise
+        except Exception:
+            raise
 
 
 def embed_and_store(chunks: list[dict], batch_size: int = 100) -> None:

--- a/rag/pipeline/index_manager.py
+++ b/rag/pipeline/index_manager.py
@@ -1,0 +1,102 @@
+"""
+rag/pipeline/index_manager.py
+
+Manages the document_chunks vector index lifecycle.
+
+CLI:
+    python -m rag.pipeline.index_manager build
+    python -m rag.pipeline.index_manager stats
+    python -m rag.pipeline.index_manager clear
+"""
+
+import os
+import sys
+
+import psycopg2
+import psycopg2.extras
+from dotenv import load_dotenv
+
+from rag.pipeline.chunker import chunk_all
+from rag.pipeline.embedder import embed_and_store
+
+load_dotenv()
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+
+def _get_conn():
+    return psycopg2.connect(DATABASE_URL, cursor_factory=psycopg2.extras.RealDictCursor)
+
+
+def build_index() -> None:
+    """Truncate document_chunks, regenerate all chunks, embed and store."""
+    print("Clearing existing index...")
+    clear_index()
+
+    print("Building chunks from database...")
+    chunks = chunk_all()
+    print(f"Starting embedding — {len(chunks)} chunks to process.\n")
+
+    embed_and_store(chunks)
+
+
+def clear_index() -> None:
+    """Truncate document_chunks and reset the sequence."""
+    conn = _get_conn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("TRUNCATE document_chunks RESTART IDENTITY")
+        conn.commit()
+        print("document_chunks truncated.")
+    finally:
+        conn.close()
+
+
+def get_index_stats() -> None:
+    """Print chunk counts and average content length by chunk_type."""
+    conn = _get_conn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT
+                    metadata->>'chunk_type'      AS chunk_type,
+                    COUNT(*)                     AS total_chunks,
+                    ROUND(AVG(LENGTH(content)))  AS avg_content_chars
+                FROM document_chunks
+                GROUP BY metadata->>'chunk_type'
+                ORDER BY chunk_type
+                """
+            )
+            rows = cur.fetchall()
+
+            cur.execute("SELECT COUNT(*) AS total FROM document_chunks")
+            grand_total = cur.fetchone()["total"]
+    finally:
+        conn.close()
+
+    if not rows:
+        print("document_chunks is empty.")
+        return
+
+    print(f"\n{'chunk_type':<12} {'total_chunks':>14} {'avg_chars':>12}")
+    print("-" * 42)
+    for row in rows:
+        print(
+            f"{row['chunk_type'] or 'NULL':<12} "
+            f"{row['total_chunks']:>14,} "
+            f"{row['avg_content_chars']:>12}"
+        )
+    print("-" * 42)
+    print(f"{'TOTAL':<12} {grand_total:>14,}")
+    print()
+
+
+if __name__ == "__main__":
+    commands = {"build": build_index, "stats": get_index_stats, "clear": clear_index}
+
+    if len(sys.argv) != 2 or sys.argv[1] not in commands:
+        print(f"Usage: python -m rag.pipeline.index_manager [{' | '.join(commands)}]")
+        sys.exit(1)
+
+    commands[sys.argv[1]]()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ slowapi==0.1.9
 uvicorn[standard]>=0.34.0
 gunicorn==22.0.0
 psycopg2-binary>=2.9.10
-sqlalchemy==2.0.30
+sqlalchemy==2.0.49
 requests==2.32.2
 python-dotenv==1.0.1
 httpx==0.27.0
@@ -12,6 +12,6 @@ pandas==2.2.2
 openai==1.40.0
 groq==0.9.0
 tiktoken==0.7.0
-mlflow==2.15.0
+mlflow==3.11.1
 pgvector==0.3.2
 numpy>=1.26.0


### PR DESCRIPTION
## What
Adds a full RAG chatbot pipeline to MonÉlu — 3,726 pgvector embeddings (OpenAI text-embedding-3-small), a Groq-powered retrieval chain, MLflow evaluation, and a `POST /search/` API endpoint that answers questions in French about deputies and votes.

## Why
Phase 1 exposed structured data via REST endpoints. Phase 2 makes it conversational: users can ask natural-language questions ("Quel est le taux de présence de Yaël Braun-Pivet ?") and get factual answers grounded in the actual vote and deputy data — with sources attached.

## Changes

**Indexing pipeline (`rag/pipeline/`)**
- `embedder.py` — batched OpenAI embedding (100 chunks/batch), fresh psycopg2 connection per batch with pgvector registration, cost tracking from `response.usage.total_tokens`. Plain `INSERT` (no upsert) — safe because `build_index` always truncates first
- `index_manager.py` — `build` / `stats` / `clear` CLI; `build` always calls `TRUNCATE ... RESTART IDENTITY` before embedding to prevent duplicates (no unique constraint on `document_chunks`)
- 3,726 chunks stored: 3,149 vote + 577 deputy, avg 86 tokens, $0.0064 total

**Retrieval chain (`rag/chain/`)**
- `retriever.py` — cosine similarity via pgvector `<=>` operator; supports `chunk_type` and `deputy_id` filters. Fix: `register_vector` must receive a plain psycopg2 cursor — passing a `RealDictCursor` breaks its internal `dict(fetchall())` type-OID unpacking
- `prompts.py` — French civic assistant system prompt (factual, neutral, no political judgement) + RAG context template
- `rag_chain.py` — `ask()` orchestrates retrieve → format → Groq `llama-3.3-70b-versatile` (temperature=0.2, max_tokens=1024)

**Evaluation (`rag/experiments/`)**
- `mlflow_eval.py` — 10 golden Q&A pairs, keyword scoring, k=3 vs k=5 MLflow experiment comparison
- Results: both configs score **0.58**; 3 retrieval gaps all share the same root cause — aggregate facts (total deputy count, party totals, vote volume) are absent from individual chunks. Phase 3 fix: add a global-stats chunk to the index

**API (`api/routers/search.py`, `api/main.py`)**
- `POST /search/` with `SearchRequest` / `SearchResponse` Pydantic models, registered under `tags=["Search"]`
- CORS updated to allow `POST` (was GET-only)

**Makefile / .gitignore**
- New targets: `rag-index`, `rag-stats`, `rag-clear`, `rag-test`, `rag-eval`, `mlflow-ui`
- `mlruns/` added to `.gitignore` (local MLflow file store, contains machine-specific absolute paths)

## Testing
- `make rag-index` — ran successfully, 3,726 chunks stored, $0.0064
- `make rag-eval` — both MLflow runs logged (k=3 and k=5), keyword_score=0.58
- `curl -X POST http://localhost:8000/search/` — full JSON response verified (answer + 5 sources with similarity scores)
- Swagger UI at `/docs` — Search section confirmed with documented `POST /search/` endpoint

## Risks / Notes
- **Retrieval gaps identified by eval:** questions requiring aggregate counts (total deputies, party sizes, total vote volume) score 0 — no individual chunk contains these facts. Fix in Phase 3: inject a single "global stats" chunk at index time
- **Groq free tier:** `llama-3.3-70b-versatile` has rate limits — the endpoint will return 500 if the Groq quota is exceeded. A retry/fallback is a Phase 3 concern
- **`OPENAI_API_KEY` and `GROQ_API_KEY`** must be set in Railway env vars before this can serve production traffic
- Python 3.14 required upgrading `sqlalchemy` to `>=2.0.40` and `mlflow` to `3.11.1` — `requirements.txt` is not pinned for these yet (tracked separately)

## Breaking Changes
None — existing `/deputies` and `/votes` endpoints are unchanged. The CORS change (adding POST) is additive.