### PR TITLE
rag: centralise constants and externalise notable deputies config

### DIFF
--- a/rag/chain/rag_chain.py
+++ b/rag/chain/rag_chain.py
@@ -14,6 +14,7 @@ load_dotenv()
 
 from rag.chain.prompts import RAG_TEMPLATE, SYSTEM_PROMPT  # noqa: E402
 from rag.chain.retriever import retrieve  # noqa: E402
+from rag.constants import LLM_MODEL  # noqa: E402
 
 _groq_client = Groq(api_key=os.getenv("GROQ_API_KEY"), timeout=30.0)
 
@@ -30,7 +31,7 @@ def ask(
     user_message = RAG_TEMPLATE.format(context=context, question=question)
 
     response = _groq_client.chat.completions.create(
-        model="llama-3.3-70b-versatile",
+        model=LLM_MODEL,
         messages=[
             {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user", "content": user_message},

--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -5,8 +5,10 @@ Retrieves relevant chunks from document_chunks using cosine similarity
 via pgvector. The query is embedded with the same model used at index time.
 """
 
+import json
 import logging
 import os
+from pathlib import Path
 
 import numpy as np
 import psycopg2
@@ -15,6 +17,7 @@ from dotenv import load_dotenv
 from openai import OpenAI
 from pgvector.psycopg2 import register_vector
 
+from rag.constants import EMBEDDING_MODEL, IVFFLAT_PROBES
 from rag.db_utils import connect_with_retry
 
 log = logging.getLogger(__name__)
@@ -23,12 +26,13 @@ log = logging.getLogger(__name__)
 load_dotenv()
 
 DATABASE_URL = os.getenv("DATABASE_URL")
-EMBEDDING_MODEL = "text-embedding-3-small"
 
-
-NOTABLE_DEPUTY_NAMES = {
-    "attal": "PA722190",
-    "le pen": "PA720614",
+_NOTABLE_DEPUTIES: dict = json.loads(
+    (Path(__file__).parent.parent / "notable_deputies.json").read_text()
+)
+# Map each keyword → deputy_id for fast question matching
+NOTABLE_DEPUTY_NAMES: dict[str, str] = {
+    kw: dep_id for dep_id, info in _NOTABLE_DEPUTIES.items() for kw in info["keywords"]
 }
 
 
@@ -93,7 +97,7 @@ def retrieve(
 
             semantic_k = k - len(pinned)
             pinned_ids = {p["metadata"].get("deputy_id") for p in pinned}
-            cur.execute("SET LOCAL ivfflat.probes = 10")
+            cur.execute("SET LOCAL ivfflat.probes = %s", (IVFFLAT_PROBES,))
             cur.execute(
                 """
                 SELECT content, metadata,

--- a/rag/constants.py
+++ b/rag/constants.py
@@ -1,0 +1,8 @@
+import os
+
+EMBEDDING_MODEL = "text-embedding-3-small"
+LLM_MODEL = "llama-3.3-70b-versatile"
+
+# probes ≈ sqrt(IVFFlat lists). Default lists=100 → probes=10.
+# Raise if chunk count grows significantly past ~50k.
+IVFFLAT_PROBES = int(os.getenv("IVFFLAT_PROBES", "10"))

--- a/rag/notable_deputies.json
+++ b/rag/notable_deputies.json
@@ -1,0 +1,12 @@
+{
+  "PA722190": {
+    "name": "Gabriel Attal",
+    "bio": "Ancien Premier ministre (janvier 2025).",
+    "keywords": ["attal"]
+  },
+  "PA720614": {
+    "name": "Marine Le Pen",
+    "bio": "Cheffe de file du Rassemblement National.",
+    "keywords": ["le pen"]
+  }
+}

--- a/rag/pipeline/chunker.py
+++ b/rag/pipeline/chunker.py
@@ -8,8 +8,10 @@ Produces two types of text chunks for embedding:
 Each chunk is {"content": str, "metadata": dict}.
 """
 
+import json
 import os
 import warnings
+from pathlib import Path
 
 import psycopg2
 import psycopg2.extras
@@ -344,18 +346,9 @@ def chunk_global_stats() -> list[dict]:
 # Strategy E — Notable deputy chunks (detailed vote-by-vote, top profiles)
 # ---------------------------------------------------------------------------
 
-NOTABLE_DEPUTIES: dict[str, dict] = {
-    "PA722190": {
-        "name": "Gabriel Attal",
-        "bio": "Ancien Premier ministre (janvier 2025).",
-        "keywords": ["attal"],
-    },
-    "PA720614": {
-        "name": "Marine Le Pen",
-        "bio": "Cheffe de file du Rassemblement National.",
-        "keywords": ["le pen"],
-    },
-}
+NOTABLE_DEPUTIES: dict[str, dict] = json.loads(
+    (Path(__file__).parent.parent / "notable_deputies.json").read_text()
+)
 
 
 def chunk_notable_deputies() -> list[dict]:

--- a/rag/pipeline/embedder.py
+++ b/rag/pipeline/embedder.py
@@ -18,12 +18,12 @@ from dotenv import load_dotenv
 from openai import OpenAI, RateLimitError
 from pgvector.psycopg2 import register_vector
 
+from rag.constants import EMBEDDING_MODEL
 from rag.db_utils import connect_with_retry
 
 load_dotenv()
 
 DATABASE_URL = os.getenv("DATABASE_URL")
-EMBEDDING_MODEL = "text-embedding-3-small"
 COST_PER_1M_TOKENS = 0.020  # USD
 
 


### PR DESCRIPTION
## What
Introduces `rag/constants.py` and `rag/notable_deputies.json` to eliminate duplicated magic strings scattered across the RAG pipeline.

## Why
`EMBEDDING_MODEL`, `LLM_MODEL`, and `IVFFLAT_PROBES` were duplicated in 3+ files with no single source of truth — a rename would require hunting across the codebase. `NOTABLE_DEPUTIES` was hardcoded in `chunker.py`, meaning adding or removing a notable deputy required a code change and redeploy.

## Changes
- **`rag/constants.py`** (new): `EMBEDDING_MODEL`, `LLM_MODEL`, `IVFFLAT_PROBES` — probes is env-overridable (`IVFFLAT_PROBES`) with a comment explaining the `sqrt(lists)` derivation
- **`rag/notable_deputies.json`** (new): deputy IDs, names, bios, and keyword matchers — edit this file to add/remove notable deputies without touching Python
- **`rag/pipeline/embedder.py`**: imports `EMBEDDING_MODEL` from `rag.constants`
- **`rag/chain/retriever.py`**: imports `EMBEDDING_MODEL`, `IVFFLAT_PROBES`; derives `NOTABLE_DEPUTY_NAMES` from the JSON; uses parameterised `SET LOCAL` for probes
- **`rag/chain/rag_chain.py`**: imports `LLM_MODEL` from `rag.constants`
- **`rag/pipeline/chunker.py`**: loads `NOTABLE_DEPUTIES` from the JSON at import time

## Testing
- Pre-commit hooks pass (ruff, detect-secrets)
- No behaviour change — only source of constants moved

## Risks / Notes
- `notable_deputies.json` must be present at deploy time — it's committed to the repo so this is safe
- `IVFFLAT_PROBES` env var allows runtime tuning without a code deploy

## Breaking Changes
None — pure refactor, no API or data changes.

Closes #49
Closes #52
Closes #54