### PR TITLE
fix: connection pooling, Groq timeout, pgvector hard fail, rolling ingest default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,24 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code when working with code in this repository.
 
 ## Project Overview
 
-**MonÉlu** is an open-source civic data platform tracking every vote cast by every French deputy in the Assemblée Nationale (17th legislature, since 2024-07-07). The tagline is "Every vote. Every deputy. In plain French."
+**MonÉlu** is a civic transparency platform exposing the complete voting record of every deputy in the French Assemblée Nationale (17th legislature, since 2024-07-07). The tagline is "Every vote. Every deputy. In plain French."
+
+This is a production application — not a data engineering exercise. The API and landing page are live. Phase 3 (automated pipeline orchestration) is actively in development.
 
 Production API: https://monelu-production.up.railway.app
+
+### Phases
+
+| Phase | Status | Scope |
+|-------|--------|-------|
+| Phase 1 | Live | Ingestion pipeline, REST API, deputy profiles, vote records, scorecards |
+| Phase 2 | Live | Semantic search — RAG over the legislative corpus (pgvector + Groq) |
+| Phase 3 | In progress | Production-grade data orchestration and automated refresh pipelines |
+
+---
 
 ## Common Commands
 
@@ -42,42 +54,45 @@ ruff format .       # Format
 pre-commit run --all-files  # Run all hooks
 ```
 
+---
+
 ## Architecture
 
 ### Data Flow
+
 ```
 Assemblée Nationale Open Data (ZIPs)
-  → scripts/ingest_*.py  (fetch, parse, upsert with ON CONFLICT)
-  → PostgreSQL (deputies, votes, vote_positions tables)
-  → api/routers/  (direct psycopg2 with RealDictCursor, parameterized SQL)
-  → FastAPI JSON responses / HTML landing page
+  → scripts/ingest_*.py  (fetch · parse · upsert with ON CONFLICT)
+  → PostgreSQL  (deputies · votes · vote_positions · document_chunks)
+  → api/routers/  (direct psycopg2, RealDictCursor, parameterized SQL)
+  → FastAPI JSON responses  /  HTML landing page  /  POST /search (RAG)
 ```
 
 ### Key Layers
 
 **`api/`** — FastAPI application
 - `main.py`: App factory, CORS (GET-only public read), slowapi rate limiting (60 req/min global, 10 req/min on scorecard), global exception handler, HTML landing page with live stats
-- `routers/deputies.py`, `routers/votes.py`: All DB queries live here — direct SQL, no ORM
-- `schemas.py`: Pydantic models for all responses; all fields `Optional` to match DB NULLs
+- `routers/deputies.py`, `routers/votes.py`: All DB queries — direct SQL, no ORM
+- `schemas.py`: Pydantic response models; all fields `Optional` to match DB NULLs
 - `limiter.py`: Shared slowapi `Limiter` instance imported by routers
 
 **`scripts/`** — Data ingestion and maintenance
-- Scripts fetch ZIPs from the AN API with exponential-backoff retry, parse JSON entries, and upsert via `ON CONFLICT ... DO UPDATE`
-- `migrate.py` is also the Railway start hook (runs before uvicorn in `railway.json`)
+- Scripts fetch ZIPs from the AN open data portal with exponential-backoff retry (5 attempts, 2 s base) and upsert via `ON CONFLICT ... DO UPDATE`
+- `migrate.py` doubles as the Railway start hook (runs before uvicorn in `railway.json`)
 - `run_ingestion_prod.py` orchestrates the full pipeline for production runs
 
-**`rag/`** — Phase 2 semantic search (live)
-- `pipeline/chunker.py`: Generates text chunks — five strategies: vote (one per scrutin), deputy (one per député), party (one per parliamentary group), global_stats (one aggregate overview), notable_deputy (detailed vote-by-vote for high-profile deputies). Uses tiktoken (cl100k_base) for token counting.
-- `pipeline/embedder.py`: Batched OpenAI embedding (100 chunks/batch), stores into `document_chunks` via pgvector. Assumes table is empty — callers must truncate first.
-- `pipeline/index_manager.py`: `build` / `stats` / `clear` CLI. `build` always truncates before embedding to prevent duplicates.
-- `chain/retriever.py`: Cosine similarity retrieval via pgvector `<=>`. Supports `chunk_type`, `deputy_id`, and auto-detected `result` filters (`adopté`/`rejeté` from question keywords). Notable deputy names (Attal, Le Pen) are detected and their chunk pinned as the first result, bypassing IVFFlat recall gaps. `ivfflat.probes=10` is set per query for better recall. Note: `register_vector` must receive a plain psycopg2 cursor, not a `RealDictCursor`.
-- `chain/prompts.py`: French civic assistant system prompt + RAG context template.
-- `chain/rag_chain.py`: `ask()` — retrieve → format → Groq `llama-3.3-70b-versatile` (temperature=0.2).
+**`rag/`** — Phase 2 semantic search
+- `pipeline/chunker.py`: Five chunk strategies: `vote` (one per scrutin), `deputy` (one per député), `party` (one per parliamentary group), `global_stats` (aggregate overview), `notable_deputy` (vote-by-vote for high-profile deputies). Uses tiktoken (cl100k_base) for token counting.
+- `pipeline/embedder.py`: Batched OpenAI embedding (100 chunks/batch), stores into `document_chunks`. Assumes table is empty — callers must truncate first.
+- `pipeline/index_manager.py`: `build` / `stats` / `clear` CLI. `build` always truncates before embedding.
+- `chain/retriever.py`: Cosine similarity via pgvector `<=>`. Supports `chunk_type`, `deputy_id`, and auto-detected `result` filters (`adopté`/`rejeté`). Notable deputy names (Attal, Le Pen) are detected and their chunk pinned as the first result, bypassing IVFFlat recall gaps. `ivfflat.probes=10` is set per query. Note: `register_vector` requires a plain psycopg2 cursor, not a `RealDictCursor`.
+- `chain/prompts.py`: French civic assistant system prompt + RAG context template
+- `chain/rag_chain.py`: `ask()` — retrieve → format → Groq `llama-3.3-70b-versatile` (temperature=0.2)
 - `experiments/mlflow_eval.py`: 10 golden Q&A pairs, keyword scoring, k=3 vs k=5 MLflow experiment. Baseline score: 0.58.
-- 3,741 chunks in production: 3,149 vote + 577 deputy + 12 party + 1 global_stats + 2 notable_deputy, avg 87 tokens, $0.0065 to embed.
+- 3,741 chunks in production: 3,149 vote + 577 deputy + 12 party + 1 global_stats + 2 notable_deputy · avg 87 tokens · $0.0065 to embed
 
 **`data/migrations/001_init.sql`** — Full schema
-- Four tables: `deputies`, `votes`, `vote_positions`, `document_chunks` (pgvector)
+- Four tables: `deputies`, `votes`, `vote_positions`, `document_chunks`
 - All `CREATE TABLE IF NOT EXISTS` — safe to re-run
 
 ### Database
@@ -87,41 +102,47 @@ Assemblée Nationale Open Data (ZIPs)
 | `deputies` | 577 deputy profiles (party, department, photo_url, mandate dates) |
 | `votes` | Legislative votes (title, result adopté/rejeté, aggregate counts) |
 | `vote_positions` | Per-deputy position per vote (pour/contre/abstention/nonVotant) |
-| `document_chunks` | Phase 2 embeddings: content + JSONB metadata + vector(1536) |
+| `document_chunks` | Phase 2: content + JSONB metadata + vector(1536) |
 
 Important data quirks:
 - `nonVotant` ≠ `abstention`: present in chamber but did not vote vs. formally abstained
-- Yaël Braun-Pivet shows 100% presence — she is Présidente de l'AN and appears on every scrutin by design
-- Production DB only stores votes from 2025-07-01 (Railway free tier); local dev can hold the full legislature from 2024-07-07
+- Yaël Braun-Pivet shows 100% presence — Présidente de l'AN, appears on every scrutin by design
+- Production DB holds votes from `2025-07-01` (Supabase free tier); local dev can hold the full legislature from `2024-07-07`
+
+---
 
 ## Environment
 
-Copy `.env.example` to `.env` for local development. Key variables:
+Copy `.env.example` to `.env` for local development:
 
 ```ini
 DATABASE_URL=postgresql://monelu:monelu@localhost:5432/monelu
 AN_API_BASE_URL=https://data.assemblee-nationale.fr
 CORS_ORIGINS=*
