### PR TITLE
api: add keyset cursor pagination to /votes so the full list stays reachable

### DIFF
--- a/api/routers/votes.py
+++ b/api/routers/votes.py
@@ -1,3 +1,8 @@
+import base64
+import binascii
+from datetime import datetime
+from typing import Optional
+
 import psycopg2.errors
 from fastapi import APIRouter, HTTPException, Query
 from psycopg2 import sql
@@ -10,14 +15,39 @@ from api.schemas import VoteDetail, VoteListResponse, VotePosition, VoteSummary
 router = APIRouter()
 
 
+def _encode_cursor(voted_at: datetime, vote_id: str) -> str:
+    """Opaque keyset cursor over the list's sort key (voted_at, vote_id)."""
+    raw = f"{voted_at.isoformat()}|{vote_id}"
+    return base64.urlsafe_b64encode(raw.encode()).decode()
+
+
+def _decode_cursor(token: str) -> tuple[datetime, str]:
+    """Reverse of _encode_cursor; raises 422 on a malformed token."""
+    try:
+        raw = base64.urlsafe_b64decode(token.encode()).decode()
+        ts, vote_id = raw.rsplit("|", 1)
+        return datetime.fromisoformat(ts), vote_id
+    except (ValueError, binascii.Error) as exc:
+        raise HTTPException(status_code=422, detail="Invalid cursor") from exc
+
+
 @router.get("/", response_model=VoteListResponse)
 @limiter.limit("30/minute")
 def list_votes(
     request: Request,
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0, le=2_000),
+    before: Optional[str] = Query(
+        None,
+        description="Keyset cursor for deep pagination — pass the next_cursor from a "
+        "previous response. Overrides offset when set, so it reaches votes beyond "
+        "the offset ceiling.",
+    ),
     result: str = Query(None, description="Filter by result: adopté | rejeté"),
 ):
+    # Decode before opening a connection so a bad cursor fails fast with 422.
+    cursor_key = _decode_cursor(before) if before else None
+
     try:
         with get_conn() as conn:
             with conn.cursor() as cur:
