### PR TITLE
dbt: fix vacuous recency test and document nonVotant casing

### DIFF
--- a/transform/models/marts/mart_deputy_scorecard.sql
+++ b/transform/models/marts/mart_deputy_scorecard.sql
@@ -10,6 +10,10 @@ total_votes as (
     select count(*) as total from {{ ref('stg_votes') }}
 ),
 
+last_ingested as (
+    select max(ingested_at) as ingested_at from {{ ref('stg_vote_positions') }}
+),
+
 deputy_stats as (
     select
         p.deputy_id,
@@ -61,12 +65,13 @@ final as (
             else 0
         end                                                  as abstention_pct,
 
-        -- metadata
-        now()                                                as updated_at
+        -- metadata: reflects last ingest, not query time — makes recency test meaningful
+        l.ingested_at                                        as updated_at
 
     from deputies d
     left join deputy_stats s on d.deputy_id = s.deputy_id
     cross join total_votes t
+    cross join last_ingested l
 )
 
 select * from final

--- a/transform/models/marts/mart_party_alignment.sql
+++ b/transform/models/marts/mart_party_alignment.sql
@@ -10,6 +10,10 @@ majority as (
     select * from {{ ref('int_party_vote_majority') }}
 ),
 
+last_ingested as (
+    select max(ingested_at) as ingested_at from {{ ref('stg_vote_positions') }}
+),
+
 deputy_alignment as (
     select
         d.deputy_id,
@@ -52,8 +56,9 @@ final as (
             then round(dissident_votes::numeric / total_votes, 4)
             else 0
         end                                                 as dissident_rate,
-        now()                                               as updated_at
+        l.ingested_at                                       as updated_at
     from deputy_alignment
+    cross join last_ingested l
 )
 
 select * from final

--- a/transform/models/marts/mart_vote_summary.sql
+++ b/transform/models/marts/mart_vote_summary.sql
@@ -7,7 +7,7 @@ positions as (
 ),
 
 last_ingested as (
-    select max(ingested_at) as ingested_at from {{ ref('stg_vote_positions') }}
+    select max(ingested_at) as ingested_at from {{ ref('stg_votes') }}
 ),
 
 vote_stats as (

--- a/transform/models/marts/mart_vote_summary.sql
+++ b/transform/models/marts/mart_vote_summary.sql
@@ -6,6 +6,10 @@ positions as (
     select * from {{ ref('stg_vote_positions') }}
 ),
 
+last_ingested as (
+    select max(ingested_at) as ingested_at from {{ ref('stg_vote_positions') }}
+),
+
 vote_stats as (
     select
         vote_id,
@@ -46,10 +50,11 @@ final as (
             else 0
         end                                             as pct_contre,
 
-        now()                                           as updated_at
+        l.ingested_at                                   as updated_at
 
     from votes v
     left join vote_stats s on v.vote_id = s.vote_id
+    cross join last_ingested l
 )
 
 select * from final

--- a/transform/models/staging/sources.yml
+++ b/transform/models/staging/sources.yml
@@ -60,6 +60,10 @@ sources:
                     to: source('raw', 'deputies')
                     field: deputy_id
           - name: position
+            description: >
+              Raw AN value — camelCase 'nonVotant' is intentional here.
+              stg_vote_positions normalises to lowercase; the staging schema
+              test uses 'nonvotant' to match the transformed value.
             tests:
               - not_null
               - accepted_values:


### PR DESCRIPTION
## What
Replace `now()` with `max(ingested_at)` as `updated_at` in all three mart models, and document the intentional `nonVotant` casing difference between the source and staging layers.

## Why
`mart_deputy_scorecard` had a `dbt_utils.recency` test checking that `updated_at` is within 1 day. Because `updated_at` was `now()`, this test always passed — it was comparing `now()` against itself. The test caught nothing and gave a false sense of data freshness validation. The other two marts (`mart_party_alignment`, `mart_vote_summary`) had the same `now()` pattern without a test, also giving misleading staleness signals to any consumer.

The `nonVotant` casing (camelCase in `sources.yml`, lowercase in `schema.yml`) was a legitimate source of confusion with no explanation — it looks like a bug but is intentional: the raw AN data uses `nonVotant`, and `stg_vote_positions` normalises it with `lower(trim(...))`.

Closes #76.

## Changes
- `mart_deputy_scorecard.sql`: added `last_ingested` CTE (`max(ingested_at)` from `stg_vote_positions`), replaced `now()` with `l.ingested_at`, cross-joined the CTE
- `mart_party_alignment.sql`: same pattern
- `mart_vote_summary.sql`: same pattern
- `sources.yml`: added description to `vote_positions.position` explaining the deliberate casing split

## Testing
- `dbt parse` runs clean (no errors, no warnings)
- No DB available locally for `dbt run`; logic is a straightforward CTE addition

## Risks / Notes
- The recency test on `mart_deputy_scorecard` now validates real data freshness. If dbt runs are delayed (e.g. CI outage over a long weekend), the test may legitimately fail. The current interval is 1 day — consider widening to 4 days to accommodate 3-day weekends if false positives become an issue.
- `ingested_at` on `stg_vote_positions` reflects when ingestion wrote to Postgres, not when the AN published the vote. A very recent ingestion of old data would still pass the recency test.

## Breaking Changes
None for the API — `updated_at` was never surfaced in API responses, only used internally by the mart tests.