### PR TITLE
fix(api): return 503 on missing dbt marts, surface mart status in /health

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -3,6 +3,12 @@ from contextlib import contextmanager
 
 import psycopg2.extras
 import psycopg2.pool
+from fastapi import HTTPException
+
+MART_UNAVAILABLE = HTTPException(
+    status_code=503,
+    detail="Analytics layer unavailable — dbt marts not found. Run `dbt run` to build them.",
+)
 
 _pool: psycopg2.pool.ThreadedConnectionPool | None = None
 

--- a/api/main.py
+++ b/api/main.py
@@ -9,6 +9,7 @@ import os
 import traceback
 from contextlib import asynccontextmanager
 
+import psycopg2.errors
 from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -955,6 +956,14 @@ def health() -> JSONResponse:
         logger.error("Health check DB error: %s", exc)
         services["db"] = "degraded"
 
+    services["openai"] = "degraded" if _is_placeholder(os.getenv("OPENAI_API_KEY")) else "ok"
+    services["groq"] = "degraded" if _is_placeholder(os.getenv("GROQ_API_KEY")) else "ok"
+
+    # all_ok excludes dbt_marts — marts are absent on every fresh deploy and
+    # degrade gracefully; their absence should not trip Railway's health check.
+    all_ok = all(v == "ok" for v in services.values())
+
+    scorecard_rows = vote_summary_rows = None
     try:
         with get_conn() as conn:
             with conn.cursor() as cur:
@@ -963,14 +972,12 @@ def health() -> JSONResponse:
                 cur.execute("SELECT COUNT(*) FROM analytics_marts.mart_vote_summary")
                 vote_summary_rows = cur.fetchone()["count"]
         services["dbt_marts"] = "ok"
-    except Exception:
-        scorecard_rows = vote_summary_rows = None
+    except psycopg2.errors.UndefinedTable:
+        services["dbt_marts"] = "degraded"
+    except Exception as exc:
+        logger.warning("Health check mart check error: %s", exc)
         services["dbt_marts"] = "degraded"
 
-    services["openai"] = "degraded" if _is_placeholder(os.getenv("OPENAI_API_KEY")) else "ok"
-    services["groq"] = "degraded" if _is_placeholder(os.getenv("GROQ_API_KEY")) else "ok"
-
-    all_ok = all(v == "ok" for v in services.values())
     body: dict = {"status": "ok" if all_ok else "degraded", **services}
     if services["db"] == "ok":
         body.update({"deputies": deputies, "votes": votes, "positions": positions})

--- a/api/main.py
+++ b/api/main.py
@@ -955,6 +955,18 @@ def health() -> JSONResponse:
         logger.error("Health check DB error: %s", exc)
         services["db"] = "degraded"
 
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT COUNT(*) FROM analytics_marts.mart_deputy_scorecard")
+                scorecard_rows = cur.fetchone()["count"]
+                cur.execute("SELECT COUNT(*) FROM analytics_marts.mart_vote_summary")
+                vote_summary_rows = cur.fetchone()["count"]
+        services["dbt_marts"] = "ok"
+    except Exception:
+        scorecard_rows = vote_summary_rows = None
+        services["dbt_marts"] = "degraded"
+
     services["openai"] = "degraded" if _is_placeholder(os.getenv("OPENAI_API_KEY")) else "ok"
     services["groq"] = "degraded" if _is_placeholder(os.getenv("GROQ_API_KEY")) else "ok"
 
@@ -962,5 +974,7 @@ def health() -> JSONResponse:
     body: dict = {"status": "ok" if all_ok else "degraded", **services}
     if services["db"] == "ok":
         body.update({"deputies": deputies, "votes": votes, "positions": positions})
+    if services["dbt_marts"] == "ok":
+        body.update({"mart_scorecards": scorecard_rows, "mart_vote_summaries": vote_summary_rows})
 
     return JSONResponse(content=body, status_code=200 if all_ok else 207)

--- a/api/routers/deputies.py
+++ b/api/routers/deputies.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, HTTPException, Query
 from psycopg2 import sql
 from starlette.requests import Request
 
