### PR TITLE
dbt: pin local dbt version to 1.9 to match CI

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
 pytest>=8.0.0
 detect-secrets==1.5.0
+dbt-core>=1.9,<1.10
+dbt-postgres>=1.9,<1.10


### PR DESCRIPTION
## What
Pin `dbt-core` and `dbt-postgres` to `>=1.9,<1.10` in `requirements-dev.txt` to match the version already used in CI.

## Why
Local venv was running `dbt=1.12.0-b1` (a pre-release) while `ci.yml`, `ingest_prod.yml`, and `dbt_docs.yml` all pin to `>=1.9,<1.10`. The mismatch had a concrete consequence: dbt 1.12 introduced a new convention where generic test parameters must be nested under an `arguments:` key, while dbt 1.9 expects them at the top level without that wrapper. Any developer running `dbt test` locally got a different evaluation of `schema.yml` than CI — and any linter or dbt feedback loop would flip the syntax back and forth. Tracked in #78.

## Changes
- `requirements-dev.txt`: added `dbt-core>=1.9,<1.10` and `dbt-postgres>=1.9,<1.10`

Note: `transform/profiles.yml` was also corrected locally (prod `DBT_PORT` default from `6543` → `5432` to match the CI heredoc), but that file is untracked by git. The fix is on disk.

## Testing
- Pre-commit hooks passed
- No logic change, no SQL touched

## Risks / Notes
- Developers with the old venv need to re-run `pip install -r requirements-dev.txt`
- This unblocks #75 (schema.yml test syntax): once everyone is on 1.9, the correct syntax (no `arguments:` wrapper) is unambiguous

## Breaking Changes
None. CI was already on 1.9 — only local dev environments are affected.

Closes #78