-# Phase 2 — required for POST /search/
+# Phase 2 — required for POST /search
 OPENAI_API_KEY=sk-...
 GROQ_API_KEY=gsk_...
 ```
 
-Production uses Supabase (managed Postgres + pgvector pre-installed). Local uses Docker (`docker-compose.yml` starts Postgres 15 + pgAdmin 8).
+Production uses Supabase (managed Postgres + pgvector). Local uses Docker (`docker-compose.yml` starts Postgres 15 + pgAdmin 8).
+
+---
 
 ## Deployment
 
-Hosted on Railway. On every deploy, `railway.json` runs:
+Hosted on Railway. Every deploy runs:
 ```
 python scripts/migrate.py && uvicorn api.main:app --host 0.0.0.0 --port $PORT
 ```
 
-Health check endpoint: `GET /health` (returns DB status + row counts).
+Health check: `GET /health` — returns DB status and live record counts.
+
+---
 
 ## Code Style
 
-Ruff is the single tool for both linting and formatting (see `ruff.toml`):
+Ruff is the single tool for lint and formatting (`ruff.toml`):
 - Line length: 100
-- `print()` is allowed in `scripts/` and `rag/` but blocked elsewhere (T201)
+- `print()` allowed in `scripts/` and `rag/` (T201 ignored there), blocked elsewhere
 - B008 ignored to allow FastAPI `Depends()` defaults
 - Pre-commit hooks run automatically on `git commit`

--- a/README.md
+++ b/README.md
@@ -1,59 +1,70 @@
 # MonÉlu
 > Every vote. Every deputy. In plain French.
 
-Live API: https://monelu-production.up.railway.app
+MonÉlu is a civic transparency platform that makes the voting record of every deputy in the French Assemblée Nationale fully accessible — in plain language, in real time. Built for journalists, researchers, and engaged citizens who shouldn't need to dig through government ZIP exports to understand how their representatives vote.
+
+**Live:** https://monelu-production.up.railway.app · **API docs:** `/docs`
+
+---
+
+## Roadmap
+
+| Phase | Status | What it covers |
+|-------|--------|----------------|
+| **Phase 1** — Data platform | **Live** | Full ingestion pipeline, REST API, deputy profiles, vote records, scorecards |
+| **Phase 2** — Intelligence layer | **Live** | Semantic search over the legislative corpus (RAG, pgvector, Groq LLM) |
+| **Phase 3** — Pipeline infrastructure | *In progress* | Production-grade data orchestration and automated refresh pipelines |
 
 ---
 
 ## Architecture
 
 ```