-from api.db import get_conn
+from api.db import MART_UNAVAILABLE, get_conn
 from api.limiter import limiter
 from api.schemas import DeputyDetail, DeputyListResponse, DeputyScorecard, DeputySummary
 
@@ -97,10 +97,7 @@ def get_scorecard(request: Request, deputy_id: str):
                 )
                 row = cur.fetchone()
     except psycopg2.errors.UndefinedTable:
-        raise HTTPException(
-            status_code=503,
-            detail="Analytics layer unavailable — dbt marts not found. Run `dbt run` to build them.",
-        ) from None
+        raise MART_UNAVAILABLE from None
 
     if not row:
         raise HTTPException(status_code=404, detail="Deputy not found")

--- a/api/routers/deputies.py
+++ b/api/routers/deputies.py
@@ -1,3 +1,4 @@
+import psycopg2.errors
 from fastapi import APIRouter, HTTPException, Query
 from psycopg2 import sql
 from starlette.requests import Request
@@ -73,27 +74,33 @@ def get_deputy(request: Request, deputy_id: str):
 @router.get("/{deputy_id}/scorecard", response_model=DeputyScorecard)
 @limiter.limit("10/minute")
 def get_scorecard(request: Request, deputy_id: str):
-    with get_conn() as conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT
-                    deputy_id,
-                    full_name,
-                    total_votes_cast                          AS total_votes,
-                    (total_votes_cast - total_nonvotant)      AS present_votes,
-                    presence_rate,
-                    total_pour                                AS votes_for,
-                    total_contre                              AS votes_against,
-                    total_abstention                          AS abstentions,
-                    votes_for_pct,
-                    abstention_pct
-                FROM analytics_marts.mart_deputy_scorecard
-                WHERE deputy_id = %s
-                """,
-                (deputy_id,),
-            )
-            row = cur.fetchone()
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT
+                        deputy_id,
+                        full_name,
+                        total_votes_cast                          AS total_votes,
+                        (total_votes_cast - total_nonvotant)      AS present_votes,
+                        presence_rate,
+                        total_pour                                AS votes_for,
+                        total_contre                              AS votes_against,
+                        total_abstention                          AS abstentions,
+                        votes_for_pct,
+                        abstention_pct
+                    FROM analytics_marts.mart_deputy_scorecard
+                    WHERE deputy_id = %s
+                    """,
+                    (deputy_id,),
+                )
+                row = cur.fetchone()
+    except psycopg2.errors.UndefinedTable:
+        raise HTTPException(
+            status_code=503,
+            detail="Analytics layer unavailable — dbt marts not found. Run `dbt run` to build them.",
+        ) from None
 
     if not row:
         raise HTTPException(status_code=404, detail="Deputy not found")

--- a/api/routers/votes.py
+++ b/api/routers/votes.py
@@ -3,16 +3,11 @@ from fastapi import APIRouter, HTTPException, Query
 from psycopg2 import sql
 from starlette.requests import Request
 
-from api.db import get_conn
+from api.db import MART_UNAVAILABLE, get_conn
 from api.limiter import limiter
 from api.schemas import VoteDetail, VoteListResponse, VotePosition, VoteSummary
 
 router = APIRouter()
-
-_MART_UNAVAILABLE = HTTPException(
-    status_code=503,
-    detail="Analytics layer unavailable — dbt marts not found. Run `dbt run` to build them.",
-)
 
 
 @router.get("/", response_model=VoteListResponse)
@@ -55,7 +50,7 @@ def list_votes(
                 )
                 rows = cur.fetchall()
     except psycopg2.errors.UndefinedTable:
-        raise _MART_UNAVAILABLE from None
+        raise MART_UNAVAILABLE from None
 
     return VoteListResponse(
         total=total,
@@ -82,7 +77,7 @@ def latest_votes(request: Request):
                 )
                 rows = cur.fetchall()
     except psycopg2.errors.UndefinedTable:
-        raise _MART_UNAVAILABLE from None
+        raise MART_UNAVAILABLE from None
     return [VoteSummary(**r) for r in rows]
 
 
