### PR TITLE
security: rate-limit all public endpoints, fix CORS default, and guard SQL table name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ PGADMIN_PASSWORD=admin
 # Assemblée Nationale Open Data API
 AN_API_BASE_URL=https://data.assemblee-nationale.fr
 
-# API — comma-separated origins, or * for dev
+# API — comma-separated allowed origins. Set to * for local dev; leave blank to deny all cross-origin requests.
 CORS_ORIGINS=*
 
 # Phase 2 — RAG pipeline (required for POST /search/)

--- a/api/main.py
+++ b/api/main.py
@@ -97,7 +97,7 @@ app.add_exception_handler(Exception, _unhandled_exception_handler)
 # ---------------------------------------------------------------------------
 # CORS
 # ---------------------------------------------------------------------------
-ALLOWED_ORIGINS = os.getenv("CORS_ORIGINS", "*").split(",")
+ALLOWED_ORIGINS = [o for o in os.getenv("CORS_ORIGINS", "").split(",") if o]
 
 app.add_middleware(
     CORSMiddleware,

--- a/api/routers/deputies.py
+++ b/api/routers/deputies.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, HTTPException, Query
+from starlette.requests import Request
 
 from api.db import get_conn
 from api.limiter import limiter

--- a/api/routers/deputies.py
+++ b/api/routers/deputies.py
@@ -9,7 +9,9 @@ router = APIRouter()
 
 
 @router.get("/", response_model=DeputyListResponse)
+@limiter.limit("30/minute")
 def list_deputies(
+    request: Request,
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0, le=100_000),
     search: str = Query(None, description="Filter by name (case-insensitive)"),
@@ -53,7 +55,8 @@ def list_deputies(
 
 
 @router.get("/{deputy_id}", response_model=DeputyDetail)
-def get_deputy(deputy_id: str):
+@limiter.limit("30/minute")
+def get_deputy(request: Request, deputy_id: str):
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute("SELECT * FROM deputies WHERE deputy_id = %s", (deputy_id,))

--- a/api/routers/votes.py
+++ b/api/routers/votes.py
@@ -1,13 +1,17 @@
 from fastapi import APIRouter, HTTPException, Query
+from starlette.requests import Request
 
 from api.db import get_conn
+from api.limiter import limiter
 from api.schemas import VoteDetail, VoteListResponse, VotePosition, VoteSummary
 
 router = APIRouter()
 
 
 @router.get("/", response_model=VoteListResponse)
+@limiter.limit("30/minute")
 def list_votes(
+    request: Request,
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0, le=100_000),
     result: str = Query(None, description="Filter by result: adopté | rejeté"),
@@ -47,7 +51,8 @@ def list_votes(
 
 
 @router.get("/latest", response_model=list[VoteSummary])
-def latest_votes():
+@limiter.limit("30/minute")
+def latest_votes(request: Request):
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
@@ -64,7 +69,8 @@ def latest_votes():
 
 
 @router.get("/{vote_id}", response_model=VoteDetail)
-def get_vote(vote_id: str):
+@limiter.limit("30/minute")
+def get_vote(request: Request, vote_id: str):
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute("SELECT * FROM votes WHERE vote_id = %s", (vote_id,))

--- a/scripts/run_ingestion_prod.py
+++ b/scripts/run_ingestion_prod.py
@@ -32,7 +32,12 @@ log = logging.getLogger(__name__)
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
+_ALLOWED_TABLES = {"deputies", "votes", "vote_positions", "document_chunks"}
+
+
 def row_count(conn, table: str) -> int:
+    if table not in _ALLOWED_TABLES:
+        raise ValueError(f"Unknown table: {table!r}")
     with conn.cursor() as cur:
         cur.execute(f"SELECT COUNT(*) FROM {table}")
         return cur.fetchone()[0]

--- a/scripts/run_ingestion_prod.py
+++ b/scripts/run_ingestion_prod.py
@@ -19,6 +19,7 @@ from datetime import date, timedelta
 
 import psycopg2
 from dotenv import load_dotenv
+from psycopg2 import sql
 
 load_dotenv()
 
@@ -39,7 +40,7 @@ def row_count(conn, table: str) -> int:
     if table not in _ALLOWED_TABLES:
         raise ValueError(f"Unknown table: {table!r}")
     with conn.cursor() as cur:
-        cur.execute(f"SELECT COUNT(*) FROM {table}")
+        cur.execute(sql.SQL("SELECT COUNT(*) FROM {}").format(sql.Identifier(table)))
         return cur.fetchone()[0]
 
 


### PR DESCRIPTION
## What
Addresses three security issues tracked in the GitHub backlog: a SQL injection vector in the ingestion script, missing rate limits on all public list/detail endpoints, and a wildcard CORS default that should require an explicit opt-in.

## Why
- **#39 (critical)** — `row_count()` in `run_ingestion_prod.py` interpolated the table name directly into a SQL string with no validation. If the argument ever came from an untrusted source, this is a textbook injection vector.
- **#40 (high)** — Only `/deputies/{id}/scorecard` and `/search/` had rate limits. All list and detail endpoints (`GET /deputies/`, `GET /deputies/{id}`, `GET /votes/`, `GET /votes/latest`, `GET /votes/{id}`) were completely unprotected, making it trivial to saturate the DB connection pool.
- **#43 (high)** — `CORS_ORIGINS` defaulted to `"*"`, meaning any production deploy without the env var set would allow all cross-origin requests. The safe default should be to deny all, with wildcard as an explicit dev opt-in.

## Changes
- **`scripts/run_ingestion_prod.py`** — added `_ALLOWED_TABLES` allowlist; `row_count()` raises `ValueError` on any table name not in the set
- **`api/routers/deputies.py`** — added `@limiter.limit("30/minute")` and `request: Request` to `list_deputies` and `get_deputy`; switched `Request` import to `starlette.requests`
- **`api/routers/votes.py`** — imported `limiter` and `Request`; added `@limiter.limit("30/minute")` and `request: Request` to `list_votes`, `latest_votes`, and `get_vote`
- **`api/main.py`** — changed CORS default from `"*"` to `""` (deny all cross-origin by default); filters empty strings after split so an unset var produces `[]` not `[""]`
- **`.env.example`** — updated comment to clarify that `CORS_ORIGINS=*` is a dev-only opt-in

## Testing
- `_ALLOWED_TABLES` rejects unknown table names with `ValueError`
- Rate limit decorators follow the same pattern already verified on `/scorecard` and `/search/`
- CORS: with `CORS_ORIGINS` unset, `ALLOWED_ORIGINS` is now `[]`; with `CORS_ORIGINS=*`, behaviour is unchanged

## Risks / Notes
- **CORS deployment note**: any environment that relies on the `"*"` default (does not set `CORS_ORIGINS`) will reject all cross-origin requests after deploy. Railway already sets `CORS_ORIGINS=*` explicitly — production is unaffected, but worth confirming before merge.
- Rate limit of `30/minute` on list/detail endpoints is deliberately more permissive than `10/minute` on scorecard/search (which hit external APIs). Adjust if needed.
- The `row_count()` allowlist has no operational risk — the four table names are the only ones ever passed at the two call sites.

## Breaking Changes
None for production (Railway sets `CORS_ORIGINS` explicitly). Local dev setups relying on the wildcard default will need `CORS_ORIGINS=*` in `.env` — documented in `.env.example`.

Closes #39, #40, #43