### PR TITLE
airflow: fix XCom size risk in both DAGs, add read_by_key, and enable configurable Fernet key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,7 @@ CORS_ORIGINS=*
 OPENAI_API_KEY=sk-...
 # Groq: https://console.groq.com/keys
 GROQ_API_KEY=gsk_...
+
+# Phase 3 — Airflow (required for staging/prod; blank is OK for local dev only)
+# Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+AIRFLOW_FERNET_KEY=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     environment:
       AIRFLOW__CORE__EXECUTOR: LocalExecutor
       AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres-airflow/airflow
-      AIRFLOW__CORE__FERNET_KEY: ''  # TODO: set a real Fernet key for staging/prod
+      AIRFLOW__CORE__FERNET_KEY: ${AIRFLOW_FERNET_KEY:-}
       AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
       AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
       AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth'
@@ -78,7 +78,7 @@ services:
     environment:
       AIRFLOW__CORE__EXECUTOR: LocalExecutor
       AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres-airflow/airflow
-      AIRFLOW__CORE__FERNET_KEY: ''  # TODO: set a real Fernet key for staging/prod
+      AIRFLOW__CORE__FERNET_KEY: ${AIRFLOW_FERNET_KEY:-}
       AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
       AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
       AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth'
@@ -114,7 +114,7 @@ services:
     environment:
       AIRFLOW__CORE__EXECUTOR: LocalExecutor
       AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres-airflow/airflow
-      AIRFLOW__CORE__FERNET_KEY: ''  # TODO: set a real Fernet key for staging/prod
+      AIRFLOW__CORE__FERNET_KEY: ${AIRFLOW_FERNET_KEY:-}
       AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
       AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
       AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth'

--- a/ingestion/dags/dag_deputies_incremental.py
+++ b/ingestion/dags/dag_deputies_incremental.py
@@ -48,13 +48,13 @@ def fetch_deputies(**context):
 
 def validate_deputies(**context):
     """Run Great Expectations suite — fail DAG if validation fails."""
-    from ingestion.utils.bronze_writer import BronzeWriter
-    from quality.expectations.deputies_suite import validate_deputies as gx_validate
-
     bronze_path = context["ti"].xcom_pull(key="bronze_path", task_ids="fetch_deputies")
     if bronze_path is None:
         print("No new Bronze data — skipping validation")
         return
+
+    from ingestion.utils.bronze_writer import BronzeWriter
+    from quality.expectations.deputies_suite import validate_deputies as gx_validate
 
     writer = BronzeWriter()
     deputies = writer.read_by_key(bronze_path)

