### PR TITLE
fix: EC2 private subnet access — replace public_ip output with private_ip and add SSM access

### DIFF
--- a/infra/modules/ec2/main.tf
+++ b/infra/modules/ec2/main.tf
@@ -59,6 +59,11 @@ resource "aws_iam_role_policy" "s3_access" {
   })
 }
 
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.ec2.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
 resource "aws_iam_instance_profile" "ec2" {
   name = "${var.name_prefix}-ec2-profile"
   role = aws_iam_role.ec2.name

--- a/infra/modules/ec2/outputs.tf
+++ b/infra/modules/ec2/outputs.tf
@@ -8,7 +8,7 @@ output "spark_instance_id" {
   value       = aws_instance.spark.id
 }
 
-output "airflow_public_ip" {
-  description = "Public IP of the Airflow instance"
-  value       = aws_instance.airflow.public_ip
+output "airflow_private_ip" {
+  description = "Private IP of the Airflow instance (use SSM Session Manager or a bastion for access)"
+  value       = aws_instance.airflow.private_ip
 }

--- a/infra/modules/ec2/variables.tf
+++ b/infra/modules/ec2/variables.tf
@@ -19,7 +19,7 @@ variable "vpc_id" {
 }
 
 variable "subnet_id" {
-  description = "Public subnet ID for the EC2 instances"
+  description = "Subnet ID for the EC2 instances"
   type        = string
 }
 

--- a/infra/modules/networking/main.tf
+++ b/infra/modules/networking/main.tf
@@ -95,11 +95,13 @@ resource "aws_security_group" "app" {
   vpc_id      = aws_vpc.main.id
   description = "EC2 instances — Airflow and Spark"
 
-  # SSH — only opened when admin_cidr is explicitly set; empty string disables the rule.
+  # SSH — only opened when admin_cidr is set (e.g., VPN or bastion CIDR). Instances are
+  # in a private subnet so this rule is only reachable via an internal network path.
+  # For zero-port access use SSM Session Manager (enabled via IAM policy on the EC2 role).
   dynamic "ingress" {
     for_each = var.admin_cidr != "" ? [var.admin_cidr] : []
     content {
-      description = "SSH from admin CIDR"
+      description = "SSH from admin CIDR (VPN/bastion only)"
       from_port   = 22
       to_port     = 22
       protocol    = "tcp"
@@ -107,11 +109,11 @@ resource "aws_security_group" "app" {
     }
   }
 
-  # Airflow web UI — only opened when admin_cidr is explicitly set.
+  # Airflow web UI — same constraint; only reachable via internal network path.
   dynamic "ingress" {
     for_each = var.admin_cidr != "" ? [var.admin_cidr] : []
     content {
-      description = "Airflow web UI from admin CIDR"
+      description = "Airflow web UI from admin CIDR (VPN/bastion only)"
       from_port   = 8080
       to_port     = 8080
       protocol    = "tcp"


### PR DESCRIPTION
## What
Fixes the broken EC2 access model introduced in Phase 6a where instances were placed in a private subnet but the codebase assumed public reachability.

## Why
`ec2/variables.tf` described `subnet_id` as "Public subnet ID" and `ec2/outputs.tf` exported `airflow_public_ip` (`aws_instance.airflow.public_ip`). Both are wrong — instances are in `private_subnet_ids[0]` and never receive a public IP. The `airflow_public_ip` output would always be `""`, and the `admin_cidr` SSH/Airflow-UI security group rules were unreachable from outside the VPC.

Closes #107

## Changes
- `ec2/variables.tf` — fix `subnet_id` description from "Public subnet ID" → "Subnet ID"
- `ec2/outputs.tf` — replace `airflow_public_ip` (always `""`) with `airflow_private_ip` (`aws_instance.airflow.private_ip`), which is the actually useful value for internal routing and bastion hops
- `ec2/main.tf` — attach `AmazonSSMManagedInstanceCore` managed policy to the EC2 IAM role; this enables AWS SSM Session Manager access without requiring SSH, a public IP, or open port 22
- `networking/main.tf` — update `admin_cidr` ingress rule descriptions to clarify they are for VPN/bastion-only access (instances are private-subnet), not public internet access

## Testing
- `terraform validate` passes
- `terraform fmt -check` passes

## Risks / Notes
- `AmazonSSMManagedInstanceCore` is an AWS-managed policy granting the SSM agent permission to register with the SSM service. It adds no S3/RDS/network permissions.
- The `admin_cidr` SSH/8080 SG rules are kept — they are valid for VPN or bastion-hop scenarios where an operator has a direct private network path to the instances.
- No applied infrastructure changes — validate-only.

## Breaking Changes
- `airflow_public_ip` output is renamed to `airflow_private_ip`. Any caller reading `module.ec2.airflow_public_ip` must be updated to `module.ec2.airflow_private_ip`. No such caller exists in this repo currently.