### PR TITLE
fix: call load_dotenv() before internal imports in api and rag modules

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -19,12 +19,12 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from starlette.requests import Request
 
+load_dotenv()
+
 logger = logging.getLogger(__name__)
 
 from api.db import close_pool, get_conn, init_pool  # noqa: E402
 from api.limiter import limiter  # noqa: E402
-
-load_dotenv()
 
 
 @asynccontextmanager

--- a/rag/chain/rag_chain.py
+++ b/rag/chain/rag_chain.py
@@ -10,10 +10,10 @@ import os
 from dotenv import load_dotenv
 from groq import Groq
 
-from rag.chain.prompts import RAG_TEMPLATE, SYSTEM_PROMPT
-from rag.chain.retriever import retrieve
-
 load_dotenv()
+
+from rag.chain.prompts import RAG_TEMPLATE, SYSTEM_PROMPT  # noqa: E402
+from rag.chain.retriever import retrieve  # noqa: E402
 
 _groq_client = Groq(api_key=os.getenv("GROQ_API_KEY"), timeout=30.0)
 

--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -17,6 +17,7 @@ from pgvector.psycopg2 import register_vector
 
 log = logging.getLogger(__name__)
 
+# Must run before os.getenv() calls below so .env is loaded before module-level vars are set.
 load_dotenv()
 
 DATABASE_URL = os.getenv("DATABASE_URL")

--- a/rag/pipeline/chunker.py
+++ b/rag/pipeline/chunker.py
@@ -16,6 +16,7 @@ import psycopg2.extras
 import tiktoken
 from dotenv import load_dotenv
 
+# Must run before os.getenv() calls below so .env is loaded before module-level vars are set.
 load_dotenv()
 
 DATABASE_URL = os.getenv("DATABASE_URL")

--- a/rag/pipeline/index_manager.py
+++ b/rag/pipeline/index_manager.py
@@ -16,10 +16,10 @@ import psycopg2
 import psycopg2.extras
 from dotenv import load_dotenv
 
-from rag.pipeline.chunker import chunk_all
-from rag.pipeline.embedder import embed_and_store
-
 load_dotenv()
+
+from rag.pipeline.chunker import chunk_all  # noqa: E402
+from rag.pipeline.embedder import embed_and_store  # noqa: E402
 
 DATABASE_URL = os.getenv("DATABASE_URL")
 


### PR DESCRIPTION
## What
Move `load_dotenv()` above internal imports in three modules so environment variables are available when those modules are first imported.

## Why
Python executes module-level code at import time. `api.db`, `api.limiter`, `rag.chain.retriever`, `rag.pipeline.chunker`, and `rag.pipeline.embedder` all read from `os.environ` (for `DATABASE_URL`, `GROQ_API_KEY`, `OPENAI_API_KEY`, etc.) when they are imported. Calling `load_dotenv()` after those imports means the `.env` file is never loaded in time — the modules see an empty environment, falling back to `None` for every key. This silently breaks local dev and any environment that relies on a `.env` file.

## Changes
- `api/main.py` — move `load_dotenv()` above imports of `api.db` and `api.limiter`
- `rag/chain/rag_chain.py` — move `load_dotenv()` above imports of `rag.chain.prompts` and `rag.chain.retriever`
- `rag/pipeline/index_manager.py` — move `load_dotenv()` above imports of `rag.pipeline.chunker` and `rag.pipeline.embedder`
- Added `# noqa: E402` to the now-deferred internal imports to satisfy the linter

## Testing
- `venv/bin/ruff check` passes clean on all three files
- No behaviour change in production (Railway sets env vars directly; `load_dotenv()` is a no-op when vars are already set)

## Risks / Notes
- Low risk — purely ordering change, no logic modified
- In practice the bug was masked in production because Railway injects env vars before process start; it would surface in local dev or CI environments relying solely on `.env`

## Breaking Changes
None