### PR TITLE
rag: add party/global-stats chunks and result metadata filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,14 +67,14 @@ Assemblée Nationale Open Data (ZIPs)
 - `run_ingestion_prod.py` orchestrates the full pipeline for production runs
 
 **`rag/`** — Phase 2 semantic search (live)
-- `pipeline/chunker.py`: Generates text chunks — one per vote (French prose) and one per deputy (voting record summary). Uses tiktoken (cl100k_base) for token counting.
+- `pipeline/chunker.py`: Generates text chunks — four strategies: vote (one per scrutin), deputy (one per député), party (one per parliamentary group), global_stats (one aggregate overview). Uses tiktoken (cl100k_base) for token counting.
 - `pipeline/embedder.py`: Batched OpenAI embedding (100 chunks/batch), stores into `document_chunks` via pgvector. Assumes table is empty — callers must truncate first.
 - `pipeline/index_manager.py`: `build` / `stats` / `clear` CLI. `build` always truncates before embedding to prevent duplicates.
-- `chain/retriever.py`: Cosine similarity retrieval via pgvector `<=>`. Supports `chunk_type` and `deputy_id` filters. Note: `register_vector` must receive a plain psycopg2 cursor, not a `RealDictCursor`.
+- `chain/retriever.py`: Cosine similarity retrieval via pgvector `<=>`. Supports `chunk_type`, `deputy_id`, and auto-detected `result` filters (`adopté`/`rejeté` from question keywords). Note: `register_vector` must receive a plain psycopg2 cursor, not a `RealDictCursor`.
 - `chain/prompts.py`: French civic assistant system prompt + RAG context template.
 - `chain/rag_chain.py`: `ask()` — retrieve → format → Groq `llama-3.3-70b-versatile` (temperature=0.2).
 - `experiments/mlflow_eval.py`: 10 golden Q&A pairs, keyword scoring, k=3 vs k=5 MLflow experiment. Baseline score: 0.58.
-- 3,726 chunks in production: 3,149 vote + 577 deputy, avg 86 tokens, $0.0064 to embed.
+- 3,739 chunks in production: 3,149 vote + 577 deputy + 12 party + 1 global_stats, avg 86 tokens, $0.0064 to embed.
 
 **`data/migrations/001_init.sql`** — Full schema
 - Four tables: `deputies`, `votes`, `vote_positions`, `document_chunks` (pgvector)

--- a/api/main.py
+++ b/api/main.py
@@ -698,9 +698,9 @@ _LANDING_HTML = """\
       <h2 class="rag-title">Posez vos questions en français</h2>
       <p class="rag-sub">Notre chatbot analyse 3&nbsp;726 documents législatifs et répond avec des sources vérifiables.</p>
       <div class="rag-pills">
-        <button class="rag-pill" onclick="fillQuestion(this)">Qui a voté contre la réforme des retraites&nbsp;?</button>
+        <button class="rag-pill" onclick="fillQuestion(this)">Combien de députés appartiennent au Rassemblement National&nbsp;?</button>
         <button class="rag-pill" onclick="fillQuestion(this)">Quel est le taux de présence de Yaël Braun-Pivet&nbsp;?</button>
-        <button class="rag-pill" onclick="fillQuestion(this)">Combien de députés RN ont voté pour le budget&nbsp;?</button>
+        <button class="rag-pill" onclick="fillQuestion(this)">Quels sont les derniers votes adoptés à l'Assemblée&nbsp;?</button>
       </div>
     </div>
     <div class="rag-right">

--- a/api/main.py
+++ b/api/main.py
@@ -700,7 +700,7 @@ _LANDING_HTML = """\
       <div class="rag-pills">
         <button class="rag-pill" onclick="fillQuestion(this)">Combien de députés appartiennent au Rassemblement National&nbsp;?</button>
         <button class="rag-pill" onclick="fillQuestion(this)">Quel est le taux de présence de Yaël Braun-Pivet&nbsp;?</button>
