### PR TITLE
perf: add missing indexes for full_name, vote_title, and created_at

### DIFF
--- a/data/migrations/001_init.sql
+++ b/data/migrations/001_init.sql
@@ -46,6 +46,8 @@ CREATE INDEX IF NOT EXISTS idx_positions_vote     ON vote_positions(vote_id);
 CREATE INDEX IF NOT EXISTS idx_vote_positions_pos ON vote_positions(position);
 CREATE INDEX IF NOT EXISTS idx_votes_voted_at     ON votes(voted_at DESC);
 CREATE INDEX IF NOT EXISTS idx_deputies_party     ON deputies(party_short);
+CREATE INDEX IF NOT EXISTS idx_deputies_full_name ON deputies(full_name);
+CREATE INDEX IF NOT EXISTS idx_votes_vote_title   ON votes(vote_title);
 
 -- ---------------------------------------------------------------------------
 -- Phase 2: semantic search via pgvector
@@ -67,6 +69,8 @@ CREATE TABLE IF NOT EXISTS document_chunks (
 CREATE INDEX IF NOT EXISTS idx_chunks_embedding
     ON document_chunks USING ivfflat (embedding vector_cosine_ops)
     WITH (lists = 100);
+
+CREATE INDEX IF NOT EXISTS idx_chunks_created_at  ON document_chunks(created_at);
 
 -- ---------------------------------------------------------------------------
 -- Row-Level Security


### PR DESCRIPTION
## What
Adds three missing indexes to `data/migrations/001_init.sql`.

## Why
The three columns were used in query patterns but had no index:
- `deputies.full_name` — the `GET /deputies/?search=` endpoint runs `ILIKE %s%` full-table scans (577 rows today, grows with each legislature)
- `votes.vote_title` — `GET /votes/` has a title filter; the table grows by ~10 rows/week
- `document_chunks.created_at` — needed for future TTL / chunk-refresh cleanup queries; cheaper to add now than retroactively on a large table

## Changes
- `data/migrations/001_init.sql`: three new `CREATE INDEX IF NOT EXISTS` statements
  - `idx_deputies_full_name` placed with the existing Phase 1 indexes
  - `idx_votes_vote_title` placed with the existing Phase 1 indexes
  - `idx_chunks_created_at` placed after `document_chunks` table creation (required — table must exist before its index)

## Testing
- Migration is idempotent (`IF NOT EXISTS`) — safe to re-run on prod Supabase and local Docker
- Run `make migrate` locally to apply

## Risks / Notes
- **Production deployment**: these `CREATE INDEX IF NOT EXISTS` statements run as part of `scripts/migrate.py` on every Railway deploy. On a live table they take a brief lock; at current row counts (<4k chunks, <600 deputies, <1k votes) this is sub-second.
- No application code changes — indexes are transparent to the query layer.

## Breaking Changes
None.

Closes #50