### PR TITLE
tests: add edge-case coverage for API boundary conditions

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 """Smoke tests for API routers — no real DB required."""
 
-from unittest.mock import patch
+import asyncio
+from unittest.mock import MagicMock, patch
 
 import groq
 import httpx
@@ -60,10 +61,17 @@ _POSITION = {
 
 def test_health_ok(client, mock_cursor):
     mock_cursor.fetchone.side_effect = [{"count": 577}, {"count": 821}, {"count": 289_411}]
-    resp = client.get("/health")
+    with patch.dict(
+        "os.environ",
+        {"OPENAI_API_KEY": "sk-real", "GROQ_API_KEY": "gsk_real"},  # pragma: allowlist secret
+    ):
+        resp = client.get("/health")
     assert resp.status_code == 200
     data = resp.json()
     assert data["status"] == "ok"
+    assert data["db"] == "ok"
+    assert data["openai"] == "ok"
+    assert data["groq"] == "ok"
     assert data["deputies"] == 577
     assert data["votes"] == 821
     assert data["positions"] == 289_411
@@ -72,8 +80,9 @@ def test_health_ok(client, mock_cursor):
 def test_health_db_unavailable(client):
     with patch.object(_db, "_pool", None):
         resp = client.get("/health")
-    assert resp.status_code == 200
+    assert resp.status_code == 207
     assert resp.json()["status"] == "degraded"
+    assert resp.json()["db"] == "degraded"
 
 
 # ---------------------------------------------------------------------------
@@ -189,3 +198,91 @@ def test_search_groq_timeout_returns_504(client):
     with patch("api.routers.search.ask", side_effect=exc):
         resp = client.post("/search/", json={"question": "Combien de députés RN ?"})
     assert resp.status_code == 504
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — boundary conditions (issue #57)
+# ---------------------------------------------------------------------------
+
+
+def test_scorecard_zero_votes(client, mock_cursor):
+    """Deputy who has never voted — division-by-zero guards must yield 0.0."""
+    mock_cursor.fetchone.side_effect = [
+        {"deputy_id": "PA99", "full_name": "Nouveau Député"},
+        {
+            "total_votes": 0,
+            "present_votes": 0,
+            "votes_for": 0,
+            "votes_against": 0,
+            "abstentions": 0,
+        },
+    ]
+    resp = client.get("/deputies/PA99/scorecard")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["presence_rate"] == 0.0
+    assert data["votes_for_pct"] == 0.0
+    assert data["abstention_pct"] == 0.0
+
+
+def test_search_empty_chunks(client):
+    """ask() returning zero chunks must yield 200 with an empty sources list, not 500."""
+    empty = {"answer": "Aucune information.", "question": "?", "chunks_retrieved": 0, "sources": []}
+    with patch("api.routers.search.ask", return_value=empty):
+        resp = client.post("/search/", json={"question": "Question sans résultat ?"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["chunks_retrieved"] == 0
+    assert data["sources"] == []
+
+
+def test_list_deputies_offset_exceeds_max(client):
+    """offset > 10_000 is rejected by FastAPI query validation."""
+    resp = client.get("/deputies/?offset=10001")
+    assert resp.status_code == 422
+
+
+def test_list_votes_offset_exceeds_max(client):
+    """offset > 10_000 is rejected by FastAPI query validation."""
+    resp = client.get("/votes/?offset=10001")
+    assert resp.status_code == 422
+
+
+def test_rate_limit_handler_includes_retry_after():
+    """429 response from _rate_limit_handler must carry a Retry-After header."""
+    from limits import parse as parse_limit
+    from slowapi.errors import RateLimitExceeded
+    from starlette.requests import Request as StarletteRequest
+
+    from api.main import _rate_limit_handler
+
+    limit_item = parse_limit("30/minute")
+    mock_limit = MagicMock()
+    mock_limit.limit = limit_item
+
+    exc = RateLimitExceeded(mock_limit)
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/deputies/",
+        "headers": [],
+        "query_string": b"",
+    }
+    request = StarletteRequest(scope)
+
+    response = asyncio.run(_rate_limit_handler(request, exc))
+    assert response.status_code == 429
+    assert "Retry-After" in response.headers
+    assert int(response.headers["Retry-After"]) == 60
+
+
+def test_health_degraded_when_openai_key_is_placeholder(client, mock_cursor):
+    """Health endpoint returns 207 and marks openai=degraded when key is a placeholder."""
+    mock_cursor.fetchone.side_effect = [{"count": 577}, {"count": 821}, {"count": 289_411}]
+    with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-..."}):  # pragma: allowlist secret
+        resp = client.get("/health")
+    assert resp.status_code == 207
+    data = resp.json()
+    assert data["status"] == "degraded"
+    assert data["openai"] == "degraded"
+    assert data["db"] == "ok"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -220,6 +220,7 @@ def test_scorecard_zero_votes(client, mock_cursor):
     resp = client.get("/deputies/PA99/scorecard")
     assert resp.status_code == 200
     data = resp.json()
+    assert data["total_votes"] == 0
     assert data["presence_rate"] == 0.0
     assert data["votes_for_pct"] == 0.0
     assert data["abstention_pct"] == 0.0


### PR DESCRIPTION
## What
Adds 6 new edge-case tests and fixes 2 existing tests in `tests/test_api.py` to cover boundary conditions identified in issue #57.

## Why
The existing smoke suite didn't cover: division-by-zero in scorecard when a deputy has 0 votes, empty RAG results, pagination offset overflow, rate-limit `Retry-After` header correctness, and placeholder API key detection in the health endpoint. Two existing tests were also stale after the health endpoint was updated to return 207 on degradation.

## Changes
- **`tests/test_api.py`**
  - `test_health_ok`: now patches `OPENAI_API_KEY` / `GROQ_API_KEY` to real-looking values and asserts `db`, `openai`, `groq` fields are all `"ok"`
  - `test_health_db_unavailable`: updated assertion from `200` → `207` and added `db == "degraded"` check
  - `test_scorecard_zero_votes` (new): deputy with 0 total votes → `presence_rate`, `votes_for_pct`, `abstention_pct` all return `0.0`, not a ZeroDivisionError
  - `test_search_empty_chunks` (new): `ask()` returning 0 chunks → 200 with `sources: []`, not 500
  - `test_list_deputies_offset_exceeds_max` (new): `offset=10001` → 422 from FastAPI validation
  - `test_list_votes_offset_exceeds_max` (new): same for `/votes/`
  - `test_rate_limit_handler_includes_retry_after` (new): 429 response carries `Retry-After: 60` header
  - `test_health_degraded_when_openai_key_is_placeholder` (new): `sk-...` placeholder → 207 with `openai: degraded`

## Testing
- `pytest tests/test_api.py` — 19 tests, all pass

## Risks / Notes
- No production code changed — test-only PR.
- `# pragma: allowlist secret` on lines containing test placeholder keys to satisfy `detect-secrets`.

## Breaking Changes
None

Closes #57