### PR TITLE
fix: DB retry for RAG chain, /search/ response type safety, surface ingestion parse errors

### DIFF
--- a/api/routers/search.py
+++ b/api/routers/search.py
@@ -52,7 +52,12 @@ async def search(request: Request, body: SearchRequest):
             deputy_id=body.deputy_id,
             chunk_type=body.chunk_type,
         )
-        return result
+        return SearchResponse(
+            answer=result["answer"],
+            question=result["question"],
+            chunks_retrieved=result["chunks_retrieved"],
+            sources=[SourceItem(**s) for s in result["sources"]],
+        )
     except groq.APITimeoutError as e:
         raise HTTPException(
             status_code=504,

--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -15,6 +15,8 @@ from dotenv import load_dotenv
 from openai import OpenAI
 from pgvector.psycopg2 import register_vector
 
+from rag.db_utils import connect_with_retry
+
 log = logging.getLogger(__name__)
 
 # Must run before os.getenv() calls below so .env is loaded before module-level vars are set.
@@ -60,7 +62,7 @@ def retrieve(
     response = client.embeddings.create(input=[question], model=EMBEDDING_MODEL)
     query_vector = np.array(response.data[0].embedding, dtype=np.float32)
 
-    conn = psycopg2.connect(DATABASE_URL, cursor_factory=psycopg2.extras.RealDictCursor)
+    conn = connect_with_retry(DATABASE_URL, cursor_factory=psycopg2.extras.RealDictCursor)
     try:
         # register_vector must receive a plain cursor — RealDictCursor breaks
         # its internal dict(fetchall()) unpacking

--- a/rag/db_utils.py
+++ b/rag/db_utils.py
@@ -32,3 +32,4 @@ def connect_with_retry(database_url: str, **kwargs) -> psycopg2.extensions.conne
                 _MAX_RETRIES,
             )
             time.sleep(wait)
+    raise RuntimeError("connect_with_retry: exhausted retries without raising")

--- a/rag/db_utils.py
+++ b/rag/db_utils.py
@@ -1,0 +1,34 @@
+"""
+rag/db_utils.py
+
+Shared DB connection helper for the RAG pipeline.
+"""
+
+import logging
+import time
+
+import psycopg2
+
+log = logging.getLogger(__name__)
+
+_MAX_RETRIES = 5
+_BACKOFF_BASE = 2  # seconds
+
+
+def connect_with_retry(database_url: str, **kwargs) -> psycopg2.extensions.connection:
+    """Open a psycopg2 connection with exponential-backoff retry on transient errors."""
+    for attempt in range(_MAX_RETRIES):
+        try:
+            return psycopg2.connect(database_url, **kwargs)
+        except psycopg2.OperationalError as exc:
+            if attempt == _MAX_RETRIES - 1:
+                raise
+            wait = _BACKOFF_BASE**attempt
+            log.warning(
+                "DB connection failed (%s). Retrying in %ss… (attempt %d/%d)",
+                exc,
+                wait,
+                attempt + 1,
+                _MAX_RETRIES,
+            )
+            time.sleep(wait)

--- a/rag/pipeline/embedder.py
+++ b/rag/pipeline/embedder.py
@@ -18,6 +18,8 @@ from dotenv import load_dotenv
 from openai import OpenAI, RateLimitError
 from pgvector.psycopg2 import register_vector
 
+from rag.db_utils import connect_with_retry
+
 load_dotenv()
 
 DATABASE_URL = os.getenv("DATABASE_URL")
@@ -58,7 +60,7 @@ def embed_and_store(chunks: list[dict], batch_size: int = 100) -> None:
         texts = [c["content"] for c in batch]
         embeddings, tokens_used = _embed_batch(client, texts)
 
-        conn = psycopg2.connect(DATABASE_URL)
+        conn = connect_with_retry(DATABASE_URL)
         try:
             register_vector(conn)
             with conn.cursor() as cur:

--- a/scripts/ingest_deputies.py
+++ b/scripts/ingest_deputies.py
@@ -163,7 +163,7 @@ def parse_deputy(item: dict) -> dict | None:
             "photo_url": photo_url,
         }
     except Exception as exc:
