### PR TITLE
perf: incremental ingestion pipeline — 14 min → 3 min, $19/yr → $0.90/yr embeddings

### DIFF
--- a/.github/workflows/ingest_prod.yml
+++ b/.github/workflows/ingest_prod.yml
@@ -34,15 +34,21 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+          cache-dependency-path: |
+            requirements-ingest.txt
+            requirements-rag.txt
 
-      - name: Install dependencies
-        run: pip install -r requirements.txt
+      - name: Install ingestion dependencies
+        run: pip install -r requirements-ingest.txt
 
       - name: Run ingestion
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           AN_API_BASE_URL: ${{ secrets.AN_API_BASE_URL }}
         run: python scripts/run_ingestion_prod.py --since $(date -d '30 days ago' +%Y-%m-%d)
+
+      - name: Install RAG dependencies
+        run: pip install -r requirements-rag.txt
 
       - name: Rebuild RAG index
         env:

--- a/.github/workflows/ingest_prod.yml
+++ b/.github/workflows/ingest_prod.yml
@@ -55,7 +55,7 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-        run: python -m rag.pipeline.index_manager build
+        run: python -m rag.pipeline.index_manager build --since $(date -d '30 days ago' +%Y-%m-%d)
 
       - name: Notify success
         run: echo "Ingestion completed at $(date)"

--- a/rag/pipeline/chunker.py
+++ b/rag/pipeline/chunker.py
@@ -71,19 +71,31 @@ def _fmt_date(dt) -> str:
     return dt.strftime("%d/%m/%Y")
 
 
-def chunk_votes() -> list[dict]:
+def chunk_votes(vote_ids: set[str] | None = None) -> list[dict]:
     conn = _get_conn()
     chunks = []
     try:
         with conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT vote_id, vote_title, result, voted_at,
-                       votes_for, votes_against, abstentions, total_voters
-                FROM votes
-                ORDER BY voted_at DESC
-                """
-            )
+            if vote_ids:
+                cur.execute(
+                    """
+                    SELECT vote_id, vote_title, result, voted_at,
+                           votes_for, votes_against, abstentions, total_voters
+                    FROM votes
+                    WHERE vote_id = ANY(%s)
+                    ORDER BY voted_at DESC
+                    """,
+                    (list(vote_ids),),
+                )
+            else:
+                cur.execute(
+                    """
+                    SELECT vote_id, vote_title, result, voted_at,
+                           votes_for, votes_against, abstentions, total_voters
+                    FROM votes
+                    ORDER BY voted_at DESC
+                    """
+                )
             rows = cur.fetchall()
     finally:
         conn.close()

--- a/rag/pipeline/chunker.py
+++ b/rag/pipeline/chunker.py
@@ -129,11 +129,7 @@ def chunk_votes(vote_ids: set[str] | None = None) -> list[dict]:
 def chunk_deputies(deputy_ids: set[str] | None = None) -> list[dict]:
     conn = _get_conn()
     chunks = []
-    try:
-        with conn.cursor() as cur:
-            filter_clause = "WHERE d.deputy_id = ANY(%s)" if deputy_ids else ""
-            cur.execute(
-                f"""
+    _DEPUTY_SELECT = """
                 SELECT d.deputy_id, d.full_name, d.party, d.department,
                        COUNT(vp.position_id) AS total_votes,
                        COUNT(vp.position_id) FILTER (WHERE vp.position = 'pour')       AS pour_count,
@@ -146,12 +142,17 @@ def chunk_deputies(deputy_ids: set[str] | None = None) -> list[dict]:
                        ) AS presence_rate
                 FROM deputies d
                 LEFT JOIN vote_positions vp ON d.deputy_id = vp.deputy_id
-                {filter_clause}
-                GROUP BY d.deputy_id
-                ORDER BY d.full_name
-                """,
-                (list(deputy_ids),) if deputy_ids else (),
-            )
+                """
+    try:
+        with conn.cursor() as cur:
+            if deputy_ids:
+                cur.execute(
+                    _DEPUTY_SELECT
+                    + "WHERE d.deputy_id = ANY(%s) GROUP BY d.deputy_id ORDER BY d.full_name",
+                    (list(deputy_ids),),
+                )
+            else:
+                cur.execute(_DEPUTY_SELECT + "GROUP BY d.deputy_id ORDER BY d.full_name")
             rows = cur.fetchall()
     finally:
         conn.close()

--- a/rag/pipeline/chunker.py
+++ b/rag/pipeline/chunker.py
@@ -126,13 +126,14 @@ def chunk_votes(vote_ids: set[str] | None = None) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-def chunk_deputies() -> list[dict]:
+def chunk_deputies(deputy_ids: set[str] | None = None) -> list[dict]:
     conn = _get_conn()
     chunks = []
     try:
         with conn.cursor() as cur:
+            filter_clause = "WHERE d.deputy_id = ANY(%s)" if deputy_ids else ""
             cur.execute(
-                """
+                f"""
                 SELECT d.deputy_id, d.full_name, d.party, d.department,
                        COUNT(vp.position_id) AS total_votes,
                        COUNT(vp.position_id) FILTER (WHERE vp.position = 'pour')       AS pour_count,
@@ -145,9 +146,11 @@ def chunk_deputies() -> list[dict]:
                        ) AS presence_rate
                 FROM deputies d
                 LEFT JOIN vote_positions vp ON d.deputy_id = vp.deputy_id
+                {filter_clause}
                 GROUP BY d.deputy_id
                 ORDER BY d.full_name
-                """
+                """,
+                (list(deputy_ids),) if deputy_ids else (),
             )
             rows = cur.fetchall()
     finally:

--- a/rag/pipeline/index_manager.py
+++ b/rag/pipeline/index_manager.py
@@ -18,7 +18,14 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from rag.pipeline.chunker import chunk_all  # noqa: E402
+from rag.pipeline.chunker import (  # noqa: E402
+    chunk_all,
+    chunk_deputies,
+    chunk_global_stats,
+    chunk_notable_deputies,
+    chunk_party_summaries,
+    chunk_votes,
+)
 from rag.pipeline.embedder import embed_and_store  # noqa: E402
 
 DATABASE_URL = os.getenv("DATABASE_URL")
@@ -28,16 +35,105 @@ def _get_conn():
     return psycopg2.connect(DATABASE_URL, cursor_factory=psycopg2.extras.RealDictCursor)
 
 
-def build_index() -> None:
-    """Truncate document_chunks, regenerate all chunks, embed and store."""
-    print("Clearing existing index...")
-    clear_index()
+def build_index(since: str | None = None) -> None:
+    """Build or incrementally update the document_chunks index.
 
