### PR TITLE
fix: sql-safe WHERE clause builder and 10k offset cap on list endpoints

### DIFF
--- a/api/routers/deputies.py
+++ b/api/routers/deputies.py
@@ -40,11 +40,11 @@ def list_deputies(
             total = cur.fetchone()["count"]
 
             cur.execute(
-                sql.SQL(
-                    "SELECT deputy_id, full_name, party, party_short,"
-                    " department, circonscription, photo_url"
-                    " FROM deputies {} ORDER BY last_name, first_name LIMIT %s OFFSET %s"
-                ).format(where),
+                sql.SQL("""
+                    SELECT deputy_id, full_name, party, party_short,
+                           department, circonscription, photo_url
+                    FROM deputies {} ORDER BY last_name, first_name LIMIT %s OFFSET %s
+                """).format(where),
                 params + [limit, offset],
             )
             rows = cur.fetchall()

--- a/api/routers/deputies.py
+++ b/api/routers/deputies.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, HTTPException, Query
+from psycopg2 import sql
 from starlette.requests import Request
 
 from api.db import get_conn
@@ -13,35 +14,37 @@ router = APIRouter()
 def list_deputies(
     request: Request,
     limit: int = Query(50, ge=1, le=200),
-    offset: int = Query(0, ge=0, le=100_000),
+    offset: int = Query(0, ge=0, le=10_000),
     search: str = Query(None, description="Filter by name (case-insensitive)"),
     department: str = Query(None),
 ):
     with get_conn() as conn:
         with conn.cursor() as cur:
-            filters = []
+            conditions: list[sql.Composable] = []
             params: list = []
 
             if search:
-                filters.append("full_name ILIKE %s")
+                conditions.append(sql.SQL("full_name ILIKE %s"))
                 params.append(f"%{search}%")
             if department:
-                filters.append("department = %s")
+                conditions.append(sql.SQL("department = %s"))
                 params.append(department)
 
-            where = ("WHERE " + " AND ".join(filters)) if filters else ""
+            where = (
+                sql.SQL(" WHERE ") + sql.SQL(" AND ").join(conditions)
+                if conditions
+                else sql.SQL("")
+            )
 
-            cur.execute(f"SELECT COUNT(*) FROM deputies {where}", params)
+            cur.execute(sql.SQL("SELECT COUNT(*) FROM deputies") + where, params)
             total = cur.fetchone()["count"]
 
             cur.execute(
-                f"""
-                SELECT deputy_id, full_name, party, party_short,
-                       department, circonscription, photo_url
-                FROM deputies {where}
-                ORDER BY last_name, first_name
-                LIMIT %s OFFSET %s
-                """,
+                sql.SQL(
+                    "SELECT deputy_id, full_name, party, party_short,"
+                    " department, circonscription, photo_url"
+                    " FROM deputies {} ORDER BY last_name, first_name LIMIT %s OFFSET %s"
+                ).format(where),
                 params + [limit, offset],
             )
             rows = cur.fetchall()

--- a/api/routers/votes.py
+++ b/api/routers/votes.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, HTTPException, Query
+from psycopg2 import sql
 from starlette.requests import Request
 
 from api.db import get_conn
@@ -13,31 +14,33 @@ router = APIRouter()
 def list_votes(
     request: Request,
     limit: int = Query(50, ge=1, le=200),
-    offset: int = Query(0, ge=0, le=100_000),
+    offset: int = Query(0, ge=0, le=10_000),
     result: str = Query(None, description="Filter by result: adopté | rejeté"),
 ):
     with get_conn() as conn:
         with conn.cursor() as cur:
-            filters = []
+            conditions: list[sql.Composable] = []
             params: list = []
 
             if result:
-                filters.append("result = %s")
+                conditions.append(sql.SQL("result = %s"))
                 params.append(result)
 
-            where = ("WHERE " + " AND ".join(filters)) if filters else ""
+            where = (
+                sql.SQL(" WHERE ") + sql.SQL(" AND ").join(conditions)
+                if conditions
+                else sql.SQL("")
+            )
 
-            cur.execute(f"SELECT COUNT(*) FROM votes {where}", params)
+            cur.execute(sql.SQL("SELECT COUNT(*) FROM votes") + where, params)
             total = cur.fetchone()["count"]
 
             cur.execute(
-                f"""
-                SELECT vote_id, voted_at, vote_title, result,
-                       votes_for, votes_against, abstentions, total_voters
-                FROM votes {where}
-                ORDER BY voted_at DESC
-                LIMIT %s OFFSET %s
-                """,
+                sql.SQL(
+                    "SELECT vote_id, voted_at, vote_title, result,"
+                    " votes_for, votes_against, abstentions, total_voters"
+                    " FROM votes {} ORDER BY voted_at DESC LIMIT %s OFFSET %s"
+                ).format(where),
                 params + [limit, offset],
             )
             rows = cur.fetchall()

--- a/api/routers/votes.py
+++ b/api/routers/votes.py
@@ -36,11 +36,11 @@ def list_votes(
             total = cur.fetchone()["count"]
 
             cur.execute(
-                sql.SQL(
-                    "SELECT vote_id, voted_at, vote_title, result,"
-                    " votes_for, votes_against, abstentions, total_voters"
-                    " FROM votes {} ORDER BY voted_at DESC LIMIT %s OFFSET %s"
-                ).format(where),
+                sql.SQL("""
+                    SELECT vote_id, voted_at, vote_title, result,
+                           votes_for, votes_against, abstentions, total_voters
+                    FROM votes {} ORDER BY voted_at DESC LIMIT %s OFFSET %s
+                """).format(where),
                 params + [limit, offset],
             )
             rows = cur.fetchall()


### PR DESCRIPTION
## What
Replaces the mutable `filters` list pattern in the deputies and votes list endpoints with `psycopg2.sql` composable objects, and lowers the maximum pagination offset from 100,000 to 10,000.

## Why
- **#44 (medium/security)** — The current pattern builds a WHERE clause by appending raw strings to a `filters` list and joining them into an f-string. While the strings are currently hardcoded literals, the pattern is a footgun: a future developer adding a filter could accidentally append a user-controlled string, producing SQL injection. By typing all SQL fragments as `sql.SQL(...)` (a `sql.Composable` subtype), the boundary is enforced at the type level — user values can only appear as `%s` parameters, never as SQL fragments.
- **#51 (medium/performance)** — `offset=100000&limit=200` forced Postgres to scan and discard 100,000 rows. With at most ~577 deputies and ~3,000 votes, an offset above 10,000 is never legitimate and only enables abuse. Option A from the issue (cap at 10,000) is the correct quick fix.

## Changes
- **`api/routers/deputies.py`**
  - Added `from psycopg2 import sql`
  - Replaced `filters: list[str]` with `conditions: list[sql.Composable]`
  - WHERE clause built via `sql.SQL(" WHERE ") + sql.SQL(" AND ").join(conditions)`
  - Query executed via `sql.SQL("...").format(where)` — no f-strings
  - `offset` cap: `le=100_000` → `le=10_000`
- **`api/routers/votes.py`** — same changes

## Testing
- No behaviour change for valid requests; all existing filter combinations still work
- A request with `offset=50000` now returns HTTP 422 (FastAPI validation) instead of executing
- Verified with `ruff` — no linting issues

## Risks / Notes
- **Pagination breaking change**: clients relying on `offset > 10_000` will now get a 422. Given the dataset size (577 deputies, ~3,000 votes), no legitimate client should be paging that deep.
- `psycopg2.sql` is already a transitive dependency (psycopg2 is in `requirements.txt`); no new package needed.

## Breaking Changes
`offset` parameter maximum reduced from 100,000 to 10,000 on `GET /deputies/` and `GET /votes/`.

Closes #44, #51