-        log.debug("Could not parse deputy item: %s — %s", item, exc)
+        log.warning("Could not parse deputy item (uid=%s): %s", item.get("uid"), exc)
         return None
 
 
@@ -210,11 +210,17 @@ def _upsert_records(records: list[dict]) -> None:
 def upsert_deputies(raw_items: list[dict]) -> int:
     """Parse raw acteur dicts and upsert into deputies table. Returns count written."""
     records = [r for item in raw_items if (r := parse_deputy(item)) is not None]
-    log.info(
-        "Parsed %d valid records (skipped %d unparseable).",
-        len(records),
-        len(raw_items) - len(records),
-    )
+    skipped = len(raw_items) - len(records)
+    skip_rate = skipped / len(raw_items) if raw_items else 0.0
+    log.info("Parsed %d valid records (skipped %d unparseable).", len(records), skipped)
+    if skip_rate > 0.05:
+        log.error(
+            "High parse failure rate: %d/%d records skipped (%.0f%%). "
+            "Check the AN data format for unexpected changes.",
+            skipped,
+            len(raw_items),
+            skip_rate * 100,
+        )
     _upsert_records(records)
     return len(records)
 


### PR DESCRIPTION
## What
Fixes three production bugs: the RAG retriever and embedder crash on any transient DB error, the `/search/` endpoint's response type relies on implicit Pydantic coercion that can silently drop fields, and ingestion parse failures are swallowed at DEBUG level with no visibility.

## Why
- **#42 (high)** — `retriever.py` and `embedder.py` call `psycopg2.connect()` directly with no retry. A transient DB hiccup (connection reset, brief overload) raises `OperationalError` and crashes the entire `POST /search/` request. The ingest scripts have HTTP retry logic but DB connections had none.
- **#45 (medium)** — `ask()` returns `{"sources": list[dict]}` but `SearchResponse.sources` is typed as `list[SourceItem]`. FastAPI silently coerces this at serialisation time. If a chunk dict ever gains or loses a field, this breaks at runtime with no type-system warning.
- **#46 (medium)** — `parse_deputy()` logs failures at `DEBUG`, meaning silently dropped records are invisible in production logs. A format change in the AN open data export would cause 0 deputies to be ingested with no alert.

## Changes
- **`rag/db_utils.py`** *(new)* — `connect_with_retry()`: exponential backoff over 5 attempts on `psycopg2.OperationalError`, shared by retriever and embedder
- **`rag/chain/retriever.py`** — replaces `psycopg2.connect()` with `connect_with_retry()`
- **`rag/pipeline/embedder.py`** — replaces `psycopg2.connect()` with `connect_with_retry()`
- **`api/routers/search.py`** — explicitly constructs `SearchResponse(sources=[SourceItem(**s) for s in ...])` instead of returning the raw dict; the type contract is now enforced at the call site
- **`scripts/ingest_deputies.py`** — parse failures raised from `DEBUG` → `WARNING` with uid in the message; `upsert_deputies()` emits `ERROR` when skip rate exceeds 5%

## Testing
- `connect_with_retry()` retries on `OperationalError` and re-raises on the 5th failure
- `SourceItem(**s)` construction is validated by Pydantic at request time — a missing field raises `ValidationError` immediately rather than silently
- Parse failure logging verified by reading the updated code path

## Risks / Notes
- The retry backoff in `connect_with_retry()` waits 1s, 2s, 4s, 8s between attempts. For `POST /search/` (live web request), worst-case added latency is ~15s before the final `OperationalError` bubbles up to a 500. This is acceptable given that the alternative is an immediate crash.
- No change to the actual query logic, response shape, or ingestion SQL.

## Breaking Changes
None.

Closes #42, #45, #46