-[FastAPI on Railway] → [PostgreSQL + pgvector on Supabase]
+Assemblée Nationale Open Data (ZIP exports)
+  → Ingestion pipeline  (fetch · parse · upsert with retry)
+  → PostgreSQL + pgvector on Supabase  (deputies · votes · positions · embeddings)
+  → FastAPI on Railway  (stateless, auto-restart)
+  → JSON API  /  HTML landing page  /  POST /search (RAG)
 ```
 
-The API tier (Railway) is stateless and auto-restarts on failure. All state lives in Supabase, which provides managed Postgres with pgvector pre-installed (used in Phase 2 for semantic search over legislative texts).
+The API tier is fully stateless. All state lives in Supabase (managed Postgres with pgvector). Railway restarts the service on failure; the health endpoint returns live DB counts on every check.
 
 ---
 
-## Endpoints
+## API Endpoints
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| GET | `/` | Landing page — editorial civic design, live DB stats, latest votes, RAG demo |
-| GET | `/deputies` | List all deputies (filter: `search`, `department`) |
+| GET | `/` | Landing page — live stats, latest votes, RAG demo |
+| GET | `/deputies` | List all deputies (`search`, `department` filters) |
 | GET | `/deputies/{id}` | Deputy profile |
-| GET | `/deputies/{id}/scorecard` | Presence rate, vote breakdown |
-| GET | `/votes` | List votes (filter: `result`) |
+| GET | `/deputies/{id}/scorecard` | Presence rate, vote breakdown by position |
+| GET | `/votes` | List votes (`result` filter) |
 | GET | `/votes/latest` | Last 10 votes |
 | GET | `/votes/{id}` | Vote detail + all individual positions |
-| GET | `/health` | API status + record counts |
-| POST | `/search` | RAG chatbot — natural language query over the legislative corpus *(Phase 2)* |
-
-Interactive docs: `/docs`
+| GET | `/health` | API status + live record counts |
+| POST | `/search` | Natural language query over the legislative corpus *(Phase 2)* |
 
 ---
 
 ## Rate Limiting
 
-Implemented with [slowapi](https://github.com/laurentS/slowapi) (limits by remote IP).
+Implemented with [slowapi](https://github.com/laurentS/slowapi), keyed by remote IP.
 
 | Scope | Limit |
 |---|---|
-| All endpoints (global default) | 60 requests / minute |
-| `GET /deputies/{id}/scorecard` | 10 requests / minute |
+| Global default | 60 req / min |
+| `GET /deputies/{id}/scorecard` | 10 req / min |
 
-When a limit is exceeded the API returns HTTP 429 with:
-- JSON body: `{"error": "Too Many Requests", "detail": "..."}`
-- `Retry-After` header (seconds until window resets)
-- `X-RateLimit-Limit` and `X-RateLimit-Remaining` headers on every response
+On limit exceeded: HTTP 429 · `{"error": "Too Many Requests", "detail": "..."}` · `Retry-After` + `X-RateLimit-*` headers.
 
 ---
 
 ## Stack
 
-FastAPI · slowapi · PostgreSQL + pgvector (Supabase) · Python 3.11 · Railway · aiofiles (StaticFiles)
+**Core:** FastAPI · PostgreSQL + pgvector (Supabase) · Python 3.11 · Railway · slowapi
 
-**Phase 2 additions:** OpenAI `text-embedding-3-small` · Groq `llama-3.3-70b-versatile` · tiktoken · MLflow
+**Phase 2:** OpenAI `text-embedding-3-small` · Groq `llama-3.3-70b-versatile` · tiktoken · MLflow
 
 **Code quality:** ruff (lint + format) · pre-commit
 
@@ -62,7 +73,7 @@ FastAPI · slowapi · PostgreSQL + pgvector (Supabase) · Python 3.11 · Railway
 ## Data Sources
 
 Assemblée Nationale Open Data — `data.assemblee-nationale.fr`
-Static ZIP exports only — no REST API is available.
+Static ZIP exports only (no REST API available from the source).
 
 | Dataset | File |
 |---|---|
@@ -75,8 +86,8 @@ Static ZIP exports only — no REST API is available.
 
 ### Prerequisites
 
-- Docker + Docker Compose (for local Postgres)
-- Python 3.11+ (tested on 3.14)
+- Docker + Docker Compose
+- Python 3.11+
 
 ### Steps
 
@@ -84,46 +95,35 @@ Static ZIP exports only — no REST API is available.
 git clone <repo> && cd MonElu
 cp .env.example .env        # set DATABASE_URL, OPENAI_API_KEY, GROQ_API_KEY
 
-# create virtualenv
 python3 -m venv venv
 venv/bin/pip install -r requirements.txt
 
-# start local Postgres
-make start
-
-# apply schema
-make migrate
-
-# ingest data
-make ingest                 # local, full dataset
-make ingest-prod            # remote, since 2025-01-01
-
-# fix party names and department codes
+make start      # start local Postgres
+make migrate    # apply schema
+make ingest     # deputies → votes → positions
 make fix-deputies
-
-# start API
-make api
-# → http://localhost:8000/docs
+make api        # → http://localhost:8000/docs
 ```
 
-### Makefile targets
+### Makefile reference
 
 ```
 make start          docker compose up -d
 make stop           docker compose down
 make migrate        apply 001_init.sql to DATABASE_URL
-make ingest         deputies → votes → positions (local, full)
-make ingest-prod    run_ingestion_prod.py --since 2025-01-01
+make ingest         full local ingestion (deputies → votes → positions)
+make ingest-prod    production ingestion (--since 2025-01-01)
 make fix-deputies   resolve party names + expand department codes
 make api            uvicorn api.main:app --reload
 make psql           psql into the running Postgres container
-make check-db       print table sizes, row counts, pgvector status
-make rag-index      embed all chunks and store to document_chunks
-make rag-stats      print document_chunks breakdown by chunk_type
+make check-db       table sizes, row counts, pgvector status
+
+make rag-index      truncate + re-embed all chunks (~$0.006)
+make rag-stats      chunk counts by type
 make rag-clear      truncate document_chunks
-make rag-test       run a sample RAG query end-to-end
-make rag-eval       run MLflow evaluation over 10 golden Q&A pairs
-make mlflow-ui      open MLflow experiment dashboard on port 5001
+make rag-test       run 3 sample queries end-to-end
+make rag-eval       MLflow k=3 vs k=5 evaluation
+make mlflow-ui      MLflow dashboard at http://localhost:5001
 ```
 
 ---
