### PR TITLE
fix: connection pool robustness, RAG hygiene, rate limit tightening

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Implemented with [slowapi](https://github.com/laurentS/slowapi), keyed by remote
 
 | Scope | Limit |
 |---|---|
-| Global default | 60 req / min |
+| Global default | 30 req / min |
 | `GET /deputies/{id}/scorecard` | 10 req / min |
 
 On limit exceeded: HTTP 429 · `{"error": "Too Many Requests", "detail": "..."}` · `Retry-After` + `X-RateLimit-*` headers.

--- a/api/db.py
+++ b/api/db.py
@@ -27,13 +27,14 @@ def get_conn():
     if _pool is None:
         raise RuntimeError("DB pool is not initialized — call init_pool() first")
     conn = _pool.getconn()
+    broken = False
     try:
         yield conn
     except Exception:
         try:
             conn.rollback()
         except Exception:
-            pass
+            broken = True
         raise
     finally:
-        _pool.putconn(conn)
+        _pool.putconn(conn, close=broken)

--- a/api/db.py
+++ b/api/db.py
@@ -24,11 +24,16 @@ def close_pool() -> None:
 
 @contextmanager
 def get_conn():
+    if _pool is None:
+        raise RuntimeError("DB pool is not initialized — call init_pool() first")
     conn = _pool.getconn()
     try:
         yield conn
     except Exception:
-        conn.rollback()
+        try:
+            conn.rollback()
+        except Exception:
+            pass
         raise
     finally:
         _pool.putconn(conn)

--- a/api/limiter.py
+++ b/api/limiter.py
@@ -7,4 +7,4 @@ Keeping it in its own module avoids circular imports.
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
-limiter = Limiter(key_func=get_remote_address, default_limits=["60/minute"])
+limiter = Limiter(key_func=get_remote_address, default_limits=["30/minute"])

--- a/rag/chain/rag_chain.py
+++ b/rag/chain/rag_chain.py
@@ -15,6 +15,8 @@ from rag.chain.retriever import retrieve
 
 load_dotenv()
 
+_groq_client = Groq(api_key=os.getenv("GROQ_API_KEY"), timeout=30.0)
+
 
 def ask(
     question: str,
@@ -27,8 +29,7 @@ def ask(
 
     user_message = RAG_TEMPLATE.format(context=context, question=question)
 
-    client = Groq(api_key=os.getenv("GROQ_API_KEY"), timeout=30.0)
-    response = client.chat.completions.create(
+    response = _groq_client.chat.completions.create(
         model="llama-3.3-70b-versatile",
         messages=[
             {"role": "system", "content": SYSTEM_PROMPT},

--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -5,6 +5,7 @@ Retrieves relevant chunks from document_chunks using cosine similarity
 via pgvector. The query is embedded with the same model used at index time.
 """
 
+import logging
 import os
 
 import numpy as np
@@ -13,6 +14,8 @@ import psycopg2.extras
 from dotenv import load_dotenv
 from openai import OpenAI
 from pgvector.psycopg2 import register_vector
+
+log = logging.getLogger(__name__)
 
 load_dotenv()
 
@@ -127,8 +130,11 @@ def retrieve(
     results = (pinned + semantic_rows)[:k]
 
     top_sim = results[0]["similarity"] if results else 0.0
-    print(
-        f"Retrieved {len(results)} chunks — top similarity: {top_sim:.3f} (result_filter={result_filter})"
+    log.debug(
+        "Retrieved %d chunks — top similarity: %.3f (result_filter=%s)",
+        len(results),
+        top_sim,
+        result_filter,
     )
     return results
 


### PR DESCRIPTION
## What
Three focused fixes from the post-diagnostic backlog: connection pool robustness, RAG chain production hygiene, and API rate limit tightening. Closes #9, #10, #12.

## Why
These were the lowest-effort items from the diagnostic with the highest signal-to-noise ratio — all under 10 minutes each, no risk, no behaviour change for correct callers.

## Changes

**Connection pool robustness (`api/db.py`) — closes #9**
- `get_conn()` now raises `RuntimeError("DB pool is not initialized — call init_pool() first")` if called before `init_pool()`, instead of a cryptic `AttributeError`
- `conn.rollback()` wrapped in its own `try/except` so a dead connection cannot replace the original exception with a rollback error

**RAG chain hygiene (`rag/chain/retriever.py`, `rag/chain/rag_chain.py`) — closes #10**
- `print()` in `retriever.py` replaced with `logging.debug()` — was printing to stdout on every `/search` call, cluttering Railway logs
- Groq client moved from inside `ask()` to a module-level singleton `_groq_client` — previously a new `httpx.Client` was created and discarded on every search request

**Rate limit tightening (`api/limiter.py`) — closes #12**
- Global default lowered from `60/minute` to `30/minute` per IP
- `/search` (10/min) and `/scorecard` (10/min) unchanged

## Testing
- `ruff check` + `ruff-format` pass on all files (pre-commit hooks)
- No automated test suite yet (tracked in #13)

## Risks / Notes
- Rate limit is the only user-visible change. Clients exceeding 30 req/min will now get HTTP 429.
- Groq singleton initializes at module import time — `GROQ_API_KEY` must be set before import. Already required; no behaviour change.

## Breaking Changes
None for the public API surface. Clients exceeding 30 req/min (previously 60) will receive 429s.