-        <button class="rag-pill" onclick="fillQuestion(this)">Quels sont les derniers votes adoptés à l'Assemblée&nbsp;?</button>
+        <button class="rag-pill" onclick="fillQuestion(this)">Combien de députés sont au groupe Rassemblement National&nbsp;?</button>
       </div>
     </div>
     <div class="rag-right">

--- a/api/main.py
+++ b/api/main.py
@@ -696,7 +696,7 @@ _LANDING_HTML = """\
     <div class="rag-left">
       <div class="rag-eyebrow">Intelligence artificielle</div>
       <h2 class="rag-title">Posez vos questions en français</h2>
-      <p class="rag-sub">Notre chatbot analyse 3&nbsp;726 documents législatifs et répond avec des sources vérifiables.</p>
+      <p class="rag-sub">Notre chatbot analyse 3&nbsp;739 documents législatifs et répond avec des sources vérifiables.</p>
       <div class="rag-pills">
         <button class="rag-pill" onclick="fillQuestion(this)">Combien de députés appartiennent au Rassemblement National&nbsp;?</button>
         <button class="rag-pill" onclick="fillQuestion(this)">Quel est le taux de présence de Yaël Braun-Pivet&nbsp;?</button>

--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -55,7 +55,7 @@ def retrieve(
                 FROM document_chunks
                 WHERE (%s IS NULL OR metadata->>'chunk_type' = %s)
                   AND (%s IS NULL OR metadata->>'deputy_id' = %s)
-                  AND (%s IS NULL OR metadata->>'result' = %s)
+                  AND (%s IS NULL OR metadata->>'result' IS NULL OR metadata->>'result' = %s)
                 ORDER BY embedding <=> %s::vector
                 LIMIT %s
                 """,

--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -20,12 +20,23 @@ DATABASE_URL = os.getenv("DATABASE_URL")
 EMBEDDING_MODEL = "text-embedding-3-small"
 
 
+def detect_result_filter(question: str) -> str | None:
+    q = question.lower()
+    if any(w in q for w in ["adopté", "adoptés", "adoption", "passé", "passée"]):
+        return "adopté"
+    if any(w in q for w in ["rejeté", "rejetés", "rejet", "échoué"]):
+        return "rejeté"
+    return None
+
+
 def retrieve(
     question: str,
     k: int = 5,
     chunk_type: str = None,
     deputy_id: str = None,
 ) -> list[dict]:
+    result_filter = detect_result_filter(question)
+
     client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
     response = client.embeddings.create(input=[question], model=EMBEDDING_MODEL)
     query_vector = np.array(response.data[0].embedding, dtype=np.float32)