@@ -133,14 +133,14 @@ make mlflow-ui      open MLflow experiment dashboard on port 5001
 ### `deputies`
 | Column | Type | Notes |
 |---|---|---|
-| `deputy_id` | TEXT PK | AN uid e.g. `PA1592` |
+| `deputy_id` | TEXT PK | AN uid, e.g. `PA1592` |
 | `full_name` | TEXT | |
 | `first_name` / `last_name` | TEXT | |
-| `party` | TEXT | Full GP name e.g. `Rassemblement National` |
-| `party_short` | TEXT | organeRef e.g. `PO845401` |
-| `circonscription` / `department` | TEXT | Full name e.g. `Yvelines` |
-| `mandate_start` / `mandate_end` | DATE | end is null if active |
-| `photo_url` | TEXT | `assemblee-nationale.fr/dyn/static/tribun/photos/{uid}.jpg` |
+| `party` | TEXT | Full GP name, e.g. `Rassemblement National` |
+| `party_short` | TEXT | organeRef, e.g. `PO845401` |
+| `circonscription` / `department` | TEXT | Full name, e.g. `Yvelines` |
+| `mandate_start` / `mandate_end` | DATE | `mandate_end` is null if active |
+| `photo_url` | TEXT | Official portrait from `assemblee-nationale.fr` |
 
 ### `votes`
 | Column | Type | Notes |
@@ -161,116 +161,112 @@ make mlflow-ui      open MLflow experiment dashboard on port 5001
 | `deputy_id` | TEXT FK → deputies | |
 | `position` | VARCHAR(15) | `pour` / `contre` / `abstention` / `nonVotant` |
 
-### `document_chunks` *(Phase 2 — semantic search)*
+### `document_chunks` *(Phase 2)*
 | Column | Type | Notes |
 |---|---|---|
 | `id` | BIGSERIAL PK | |
-| `content` | TEXT | French prose chunk ready for embedding |
+| `content` | TEXT | French prose chunk |
 | `metadata` | JSONB | `chunk_type`, `vote_id` or `deputy_id`, etc. |
 | `embedding` | vector(1536) | OpenAI text-embedding-3-small |
 
 ---
 
-## API Modules
+## Code Structure
 
-| Module | What it does |
+### API (`api/`)
+
+| Module | Purpose |
 |---|---|
-| `api/main.py` | App entry point — CORS, rate limiting, exception handlers, landing page (full editorial redesign + inline SVG logo), health check |
-| `static/assemblee_nationale.jpg` | Hero photo served via `StaticFiles` at `/static` |
-| `api/limiter.py` | Shared slowapi `Limiter` instance (60 req/min default, IP-keyed) |
-| `api/routers/deputies.py` | Deputy list, profile, and scorecard endpoints |
-| `api/routers/votes.py` | Vote list, latest, and detail endpoints |
-| `api/routers/search.py` | `POST /search` — RAG query endpoint *(Phase 2)* |
-| `api/schemas.py` | Pydantic response models |
+| `main.py` | App entry point — CORS, rate limiting, exception handlers, landing page, health check |
+| `limiter.py` | Shared slowapi `Limiter` instance |
+| `routers/deputies.py` | Deputy list, profile, and scorecard endpoints |
+| `routers/votes.py` | Vote list, latest, and detail endpoints |
+| `routers/search.py` | `POST /search` — RAG query endpoint |
+| `schemas.py` | Pydantic response models (all fields `Optional` to match DB NULLs) |
 
-## Ingestion Scripts
+### Ingestion (`scripts/`)
 
-| Script | What it does |
+| Script | Purpose |
 |---|---|
-| `scripts/explore_an_exports.py` | Lists all ZIP export URLs from any portal page |
-| `scripts/ingest_deputies.py` | Downloads AMO10 ZIP, upserts deputies |
-| `scripts/ingest_votes.py` | Downloads Scrutins ZIP, upserts votes (`--since` flag) |
-| `scripts/ingest_positions.py` | Same ZIP, extracts individual deputy positions |
-| `scripts/run_ingestion_prod.py` | Runs all three in order with timing summary |
-| `scripts/explore_organes.py` | Explores organe ZIP structure (used for debugging) |
-| `scripts/ingest_organes.py` | Builds `{organe_uid → party_name}` and `{deputy_id → party}` maps |
-| `scripts/update_party.py` | Updates `deputies.party` (GP names) and `deputies.department` (full names) |
-| `scripts/migrate.py` | Applies 001_init.sql, checks pgvector |
-| `scripts/check_db_size.py` | Prints table sizes and DB storage usage |
+| `ingest_deputies.py` | Downloads AMO10 ZIP, upserts deputy profiles |
+| `ingest_votes.py` | Downloads Scrutins ZIP, upserts votes (`--since` flag) |
+| `ingest_positions.py` | Extracts individual deputy positions from Scrutins ZIP |
+| `run_ingestion_prod.py` | Orchestrates the full pipeline with timing summary |
+| `update_party.py` | Resolves GP party names and expands department codes |
+| `migrate.py` | Applies `001_init.sql` — also the Railway start hook |
+| `check_db_size.py` | Prints table sizes and DB storage usage |
 
-All ingestion scripts use exponential-backoff retry (5 attempts, base 2s) and upsert with `ON CONFLICT ... DO UPDATE`.
+All scripts use exponential-backoff retry (5 attempts, 2 s base) and upsert via `ON CONFLICT ... DO UPDATE`.
 