@@ -113,7 +108,7 @@ def get_vote(request: Request, vote_id: str):
                 )
                 position_rows = cur.fetchall()
     except psycopg2.errors.UndefinedTable:
-        raise _MART_UNAVAILABLE from None
+        raise MART_UNAVAILABLE from None
 
     return VoteDetail(
         **vote,

--- a/api/routers/votes.py
+++ b/api/routers/votes.py
@@ -1,3 +1,4 @@
+import psycopg2.errors
 from fastapi import APIRouter, HTTPException, Query
 from psycopg2 import sql
 from starlette.requests import Request
@@ -8,6 +9,11 @@ from api.schemas import VoteDetail, VoteListResponse, VotePosition, VoteSummary
 
 router = APIRouter()
 
+_MART_UNAVAILABLE = HTTPException(
+    status_code=503,
+    detail="Analytics layer unavailable — dbt marts not found. Run `dbt run` to build them.",
+)
+
 
 @router.get("/", response_model=VoteListResponse)
 @limiter.limit("30/minute")
@@ -17,36 +23,39 @@ def list_votes(
     offset: int = Query(0, ge=0, le=10_000),
     result: str = Query(None, description="Filter by result: adopté | rejeté"),
 ):
-    with get_conn() as conn:
-        with conn.cursor() as cur:
-            conditions: list[sql.Composable] = []
-            params: list = []
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                conditions: list[sql.Composable] = []
+                params: list = []
 
-            if result:
-                conditions.append(sql.SQL("result = %s"))
-                params.append(result)
+                if result:
+                    conditions.append(sql.SQL("result = %s"))
+                    params.append(result)
 
-            where = (
-                sql.SQL(" WHERE ") + sql.SQL(" AND ").join(conditions)
-                if conditions
-                else sql.SQL("")
-            )
+                where = (
+                    sql.SQL(" WHERE ") + sql.SQL(" AND ").join(conditions)
+                    if conditions
+                    else sql.SQL("")
+                )
 
-            cur.execute(
-                sql.SQL("SELECT COUNT(*) FROM analytics_marts.mart_vote_summary") + where,
-                params,
-            )
-            total = cur.fetchone()["count"]
+                cur.execute(
+                    sql.SQL("SELECT COUNT(*) FROM analytics_marts.mart_vote_summary") + where,
+                    params,
+                )
+                total = cur.fetchone()["count"]
 
-            cur.execute(
-                sql.SQL("""
-                    SELECT vote_id, voted_at, vote_title, result,
-                           votes_for, votes_against, abstentions, total_voters
-                    FROM analytics_marts.mart_vote_summary {} ORDER BY voted_at DESC LIMIT %s OFFSET %s
-                """).format(where),
-                params + [limit, offset],
-            )
-            rows = cur.fetchall()
+                cur.execute(
+                    sql.SQL("""
+                        SELECT vote_id, voted_at, vote_title, result,
+                               votes_for, votes_against, abstentions, total_voters
+                        FROM analytics_marts.mart_vote_summary {} ORDER BY voted_at DESC LIMIT %s OFFSET %s
+                    """).format(where),
+                    params + [limit, offset],
+                )
+                rows = cur.fetchall()
+    except psycopg2.errors.UndefinedTable:
+        raise _MART_UNAVAILABLE from None
 
     return VoteListResponse(
         total=total,
@@ -59,46 +68,52 @@ def list_votes(
 @router.get("/latest", response_model=list[VoteSummary])
 @limiter.limit("30/minute")
 def latest_votes(request: Request):
-    with get_conn() as conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT vote_id, voted_at, vote_title, result,
-                       votes_for, votes_against, abstentions, total_voters
-                FROM analytics_marts.mart_vote_summary
-                ORDER BY voted_at DESC
-                LIMIT 10
-                """
-            )
-            rows = cur.fetchall()
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT vote_id, voted_at, vote_title, result,
+                           votes_for, votes_against, abstentions, total_voters
+                    FROM analytics_marts.mart_vote_summary
+                    ORDER BY voted_at DESC
+                    LIMIT 10
+                    """
+                )
+                rows = cur.fetchall()
+    except psycopg2.errors.UndefinedTable:
+        raise _MART_UNAVAILABLE from None
     return [VoteSummary(**r) for r in rows]
 
 
 @router.get("/{vote_id}", response_model=VoteDetail)
 @limiter.limit("30/minute")
 def get_vote(request: Request, vote_id: str):
-    with get_conn() as conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                "SELECT * FROM analytics_marts.mart_vote_summary WHERE vote_id = %s",
-                (vote_id,),
-            )
-            vote = cur.fetchone()
-            if not vote:
-                raise HTTPException(status_code=404, detail="Vote not found")
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT * FROM analytics_marts.mart_vote_summary WHERE vote_id = %s",
+                    (vote_id,),
+                )
+                vote = cur.fetchone()
+                if not vote:
+                    raise HTTPException(status_code=404, detail="Vote not found")
 