@@ -28,35 +58,58 @@ def list_votes(
                     conditions.append(sql.SQL("result = %s"))
                     params.append(result)
 
-                where = (
+                # total reflects the full filtered set, independent of the cursor window.
+                count_where = (
                     sql.SQL(" WHERE ") + sql.SQL(" AND ").join(conditions)
                     if conditions
                     else sql.SQL("")
                 )
-
                 cur.execute(
-                    sql.SQL("SELECT COUNT(*) FROM analytics_marts.mart_vote_summary") + where,
+                    sql.SQL("SELECT COUNT(*) FROM analytics_marts.mart_vote_summary") + count_where,
                     params,
                 )
                 total = cur.fetchone()["count"]
+
+                page_conditions = list(conditions)
+                page_params = list(params)
+                if cursor_key:
+                    page_conditions.append(sql.SQL("(voted_at, vote_id) < (%s, %s)"))
+                    page_params.extend(cursor_key)
+
+                where = (
+                    sql.SQL(" WHERE ") + sql.SQL(" AND ").join(page_conditions)
+                    if page_conditions
+                    else sql.SQL("")
+                )
+
+                # Cursor paging walks the keyset directly; offset is only for shallow
+                # (cursor-less) paging and is ignored once a cursor is supplied.
+                effective_offset = 0 if cursor_key else offset
 
                 cur.execute(
                     sql.SQL("""
                         SELECT vote_id, voted_at, vote_title, result,
                                votes_for, votes_against, abstentions, total_voters
-                        FROM analytics_marts.mart_vote_summary {} ORDER BY voted_at DESC LIMIT %s OFFSET %s
+                        FROM analytics_marts.mart_vote_summary {}
+                        ORDER BY voted_at DESC, vote_id DESC LIMIT %s OFFSET %s
                     """).format(where),
-                    params + [limit, offset],
+                    page_params + [limit, effective_offset],
                 )
                 rows = cur.fetchall()
     except psycopg2.errors.UndefinedTable:
         raise MART_UNAVAILABLE from None
+
+    # A full page implies there may be more; hand back a cursor to the next window.
+    next_cursor = (
+        _encode_cursor(rows[-1]["voted_at"], rows[-1]["vote_id"]) if len(rows) == limit else None
+    )
 
     return VoteListResponse(
         total=total,
         limit=limit,
         offset=offset,
         items=[VoteSummary(**r) for r in rows],
+        next_cursor=next_cursor,
     )
 
 

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -110,3 +110,8 @@ class VoteListResponse(_Base):
     limit: int
     offset: int
     items: list[VoteSummary]
+    next_cursor: Optional[str] = Field(
+        default=None,
+        description="Opaque keyset cursor — pass as ?before= to fetch the next page; "
+        "null when there are no more rows.",
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,7 +8,7 @@ import groq
 import httpx
 
 import api.db as _db
-from api.routers.votes import _encode_cursor
+from api.routers.votes import _decode_cursor, _encode_cursor
 
 _DEPUTY_SUMMARY = {
     "deputy_id": "PA1",
@@ -167,23 +167,33 @@ def test_list_votes(client, mock_cursor):
 
 
 def test_list_votes_returns_next_cursor(client, mock_cursor):
-    """A full page hands back an opaque next_cursor for keyset paging."""
-    row = {**_VOTE_SUMMARY, "voted_at": datetime(2024, 7, 16, 15, 0, 0)}
+    """A full page hands back an opaque next_cursor that round-trips to its keyset."""
+    ts = datetime(2024, 7, 16, 15, 0, 0)
+    row = {**_VOTE_SUMMARY, "voted_at": ts, "vote_id": "VTANR5L17V1"}
     mock_cursor.fetchone.return_value = {"count": 5_000}
     mock_cursor.fetchall.return_value = [row]  # one row == limit=1 → full page
     resp = client.get("/votes/?limit=1")
     assert resp.status_code == 200
-    assert resp.json()["next_cursor"] is not None
+    cursor = resp.json()["next_cursor"]
+    assert cursor is not None
+    assert _decode_cursor(cursor) == (ts, "VTANR5L17V1")
 
 
 def test_list_votes_before_cursor_overrides_offset(client, mock_cursor):
-    """A valid before= cursor reaches votes beyond the offset ceiling."""
-    token = _encode_cursor(datetime(2024, 7, 16, 15, 0, 0), "VTANR5L17V1")
+    """A valid before= cursor drives the keyset predicate and zeroes the offset."""
+    ts = datetime(2024, 7, 16, 15, 0, 0)
+    token = _encode_cursor(ts, "VTANR5L17V1")
     mock_cursor.fetchone.return_value = {"count": 5_000}
     mock_cursor.fetchall.return_value = [_VOTE_SUMMARY]
-    resp = client.get(f"/votes/?before={token}")
+    resp = client.get(f"/votes/?before={token}&offset=100")
     assert resp.status_code == 200
     assert resp.json()["total"] == 5_000
+    # The SELECT (last execute call) must carry the decoded cursor values, and the
+    # offset must be zeroed because keyset paging supersedes it.
+    select_params = mock_cursor.execute.call_args.args[1]
+    assert ts in select_params
+    assert "VTANR5L17V1" in select_params
+    assert select_params[-1] == 0
 
 
 def test_list_votes_invalid_cursor_rejected(client):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,12 +1,14 @@
 """Smoke tests for API routers — no real DB required."""
 
 import asyncio
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import groq
 import httpx
 
 import api.db as _db
+from api.routers.votes import _encode_cursor
 
 _DEPUTY_SUMMARY = {
     "deputy_id": "PA1",
@@ -160,6 +162,34 @@ def test_list_votes(client, mock_cursor):
     assert "total" in data
     assert "items" in data
     assert len(data["items"]) == 1
+    # Partial page (1 row < default limit) → no further pages.
+    assert data["next_cursor"] is None
+
+
+def test_list_votes_returns_next_cursor(client, mock_cursor):
+    """A full page hands back an opaque next_cursor for keyset paging."""
+    row = {**_VOTE_SUMMARY, "voted_at": datetime(2024, 7, 16, 15, 0, 0)}
+    mock_cursor.fetchone.return_value = {"count": 5_000}
+    mock_cursor.fetchall.return_value = [row]  # one row == limit=1 → full page
+    resp = client.get("/votes/?limit=1")
+    assert resp.status_code == 200
+    assert resp.json()["next_cursor"] is not None
+
+
+def test_list_votes_before_cursor_overrides_offset(client, mock_cursor):
+    """A valid before= cursor reaches votes beyond the offset ceiling."""
+    token = _encode_cursor(datetime(2024, 7, 16, 15, 0, 0), "VTANR5L17V1")
+    mock_cursor.fetchone.return_value = {"count": 5_000}
+    mock_cursor.fetchall.return_value = [_VOTE_SUMMARY]
+    resp = client.get(f"/votes/?before={token}")
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 5_000
+
+
+def test_list_votes_invalid_cursor_rejected(client):
+    """A malformed before= cursor returns 422, not 500."""
+    resp = client.get("/votes/?before=not-a-valid-cursor")
+    assert resp.status_code == 422
 
 
 def test_latest_votes(client, mock_cursor):
@@ -244,8 +274,8 @@ def test_list_deputies_offset_exceeds_max(client):
 
 
 def test_list_votes_offset_exceeds_max(client):
-    """offset > 10_000 is rejected by FastAPI query validation."""
-    resp = client.get("/votes/?offset=10001")
+    """offset > 2_000 is rejected by query validation (use ?before= cursor instead)."""
+    resp = client.get("/votes/?offset=2001")
     assert resp.status_code == 422
 
 


### PR DESCRIPTION
## What

Add optional keyset (cursor) pagination to `GET /votes/` so the entire vote list
stays reachable, even past the `offset` ceiling.

## Why

In #94 the max `offset` on the list endpoints was lowered from 10,000 to 2,000 to
guard against expensive deep-`OFFSET` scans. For `/deputies` (577 rows) that is
harmless, but for `/votes` it became a behavior regression: with `limit ≤ 200`
the highest reachable row is index ~2,199, while the full 17th legislature is
~3,149 scrutins. Worse, a client paginating `offset += limit` past 2,000 received
an **HTTP 422** (FastAPI rejects `offset > 2_000`) even though the response's
`total` reported more rows. The tail of the vote list was simply unretrievable.
(See #103.)

## Changes

- `api/routers/votes.py`
  - New optional `before` query param on `GET /votes/` — an opaque keyset cursor.
    When supplied it overrides `offset`, so it reaches votes beyond the offset cap.
  - Cursor is **composite** over `(voted_at, vote_id)`: `voted_at` is date-granular
    and not unique, so a single-column cursor would skip or duplicate rows at date
    boundaries. The keyset predicate is `(voted_at, vote_id) < (%s, %s)`.
  - List ordering is now `ORDER BY voted_at DESC, vote_id DESC` (deterministic tie-break).
  - `next_cursor` is returned whenever a full page is sent (more rows may exist),
    and is `null` at the end. `total` still reflects the full filtered set,
    independent of the cursor window.
  - `_encode_cursor` / `_decode_cursor` helpers; a malformed cursor fails fast with
    `422` before a DB connection is opened.
- `api/schemas.py` — `VoteListResponse` gains `next_cursor: Optional[str]`.
- `tests/test_api.py` — new tests: next_cursor on a full page, `before` cursor
  accepted and overriding offset, malformed cursor → 422; updated the offset-cap
  test to the new `le=2_000` boundary.

## Testing

- `pytest tests/test_api.py` — all vote/pagination tests pass (22 passed).
- Two pre-existing scorecard test failures are unrelated (Pydantic V1 / Python 3.14
  incompatibility) and fail on `master` as well.
- `ruff check` and `ruff format --check` clean; pre-commit hooks pass.

## Risks / Notes

- The `offset` path is unchanged and still capped at `le=2_000`; existing shallow-
  pagination clients are unaffected.
- The cursor is opaque (base64 of `voted_at|vote_id`) rather than a raw timestamp,
  so callers must round-trip `next_cursor` verbatim rather than constructing it.
  This is intentional — it makes the composite tie-breaker correct and lets the
  encoding evolve without breaking clients.
- No DB migration. No index is added; the keyset predicate is at worst no slower
  than the old `OFFSET` scan. A composite index on `(voted_at DESC, vote_id DESC)`
  on `mart_vote_summary` would make deep cursor paging O(log n) — possible follow-up.

## Breaking Changes

None. `before`/`next_cursor` are purely additive; all existing query shapes and
response fields are preserved.