-## RAG Pipeline *(Phase 2)*
+### RAG Pipeline (`rag/`) — Phase 2
 
 ```
 rag/
 ├── pipeline/
-│   ├── chunker.py        Two strategies: vote chunks + deputy summary chunks
-│   ├── embedder.py       Batch embed via OpenAI, store to document_chunks
+│   ├── chunker.py        Five chunk strategies: vote, deputy, party, global_stats, notable_deputy
+│   ├── embedder.py       Batched OpenAI embedding (100 chunks/batch) → document_chunks
 │   └── index_manager.py  CLI: build / stats / clear
 ├── chain/
-│   ├── retriever.py      pgvector cosine similarity search
-│   ├── prompts.py        System prompt + RAG template (French, factual)
-│   └── rag_chain.py      ask() — retrieves context, calls Groq LLM
+│   ├── retriever.py      pgvector cosine similarity (ivfflat.probes=10, notable deputy pinning)
+│   ├── prompts.py        French civic assistant system prompt + RAG template
+│   └── rag_chain.py      ask() — retrieve → format → Groq LLM
 └── experiments/
-    └── mlflow_eval.py    10 golden Q&A pairs, keyword scoring, MLflow logging
+    └── mlflow_eval.py    10 golden Q&A pairs, keyword scoring, k=3 vs k=5 experiment
 ```
 
-**Chunking stats:** 3,149 vote chunks + 577 deputy chunks = 3,726 total · avg 85.7 tokens/chunk · estimated embedding cost ~$0.006
+**Index stats:** 3,741 chunks · avg 87 tokens · $0.0065 to embed
 
 ---
 
 ## Code Quality
 
-Pre-commit hooks run automatically on every `git commit`. Install once after cloning:
-
 ```bash
 pip install pre-commit ruff
-pre-commit install
+pre-commit install       # runs automatically on every git commit
 ```
 
-| Hook | What it catches |
+| Hook | What it enforces |
 |---|---|
-| `trailing-whitespace` | Stray spaces at line ends |
-| `end-of-file-fixer` | Files not ending with a newline |
+| `trailing-whitespace` | No stray spaces at line ends |
+| `end-of-file-fixer` | Files end with a newline |
 | `check-yaml` / `check-json` | Syntax errors in config files |
-| `check-merge-conflict` | Accidentally committed `<<<<<<` markers |
-| `check-added-large-files` | Files over 500 KB (prevents committing ZIPs or weights) |
+| `check-merge-conflict` | No committed `<<<<<<` markers |
+| `check-added-large-files` | Blocks files over 500 KB |
 | `debug-statements` | Blocks `breakpoint()` / `pdb.set_trace()` |
-| `ruff` (lint + `--fix`) | Unused imports, undefined names, bugbear patterns, isort |
+| `ruff` | Lint + auto-fix (imports, bugbear patterns, isort) |
 | `ruff-format` | Black-compatible formatting |
 
-Lint rules are in `ruff.toml` — line length 100, `T201` (print) ignored for `scripts/` and `rag/`.
+Lint config: `ruff.toml` — line length 100, `T201` (print) allowed in `scripts/` and `rag/`.
 
 ---
 
 ## Security
 
 - **CORS:** `allow_credentials=False`, `allow_methods=["GET"]` — public read-only API
-- **Input validation:** `limit` capped at 200, `offset` capped at 100,000 on all list endpoints
-- **Error handling:** Global 500 handler returns generic message — no tracebacks or DSNs in responses
-- **Rate limiting:** 60 req/min global, 10 req/min on scorecard (by IP)
+- **Input validation:** `limit` capped at 200, `offset` at 100,000 on all list endpoints
+- **Error handling:** Global 500 handler returns a generic message — no tracebacks or DSNs in responses
+- **Rate limiting:** 60 req/min global, 10 req/min on scorecard, by IP
 - **No secrets in git:** All credentials via environment variables; `.env` is gitignored
 
 ---
 
-## Known Data Notes
+## Data Notes
 
-- **Party names now populated** — resolved from `Organes.json` GP mandats in the deputies ZIP. 575/577 deputies have a party name; 2 had no active GP or PARPOL mandat in the export.
-- **Department names now full text** — `"78"` → `"Yvelines"`, etc. for all 96 metropolitan + DOM departments.
-- **`nonVotant` ≠ `abstention`** — a `nonVotant` deputy was present but did not cast a vote. Excluded from `presence_rate` in the scorecard.
-- **Yaël Braun-Pivet at 100% presence** — Présidente de l'AN, recorded on every scrutin by the AN data system.
-- **`rejeté` outnumbers `adopté`** — the 17th legislature has no stable majority; most amendments are rejected.
-- **Ingestion window** — production DB uses `--since 2025-07-01` (Supabase free tier). Run `--since 2024-07-07` for the full legislature.
+- **`nonVotant` ≠ `abstention`** — present in chamber but did not vote; excluded from `presence_rate`
+- **Yaël Braun-Pivet at 100% presence** — Présidente de l'AN, recorded on every scrutin by the AN data system
+- **`rejeté` outnumbers `adopté`** — the 17th legislature has no stable majority
+- **Party names** — resolved from `Organes.json` GP mandats; 575/577 deputies covered
+- **Department names** — full text (`"78"` → `"Yvelines"`) for all 96 metropolitan + DOM departments
+- **Ingestion window** — production DB holds votes from `2025-07-01` (Supabase free tier); run `--since 2024-07-07` locally for the full legislature
 
 ---
 
 ## Error Handling
 
-All unhandled exceptions are caught by a global handler in `api/main.py`. The client always receives:
+All unhandled exceptions return a consistent envelope — never a traceback:
 
 ```json
 {"error": "Internal server error", "status": 500}
 ```
 
-The full traceback is written to the server log (`logging.error`) and never exposed in the response body.
+Full stack traces are written to the server log (`logging.error`) and never exposed to clients.

--- a/api/db.py
+++ b/api/db.py
@@ -1,0 +1,34 @@
+import os
+from contextlib import contextmanager
+
+import psycopg2.extras
+import psycopg2.pool
+
+_pool: psycopg2.pool.ThreadedConnectionPool | None = None
+
+
+def init_pool(minconn: int = 2, maxconn: int = 10) -> None:
+    global _pool
+    _pool = psycopg2.pool.ThreadedConnectionPool(
+        minconn=minconn,
+        maxconn=maxconn,
+        dsn=os.getenv("DATABASE_URL"),
+        cursor_factory=psycopg2.extras.RealDictCursor,
+    )
+
+
+def close_pool() -> None:
+    if _pool and not _pool.closed:
+        _pool.closeall()
+
+
+@contextmanager
+def get_conn():
+    conn = _pool.getconn()
+    try:
+        yield conn
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        _pool.putconn(conn)