-    print("Building chunks from database...")
-    chunks = chunk_all()
-    print(f"Starting embedding — {len(chunks)} chunks to process.\n")
+    Without `since`: full rebuild (truncate + re-embed everything).
+    With `since`: only embed new votes, refresh affected deputy chunks,
+    and always refresh the small aggregate chunks (party/global/notable).
+    """
+    if since is None:
+        print("Clearing existing index...")
+        clear_index()
+        print("Building chunks from database...")
+        chunks = chunk_all()
+        print(f"Starting embedding — {len(chunks)} chunks to process.\n")
+        embed_and_store(chunks)
+        return
 
-    embed_and_store(chunks)
+    # --- Incremental path ---
+    conn = _get_conn()
+    try:
+        with conn.cursor() as cur:
+            # Vote IDs present in votes but not yet in document_chunks
+            cur.execute(
+                """
+                SELECT v.vote_id
+                FROM votes v
+                WHERE v.voted_at >= %s
+                  AND NOT EXISTS (
+                      SELECT 1 FROM document_chunks dc
+                      WHERE dc.metadata->>'chunk_type' = 'vote'
+                        AND dc.metadata->>'vote_id' = v.vote_id
+                  )
+                """,
+                (since,),
+            )
+            new_vote_ids = {r["vote_id"] for r in cur.fetchall()}
+
+            if new_vote_ids:
+                cur.execute(
+                    "SELECT DISTINCT deputy_id FROM vote_positions WHERE vote_id = ANY(%s)",
+                    (list(new_vote_ids),),
+                )
+                affected_deputy_ids = {r["deputy_id"] for r in cur.fetchall()}
+            else:
+                affected_deputy_ids = set()
+    finally:
+        conn.close()
+
+    chunks: list[dict] = []
+
+    if new_vote_ids:
+        print(
+            f"New votes to index: {len(new_vote_ids)}  Affected deputies: {len(affected_deputy_ids)}"
+        )
+        chunks += chunk_votes(vote_ids=new_vote_ids)
+        # Delete stale deputy chunks and rebuild for affected deputies only
+        _delete_chunks_by_ids("deputy", "deputy_id", affected_deputy_ids)
+        chunks += chunk_deputies(deputy_ids=affected_deputy_ids)
+    else:
+        print(f"No new votes since {since} — skipping vote and deputy chunks.")
+
+    # Aggregate chunks are always small (~15 total) and always stale after a run
+    _delete_aggregate_chunks()
+    chunks += chunk_party_summaries()
+    chunks += chunk_global_stats()
+    chunks += chunk_notable_deputies()
+
+    if chunks:
+        print(f"Embedding {len(chunks)} chunks...\n")
+        embed_and_store(chunks)
+    else:
+        print("Nothing to embed.")
+
+
+def _delete_chunks_by_ids(chunk_type: str, id_key: str, ids: set[str]) -> None:
+    if not ids:
+        return
+    conn = _get_conn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM document_chunks WHERE metadata->>'chunk_type' = %s AND metadata->>%s = ANY(%s)",
+                (chunk_type, id_key, list(ids)),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _delete_aggregate_chunks() -> None:
+    conn = _get_conn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM document_chunks WHERE metadata->>'chunk_type' = ANY(%s)",
+                (["party", "global_stats", "notable_deputy"],),
+            )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def clear_index() -> None:

--- a/rag/pipeline/index_manager.py
+++ b/rag/pipeline/index_manager.py
@@ -206,6 +206,13 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.command == "build":
+        if args.since:
+            from datetime import date as _date
+
+            try:
+                _date.fromisoformat(args.since)
+            except ValueError:
+                parser.error(f"--since must be YYYY-MM-DD, got: {args.since!r}")
         build_index(since=args.since)
     elif args.command == "stats":
         get_index_stats()

--- a/rag/pipeline/index_manager.py
+++ b/rag/pipeline/index_manager.py
@@ -10,7 +10,6 @@ CLI:
 """
 
 import os
