### PR TITLE
ci: add GitHub Actions workflow for lint and format checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install ruff
+      - run: ruff check .
+      - run: ruff format --check .

--- a/rag/pipeline/chunker.py
+++ b/rag/pipeline/chunker.py
@@ -451,9 +451,9 @@ def chunk_all() -> list[dict]:
         if t > TOKEN_WARN_THRESHOLD
     ]
 
-    print(f"\n{'='*50}")
+    print(f"\n{'=' * 50}")
     print("  Chunker summary")
-    print(f"{'='*50}")
+    print(f"{'=' * 50}")
     print(f"  Vote chunks    : {len(vote_chunks):>6,}")
     print(f"  Deputy chunks  : {len(deputy_chunks):>6,}")
     print(f"  Party chunks   : {len(party_chunks):>6,}")
@@ -470,7 +470,7 @@ def chunk_all() -> list[dict]:
         )
     else:
         print(f"  Token check    : OK — all chunks within {TOKEN_WARN_THRESHOLD}-token limit")
-    print(f"{'='*50}\n")
+    print(f"{'=' * 50}\n")
 
     return all_chunks
 
@@ -496,9 +496,9 @@ if __name__ == "__main__":
 
     oversized = [t for t in token_counts if t > TOKEN_WARN_THRESHOLD]
 
-    print(f"\n{'='*56}")
+    print(f"\n{'=' * 56}")
     print("  CHUNKER REPORT")
-    print(f"{'='*56}")
+    print(f"{'=' * 56}")
     print(f"  Vote chunks      : {len(vote_chunks):>6,}")
     print(f"  Deputy chunks    : {len(deputy_chunks):>6,}")
     print(f"  Party chunks     : {len(party_chunks):>6,}")
@@ -508,7 +508,7 @@ if __name__ == "__main__":
     print(f"  Avg tokens/chunk : {avg_tokens:>6.1f}")
     print(f"  Total tokens     : {total_tokens:>6,}")
     print(f"  Chunks > {TOKEN_WARN_THRESHOLD}t     : {len(oversized):>6,}")
-    print(f"{'='*56}")
+    print(f"{'=' * 56}")
 
     print("\n--- SAMPLE: vote chunk ---")
     sample_vote = vote_chunks[0]

--- a/scripts/explore_organes.py
+++ b/scripts/explore_organes.py
@@ -26,10 +26,10 @@ CANDIDATES = [
     "/static/openData/repository/17/amo/deputes_actifs_mandats_actifs_organes"
     "/AMO10_deputes_actifs_mandats_actifs_organes.json.zip",
     # Dedicated organes export (17th legislature)
-    "/static/openData/repository/17/amo/tous_les_organes" "/AMO30_tous_les_organes.json.zip",
+    "/static/openData/repository/17/amo/tous_les_organes/AMO30_tous_les_organes.json.zip",
     # Alternative naming
-    "/static/openData/repository/17/amo/tous_les_organes" "/AMO20_tous_les_organes.json.zip",
-    "/static/openData/repository/17/amo/organes" "/AMO30_organes.json.zip",
+    "/static/openData/repository/17/amo/tous_les_organes/AMO20_tous_les_organes.json.zip",
+    "/static/openData/repository/17/amo/organes/AMO30_organes.json.zip",
 ]
 
 
@@ -48,9 +48,9 @@ def try_download(path: str) -> bytes | None:
 
 
 def inspect_zip(raw: bytes, label: str) -> None:
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"  ZIP contents — {label}")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
 
     with zipfile.ZipFile(io.BytesIO(raw)) as zf:
         names = zf.namelist()
@@ -116,17 +116,17 @@ def inspect_zip(raw: bytes, label: str) -> None:
             print(f"    {t:<20} {c:>4} entries")
 
         if gp_samples:
-            print(f"\n{'='*60}")
+            print(f"\n{'=' * 60}")
             print(f"  GP (Groupe Parlementaire) samples — {len(gp_samples)} found")
-            print(f"{'='*60}")
+            print(f"{'=' * 60}")
             for fname, item in gp_samples:
                 print(f"\n  File: {fname}")
                 print(json.dumps(item, ensure_ascii=False, indent=2)[:2000])
 
         if parpol_samples:
-            print(f"\n{'='*60}")
+            print(f"\n{'=' * 60}")
             print(f"  PARPOL samples — {len(parpol_samples)} found")
-            print(f"{'='*60}")
+            print(f"{'=' * 60}")
             for fname, item in parpol_samples:
                 print(f"\n  File: {fname}")
                 print(json.dumps(item, ensure_ascii=False, indent=2)[:1000])

--- a/scripts/ingest_organes.py
+++ b/scripts/ingest_organes.py
@@ -112,18 +112,18 @@ def main():
 
     print("\nBuilding GP/PARPOL organe map …")
     gp_map = build_gp_map(zf)
-    print(f"\n{'='*50}")
+    print(f"\n{'=' * 50}")
     print(f"  Organe map ({len(gp_map)} entries)")
-    print(f"{'='*50}")
+    print(f"{'=' * 50}")
     for uid, name in sorted(gp_map.items(), key=lambda x: x[1]):
         print(f"  {uid}  →  {name}")
 
     print("\nBuilding deputy → party map …")
     deputy_map = build_deputy_party_map(zf, gp_map)
 
-    print(f"\n{'='*50}")
+    print(f"\n{'=' * 50}")
     print(f"  Deputy party map: {len(deputy_map)} deputies resolved")
-    print(f"{'='*50}")
+    print(f"{'=' * 50}")
 
     # Party breakdown
     from collections import Counter

--- a/scripts/update_party.py
+++ b/scripts/update_party.py
@@ -174,9 +174,9 @@ def update_departments(conn) -> None:
 
 
 def print_summary(conn) -> None:
-    print(f"\n{'='*56}")
+    print(f"\n{'=' * 56}")
     print("  VERIFICATION")
-    print(f"{'='*56}")
+    print(f"{'=' * 56}")
 
     with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
         print("\n  Party breakdown:")


### PR DESCRIPTION
Closes #16

## What
Adds `.github/workflows/ci.yml` — a GitHub Actions workflow that runs `ruff check` and `ruff format --check` on every push and pull request.

## Why
Pre-commit hooks only run locally. A contributor who skips them (or never installs them) can merge code that fails lint or format checks. This workflow closes that gap by enforcing the same checks in CI, regardless of local setup.

## Changes
- `.github/workflows/ci.yml` — new file; triggers on `push` and `pull_request`, installs ruff, then runs `ruff check .` and `ruff format --check .` on Python 3.11 / ubuntu-latest.

## Testing
- Workflow file passes `check yaml` pre-commit hook locally.
- Will self-validate on first push — CI runs against this branch immediately.

## Risks / Notes
- Once this lands, enable branch protection on `master` (require the `lint` status check to pass) to make enforcement automatic.
- A `test` job can be added to this same workflow once issue #13 (tests) lands.

## Breaking Changes
None.