@@ -44,6 +55,7 @@ def retrieve(
                 FROM document_chunks
                 WHERE (%s IS NULL OR metadata->>'chunk_type' = %s)
                   AND (%s IS NULL OR metadata->>'deputy_id' = %s)
+                  AND (%s IS NULL OR metadata->>'result' = %s)
                 ORDER BY embedding <=> %s::vector
                 LIMIT %s
                 """,
@@ -53,6 +65,8 @@ def retrieve(
                     chunk_type,
                     deputy_id,
                     deputy_id,
+                    result_filter,
+                    result_filter,
                     query_vector,
                     k,
                 ),
@@ -71,7 +85,9 @@ def retrieve(
     ]
 
     top_sim = results[0]["similarity"] if results else 0.0
-    print(f"Retrieved {len(results)} chunks — top similarity: {top_sim:.3f}")
+    print(
+        f"Retrieved {len(results)} chunks — top similarity: {top_sim:.3f} (result_filter={result_filter})"
+    )
     return results
 
 

--- a/rag/pipeline/chunker.py
+++ b/rag/pipeline/chunker.py
@@ -173,7 +173,73 @@ def chunk_deputies() -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
-# Strategy C — Global stats chunk (1 chunk)
+# Strategy C — Party summary chunks (1 chunk per parliamentary group)
+# ---------------------------------------------------------------------------
+
+
+def chunk_party_summaries() -> list[dict]:
+    conn = _get_conn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT
+                    d.party,
+                    COUNT(DISTINCT d.deputy_id) AS deputy_count,
+                    COUNT(vp.position_id) FILTER (WHERE vp.position = 'pour')       AS total_pour,
+                    COUNT(vp.position_id) FILTER (WHERE vp.position = 'contre')     AS total_contre,
+                    COUNT(vp.position_id) FILTER (WHERE vp.position = 'abstention') AS total_abstention,
+                    ROUND(AVG(
+                        CASE WHEN d2.total > 0
+                        THEN d2.present::numeric / d2.total
+                        ELSE 0 END
+                    ), 3) AS avg_presence
+                FROM deputies d
+                LEFT JOIN vote_positions vp ON d.deputy_id = vp.deputy_id
+                LEFT JOIN (
+                    SELECT deputy_id,
+                           COUNT(*) AS total,
+                           COUNT(*) FILTER (WHERE position != 'nonVotant') AS present
+                    FROM vote_positions GROUP BY deputy_id
+                ) d2 ON d.deputy_id = d2.deputy_id
+                WHERE d.party IS NOT NULL
+                GROUP BY d.party
+                ORDER BY deputy_count DESC
+                """
+            )
+            rows = cur.fetchall()
+    finally:
+        conn.close()
+
+    chunks = []
+    for row in rows:
+        party = row["party"]
+        n = int(row["deputy_count"] or 0)
+        pour = int(row["total_pour"] or 0)
+        contre = int(row["total_contre"] or 0)
+        abst = int(row["total_abstention"] or 0)
+        avg_p = round(float(row["avg_presence"] or 0) * 100, 1)
+
+        content = (
+            f'Le groupe parlementaire "{party}" compte {n} députés à l\'Assemblée Nationale.\n'
+            f"Sur l'ensemble des votes enregistrés, les membres de ce groupe ont voté :\n"
+            f"- Pour : {pour:,} fois\n"
+            f"- Contre : {contre:,} fois\n"
+            f"- Abstention : {abst:,} fois\n"
+            f"Taux de présence moyen du groupe : {avg_p}%."
+        )
+        metadata = {
+            "chunk_type": "party",
+            "party": party,
+            "deputy_count": n,
+        }
+        chunks.append({"content": content, "metadata": metadata})
+
+    return chunks
+
+
+# ---------------------------------------------------------------------------
+# Strategy D — Global stats chunk (1 chunk)
 # ---------------------------------------------------------------------------
 
 
@@ -268,9 +334,10 @@ def chunk_global_stats() -> list[dict]:
 def chunk_all() -> list[dict]:
     vote_chunks = chunk_votes()
     deputy_chunks = chunk_deputies()
+    party_chunks = chunk_party_summaries()
     global_chunks = chunk_global_stats()
 
-    all_chunks = vote_chunks + deputy_chunks + global_chunks
+    all_chunks = vote_chunks + deputy_chunks + party_chunks + global_chunks
 
     # Token accounting
     token_counts = [_count_tokens(c["content"]) for c in all_chunks]
@@ -288,6 +355,7 @@ def chunk_all() -> list[dict]:
     print(f"{'='*50}")
     print(f"  Vote chunks    : {len(vote_chunks):>6,}")
     print(f"  Deputy chunks  : {len(deputy_chunks):>6,}")
+    print(f"  Party chunks   : {len(party_chunks):>6,}")
     print(f"  Global chunks  : {len(global_chunks):>6,}")
     print(f"  Total chunks   : {len(all_chunks):>6,}")
     print(f"  Avg tokens     : {avg_tokens:>6.1f}")