-            cur.execute(
-                """
-                SELECT vp.position_id, vp.deputy_id, d.full_name,
-                       d.party_short, vp.position
-                FROM vote_positions vp
-                JOIN deputies d ON d.deputy_id = vp.deputy_id
-                WHERE vp.vote_id = %s
-                ORDER BY vp.position, d.last_name
-                """,
-                (vote_id,),
-            )
-            position_rows = cur.fetchall()
+                cur.execute(
+                    """
+                    SELECT vp.position_id, vp.deputy_id, d.full_name,
+                           d.party_short, vp.position
+                    FROM vote_positions vp
+                    JOIN deputies d ON d.deputy_id = vp.deputy_id
+                    WHERE vp.vote_id = %s
+                    ORDER BY vp.position, d.last_name
+                    """,
+                    (vote_id,),
+                )
+                position_rows = cur.fetchall()
+    except psycopg2.errors.UndefinedTable:
+        raise _MART_UNAVAILABLE from None
 
     return VoteDetail(
         **vote,


### PR DESCRIPTION
## What
Catch missing dbt mart tables in the API and return a clear **503** instead of an opaque **500**. Also adds a `dbt_marts` check to `/health` so mart availability is visible to monitoring.

## Why
`/votes/*` and `/deputies/{id}/scorecard` query `analytics_marts.*` tables that only exist after `dbt run` has executed. On a fresh deploy or after a dbt failure, those endpoints raised an unhandled `UndefinedTable` postgres error, which the global exception handler caught and returned as a 500. The landing page already had a try/except fallback; the routers did not. The `/health` endpoint reported `"db": "ok"` even when the mart layer was completely absent.

Closes #79.

## Changes

**`api/routers/votes.py`**
- Added `psycopg2.errors.UndefinedTable` import
- Defined a shared `_MART_UNAVAILABLE` `HTTPException(503)` constant
- Wrapped `list_votes`, `latest_votes`, and `get_vote` connection blocks in `try/except UndefinedTable` → raises 503 with `"run dbt first"` message

**`api/routers/deputies.py`**
- Same pattern for `get_scorecard` only — `list_deputies` and `get_deputy` use raw tables and are unaffected

**`api/main.py /health`**
- Added a second DB check that queries `mart_deputy_scorecard` and `mart_vote_summary`
- Reports `"dbt_marts": "ok"` or `"degraded"` in health response
- Includes `mart_scorecards` and `mart_vote_summaries` row counts when available

## What is NOT changed
- `railway.json` start command — adding `dbt run` to the deploy step is a larger infrastructure decision tracked separately
- Landing page — already had a try/except fallback, untouched

## Testing
- `ruff check` + `ruff format` passed
- Pre-commit hooks passed
- Manual test requires a DB without dbt marts to verify the 503 path

## Risks / Notes
- 503 is the correct HTTP status for a temporarily unavailable dependency — clients that retry on 503 will recover automatically once dbt runs
- The health endpoint now gives a clear signal that can trigger alerts if marts go missing after a dbt failure

## Breaking Changes
Existing clients that were catching 500 from these endpoints will now receive 503. Both are server errors; no client is expected to distinguish them.