--- a/ingestion/dags/dag_deputies_incremental.py
+++ b/ingestion/dags/dag_deputies_incremental.py
@@ -17,11 +17,30 @@ default_args = {
 
 
 def fetch_deputies(**context):
-    """Download deputies ZIP and parse JSON files."""
+    """
+    Download deputies ZIP, write raw data to Bronze, and push only the S3 path
+    via XCom. Avoids the Airflow metadata-DB XCom size limit (~48 KB) that
+    would be hit by the full 577-deputy JSON payload (~150–300 KB).
+    """
+    from ingestion.utils.bronze_writer import BronzeWriter
     from scripts.ingest_deputies import fetch_all_deputies
 
     deputies = fetch_all_deputies()
-    context["ti"].xcom_push(key="deputies", value=deputies)
+
+    writer = BronzeWriter()
+    stable = sorted(deputies, key=lambda d: d.get("uid", ""))
+    current_hash = hashlib.md5(json.dumps(stable, sort_keys=True).encode()).hexdigest()
+    last_hash = writer.get_last_hash("deputies")
+
+    if current_hash == last_hash:
+        print("No changes detected — skipping Bronze write")
+        context["ti"].xcom_push(key="bronze_path", value=None)
+    else:
+        path = writer.write("deputies", deputies, context["ds"])
+        writer.save_hash("deputies", current_hash)
+        context["ti"].xcom_push(key="bronze_path", value=path)
+        print(f"Bronze written: {path}")
+
     context["ti"].xcom_push(key="count", value=len(deputies))
     print(f"Fetched {len(deputies)} deputies")
     return len(deputies)
@@ -29,9 +48,16 @@ def fetch_deputies(**context):
 
 def validate_deputies(**context):
     """Run Great Expectations suite — fail DAG if validation fails."""
+    from ingestion.utils.bronze_writer import BronzeWriter
     from quality.expectations.deputies_suite import validate_deputies as gx_validate
 
-    deputies = context["ti"].xcom_pull(key="deputies", task_ids="fetch_deputies")
+    bronze_path = context["ti"].xcom_pull(key="bronze_path", task_ids="fetch_deputies")
+    if bronze_path is None:
+        print("No new Bronze data — skipping validation")
+        return
+
+    writer = BronzeWriter()
+    deputies = writer.read_by_key(bronze_path)
     result = gx_validate(deputies)
     if not result["success"]:
         raise ValueError(
@@ -41,31 +67,28 @@ def validate_deputies(**context):
     print(f"GE validation passed: {result['evaluated']} checks")
 
 
-def check_and_write_bronze(**context):
-    """
-    Hash-based change detection.
-    Only write to Bronze if data has changed since last run.
-    """
-    from ingestion.utils.bronze_writer import BronzeWriter
-
-    deputies = context["ti"].xcom_pull(key="deputies", task_ids="fetch_deputies")
-    writer = BronzeWriter()
-    current_hash = hashlib.md5(json.dumps(deputies, sort_keys=True).encode()).hexdigest()
-    last_hash = writer.get_last_hash("deputies")
-    if current_hash == last_hash:
-        print("No changes detected — skipping Bronze write")
+def confirm_bronze(**context):
+    """Log the Bronze path written by fetch_deputies — the actual write happened there."""
+    bronze_path = context["ti"].xcom_pull(key="bronze_path", task_ids="fetch_deputies")
+    if bronze_path is None:
+        print("No changes detected — Bronze write was skipped")
         return "skipped"
-    path = writer.write("deputies", deputies, context["ds"])
-    writer.save_hash("deputies", current_hash)
-    print(f"Bronze written: {path}")
-    return path
+    print(f"Bronze path confirmed: {bronze_path}")
+    return bronze_path
 
 
 def upsert_postgres(**context):
-    """Upsert deputies into PostgreSQL from XCom."""
+    """Upsert deputies into PostgreSQL, reading from Bronze S3 instead of XCom."""
+    from ingestion.utils.bronze_writer import BronzeWriter
     from scripts.ingest_deputies import upsert_deputies
 
-    deputies = context["ti"].xcom_pull(key="deputies", task_ids="fetch_deputies")
+    bronze_path = context["ti"].xcom_pull(key="bronze_path", task_ids="fetch_deputies")
+    if bronze_path is None:
+        print("No new Bronze data — skipping Postgres upsert")
+        return
+
+    writer = BronzeWriter()
+    deputies = writer.read_by_key(bronze_path)
     upsert_deputies(deputies)
     print(f"Upserted {len(deputies)} deputies to Postgres")
 
@@ -90,8 +113,8 @@ with DAG(
     )
 
     t3 = PythonOperator(
-        task_id="write_bronze",
-        python_callable=check_and_write_bronze,
+        task_id="confirm_bronze",
+        python_callable=confirm_bronze,
     )
 
     t4 = PythonOperator(

--- a/ingestion/dags/dag_votes_batch.py
+++ b/ingestion/dags/dag_votes_batch.py
@@ -63,13 +63,13 @@ def fetch_votes(**context):
 
 def validate_votes(**context):
     """Run Great Expectations suite — fail DAG if validation fails."""
-    from ingestion.utils.bronze_writer import BronzeWriter
-    from quality.expectations.votes_suite import validate_votes as gx_validate
-
     bronze_path = context["ti"].xcom_pull(key="bronze_path", task_ids="fetch_votes")
     if bronze_path is None:
         print("No new Bronze data — skipping validation")
         return
+
+    from ingestion.utils.bronze_writer import BronzeWriter
+    from quality.expectations.votes_suite import validate_votes as gx_validate
 
     writer = BronzeWriter()
     votes = writer.read_by_key(bronze_path)

--- a/ingestion/dags/dag_votes_batch.py
+++ b/ingestion/dags/dag_votes_batch.py
@@ -31,12 +31,30 @@ def check_session_active(**context):
 
 
 def fetch_votes(**context):
-    """Download votes ZIP for the last 7 days and parse JSON files."""
+    """
+    Download votes ZIP for the last 7 days, write raw data to Bronze, and push
+    only the S3 path via XCom. Avoids the 48 KB Airflow metadata-DB XCom limit
+    that would be hit if the full dataset were serialised directly.
+    """
+    from ingestion.utils.bronze_writer import BronzeWriter
     from scripts.ingest_votes import fetch_all_scrutins
 
     since = (datetime.utcnow() - timedelta(days=7)).strftime("%Y-%m-%d")
     votes = fetch_all_scrutins(since=since)
-    context["ti"].xcom_push(key="votes", value=votes)
+
+    writer = BronzeWriter()
+    current_hash = hashlib.md5(json.dumps(votes, sort_keys=True).encode()).hexdigest()
+    last_hash = writer.get_last_hash("votes")
+
+    if current_hash == last_hash:
+        print("No changes detected — skipping Bronze write")
+        context["ti"].xcom_push(key="bronze_path", value=None)
+    else:
+        path = writer.write("votes", votes, context["ds"])
+        writer.save_hash("votes", current_hash)
+        context["ti"].xcom_push(key="bronze_path", value=path)
+        print(f"Bronze written: {path}")
+
     context["ti"].xcom_push(key="count", value=len(votes))
     print(f"Fetched {len(votes)} votes since {since}")
     return len(votes)
@@ -44,9 +62,16 @@ def fetch_votes(**context):
 
 def validate_votes(**context):
     """Run Great Expectations suite — fail DAG if validation fails."""
+    from ingestion.utils.bronze_writer import BronzeWriter
     from quality.expectations.votes_suite import validate_votes as gx_validate
 
-    votes = context["ti"].xcom_pull(key="votes", task_ids="fetch_votes")
+    bronze_path = context["ti"].xcom_pull(key="bronze_path", task_ids="fetch_votes")
+    if bronze_path is None:
+        print("No new Bronze data — skipping validation")
+        return
+
+    writer = BronzeWriter()
+    votes = writer.read_latest("votes")
     result = gx_validate(votes)
     if not result["success"]:
         raise ValueError(
@@ -56,31 +81,28 @@ def validate_votes(**context):
     print(f"GE validation passed: {result['evaluated']} checks")
 
 
-def check_and_write_bronze(**context):
-    """
-    Hash-based change detection.
-    Only write to Bronze if data has changed since last run.
-    """
-    from ingestion.utils.bronze_writer import BronzeWriter
-
-    votes = context["ti"].xcom_pull(key="votes", task_ids="fetch_votes")
-    writer = BronzeWriter()
-    current_hash = hashlib.md5(json.dumps(votes, sort_keys=True).encode()).hexdigest()
-    last_hash = writer.get_last_hash("votes")
-    if current_hash == last_hash:
-        print("No changes detected — skipping Bronze write")
+def write_bronze(**context):
+    """Bronze write already happened in fetch_votes — just log the path."""
+    bronze_path = context["ti"].xcom_pull(key="bronze_path", task_ids="fetch_votes")
+    if bronze_path is None:
+        print("No changes detected — Bronze write was skipped")
         return "skipped"
-    path = writer.write("votes", votes, context["ds"])
-    writer.save_hash("votes", current_hash)
-    print(f"Bronze written: {path}")
-    return path
+    print(f"Bronze path confirmed: {bronze_path}")
+    return bronze_path
 
 
 def upsert_postgres(**context):
-    """Upsert votes into PostgreSQL from XCom."""
+    """Upsert votes into PostgreSQL, reading from Bronze S3 instead of XCom."""
+    from ingestion.utils.bronze_writer import BronzeWriter
     from scripts.ingest_votes import upsert_votes
 
-    votes = context["ti"].xcom_pull(key="votes", task_ids="fetch_votes")
+    bronze_path = context["ti"].xcom_pull(key="bronze_path", task_ids="fetch_votes")
+    if bronze_path is None:
+        print("No new Bronze data — skipping Postgres upsert")
+        return
+
+    writer = BronzeWriter()
+    votes = writer.read_latest("votes")
     upsert_votes(votes)
     print(f"Upserted {len(votes)} votes to Postgres")
 
@@ -119,7 +141,7 @@ with DAG(
 
     t3 = PythonOperator(
         task_id="write_bronze",
-        python_callable=check_and_write_bronze,
+        python_callable=write_bronze,
     )
 
     t4 = PythonOperator(

--- a/ingestion/dags/dag_votes_batch.py
+++ b/ingestion/dags/dag_votes_batch.py
@@ -72,7 +72,7 @@ def validate_votes(**context):
         return
 
     writer = BronzeWriter()
-    votes = writer.read_latest("votes")
+    votes = writer.read_by_key(bronze_path)
     result = gx_validate(votes)
     if not result["success"]:
         raise ValueError(
@@ -82,8 +82,8 @@ def validate_votes(**context):
     print(f"GE validation passed: {result['evaluated']} checks")
 
 
-def write_bronze(**context):
-    """Bronze write already happened in fetch_votes — just log the path."""
+def confirm_bronze(**context):
+    """Log the Bronze path written by fetch_votes — the actual write happened there."""
     bronze_path = context["ti"].xcom_pull(key="bronze_path", task_ids="fetch_votes")
     if bronze_path is None:
         print("No changes detected — Bronze write was skipped")
@@ -103,7 +103,7 @@ def upsert_postgres(**context):
         return
 
     writer = BronzeWriter()
-    votes = writer.read_latest("votes")
+    votes = writer.read_by_key(bronze_path)
     upsert_votes(votes)
     print(f"Upserted {len(votes)} votes to Postgres")
 
@@ -141,8 +141,8 @@ with DAG(
     )
 
     t3 = PythonOperator(
-        task_id="write_bronze",
-        python_callable=write_bronze,
+        task_id="confirm_bronze",
+        python_callable=confirm_bronze,
     )
 
     t4 = PythonOperator(

--- a/ingestion/dags/dag_votes_batch.py
+++ b/ingestion/dags/dag_votes_batch.py
@@ -43,7 +43,8 @@ def fetch_votes(**context):
     votes = fetch_all_scrutins(since=since)
 
     writer = BronzeWriter()
-    current_hash = hashlib.md5(json.dumps(votes, sort_keys=True).encode()).hexdigest()
+    stable = sorted(votes, key=lambda v: v.get("uid", ""))
+    current_hash = hashlib.md5(json.dumps(stable, sort_keys=True).encode()).hexdigest()
     last_hash = writer.get_last_hash("votes")
 
     if current_hash == last_hash:

--- a/ingestion/utils/bronze_writer.py
+++ b/ingestion/utils/bronze_writer.py
@@ -45,6 +45,12 @@ class BronzeWriter:
         print(f"Bronze written: s3://{self.bucket}/{key} ({len(data)} records)")
         return f"s3://{self.bucket}/{key}"
 
+    def read_by_key(self, path: str) -> list[dict]:
+        """Read a specific Bronze file by its full s3:// path (as returned by write())."""
+        key = path.removeprefix(f"s3://{self.bucket}/")
+        obj = self.s3.get_object(Bucket=self.bucket, Key=key)
+        return json.loads(obj["Body"].read())
+
     def read_latest(self, entity: str) -> list[dict]:
         """Read the most recent Bronze file for an entity."""
         prefix = f"{entity}/"

--- a/tests/test_bronze_writer.py
+++ b/tests/test_bronze_writer.py
@@ -2,11 +2,31 @@
 
 import hashlib
 import json
+import sys
+import types
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from ingestion.utils.bronze_writer import BronzeWriter
+# Stub airflow so DAG modules can be imported without a real Airflow install.
+# Must happen before any import of ingestion.dags.*.
+_af = types.ModuleType("airflow")
+_af_ops = types.ModuleType("airflow.operators")
+_af_ops_py = types.ModuleType("airflow.operators.python")
+_af_ops_py.PythonOperator = MagicMock
+_af_ops_py.ShortCircuitOperator = MagicMock
+_dag_ctx = MagicMock()
+_dag_ctx.__enter__ = lambda s: s
+_dag_ctx.__exit__ = MagicMock(return_value=False)
+_af.DAG = MagicMock(return_value=_dag_ctx)
+for _name, _mod in [
+    ("airflow", _af),
+    ("airflow.operators", _af_ops),
+    ("airflow.operators.python", _af_ops_py),
+]:
+    sys.modules.setdefault(_name, _mod)
+
+from ingestion.utils.bronze_writer import BronzeWriter  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # BronzeWriter.read_by_key

--- a/tests/test_bronze_writer.py
+++ b/tests/test_bronze_writer.py
@@ -1,0 +1,259 @@
+"""Unit tests for BronzeWriter and the DAG task functions."""
+
+import hashlib
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ingestion.utils.bronze_writer import BronzeWriter
+
+# ---------------------------------------------------------------------------
+# BronzeWriter.read_by_key
+# ---------------------------------------------------------------------------
+
+
+def _make_writer(s3_mock):
+    writer = BronzeWriter.__new__(BronzeWriter)
+    writer.s3 = s3_mock
+    writer.bucket = "monelu-bronze"
+    return writer
+
+
+def test_read_by_key_strips_prefix_and_returns_data():
+    payload = [{"uid": "PA1", "name": "Test"}]
+    s3 = MagicMock()
+    s3.get_object.return_value = {"Body": MagicMock(read=lambda: json.dumps(payload).encode())}
+
+    writer = _make_writer(s3)
+    result = writer.read_by_key(
+        "s3://monelu-bronze/votes/year=2026/month=05/day=17/votes_120000.json"
+    )
+
+    s3.get_object.assert_called_once_with(
+        Bucket="monelu-bronze",
+        Key="votes/year=2026/month=05/day=17/votes_120000.json",
+    )
+    assert result == payload
+
+
+def test_read_by_key_without_prefix_passes_key_as_is():
+    """Path without s3://bucket/ prefix should be used verbatim."""
+    payload = [{"uid": "PA2"}]
+    s3 = MagicMock()
+    s3.get_object.return_value = {"Body": MagicMock(read=lambda: json.dumps(payload).encode())}
+
+    writer = _make_writer(s3)
+    # removeprefix leaves the string unchanged when prefix doesn't match
+    result = writer.read_by_key("votes/year=2026/month=05/day=17/votes_120000.json")
+
+    s3.get_object.assert_called_once_with(
+        Bucket="monelu-bronze",
+        Key="votes/year=2026/month=05/day=17/votes_120000.json",
+    )
+    assert result == payload
+
+
+# ---------------------------------------------------------------------------
+# DAG task: fetch_votes — no-change path (hash match → bronze_path=None)
+# ---------------------------------------------------------------------------
+
+
+def _make_ti(**xcom_values):
+    ti = MagicMock()
+    pushed = {}
+
+    def push(key, value):
+        pushed[key] = value
+
+    def pull(key, task_ids=None):
+        return xcom_values.get(key)
+
+    ti.xcom_push = MagicMock(side_effect=lambda key, value: pushed.__setitem__(key, value))
+    ti.xcom_pull = MagicMock(side_effect=lambda key, task_ids=None: xcom_values.get(key))
+    ti._pushed = pushed
+    return ti
+
+
+def test_fetch_votes_skips_bronze_when_hash_unchanged():
+    votes = [{"uid": "V1", "dateScrutin": "2026-05-01"}]
+    stable = sorted(votes, key=lambda v: v.get("uid", ""))
+    expected_hash = hashlib.md5(json.dumps(stable, sort_keys=True).encode()).hexdigest()
+
+    ti = _make_ti()
+    context = {"ti": ti, "ds": "2026-05-17"}
+
+    with (
+        patch("scripts.ingest_votes.fetch_all_scrutins", return_value=votes),
+        patch(
+            "ingestion.utils.bronze_writer.BronzeWriter.get_last_hash", return_value=expected_hash
+        ),
+        patch("ingestion.utils.bronze_writer.BronzeWriter.write") as mock_write,
+        patch("ingestion.utils.bronze_writer.BronzeWriter.save_hash") as mock_save,
+        patch("ingestion.utils.bronze_writer.boto3"),
+    ):
+        from ingestion.dags.dag_votes_batch import fetch_votes
+
+        fetch_votes(**context)
+
+    mock_write.assert_not_called()
+    mock_save.assert_not_called()
+    assert ti._pushed["bronze_path"] is None
+    assert ti._pushed["count"] == 1
+
+
+def test_fetch_votes_writes_bronze_when_hash_changed():
+    votes = [{"uid": "V1", "dateScrutin": "2026-05-01"}]
+    ti = _make_ti()
+    context = {"ti": ti, "ds": "2026-05-17"}
+
+    with (
+        patch("scripts.ingest_votes.fetch_all_scrutins", return_value=votes),
+        patch("ingestion.utils.bronze_writer.BronzeWriter.get_last_hash", return_value="old_hash"),
+        patch(
+            "ingestion.utils.bronze_writer.BronzeWriter.write",
+            return_value="s3://monelu-bronze/votes/x.json",
+        ) as mock_write,
+        patch("ingestion.utils.bronze_writer.BronzeWriter.save_hash") as mock_save,
+        patch("ingestion.utils.bronze_writer.boto3"),
+    ):
+        from ingestion.dags.dag_votes_batch import fetch_votes
+
+        fetch_votes(**context)
+
+    mock_write.assert_called_once()
+    mock_save.assert_called_once()
+    assert ti._pushed["bronze_path"] == "s3://monelu-bronze/votes/x.json"
+
+
+# ---------------------------------------------------------------------------
+# DAG task: validate_votes — skips when bronze_path is None
+# ---------------------------------------------------------------------------
+
+
+def test_validate_votes_skips_when_no_new_bronze():
+    ti = _make_ti(bronze_path=None)
+    context = {"ti": ti}
+
+    with patch("ingestion.utils.bronze_writer.boto3"):
+        from ingestion.dags.dag_votes_batch import validate_votes
+
+        # Should return without raising
+        validate_votes(**context)
+
+
+def test_validate_votes_raises_on_ge_failure():
+    ti = _make_ti(bronze_path="s3://monelu-bronze/votes/x.json")
+    context = {"ti": ti}
+
+    bad_result = {
+        "success": False,
+        "evaluated": 3,
+        "failed": 1,
+        "results": [{"expectation": "expect_column_to_exist", "success": False}],
+    }
+
+    with (
+        patch(
+            "ingestion.utils.bronze_writer.BronzeWriter.read_by_key", return_value=[{"uid": "V1"}]
+        ),
+        patch("quality.expectations.votes_suite.validate_votes", return_value=bad_result),
+        patch("ingestion.utils.bronze_writer.boto3"),
+    ):
+        from ingestion.dags.dag_votes_batch import validate_votes
+
+        with pytest.raises(ValueError, match="GE validation failed"):
+            validate_votes(**context)
+
+
+# ---------------------------------------------------------------------------
+# DAG task: upsert_postgres — skips when bronze_path is None
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_postgres_skips_when_no_new_bronze():
+    ti = _make_ti(bronze_path=None)
+    context = {"ti": ti}
+
+    with (
+        patch("scripts.ingest_votes.upsert_votes") as mock_upsert,
+        patch("ingestion.utils.bronze_writer.boto3"),
+    ):
+        from ingestion.dags.dag_votes_batch import upsert_postgres
+
+        upsert_postgres(**context)
+
+    mock_upsert.assert_not_called()
+
+
+def test_upsert_postgres_reads_by_key_not_latest():
+    votes = [{"uid": "V1"}]
+    ti = _make_ti(bronze_path="s3://monelu-bronze/votes/x.json")
+    context = {"ti": ti}
+
+    with (
+        patch(
+            "ingestion.utils.bronze_writer.BronzeWriter.read_by_key", return_value=votes
+        ) as mock_rbk,
+        patch("ingestion.utils.bronze_writer.BronzeWriter.read_latest") as mock_rl,
+        patch("scripts.ingest_votes.upsert_votes") as mock_upsert,
+        patch("ingestion.utils.bronze_writer.boto3"),
+    ):
+        from ingestion.dags.dag_votes_batch import upsert_postgres
+
+        upsert_postgres(**context)
+
+    mock_rbk.assert_called_once_with("s3://monelu-bronze/votes/x.json")
+    mock_rl.assert_not_called()
+    mock_upsert.assert_called_once_with(votes)
+
+
+# ---------------------------------------------------------------------------
+# Deputies DAG — same skip logic
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_deputies_skips_bronze_when_hash_unchanged():
+    deputies = [{"uid": "PA1", "nom": "Martin"}]
+    stable = sorted(deputies, key=lambda d: d.get("uid", ""))
+    expected_hash = hashlib.md5(json.dumps(stable, sort_keys=True).encode()).hexdigest()
+
+    ti = _make_ti()
+    context = {"ti": ti, "ds": "2026-05-17"}
+
+    with (
+        patch("scripts.ingest_deputies.fetch_all_deputies", return_value=deputies),
+        patch(
+            "ingestion.utils.bronze_writer.BronzeWriter.get_last_hash", return_value=expected_hash
+        ),
+        patch("ingestion.utils.bronze_writer.BronzeWriter.write") as mock_write,
+        patch("ingestion.utils.bronze_writer.boto3"),
+    ):
+        from ingestion.dags.dag_deputies_incremental import fetch_deputies
+
+        fetch_deputies(**context)
+
+    mock_write.assert_not_called()
+    assert ti._pushed["bronze_path"] is None
+
+
+def test_upsert_postgres_deputies_reads_by_key_not_latest():
+    deputies = [{"uid": "PA1"}]
+    ti = _make_ti(bronze_path="s3://monelu-bronze/deputies/x.json")
+    context = {"ti": ti}
+
+    with (
+        patch(
+            "ingestion.utils.bronze_writer.BronzeWriter.read_by_key", return_value=deputies
+        ) as mock_rbk,
+        patch("ingestion.utils.bronze_writer.BronzeWriter.read_latest") as mock_rl,
+        patch("scripts.ingest_deputies.upsert_deputies") as mock_upsert,
+        patch("ingestion.utils.bronze_writer.boto3"),
+    ):
+        from ingestion.dags.dag_deputies_incremental import upsert_postgres
+
+        upsert_postgres(**context)
+
+    mock_rbk.assert_called_once_with("s3://monelu-bronze/deputies/x.json")
+    mock_rl.assert_not_called()
+    mock_upsert.assert_called_once_with(deputies)

--- a/tests/test_bronze_writer.py
+++ b/tests/test_bronze_writer.py
@@ -19,10 +19,17 @@ _dag_ctx = MagicMock()
 _dag_ctx.__enter__ = lambda s: s
 _dag_ctx.__exit__ = MagicMock(return_value=False)
 _af.DAG = MagicMock(return_value=_dag_ctx)
+_votes_suite = types.ModuleType("quality.expectations.votes_suite")
+_votes_suite.validate_votes = MagicMock()
+_deputies_suite = types.ModuleType("quality.expectations.deputies_suite")
+_deputies_suite.validate_deputies = MagicMock()
+
 for _name, _mod in [
     ("airflow", _af),
     ("airflow.operators", _af_ops),
     ("airflow.operators.python", _af_ops_py),
+    ("quality.expectations.votes_suite", _votes_suite),
+    ("quality.expectations.deputies_suite", _deputies_suite),
 ]:
     sys.modules.setdefault(_name, _mod)
 


### PR DESCRIPTION
## What
Fixes two high-priority issues from the repo diagnostic: XCom size risk in both Airflow DAGs (#23) and a blank Fernet key that leaves Airflow connection secrets unencrypted in any non-local deployment (#24). Adds 10 new unit tests covering the new logic.

## Why
**#23 — XCom size risk:** Both DAGs were serialising the full parsed dataset through Airflow XCom (~150–300 KB for deputies, potentially larger for votes), which is backed by the metadata DB with a ~48 KB default limit. Silent truncation or an opaque crash under load were the failure modes. The Bronze layer (MinIO/S3) already exists for exactly this purpose.

**#24 — Fernet key:** `AIRFLOW__CORE__FERNET_KEY` was hardcoded to `''` across all three Airflow services. A blank key means connection passwords and variable values are stored in plaintext in the metadata DB. Blocker before any staging/prod Airflow deployment (#17).

## Changes

**`ingestion/dags/dag_votes_batch.py`**
- `fetch_votes`: runs hash-based change detection and Bronze write inline; pushes only the S3 path (or `None` if unchanged) via XCom
- `validate_votes` / `upsert_postgres`: read from Bronze via `read_by_key(bronze_path)` — deterministic, run-scoped, safe under concurrent runs; skip gracefully when `bronze_path` is `None`
- `check_and_write_bronze` → `confirm_bronze`: renamed to reflect that the write happens in `fetch_votes`; task ID updated to match
- Deferred GE imports moved to after the `None` check — skips the GE import entirely on no-change runs
- Hash computed on `sorted(votes, key=lambda v: v.get("uid", ""))` for stable change detection regardless of ZIP ordering

**`ingestion/dags/dag_deputies_incremental.py`**
- Same full rewrite as votes DAG — XCom size bug was identical (577 deputies ≈ 150–300 KB JSON)
- `fetch_deputies`, `validate_deputies`, `confirm_bronze`, `upsert_postgres` all follow the same Bronze-first, path-via-XCom pattern

**`ingestion/utils/bronze_writer.py`**
- Added `read_by_key(path: str)`: reads a specific Bronze file by its full `s3://` path as returned by `write()` — strips the bucket prefix and does a direct `get_object`; no list operation, no recency assumption

**`docker-compose.yml`**
- `AIRFLOW__CORE__FERNET_KEY: ''` → `${AIRFLOW_FERNET_KEY:-}` across all three Airflow service definitions

**`.env.example`**
- Added `AIRFLOW_FERNET_KEY=` with a one-liner generation command

**`tests/test_bronze_writer.py`** (new — 10 tests)
- `read_by_key` prefix stripping and verbatim key passthrough
- `fetch_votes`: hash-match skip path and hash-change write path
- `validate_votes`: skip when `bronze_path=None`; `ValueError` on GE failure
- `upsert_postgres`: skip when `bronze_path=None`; asserts `read_by_key` is called and `read_latest` is not
- Deputies DAG: same skip and `read_by_key` assertions
- Stubs `airflow` and `great_expectations` in `sys.modules` so tests run without those packages installed

## Testing
- `ruff check` — passes on all changed files
- `pytest tests/` — **31/31 passed** (21 original + 10 new), 0 failures

## Risks / Notes
- `confirm_bronze` is a no-op task kept in the DAG graph for Airflow UI visibility. Can be removed in a future cleanup if the graph is simplified.
- `validate_votes` and `upsert_postgres` each do one `get_object` call — two S3 reads per run. Acceptable at current scale.
- Fernet key defaults to `''` for local dev (same as before). **Must set `AIRFLOW_FERNET_KEY` in Railway secrets before any staging/prod Airflow deployment.**
- `great_expectations==0.18.x` is broken on Python 3.14 (tracked in #25) — tests mock it out via `sys.modules`; this does not affect the Railway/CI environment (Python 3.11).

## Breaking Changes
None for production. Both DAGs are Phase 3 and not yet running in production. Local `docker-compose.yml` behaviour is unchanged (Fernet key still defaults to blank).

Closes #23, closes #24