### PR TITLE
rag: add party/global/notable-deputy chunks and fix retriever recall

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,14 +67,14 @@ Assemblée Nationale Open Data (ZIPs)
 - `run_ingestion_prod.py` orchestrates the full pipeline for production runs
 
 **`rag/`** — Phase 2 semantic search (live)
-- `pipeline/chunker.py`: Generates text chunks — four strategies: vote (one per scrutin), deputy (one per député), party (one per parliamentary group), global_stats (one aggregate overview). Uses tiktoken (cl100k_base) for token counting.
+- `pipeline/chunker.py`: Generates text chunks — five strategies: vote (one per scrutin), deputy (one per député), party (one per parliamentary group), global_stats (one aggregate overview), notable_deputy (detailed vote-by-vote for high-profile deputies). Uses tiktoken (cl100k_base) for token counting.
 - `pipeline/embedder.py`: Batched OpenAI embedding (100 chunks/batch), stores into `document_chunks` via pgvector. Assumes table is empty — callers must truncate first.
 - `pipeline/index_manager.py`: `build` / `stats` / `clear` CLI. `build` always truncates before embedding to prevent duplicates.
-- `chain/retriever.py`: Cosine similarity retrieval via pgvector `<=>`. Supports `chunk_type`, `deputy_id`, and auto-detected `result` filters (`adopté`/`rejeté` from question keywords). Note: `register_vector` must receive a plain psycopg2 cursor, not a `RealDictCursor`.
+- `chain/retriever.py`: Cosine similarity retrieval via pgvector `<=>`. Supports `chunk_type`, `deputy_id`, and auto-detected `result` filters (`adopté`/`rejeté` from question keywords). Notable deputy names (Attal, Le Pen) are detected and their chunk pinned as the first result, bypassing IVFFlat recall gaps. `ivfflat.probes=10` is set per query for better recall. Note: `register_vector` must receive a plain psycopg2 cursor, not a `RealDictCursor`.
 - `chain/prompts.py`: French civic assistant system prompt + RAG context template.
 - `chain/rag_chain.py`: `ask()` — retrieve → format → Groq `llama-3.3-70b-versatile` (temperature=0.2).
 - `experiments/mlflow_eval.py`: 10 golden Q&A pairs, keyword scoring, k=3 vs k=5 MLflow experiment. Baseline score: 0.58.
-- 3,739 chunks in production: 3,149 vote + 577 deputy + 12 party + 1 global_stats, avg 86 tokens, $0.0064 to embed.
+- 3,741 chunks in production: 3,149 vote + 577 deputy + 12 party + 1 global_stats + 2 notable_deputy, avg 87 tokens, $0.0065 to embed.
 
 **`data/migrations/001_init.sql`** — Full schema
 - Four tables: `deputies`, `votes`, `vote_positions`, `document_chunks` (pgvector)

--- a/api/main.py
+++ b/api/main.py
@@ -696,11 +696,11 @@ _LANDING_HTML = """\
     <div class="rag-left">
       <div class="rag-eyebrow">Intelligence artificielle</div>
       <h2 class="rag-title">Posez vos questions en français</h2>
-      <p class="rag-sub">Notre chatbot analyse 3&nbsp;739 documents législatifs et répond avec des sources vérifiables.</p>
+      <p class="rag-sub">Notre chatbot analyse 3&nbsp;741 documents législatifs et répond avec des sources vérifiables.</p>
       <div class="rag-pills">
         <button class="rag-pill" onclick="fillQuestion(this)">Combien de députés appartiennent au Rassemblement National&nbsp;?</button>
         <button class="rag-pill" onclick="fillQuestion(this)">Quel est le taux de présence de Yaël Braun-Pivet&nbsp;?</button>
-        <button class="rag-pill" onclick="fillQuestion(this)">Combien de députés sont au groupe Rassemblement National&nbsp;?</button>
+        <button class="rag-pill" onclick="fillQuestion(this)">Gabriel Attal a-t-il voté pour le PLFSS 2026&nbsp;?</button>
       </div>
     </div>
     <div class="rag-right">

--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -48,6 +48,7 @@ def retrieve(
         with conn.cursor(cursor_factory=psycopg2.extensions.cursor) as plain_cur:
             register_vector(plain_cur)
         with conn.cursor() as cur:
+            cur.execute("SET LOCAL ivfflat.probes = 10")
             cur.execute(
                 """
                 SELECT content, metadata,