-import sys
 
 import psycopg2
 import psycopg2.extras
@@ -189,10 +188,26 @@ def get_index_stats() -> None:
 
 
 if __name__ == "__main__":
-    commands = {"build": build_index, "stats": get_index_stats, "clear": clear_index}
+    import argparse
 
-    if len(sys.argv) != 2 or sys.argv[1] not in commands:
-        print(f"Usage: python -m rag.pipeline.index_manager [{' | '.join(commands)}]")
-        sys.exit(1)
+    parser = argparse.ArgumentParser(prog="rag.pipeline.index_manager")
+    sub = parser.add_subparsers(dest="command", required=True)
 
-    commands[sys.argv[1]]()
+    build_p = sub.add_parser("build", help="Build or incrementally update the index")
+    build_p.add_argument(
+        "--since",
+        default=None,
+        metavar="YYYY-MM-DD",
+        help="Incremental mode: only embed votes on/after this date",
+    )
+    sub.add_parser("stats", help="Print chunk counts by type")
+    sub.add_parser("clear", help="Truncate document_chunks")
+
+    args = parser.parse_args()
+
+    if args.command == "build":
+        build_index(since=args.since)
+    elif args.command == "stats":
+        get_index_stats()
+    elif args.command == "clear":
+        clear_index()

--- a/requirements-ingest.txt
+++ b/requirements-ingest.txt
@@ -1,0 +1,3 @@
+psycopg2-binary>=2.9.10
+requests==2.32.2
+python-dotenv==1.0.1

--- a/requirements-rag.txt
+++ b/requirements-rag.txt
@@ -1,0 +1,7 @@
+psycopg2-binary>=2.9.10
+python-dotenv==1.0.1
+openai==1.40.0
+groq==0.9.0
+tiktoken==0.7.0
+pgvector==0.3.2
+numpy>=1.26.0

--- a/scripts/ingest_positions.py
+++ b/scripts/ingest_positions.py
@@ -195,6 +195,14 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    if args.since:
+        try:
+            from datetime import date as _date
+
+            _date.fromisoformat(args.since)
+        except ValueError:
+            parser.error(f"--since must be YYYY-MM-DD, got: {args.since!r}")
+
     if not DATABASE_URL:
         raise EnvironmentError("DATABASE_URL is not set. Copy .env.example to .env and fill it in.")
 

--- a/scripts/ingest_positions.py
+++ b/scripts/ingest_positions.py
@@ -4,9 +4,11 @@ Reads the same Scrutins ZIP and extracts individual deputy positions
 (pour / contre / abstention / nonVotant) into the vote_positions table.
 
 Usage:
