### PR TITLE
db: discard connections on OperationalError to prevent dead-socket pool poisoning

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -37,10 +37,10 @@ def get_conn():
     broken = False
     try:
         yield conn
-    except psycopg2.OperationalError:
-        # Connection-level failure (severed socket, server restart): always discard.
-        # rollback() can return successfully on a dead socket, so we cannot rely on
-        # it raising to detect a broken connection here.
+    except (psycopg2.OperationalError, psycopg2.InterfaceError):
+        # Connection-level failure (severed socket, server restart, closed connection):
+        # always discard. rollback() can return successfully on a dead socket, so we
+        # cannot rely on it raising to detect a broken connection here.
         broken = True
         try:
             conn.rollback()

--- a/api/db.py
+++ b/api/db.py
@@ -1,6 +1,7 @@
 import os
 from contextlib import contextmanager
 
+import psycopg2
 import psycopg2.extras
 import psycopg2.pool
 from fastapi import HTTPException
@@ -36,6 +37,16 @@ def get_conn():
     broken = False
     try:
         yield conn
+    except psycopg2.OperationalError:
+        # Connection-level failure (severed socket, server restart): always discard.
+        # rollback() can return successfully on a dead socket, so we cannot rely on
+        # it raising to detect a broken connection here.
+        broken = True
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+        raise
     except Exception:
         try:
             conn.rollback()


### PR DESCRIPTION
## What
Fixes a connection pool bug where dead sockets (from network blips or server restarts) were silently returned to the pool instead of being discarded.

## Why
`psycopg2.OperationalError` (severed TCP socket, Supabase restart) was only handled by the generic `except Exception` branch, which calls `rollback()` and only marks the connection broken if `rollback()` itself raises. On a dead socket, `rollback()` can return successfully — leaving `broken=False` and returning a dead connection to the pool. Every subsequent request that draws that slot fails with `OperationalError`, cascading across all 10 pool connections until they time out naturally.

## Changes
- `api/db.py`: added explicit `import psycopg2` (previously only submodules were imported)
- `api/db.py`: added a dedicated `except psycopg2.OperationalError` clause before the generic `except Exception` that unconditionally sets `broken=True`, attempts a best-effort rollback (ignoring failure), then re-raises — ensuring the connection is always discarded on connection-level failures

## Testing
- Pre-commit hooks passed (ruff lint + format, secrets scan)
- Manual code review: the new clause intercepts before the generic handler; `broken=True` is set before `putconn(conn, close=True)` is called in `finally`
- Integration test against a live pool (kill the DB mid-request) would fully confirm, but is outside the scope of local CI

## Risks / Notes
- Low risk: the change only affects error-path behaviour; the happy path (`yield conn` with no exception) is unchanged
- `psycopg2.OperationalError` also covers auth failures and misconfigured `DATABASE_URL` — these will now immediately discard the connection rather than returning it to the pool, which is the correct behaviour in all cases

## Breaking Changes
None

Closes #87