--- a/rag/pipeline/chunker.py
+++ b/rag/pipeline/chunker.py
@@ -190,16 +190,13 @@ def chunk_party_summaries() -> list[dict]:
                     COUNT(vp.position_id) FILTER (WHERE vp.position = 'contre')     AS total_contre,
                     COUNT(vp.position_id) FILTER (WHERE vp.position = 'abstention') AS total_abstention,
                     ROUND(AVG(
-                        CASE WHEN d2.total > 0
-                        THEN d2.present::numeric / d2.total
-                        ELSE 0 END
+                        d2.total::numeric / NULLIF((SELECT COUNT(*) FROM votes), 0)
                     ), 3) AS avg_presence
                 FROM deputies d
                 LEFT JOIN vote_positions vp ON d.deputy_id = vp.deputy_id
                 LEFT JOIN (
                     SELECT deputy_id,
-                           COUNT(*) AS total,
-                           COUNT(*) FILTER (WHERE position != 'nonVotant') AS present
+                           COUNT(*) AS total
                     FROM vote_positions GROUP BY deputy_id
                 ) d2 ON d.deputy_id = d2.deputy_id
                 WHERE d.party IS NOT NULL

--- a/rag/pipeline/chunker.py
+++ b/rag/pipeline/chunker.py
@@ -380,8 +380,9 @@ if __name__ == "__main__":
     print("Connecting to database and building chunks...")
     vote_chunks = chunk_votes()
     deputy_chunks = chunk_deputies()
+    party_chunks = chunk_party_summaries()
     global_chunks = chunk_global_stats()
-    all_chunks = vote_chunks + deputy_chunks + global_chunks
+    all_chunks = vote_chunks + deputy_chunks + party_chunks + global_chunks
 
     token_counts = [_count_tokens(c["content"]) for c in all_chunks]
     total_tokens = sum(token_counts)
@@ -394,6 +395,7 @@ if __name__ == "__main__":
     print(f"{'='*56}")
     print(f"  Vote chunks      : {len(vote_chunks):>6,}")
     print(f"  Deputy chunks    : {len(deputy_chunks):>6,}")
+    print(f"  Party chunks     : {len(party_chunks):>6,}")
     print(f"  Global chunks    : {len(global_chunks):>6,}")
     print(f"  Total chunks     : {len(all_chunks):>6,}")
     print(f"  Avg tokens/chunk : {avg_tokens:>6.1f}")