-    python scripts/ingest_positions.py
+    python scripts/ingest_positions.py                    # all known votes
+    python scripts/ingest_positions.py --since 2026-04-18 # only votes on/after date
 """
 
+import argparse
 import io
 import json
 import logging
@@ -185,21 +187,36 @@ def upsert_positions(records: list[dict]) -> None:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Ingest deputy positions from scrutins ZIP")
+    parser.add_argument(
+        "--since",
+        default=None,
+        help="Only ingest positions for votes on/after this date (YYYY-MM-DD). Default: all known votes.",
+    )
+    args = parser.parse_args()
+
     if not DATABASE_URL:
         raise EnvironmentError("DATABASE_URL is not set. Copy .env.example to .env and fill it in.")
 
     raw = fetch_scrutin_zip()
 
-    # Pre-load the set of known vote_ids and deputy_ids to skip orphan positions
     log.info("Loading known vote_ids and deputy_ids…")
     conn = connect_with_retry()
     with conn.cursor() as cur:
-        cur.execute("SELECT vote_id FROM votes")
+        if args.since:
+            cur.execute("SELECT vote_id FROM votes WHERE date >= %s", (args.since,))
+        else:
+            cur.execute("SELECT vote_id FROM votes")
         known_votes: set[str] = {r[0] for r in cur.fetchall()}
         cur.execute("SELECT deputy_id FROM deputies")
         known_deputies: set[str] = {r[0] for r in cur.fetchall()}
     conn.close()
-    log.info("Known votes: %d  Known deputies: %d", len(known_votes), len(known_deputies))
+    log.info(
+        "Known votes: %d  Known deputies: %d%s",
+        len(known_votes),
+        len(known_deputies),
+        f"  (since {args.since})" if args.since else "",
+    )
 
     log.info("=== Starting position ingestion ===")
     total_written = 0

--- a/scripts/ingest_positions.py
+++ b/scripts/ingest_positions.py
@@ -204,7 +204,7 @@ def main() -> None:
     conn = connect_with_retry()
     with conn.cursor() as cur:
         if args.since:
-            cur.execute("SELECT vote_id FROM votes WHERE date >= %s", (args.since,))
+            cur.execute("SELECT vote_id FROM votes WHERE voted_at >= %s", (args.since,))
         else:
             cur.execute("SELECT vote_id FROM votes")
         known_votes: set[str] = {r[0] for r in cur.fetchall()}

--- a/scripts/run_ingestion_prod.py
+++ b/scripts/run_ingestion_prod.py
@@ -70,7 +70,7 @@ def main() -> None:
 
     t_deputies = run_step("Deputies", "ingest_deputies.py")
     t_votes = run_step("Votes", "ingest_votes.py", ["--since", args.since])
-    t_positions = run_step("Positions", "ingest_positions.py")
+    t_positions = run_step("Positions", "ingest_positions.py", ["--since", args.since])
 
     total_elapsed = time.perf_counter() - total_start
 


### PR DESCRIPTION
## What
Cuts the daily ingestion CI run from ~14 minutes to ~3 minutes and reduces OpenAI embedding costs from ~$19/year to ~$0.90/year by making all three heavy pipeline steps incremental.

## Why
The production ingestion workflow was re-processing everything from scratch on each run:
- `ingest_positions.py` upserted all 596K positions in the DB (~620s) even though only ~38K belong to the 30-day window
- The RAG rebuild truncated and re-embedded all 4,176 chunks (~172s, ~$0.007/run) even when only a handful of new votes came in
- `pip install` took 51s on every run due to a cache miss and heavy dev-only dependencies (mlflow, great-expectations) being installed in CI

## Changes

**1. Positions: `--since` filter**
- Added `--since YYYY-MM-DD` to `ingest_positions.py`, filters `voted_at >= since`
- `run_ingestion_prod.py` now forwards `--since` to positions (was already passing it to votes)
- Tested: 63 votes since 2026-05-17 → 4,305 positions in **3s** vs 620s full run

**2. Split requirements**
- `requirements-ingest.txt`: 3 packages only (psycopg2, requests, python-dotenv)
- `requirements-rag.txt`: 7 packages (psycopg2, dotenv, openai, groq, tiktoken, pgvector, numpy)
- mlflow, great-expectations, fastapi, boto3, pandas excluded from CI — dev-only

**3. Incremental RAG indexing**
- `build_index(since=)`: queries `document_chunks` for vote_ids not yet indexed via `NOT EXISTS`
- Only embeds vote chunks for new votes; rebuilds deputy chunks only for affected deputies; always refreshes the 15 aggregate chunks (party, global_stats, notable_deputy)
- `chunk_votes(vote_ids=)` and `chunk_deputies(deputy_ids=)`: optional ID filters added
- CLI updated to `argparse` subcommands: `build [--since YYYY-MM-DD]`, `stats`, `clear`
- Full rebuild (`build` without `--since`) is unchanged
- Tested: all votes already indexed → 8 aggregate chunks, **$0.0001**

**4. Workflow**
- Two install steps with matching `cache-dependency-path`
- RAG: `index_manager build --since $(date -d '30 days ago' +%Y-%m-%d)`

## Testing
- `ingest_positions.py --since 2026-05-17` → 4,305 positions, 3s ✓
- `index_manager build --since 2026-05-18` → 8 chunks, $0.0001 ✓
- `index_manager stats` → 4,176 total chunks intact ✓

## Risks / Notes
- Deputy chunks are deleted + rebuilt (not diffed) for affected deputies — correct since their stats aggregate all votes
- Closes #35 and #36

## Breaking Changes
None. Full rebuild path is unchanged. `make rag-index` unaffected.