### PR TITLE
refactor(rag): centralise notable deputy config in constants.py

### DIFF
--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -5,10 +5,8 @@ Retrieves relevant chunks from document_chunks using cosine similarity
 via pgvector. The query is embedded with the same model used at index time.
 """
 
-import json
 import logging
 import os
-from pathlib import Path
 
 import numpy as np
 import psycopg2
@@ -17,7 +15,7 @@ from dotenv import load_dotenv
 from openai import OpenAI
 from pgvector.psycopg2 import register_vector
 
-from rag.constants import EMBEDDING_MODEL, IVFFLAT_PROBES
+from rag.constants import EMBEDDING_MODEL, IVFFLAT_PROBES, NOTABLE_DEPUTY_NAMES
 from rag.db_utils import connect_with_retry
 
 log = logging.getLogger(__name__)
@@ -26,14 +24,6 @@ log = logging.getLogger(__name__)
 load_dotenv()
 
 DATABASE_URL = os.getenv("DATABASE_URL")
-
-_NOTABLE_DEPUTIES: dict = json.loads(
-    (Path(__file__).parent.parent / "notable_deputies.json").read_text()
-)
-# Map each keyword → deputy_id for fast question matching
-NOTABLE_DEPUTY_NAMES: dict[str, str] = {
-    kw: dep_id for dep_id, info in _NOTABLE_DEPUTIES.items() for kw in info["keywords"]
-}
 
 
 def detect_notable_deputy(question: str) -> str | None:

--- a/rag/constants.py
+++ b/rag/constants.py
@@ -1,4 +1,6 @@
+import json
 import os
+from pathlib import Path
 
 EMBEDDING_MODEL = "text-embedding-3-small"
 LLM_MODEL = "llama-3.3-70b-versatile"
@@ -6,3 +8,14 @@ LLM_MODEL = "llama-3.3-70b-versatile"
 # probes ≈ sqrt(IVFFlat lists). Default lists=100 → probes=10.
 # Raise if chunk count grows significantly past ~50k.
 IVFFLAT_PROBES = int(os.getenv("IVFFLAT_PROBES", "10"))
+
+# Notable deputies: {deputy_id: {name, bio, keywords}}
+# Edit notable_deputies.json to add/remove entries — no code change needed.
+NOTABLE_DEPUTIES: dict[str, dict] = json.loads(
+    (Path(__file__).parent / "notable_deputies.json").read_text()
+)
+
+# Map each keyword → deputy_id for fast question matching in the retriever.
+NOTABLE_DEPUTY_NAMES: dict[str, str] = {
+    kw: dep_id for dep_id, info in NOTABLE_DEPUTIES.items() for kw in info["keywords"]
+}

--- a/rag/pipeline/chunker.py
+++ b/rag/pipeline/chunker.py
@@ -11,7 +11,6 @@ Each chunk is {"content": str, "metadata": dict}.
 import json
 import os
 import warnings
-from pathlib import Path
 
 import psycopg2
 import psycopg2.extras
@@ -20,6 +19,8 @@ from dotenv import load_dotenv
 
 # Must run before os.getenv() calls below so .env is loaded before module-level vars are set.
 load_dotenv()
+
+from rag.constants import NOTABLE_DEPUTIES  # noqa: E402
 
 DATABASE_URL = os.getenv("DATABASE_URL")
 TOKEN_WARN_THRESHOLD = 500
@@ -345,10 +346,6 @@ def chunk_global_stats() -> list[dict]:
 # ---------------------------------------------------------------------------
 # Strategy E — Notable deputy chunks (detailed vote-by-vote, top profiles)
 # ---------------------------------------------------------------------------
-
-NOTABLE_DEPUTIES: dict[str, dict] = json.loads(
-    (Path(__file__).parent.parent / "notable_deputies.json").read_text()
-)
 
 
 def chunk_notable_deputies() -> list[dict]:


### PR DESCRIPTION
## What
Moves the `NOTABLE_DEPUTIES` dict and `NOTABLE_DEPUTY_NAMES` keyword map from two independent JSON reads in `chunker.py` and `retriever.py` into a single shared definition in `rag/constants.py`.

## Why
`PA722190` (Attal) and `PA720614` (Le Pen) were loaded from `notable_deputies.json` independently in both modules. Adding a third notable deputy required knowing to update two separate module-level blocks and risked the two dicts drifting out of sync. With a single definition in `constants.py`, the JSON file is the only place that needs to change. Closes #11.

## Changes
- `rag/constants.py` — adds `NOTABLE_DEPUTIES` (loaded from `notable_deputies.json`) and `NOTABLE_DEPUTY_NAMES` (keyword→id map)
- `rag/pipeline/chunker.py` — removes local JSON load; imports `NOTABLE_DEPUTIES` from `rag.constants`
- `rag/chain/retriever.py` — removes local JSON load and local `NOTABLE_DEPUTY_NAMES` build; imports both from `rag.constants`

**Note on N+1 fix:** the issue also asked to replace the per-deputy SQL loop with a single UNION query. That was already implemented — `chunk_notable_deputies()` uses a single `WHERE deputy_id = ANY(%s)` query and groups client-side.

## Testing
- Pre-commit hooks pass (ruff, ruff-format, detect-secrets)
- No behaviour change — same data, same logic, one fewer file read at import time

## Risks / Notes
- None. `notable_deputies.json` is read once at module import, same as before.

## Breaking Changes
None.