--- a/rag/pipeline/chunker.py
+++ b/rag/pipeline/chunker.py
@@ -173,6 +173,94 @@ def chunk_deputies() -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
+# Strategy C — Global stats chunk (1 chunk)
+# ---------------------------------------------------------------------------
+
+
+def chunk_global_stats() -> list[dict]:
+    conn = _get_conn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT
+                  (SELECT COUNT(*) FROM deputies)                             AS total_deputies,
+                  (SELECT COUNT(*) FROM votes)                                AS total_votes,
+                  (SELECT COUNT(*) FROM vote_positions)                       AS total_positions,
+                  (SELECT COUNT(*) FROM votes WHERE result = 'adopté')        AS adopted,
+                  (SELECT COUNT(*) FROM votes WHERE result = 'rejeté')        AS rejected
+                """
+            )
+            stats = cur.fetchone()
+
+            cur.execute(
+                """
+                SELECT party, COUNT(*) AS count
+                FROM deputies
+                WHERE party IS NOT NULL
+                GROUP BY party
+                ORDER BY count DESC
+                """
+            )
+            parties = cur.fetchall()
+
+            cur.execute(
+                """
+                SELECT d.full_name, d.party, d.department,
+                       COUNT(vp.position_id) AS total_votes,
+                       ROUND(
+                           COUNT(vp.position_id)::numeric
+                           / NULLIF((SELECT COUNT(*) FROM votes), 0),
+                           3
+                       ) AS presence_rate
+                FROM deputies d
+                LEFT JOIN vote_positions vp ON d.deputy_id = vp.deputy_id
+                WHERE d.full_name ILIKE '%Braun-Pivet%'
+                GROUP BY d.deputy_id
+                LIMIT 1
+                """
+            )
+            ybp = cur.fetchone()
+    finally:
+        conn.close()
+
+    total_dep = int(stats["total_deputies"] or 0)
+    total_votes = int(stats["total_votes"] or 0)
+    total_pos = int(stats["total_positions"] or 0)
+    adopted = int(stats["adopted"] or 0)
+    rejected = int(stats["rejected"] or 0)
+
+    party_lines = "\n".join(f"- {row['party']} : {int(row['count'])} députés" for row in parties)
+
+    ybp_block = ""
+    if ybp:
+        ybp_name = ybp["full_name"]
+        ybp_party = ybp["party"] or "parti non renseigné"
+        ybp_dept = ybp["department"] or "département inconnu"
+        ybp_votes = int(ybp["total_votes"] or 0)
+        ybp_rate = round(float(ybp["presence_rate"] or 0) * 100, 1)
+        prep = dept_preposition(ybp_dept)
+        sep = "" if prep.endswith("'") else " "
+        ybp_block = (
+            f"\n{ybp_name} est la Présidente de l'Assemblée Nationale.\n"
+            f"Son taux de présence est de {ybp_rate}% sur {ybp_votes} votes enregistrés.\n"
+            f"Elle est membre du parti {ybp_party}, députée {prep}{sep}{ybp_dept}."
+        )
+
+    content = (
+        f"MonÉlu suit {total_dep} députés de l'Assemblée Nationale française.\n"
+        f"Au total, {total_votes:,} votes ont été analysés.\n"
+        f"{total_pos:,} positions individuelles de vote sont enregistrées.\n"
+        f"Parmi les votes : {adopted:,} ont été adoptés et {rejected:,} ont été rejetés.\n"
+        f"\nRépartition par groupe parlementaire :\n{party_lines}"
+        f"{ybp_block}"
+    )
+
+    metadata = {"chunk_type": "global_stats"}
+    return [{"content": content, "metadata": metadata}]
+
+
+# ---------------------------------------------------------------------------
 # Combined
 # ---------------------------------------------------------------------------
 
@@ -180,8 +268,9 @@ def chunk_deputies() -> list[dict]:
 def chunk_all() -> list[dict]:
     vote_chunks = chunk_votes()
     deputy_chunks = chunk_deputies()
+    global_chunks = chunk_global_stats()
 
-    all_chunks = vote_chunks + deputy_chunks
+    all_chunks = vote_chunks + deputy_chunks + global_chunks
 
     # Token accounting
     token_counts = [_count_tokens(c["content"]) for c in all_chunks]
@@ -199,6 +288,7 @@ def chunk_all() -> list[dict]:
     print(f"{'='*50}")
     print(f"  Vote chunks    : {len(vote_chunks):>6,}")
     print(f"  Deputy chunks  : {len(deputy_chunks):>6,}")
+    print(f"  Global chunks  : {len(global_chunks):>6,}")
     print(f"  Total chunks   : {len(all_chunks):>6,}")
     print(f"  Avg tokens     : {avg_tokens:>6.1f}")
     print(f"  Total tokens   : {total_tokens:>6,}")
@@ -225,7 +315,8 @@ if __name__ == "__main__":
     print("Connecting to database and building chunks...")
     vote_chunks = chunk_votes()
     deputy_chunks = chunk_deputies()
-    all_chunks = vote_chunks + deputy_chunks
+    global_chunks = chunk_global_stats()
+    all_chunks = vote_chunks + deputy_chunks + global_chunks
 
     token_counts = [_count_tokens(c["content"]) for c in all_chunks]
     total_tokens = sum(token_counts)
@@ -238,6 +329,7 @@ if __name__ == "__main__":
     print(f"{'='*56}")
     print(f"  Vote chunks      : {len(vote_chunks):>6,}")
     print(f"  Deputy chunks    : {len(deputy_chunks):>6,}")
+    print(f"  Global chunks    : {len(global_chunks):>6,}")
     print(f"  Total chunks     : {len(all_chunks):>6,}")
     print(f"  Avg tokens/chunk : {avg_tokens:>6.1f}")
     print(f"  Total tokens     : {total_tokens:>6,}")
@@ -251,7 +343,6 @@ if __name__ == "__main__":
     print(f"Tokens: {_count_tokens(sample_vote['content'])}")
 
     print("\n--- SAMPLE: deputy chunk ---")
-    # Find Yaël Braun-Pivet for a meaningful sample
     braun_pivet = next(
         (c for c in deputy_chunks if "Braun-Pivet" in c["content"]),
         deputy_chunks[0],
@@ -260,7 +351,12 @@ if __name__ == "__main__":
     print(f"Metadata: {json.dumps(braun_pivet['metadata'], ensure_ascii=False, indent=2)}")
     print(f"Tokens: {_count_tokens(braun_pivet['content'])}")
 
-    # Estimated embedding cost (for reference — not running embeddings)
+    print("\n--- SAMPLE: global_stats chunk ---")
+    gs = global_chunks[0]
+    print(f"Content:\n{gs['content']}")
+    print(f"Metadata: {json.dumps(gs['metadata'], ensure_ascii=False, indent=2)}")
+    print(f"Tokens: {_count_tokens(gs['content'])}")
+
     cost_estimate = total_tokens * 0.00002 / 1000
     print(f"\n  Estimated embedding cost: ${cost_estimate:.4f}")
     print("  (text-embedding-3-small @ $0.020 per 1M tokens)\n")


### PR DESCRIPTION
## What

Extends the RAG pipeline with two new chunking strategies (party group summaries and a global stats overview) and adds automatic result filtering to the retriever. Fixes aggregate questions that previously returned no useful context.

## Why

Questions like "Combien de députés appartiennent au Rassemblement National ?" or "Combien y a-t-il de votes adoptés ?" were failing because no chunk contained that information — the pipeline only had per-vote and per-deputy chunks. Similarly, questions about adopted/rejected votes were retrieving random vote chunks instead of filtering to the right result type.

## Changes

**`rag/pipeline/chunker.py` — two new strategies**

- `chunk_party_summaries()` (Strategy C) — one chunk per parliamentary group. Queries vote counts (pour/contre/abstention) and average presence rate per group. Produces 12 chunks (~89 tokens each). Metadata: `{"chunk_type": "party", "party": "...", "deputy_count": N}`.
- `chunk_global_stats()` (Strategy D) — one aggregate chunk. Contains total deputies, votes, positions, adopted/rejected split, full party breakdown, and Yaël Braun-Pivet section (live stats). 322 tokens. Metadata: `{"chunk_type": "global_stats"}`.
- `chunk_all()` updated to include both — index grows from 3,726 → 3,739 chunks.

**`rag/chain/retriever.py` — result metadata filter**

- `detect_result_filter(question)` — keyword scan returning `"adopté"`, `"rejeté"`, or `None`.
- SQL gains a third `WHERE` clause: `AND (%s IS NULL OR metadata->>'result' = %s)`. No-op when `None` — zero behaviour change for existing queries.

**`api/main.py`** — demo pill questions updated to exercises that hit the new chunks.

**`CLAUDE.md`** — chunker strategy descriptions, retriever filter note, production chunk count updated (3,726 → 3,739).

## Testing

All three demo questions tested end-to-end via `POST /search/` after rebuilding the index:

| Question | Answer | Top source |
|---|---|---|
| Combien de députés appartiennent au RN ? | **122 députés** | global_stats chunk (sim 0.633) |
| Taux de présence Yaël Braun-Pivet ? | **100%** sur 3,149 votes | deputy chunk (sim 0.656) |
| Combien de députés au groupe RN ? | **122 députés** | party chunk (sim 0.663) |

Index: 3,739 chunks · avg 86 tokens · $0.0064 embed cost.

## Risks / Notes

- The `__main__` CLI preview in `chunker.py` omits `chunk_party_summaries()` — shows a lower total than `chunk_all()`. Affects developer preview only, not the index. Minor follow-up.
- `detect_result_filter` is keyword-based — will miss paraphrases like "législation approuvée". Sufficient for current use; extend with synonyms if needed.
- The global_stats chunk hardcodes Yaël Braun-Pivet as Présidente. Stale after a reshuffle until the next `make rag-index`.
- Re-indexing required on production deploy (no schema changes — same as before).

## Breaking Changes

None. The new retriever `WHERE` clause is a no-op when `result_filter` is `None`, which is the default for all existing callers.