--- a/api/main.py
+++ b/api/main.py
@@ -8,9 +8,8 @@ import logging
 import os
 import re
 import traceback
+from contextlib import asynccontextmanager
 
-import psycopg2
-import psycopg2.extras
 from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -22,9 +21,18 @@ from starlette.requests import Request
 
 logger = logging.getLogger(__name__)
 
+from api.db import close_pool, get_conn, init_pool  # noqa: E402
 from api.limiter import limiter  # noqa: E402
 
 load_dotenv()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    init_pool()
+    yield
+    close_pool()
+
 
 app = FastAPI(
     title="MonÉlu API",
@@ -32,6 +40,7 @@ app = FastAPI(
     version="0.1.0",
     docs_url="/docs",
     redoc_url="/redoc",
+    lifespan=lifespan,
 )
 
 app.mount("/static", StaticFiles(directory="static"), name="static")
@@ -861,34 +870,32 @@ _LANDING_HTML = """\
 
 @app.get("/", response_class=HTMLResponse, include_in_schema=False)
 def landing(request: Request) -> HTMLResponse:
-    database_url = os.getenv("DATABASE_URL")
     n_deputies = n_votes = n_positions = "—"
     db_dot = "#ef4444"
     db_label = "Base de données indisponible"
     latest_votes_html = '<div class="votes-empty">Données temporairement indisponibles</div>'
 
     try:
-        conn = psycopg2.connect(database_url, cursor_factory=psycopg2.extras.RealDictCursor)
-        with conn.cursor() as cur:
-            cur.execute("SELECT COUNT(*) FROM deputies")
-            n_deputies = f"{cur.fetchone()['count']:,}"
-            cur.execute("SELECT COUNT(*) FROM votes")
-            n_votes = f"{cur.fetchone()['count']:,}"
-            cur.execute("SELECT COUNT(*) FROM vote_positions")
-            n_positions = f"{cur.fetchone()['count']:,}"
-            cur.execute(
-                """
-                SELECT vote_title, result, voted_at,
-                       votes_for, votes_against, abstentions, total_voters
-                FROM votes
-                ORDER BY voted_at DESC
-                LIMIT 5
-                """
-            )
-            rows = cur.fetchall()
-            if rows:
-                latest_votes_html = "".join(_build_vote_row(r) for r in rows)
-        conn.close()
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT COUNT(*) FROM deputies")
+                n_deputies = f"{cur.fetchone()['count']:,}"
+                cur.execute("SELECT COUNT(*) FROM votes")
+                n_votes = f"{cur.fetchone()['count']:,}"
+                cur.execute("SELECT COUNT(*) FROM vote_positions")
+                n_positions = f"{cur.fetchone()['count']:,}"
+                cur.execute(
+                    """
+                    SELECT vote_title, result, voted_at,
+                           votes_for, votes_against, abstentions, total_voters
+                    FROM votes
+                    ORDER BY voted_at DESC
+                    LIMIT 5
+                    """
+                )
+                rows = cur.fetchall()
+                if rows:
+                    latest_votes_html = "".join(_build_vote_row(r) for r in rows)
         db_dot = "#4ade80"
         db_label = "Base de données opérationnelle"
     except Exception:
@@ -913,17 +920,15 @@ def landing(request: Request) -> HTMLResponse:
 # ---------------------------------------------------------------------------
 @app.get("/health", tags=["Health"])
 def health() -> dict:
-    database_url = os.getenv("DATABASE_URL")
     try:
-        conn = psycopg2.connect(database_url)
-        with conn.cursor() as cur:
-            cur.execute("SELECT COUNT(*) FROM deputies")
-            deputies = cur.fetchone()[0]
-            cur.execute("SELECT COUNT(*) FROM votes")
-            votes = cur.fetchone()[0]
-            cur.execute("SELECT COUNT(*) FROM vote_positions")
-            positions = cur.fetchone()[0]
-        conn.close()
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT COUNT(*) FROM deputies")
+                deputies = cur.fetchone()["count"]
+                cur.execute("SELECT COUNT(*) FROM votes")
+                votes = cur.fetchone()["count"]
+                cur.execute("SELECT COUNT(*) FROM vote_positions")
+                positions = cur.fetchone()["count"]
         return {"status": "ok", "deputies": deputies, "votes": votes, "positions": positions}
     except Exception as exc:
         logger.error("Health check DB error: %s", exc)

--- a/api/routers/deputies.py
+++ b/api/routers/deputies.py
@@ -1,22 +1,10 @@
-import os
-
-import psycopg2
-import psycopg2.extras
-from dotenv import load_dotenv
 from fastapi import APIRouter, HTTPException, Query, Request
 
+from api.db import get_conn
 from api.limiter import limiter
 from api.schemas import DeputyDetail, DeputyListResponse, DeputyScorecard, DeputySummary
 
-load_dotenv()
-
 router = APIRouter()
-
-DATABASE_URL = os.getenv("DATABASE_URL")
-
-
-def get_conn():
-    return psycopg2.connect(DATABASE_URL, cursor_factory=psycopg2.extras.RealDictCursor)
 
 
 @router.get("/", response_model=DeputyListResponse)
@@ -26,8 +14,7 @@ def list_deputies(
     search: str = Query(None, description="Filter by name (case-insensitive)"),
     department: str = Query(None),
 ):
-    conn = get_conn()
-    try:
+    with get_conn() as conn:
         with conn.cursor() as cur:
             filters = []
             params: list = []
@@ -55,8 +42,6 @@ def list_deputies(
                 params + [limit, offset],
             )
             rows = cur.fetchall()
-    finally:
-        conn.close()
 
     return DeputyListResponse(
         total=total,
@@ -68,13 +53,10 @@ def list_deputies(
 
 @router.get("/{deputy_id}", response_model=DeputyDetail)
 def get_deputy(deputy_id: str):
-    conn = get_conn()
-    try:
+    with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute("SELECT * FROM deputies WHERE deputy_id = %s", (deputy_id,))
             row = cur.fetchone()
-    finally:
-        conn.close()
 
     if not row:
         raise HTTPException(status_code=404, detail="Deputy not found")
@@ -84,8 +66,7 @@ def get_deputy(deputy_id: str):
 @router.get("/{deputy_id}/scorecard", response_model=DeputyScorecard)
 @limiter.limit("10/minute")
 def get_scorecard(request: Request, deputy_id: str):
-    conn = get_conn()
-    try:
+    with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 "SELECT deputy_id, full_name FROM deputies WHERE deputy_id = %s", (deputy_id,)
@@ -108,8 +89,6 @@ def get_scorecard(request: Request, deputy_id: str):
                 (deputy_id,),
             )
             stats = cur.fetchone()
-    finally:
-        conn.close()
 
     total = stats["total_votes"] or 0
     present = stats["present_votes"] or 0

--- a/api/routers/search.py
+++ b/api/routers/search.py
@@ -1,5 +1,6 @@
 from typing import Literal
 
+import groq
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
@@ -49,5 +50,10 @@ async def search(request: Request, body: SearchRequest):
             chunk_type=body.chunk_type,
         )
         return result
+    except groq.APITimeoutError as e:
+        raise HTTPException(
+            status_code=504,
+            detail="Le service de recherche est temporairement indisponible. Réessayez dans quelques secondes.",
+        ) from e
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"RAG pipeline error: {str(e)}") from e

--- a/api/routers/votes.py
+++ b/api/routers/votes.py
@@ -1,21 +1,9 @@
-import os
-
-import psycopg2
-import psycopg2.extras
-from dotenv import load_dotenv
 from fastapi import APIRouter, HTTPException, Query
 
+from api.db import get_conn
 from api.schemas import VoteDetail, VoteListResponse, VotePosition, VoteSummary
 
-load_dotenv()
-
 router = APIRouter()
-
-DATABASE_URL = os.getenv("DATABASE_URL")
-
-
-def get_conn():
-    return psycopg2.connect(DATABASE_URL, cursor_factory=psycopg2.extras.RealDictCursor)
 
 
 @router.get("/", response_model=VoteListResponse)
@@ -24,8 +12,7 @@ def list_votes(
     offset: int = Query(0, ge=0, le=100_000),
     result: str = Query(None, description="Filter by result: adopté | rejeté"),
 ):
-    conn = get_conn()
-    try:
+    with get_conn() as conn:
         with conn.cursor() as cur:
             filters = []
             params: list = []
@@ -50,8 +37,6 @@ def list_votes(
                 params + [limit, offset],
             )
             rows = cur.fetchall()
-    finally:
-        conn.close()
 
     return VoteListResponse(
         total=total,
@@ -63,8 +48,7 @@ def list_votes(
 
 @router.get("/latest", response_model=list[VoteSummary])
 def latest_votes():
-    conn = get_conn()
-    try:
+    with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 """
@@ -76,15 +60,12 @@ def latest_votes():
                 """
             )
             rows = cur.fetchall()
-    finally:
-        conn.close()
     return [VoteSummary(**r) for r in rows]
 
 
 @router.get("/{vote_id}", response_model=VoteDetail)
 def get_vote(vote_id: str):
-    conn = get_conn()
-    try:
+    with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute("SELECT * FROM votes WHERE vote_id = %s", (vote_id,))
             vote = cur.fetchone()
@@ -103,8 +84,6 @@ def get_vote(vote_id: str):
                 (vote_id,),
             )
             position_rows = cur.fetchall()
-    finally:
-        conn.close()
 
     return VoteDetail(
         **vote,

--- a/data/migrations/001_init.sql
+++ b/data/migrations/001_init.sql
@@ -49,8 +49,12 @@ CREATE INDEX IF NOT EXISTS idx_deputies_party     ON deputies(party_short);
 
 -- ---------------------------------------------------------------------------
 -- Phase 2: semantic search via pgvector
--- Requires the vector extension (pre-installed on Supabase)
+-- Requires the vector extension (pre-installed on Supabase).
+-- This will fail loudly on environments where pgvector is not available —
+-- that is intentional: the embedding index cannot be created without it.
 -- ---------------------------------------------------------------------------
+
+CREATE EXTENSION IF NOT EXISTS vector;
 
 CREATE TABLE IF NOT EXISTS document_chunks (
     id          BIGSERIAL PRIMARY KEY,

--- a/rag/chain/rag_chain.py
+++ b/rag/chain/rag_chain.py
@@ -27,7 +27,7 @@ def ask(
 
     user_message = RAG_TEMPLATE.format(context=context, question=question)
 
-    client = Groq(api_key=os.getenv("GROQ_API_KEY"))
+    client = Groq(api_key=os.getenv("GROQ_API_KEY"), timeout=30.0)
     response = client.chat.completions.create(
         model="llama-3.3-70b-versatile",
         messages=[

--- a/scripts/ingest_votes.py
+++ b/scripts/ingest_votes.py
@@ -4,7 +4,7 @@ Downloads the Scrutins ZIP export from the Assemblée Nationale open-data portal
 and upserts each scrutin into the votes table.
 
 Usage:
-    python scripts/ingest_votes.py                      # default: since 2025-01-01
+    python scripts/ingest_votes.py                      # default: rolling 12 months
     python scripts/ingest_votes.py --since 2024-07-07   # full legislature 17
     python scripts/ingest_votes.py --since 2026-01-01   # current year only
 """
@@ -16,6 +16,7 @@ import logging
 import os
 import time
 import zipfile
+from datetime import date, timedelta
 
 import psycopg2
 import psycopg2.extras
@@ -213,8 +214,8 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Ingest AN scrutins into MonÉlu DB")
     parser.add_argument(
         "--since",
-        default="2025-07-01",
-        help="Only ingest votes on or after this date (YYYY-MM-DD). Default: 2025-07-01",
+        default=(date.today() - timedelta(days=365)).isoformat(),
+        help="Only ingest votes on or after this date (YYYY-MM-DD). Default: rolling 12 months.",
     )
     args = parser.parse_args()
 

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -35,9 +35,19 @@ def main() -> None:
     log.info("Connecting to database…")
     conn = psycopg2.connect(database_url, cursor_factory=psycopg2.extras.RealDictCursor)
     try:
-        with conn:
-            with conn.cursor() as cur:
-                cur.execute(sql)
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(sql)
+        except psycopg2.Error as exc:
+            if "vector" in str(exc).lower():
+                log.error(
+                    "pgvector extension is not available. "
+                    "Enable it on Supabase: Database → Extensions → search 'vector' → enable. "
+                    "On local Docker, use the pgvector/pgvector:pg15 image."
+                )
+                sys.exit(1)
+            raise
         log.info("Migration applied successfully.")
 
         # ── Table summary ────────────────────────────────────────────────────

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -9,6 +9,7 @@ Usage:
 
 import logging
 import os
+import sys
 
 import psycopg2
 import psycopg2.extras
@@ -62,12 +63,12 @@ def main() -> None:
         if ext:
             log.info("pgvector extension: INSTALLED")
         else:
-            log.warning(
+            log.error(
                 "pgvector extension is NOT installed. "
-                "The document_chunks table and embedding index were created but will not be "
-                "functional until pgvector is enabled. On Supabase: "
-                "Database → Extensions → search 'vector' → enable."
+                "Enable it on Supabase: Database → Extensions → search 'vector' → enable. "
+                "On local Docker, use the pgvector/pgvector:pg15 image."
             )
+            sys.exit(1)
 
     finally:
         conn.close()

--- a/scripts/run_ingestion_prod.py
+++ b/scripts/run_ingestion_prod.py
@@ -4,7 +4,7 @@ Runs all three ingestion steps in sequence: deputies → votes → positions.
 Designed to be triggered as a one-off Railway job or run locally.
 
 Usage:
-    python scripts/run_ingestion_prod.py                      # default: since 2025-01-01
+    python scripts/run_ingestion_prod.py                      # default: rolling 12 months
     python scripts/run_ingestion_prod.py --since 2024-07-07   # full legislature 17
     python scripts/run_ingestion_prod.py --since 2026-01-01   # current year only
 """
@@ -15,6 +15,7 @@ import os
 import subprocess
 import sys
 import time
+from datetime import date, timedelta
 
 import psycopg2
 from dotenv import load_dotenv
@@ -55,8 +56,8 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Run full MonÉlu ingestion pipeline")
     parser.add_argument(
         "--since",
-        default="2025-07-01",
-        help="Only ingest votes on or after this date (YYYY-MM-DD). Default: 2025-07-01",
+        default=(date.today() - timedelta(days=365)).isoformat(),
+        help="Only ingest votes on or after this date (YYYY-MM-DD). Default: rolling 12 months.",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## What
Fixes four critical production issues identified during a full repo diagnostic, and rewrites the project documentation to reflect that MonÉlu is a live production application.

## Why
The diagnostic (tracked in issue #7) identified risks that would cause real failures under load or on a fresh deployment: exhausted DB connections under traffic, silent Groq hangs on `/search`, a pgvector misconfiguration that fails silently, and a stale hardcoded date in the ingestion default. All four needed to be addressed before any further scaling or Phase 3 work.

## Changes

**Connection pooling (`api/db.py` — new file)**
- Introduces `psycopg2.pool.ThreadedConnectionPool` (2–10 connections)
- `init_pool()` / `close_pool()` wired to FastAPI's `lifespan` startup/shutdown hook in `api/main.py`
- `get_conn()` context manager handles get/put automatically, with rollback on exception
- All direct `psycopg2.connect()` calls removed from `api/routers/deputies.py`, `api/routers/votes.py`, and `api/main.py`
- Fixed `fetchone()[0]` → `fetchone()["count"]` in health endpoint (was relying on tuple cursor; pool uses `RealDictCursor`)

**Groq timeout (`rag/chain/rag_chain.py`, `api/routers/search.py`)**
- `Groq(timeout=30.0)` — requests now fail in 30s instead of hanging indefinitely
- `api/routers/search.py` catches `groq.APITimeoutError` and returns HTTP 504 with a French user-facing message, instead of a generic 500

**pgvector hard fail (`data/migrations/001_init.sql`, `scripts/migrate.py`)**
- Added `CREATE EXTENSION IF NOT EXISTS vector;` to the migration — fails at the SQL level if pgvector isn't available
- `scripts/migrate.py` post-migration check changed from `log.warning()` to `log.error()` + `sys.exit(1)`

**Rolling ingest default (`scripts/ingest_votes.py`)**
- `--since` default changed from hardcoded `"2025-07-01"` to `date.today() - timedelta(days=365)`

**Documentation (`README.md`, `CLAUDE.md`)**
- Repositioned as a production civic app with a Phase roadmap table
- Tightened structure throughout

## Testing
- `ruff check` passes on all modified files
- No automated test suite yet

## Risks / Notes
- `CREATE EXTENSION IF NOT EXISTS vector;` will now fail on local Docker using standard `postgres:15`. Use `pgvector/pgvector:pg15` instead (documented in the migrate.py error message).
- Pool `maxconn=10` is conservative — can be raised via `init_pool(maxconn=N)` if needed.

## Breaking Changes
None for the public API surface.

Closes #7