--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -22,9 +22,7 @@ EMBEDDING_MODEL = "text-embedding-3-small"
 
 NOTABLE_DEPUTY_NAMES = {
     "attal": "PA722190",
-    "gabriel attal": "PA722190",
     "le pen": "PA720614",
-    "marine le pen": "PA720614",
 }
 
 
@@ -38,7 +36,7 @@ def detect_notable_deputy(question: str) -> str | None:
 
 def detect_result_filter(question: str) -> str | None:
     q = question.lower()
-    if any(w in q for w in ["adopté", "adoptés", "adoption", "passé", "passée"]):
+    if any(w in q for w in ["adopté", "adoptés", "adoption"]):
         return "adopté"
     if any(w in q for w in ["rejeté", "rejetés", "rejet", "échoué"]):
         return "rejeté"
@@ -110,7 +108,7 @@ def retrieve(
                     result_filter,
                     result_filter,
                     query_vector,
-                    semantic_k + len(pinned),  # fetch extra to allow dedup
+                    semantic_k + len(pinned),
                 ),
             )
             semantic_rows = [

--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -20,6 +20,22 @@ DATABASE_URL = os.getenv("DATABASE_URL")
 EMBEDDING_MODEL = "text-embedding-3-small"
 
 
+NOTABLE_DEPUTY_NAMES = {
+    "attal": "PA722190",
+    "gabriel attal": "PA722190",
+    "le pen": "PA720614",
+    "marine le pen": "PA720614",
+}
+
+
+def detect_notable_deputy(question: str) -> str | None:
+    q = question.lower()
+    for name, deputy_id in NOTABLE_DEPUTY_NAMES.items():
+        if name in q:
+            return deputy_id
+    return None
+
+
 def detect_result_filter(question: str) -> str | None:
     q = question.lower()
     if any(w in q for w in ["adopté", "adoptés", "adoption", "passé", "passée"]):
@@ -36,6 +52,7 @@ def retrieve(
     deputy_id: str = None,
 ) -> list[dict]:
     result_filter = detect_result_filter(question)
+    notable_id = detect_notable_deputy(question) if not deputy_id else None
 
     client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
     response = client.embeddings.create(input=[question], model=EMBEDDING_MODEL)
@@ -48,6 +65,30 @@ def retrieve(
         with conn.cursor(cursor_factory=psycopg2.extensions.cursor) as plain_cur:
             register_vector(plain_cur)
         with conn.cursor() as cur:
+            # Inject the notable-deputy chunk first (bypasses IVFFlat recall gap)
+            pinned = []
+            if notable_id:
+                cur.execute(
+                    """
+                    SELECT content, metadata,
+                           1 - (embedding <=> %s::vector) AS similarity
+                    FROM document_chunks
+                    WHERE metadata->>'chunk_type' = 'notable_deputy'
+                      AND metadata->>'deputy_id' = %s
+                    """,
+                    (query_vector, notable_id),
+                )
+                for row in cur.fetchall():
+                    pinned.append(
+                        {
+                            "content": row["content"],
+                            "metadata": dict(row["metadata"]),
+                            "similarity": float(row["similarity"]),
+                        }
+                    )
+
+            semantic_k = k - len(pinned)
+            pinned_ids = {p["metadata"].get("deputy_id") for p in pinned}
             cur.execute("SET LOCAL ivfflat.probes = 10")
             cur.execute(
                 """
@@ -69,21 +110,23 @@ def retrieve(
                     result_filter,
                     result_filter,
                     query_vector,
-                    k,
+                    semantic_k + len(pinned),  # fetch extra to allow dedup
                 ),
             )
-            rows = cur.fetchall()
+            semantic_rows = [
+                {
+                    "content": row["content"],
+                    "metadata": dict(row["metadata"]),
+                    "similarity": float(row["similarity"]),
+                }
+                for row in cur.fetchall()
+                if row["metadata"].get("deputy_id") not in pinned_ids
+                or row["metadata"].get("chunk_type") != "notable_deputy"
+            ]
     finally:
         conn.close()
 
-    results = [
-        {
-            "content": row["content"],
-            "metadata": dict(row["metadata"]),
-            "similarity": float(row["similarity"]),
-        }
-        for row in rows
-    ]
+    results = (pinned + semantic_rows)[:k]
 
     top_sim = results[0]["similarity"] if results else 0.0
     print(

--- a/rag/pipeline/chunker.py
+++ b/rag/pipeline/chunker.py
@@ -487,7 +487,8 @@ if __name__ == "__main__":
     deputy_chunks = chunk_deputies()
     party_chunks = chunk_party_summaries()
     global_chunks = chunk_global_stats()
-    all_chunks = vote_chunks + deputy_chunks + party_chunks + global_chunks
+    notable_chunks = chunk_notable_deputies()
+    all_chunks = vote_chunks + deputy_chunks + party_chunks + global_chunks + notable_chunks
 
     token_counts = [_count_tokens(c["content"]) for c in all_chunks]
     total_tokens = sum(token_counts)
@@ -502,6 +503,7 @@ if __name__ == "__main__":
     print(f"  Deputy chunks    : {len(deputy_chunks):>6,}")
     print(f"  Party chunks     : {len(party_chunks):>6,}")
     print(f"  Global chunks    : {len(global_chunks):>6,}")
+    print(f"  Notable chunks   : {len(notable_chunks):>6,}")
     print(f"  Total chunks     : {len(all_chunks):>6,}")
     print(f"  Avg tokens/chunk : {avg_tokens:>6.1f}")
     print(f"  Total tokens     : {total_tokens:>6,}")

--- a/rag/pipeline/chunker.py
+++ b/rag/pipeline/chunker.py
@@ -324,6 +324,109 @@ def chunk_global_stats() -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
+# Strategy E — Notable deputy chunks (detailed vote-by-vote, top profiles)
+# ---------------------------------------------------------------------------
+
+NOTABLE_DEPUTIES: dict[str, dict] = {
+    "PA722190": {
+        "name": "Gabriel Attal",
+        "bio": "Ancien Premier ministre (janvier 2025).",
+    },
+    "PA720614": {
+        "name": "Marine Le Pen",
+        "bio": "Cheffe de file du Rassemblement National.",
+    },
+}
+
+
+def chunk_notable_deputies() -> list[dict]:
+    conn = _get_conn()
+    chunks = []
+    try:
+        with conn.cursor() as cur:
+            for deputy_id, info in NOTABLE_DEPUTIES.items():
+                # 15 most recent votes
+                cur.execute(
+                    """
+                    SELECT
+                        d.full_name, d.party, d.department,
+                        v.vote_id, v.vote_title, v.voted_at, v.result,
+                        vp.position
+                    FROM vote_positions vp
+                    JOIN votes v ON vp.vote_id = v.vote_id
+                    JOIN deputies d ON vp.deputy_id = d.deputy_id
+                    WHERE d.deputy_id = %s
+                    ORDER BY v.voted_at DESC
+                    LIMIT 15
+                    """,
+                    (deputy_id,),
+                )
+                recent_rows = cur.fetchall()
+                seen_ids = {r["vote_id"] for r in recent_rows}
+
+                # Up to 15 key legislative votes not already in the recent set
+                cur.execute(
+                    """
+                    SELECT
+                        d.full_name, d.party, d.department,
+                        v.vote_id, v.vote_title, v.voted_at, v.result,
+                        vp.position
+                    FROM vote_positions vp
+                    JOIN votes v ON vp.vote_id = v.vote_id
+                    JOIN deputies d ON vp.deputy_id = d.deputy_id
+                    WHERE d.deputy_id = %s
+                      AND (
+                        v.vote_title ILIKE '%PLFSS%'
+                        OR v.vote_title ILIKE '%projet de loi de finances%'
+                        OR v.vote_title ILIKE '%motion de censure%'
+                        OR v.vote_title ILIKE '%sécurité sociale%'
+                        OR v.vote_title ILIKE '%financement de la sécurité%'
+                        OR (v.vote_title ILIKE '%ensemble%' AND v.vote_title ILIKE '%projet de loi%')
+                      )
+                    ORDER BY v.voted_at DESC
+                    LIMIT 15
+                    """,
+                    (deputy_id,),
+                )
+                key_rows = [r for r in cur.fetchall() if r["vote_id"] not in seen_ids]
+
+                rows = recent_rows + key_rows
+                if not rows:
+                    continue
+
+                first = rows[0]
+                name = first["full_name"] or info["name"]
+                party = first["party"] or "parti non renseigné"
+                dept = first["department"] or "département inconnu"
+                prep = dept_preposition(dept)
+                sep = "" if prep.endswith("'") else " "
+
+                vote_lines = "\n".join(
+                    f"- {row['vote_title']} ({_fmt_date(row['voted_at'])}) : "
+                    f"{row['position']} — vote {row['result']}"
+                    for row in rows
+                )
+
+                content = (
+                    f"{name} est député(e) {prep}{sep}{dept}, "
+                    f"membre du parti {party}.\n"
+                    f"{info['bio']}\n\n"
+                    f"Ses votes récents :\n{vote_lines}"
+                )
+                metadata = {
+                    "chunk_type": "notable_deputy",
+                    "deputy_id": deputy_id,
+                    "full_name": name,
+                    "party": party,
+                }
+                chunks.append({"content": content, "metadata": metadata})
+    finally:
+        conn.close()
+
+    return chunks
+
+
+# ---------------------------------------------------------------------------
 # Combined
 # ---------------------------------------------------------------------------
 
@@ -333,8 +436,9 @@ def chunk_all() -> list[dict]:
     deputy_chunks = chunk_deputies()
     party_chunks = chunk_party_summaries()
     global_chunks = chunk_global_stats()
+    notable_chunks = chunk_notable_deputies()
 
-    all_chunks = vote_chunks + deputy_chunks + party_chunks + global_chunks
+    all_chunks = vote_chunks + deputy_chunks + party_chunks + global_chunks + notable_chunks
 
     # Token accounting
     token_counts = [_count_tokens(c["content"]) for c in all_chunks]
@@ -354,6 +458,7 @@ def chunk_all() -> list[dict]:
     print(f"  Deputy chunks  : {len(deputy_chunks):>6,}")
     print(f"  Party chunks   : {len(party_chunks):>6,}")
     print(f"  Global chunks  : {len(global_chunks):>6,}")
+    print(f"  Notable chunks : {len(notable_chunks):>6,}")
     print(f"  Total chunks   : {len(all_chunks):>6,}")
     print(f"  Avg tokens     : {avg_tokens:>6.1f}")
     print(f"  Total tokens   : {total_tokens:>6,}")

--- a/rag/pipeline/chunker.py
+++ b/rag/pipeline/chunker.py
@@ -376,12 +376,12 @@ def chunk_notable_deputies() -> list[dict]:
                     JOIN deputies d ON vp.deputy_id = d.deputy_id
                     WHERE d.deputy_id = %s
                       AND (
-                        v.vote_title ILIKE '%PLFSS%'
-                        OR v.vote_title ILIKE '%projet de loi de finances%'
-                        OR v.vote_title ILIKE '%motion de censure%'
-                        OR v.vote_title ILIKE '%sécurité sociale%'
-                        OR v.vote_title ILIKE '%financement de la sécurité%'
-                        OR (v.vote_title ILIKE '%ensemble%' AND v.vote_title ILIKE '%projet de loi%')
+                        v.vote_title ILIKE '%%PLFSS%%'
+                        OR v.vote_title ILIKE '%%projet de loi de finances%%'
+                        OR v.vote_title ILIKE '%%motion de censure%%'
+                        OR v.vote_title ILIKE '%%sécurité sociale%%'
+                        OR v.vote_title ILIKE '%%financement de la sécurité%%'
+                        OR (v.vote_title ILIKE '%%ensemble%%' AND v.vote_title ILIKE '%%projet de loi%%')
                       )
                     ORDER BY v.voted_at DESC
                     LIMIT 15

--- a/rag/pipeline/chunker.py
+++ b/rag/pipeline/chunker.py
@@ -364,31 +364,31 @@ def chunk_notable_deputies() -> list[dict]:
                 recent_rows = cur.fetchall()
                 seen_ids = {r["vote_id"] for r in recent_rows}
 
-                # Up to 15 key legislative votes not already in the recent set
-                cur.execute(
-                    """
-                    SELECT
-                        d.full_name, d.party, d.department,
-                        v.vote_id, v.vote_title, v.voted_at, v.result,
-                        vp.position
-                    FROM vote_positions vp
-                    JOIN votes v ON vp.vote_id = v.vote_id
-                    JOIN deputies d ON vp.deputy_id = d.deputy_id
-                    WHERE d.deputy_id = %s
-                      AND (
-                        v.vote_title ILIKE '%%PLFSS%%'
-                        OR v.vote_title ILIKE '%%projet de loi de finances%%'
-                        OR v.vote_title ILIKE '%%motion de censure%%'
-                        OR v.vote_title ILIKE '%%sécurité sociale%%'
-                        OR v.vote_title ILIKE '%%financement de la sécurité%%'
-                        OR (v.vote_title ILIKE '%%ensemble%%' AND v.vote_title ILIKE '%%projet de loi%%')
-                      )
-                    ORDER BY v.voted_at DESC
-                    LIMIT 15
-                    """,
-                    (deputy_id,),
-                )
-                key_rows = [r for r in cur.fetchall() if r["vote_id"] not in seen_ids]
+                # Most recent vote on each major legislation category (PLFSS, PLF, censure)
+                key_rows = []
+                for pattern in [
+                    "%%financement de la sécurité sociale%%",
+                    "%%projet de loi de finances%%",
+                    "%%motion de censure%%",
+                ]:
+                    cur.execute(
+                        """
+                        SELECT
+                            d.full_name, d.party, d.department,
+                            v.vote_id, v.vote_title, v.voted_at, v.result,
+                            vp.position
+                        FROM vote_positions vp
+                        JOIN votes v ON vp.vote_id = v.vote_id
+                        JOIN deputies d ON vp.deputy_id = d.deputy_id
+                        WHERE d.deputy_id = %s
+                          AND v.vote_title ILIKE %s
+                        ORDER BY v.voted_at DESC
+                        LIMIT 5
+                        """,
+                        (deputy_id, pattern),
+                    )
+                    key_rows += [r for r in cur.fetchall() if r["vote_id"] not in seen_ids]
+                    seen_ids.update(r["vote_id"] for r in key_rows)
 
                 rows = recent_rows + key_rows
                 if not rows:


### PR DESCRIPTION
## What

Extends the RAG pipeline with three new chunking strategies (party summaries, global stats, notable deputy profiles) and hardens the retriever with result filtering, improved IVFFlat recall, and name-based chunk pinning for high-profile deputies.

## Why

Several classes of questions were silently failing:

- **Aggregate questions** ("Combien de députés RN ?", "Combien de votes adoptés ?") — no chunk contained that information; only per-vote and per-deputy chunks existed.
- **Result-filtered questions** ("Quels votes ont été rejetés ?") — the retriever fetched random vote chunks instead of filtering by `result`.
- **Notable deputy questions** ("Attal a-t-il voté pour le PLFSS 2026 ?") — the IVFFlat index (lists=100, probes=1 default) systematically missed the Attal chunk due to approximate nearest-neighbour recall gaps.

## Changes

**`rag/pipeline/chunker.py` — three new strategies**

- `chunk_party_summaries()` (Strategy C) — 1 chunk per parliamentary group. Vote counts (pour/contre/abstention) and average presence rate. 12 chunks (~89 tokens each). Metadata: `chunk_type: party`.

- `chunk_global_stats()` (Strategy D) — 1 aggregate chunk for the full platform: total deputies, votes, positions, adopted/rejected split, full party breakdown by size, Yaël Braun-Pivet Présidente section. ~322 tokens. Metadata: `chunk_type: global_stats`.

- `chunk_notable_deputies()` (Strategy E) — 1 chunk per notable deputy (Attal, Le Pen). Two-pass query: 15 most recent votes + up to 5 per major legislation category (PLFSS, PLF, motion de censure) not already in the recent set. Guarantees PLFSS coverage even when recent votes are from a later session. Metadata: `chunk_type: notable_deputy`.

- `NOTABLE_DEPUTIES` dict maps `deputy_id → {name, bio}` — easy to extend.
- `chunk_all()` updated: 3,726 → 3,741 chunks.

**`rag/chain/retriever.py` — three retrieval improvements**

- `detect_result_filter(question)` — keyword scan (`adopté`/`rejeté` synonyms). Adds a `WHERE metadata->>'result' = %s` clause; no-op when `None` (no behaviour change for existing callers).

- `SET LOCAL ivfflat.probes = 10` before every similarity search — raises effective recall from ~1% to ~10% of clusters, reducing misses for outlier chunks.

- `detect_notable_deputy(question)` + chunk pinning — when a known name (`attal`, `le pen`, etc.) is detected in the question, the matching `notable_deputy` chunk is fetched directly (sequential scan, 1 row) and prepended to results, bypassing the IVFFlat recall gap entirely. Remaining `k-1` slots are filled by semantic search as usual.

**`api/main.py`** — demo pill questions updated to target the new chunk types.

**`CLAUDE.md`** — updated chunker description (5 strategies), retriever filter/probes/pinning notes, production chunk count.

## Testing

Index rebuilt (`make rag-index`, 3,741 chunks, $0.0065) and tested end-to-end via `POST /search/`:

| Question | Answer | Top chunk |
|---|---|---|
| Combien de députés appartiennent au RN ? | 122 députés | global_stats (sim 0.633) |
| Taux de présence Yaël Braun-Pivet ? | 100% sur 3,149 votes | deputy (sim 0.656) |
| Combien de députés au groupe RN ? | 122 députés | party (sim 0.663) |
| Attal a-t-il voté pour le PLFSS 2026 ? | Oui, pour — 16/12/2025 et 09/12/2025 | notable_deputy (sim 0.597, pinned) |

## Risks / Notes

- `notable_deputy` chunks exceed the 500-token soft limit (~1,400 tokens each). This triggers a warning in `chunk_all()` but does not block indexing or retrieval. The extra size is intentional — these chunks need to carry multiple votes to answer specific questions.
- `detect_notable_deputy` is a simple substring match. "Le Pen" will also match questions about Jean-Marie Le Pen or other family members — acceptable given the current scope.
- `detect_result_filter` uses a fixed keyword list; paraphrases like "les textes approuvés" won't trigger it.
- The global_stats chunk hardcodes Yaël Braun-Pivet as Présidente. Stale if that changes before next `make rag-index`.
- Re-indexing required on every production deploy (unchanged — no schema changes).

## Breaking Changes

None. All new `WHERE` clauses are no-ops when their filter values are `NULL`. Existing API callers and the MLflow eval are unaffected.