### PR TITLE
fix(ci): remove invalid --no-pre flag from dbt pip install

### DIFF
--- a/.github/workflows/dbt_docs.yml
+++ b/.github/workflows/dbt_docs.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install dbt
-        run: pip install --no-pre "dbt-core>=1.9,<1.10" "dbt-postgres>=1.9,<1.10"
+        run: pip install "dbt-core>=1.9,<1.10" "dbt-postgres>=1.9,<1.10"
 
       - name: Create dbt profiles.yml
         env:

--- a/.github/workflows/ingest_prod.yml
+++ b/.github/workflows/ingest_prod.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Install dbt
         if: steps.ingest.outputs.new_votes != '0'
-        run: pip install --no-pre "dbt-core>=1.9,<1.10" "dbt-postgres>=1.9,<1.10"
+        run: pip install "dbt-core>=1.9,<1.10" "dbt-postgres>=1.9,<1.10"
 
       - name: Write dbt profiles.yml
         if: steps.ingest.outputs.new_votes != '0'


### PR DESCRIPTION
## What
Remove the invalid `--no-pre` flag from the `pip install` dbt command in `ingest_prod.yml` and `dbt_docs.yml`.

## Why
`--no-pre` is not a recognised pip option and causes every dbt install step to fail immediately with `no such option: --no-pre` (exit code 2), breaking production ingestion and docs generation on every run. The version constraint `>=1.9,<1.10` already prevents pre-release installs by default — the flag was redundant even when it was valid.

The same bug in `ci.yml` is fixed separately on `fix/dbt-ci-compile` (PR #83), which adds the `dbt-compile` job and was already in review.

## Changes
- `.github/workflows/ingest_prod.yml`: removed `--no-pre` from the dbt pip install step
- `.github/workflows/dbt_docs.yml`: removed `--no-pre` from the dbt pip install step

## Testing
- Pre-commit hooks passed
- No logic change — one word removed from two shell commands

## Risks / Notes
- One-line fix per file; no functional behaviour changes
- The `>=1.9,<1.10` pin continues to enforce the correct dbt version without pre-releases

## Breaking Changes
None