### PR TITLE
api: include abstentions in vote bar fallback denominator

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -282,7 +282,7 @@ def _build_vote_row(row) -> str:
     vf = row.get("votes_for") or 0
     vc = row.get("votes_against") or 0
     ab = row.get("abstentions") or 0
-    total = row.get("total_voters") or (vf + vc)
+    total = row.get("total_voters") or (vf + vc + ab)
     pour_pct = round(vf / total * 100) if total > 0 else 0
     contre_pct = round(vc / total * 100) if total > 0 else 0
 


### PR DESCRIPTION
## What
One-line fix to include abstentions in the fallback vote-bar denominator on the landing page.

## Why
`_build_vote_row()` computes participation percentages for the landing page vote bars. When `total_voters` is NULL (which can happen for some vote rows), it fell back to `vf + vc` — omitting abstentions. A vote where all positions are abstentions (e.g. `votes_for=0`, `votes_against=0`, `abstentions=400`) produced `total=0`, causing both `pour_pct` and `contre_pct` to render as 0% — falsely implying no participation.

## Changes
- `api/main.py:285`: changed `(vf + vc)` → `(vf + vc + ab)` in the fallback denominator

## Testing
- Pre-commit hooks passed
- Logic: `ab` is already computed on the line immediately above (`ab = row.get("abstentions") or 0`), so it is always available

## Risks / Notes
- Zero risk: one character added to a fallback arithmetic expression
- The `if total > 0 else 0` guard on lines 286–287 remains correct — it handles the edge case where all three fields are zero or NULL

## Breaking Changes
None

Closes #89