### PR TITLE
fix: use name_prefix and create_before_destroy on RDS parameter group

### DIFF
--- a/infra/modules/rds/main.tf
+++ b/infra/modules/rds/main.tf
@@ -8,8 +8,8 @@ resource "aws_db_subnet_group" "main" {
 # pgvector requires no special parameter group — the extension is installed
 # via CREATE EXTENSION in SQL after provisioning.
 resource "aws_db_parameter_group" "postgres15" {
-  name   = "${var.name_prefix}-pg15"
-  family = "postgres15"
+  name_prefix = "${var.name_prefix}-pg15-"
+  family      = "postgres15"
 
   parameter {
     name         = "shared_preload_libraries"
@@ -18,6 +18,10 @@ resource "aws_db_parameter_group" "postgres15" {
   }
 
   tags = merge(var.tags, { Name = "${var.name_prefix}-pg15" })
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_db_instance" "main" {


### PR DESCRIPTION
## What
Fixes the `aws_db_parameter_group` resource in `modules/rds/main.tf` to safely handle in-place updates without blocking `terraform apply`.

## Why
The parameter group used a fixed `name`, which means any change to `var.name_prefix` or to a parameter value forces Terraform to destroy the old group before creating the new one. RDS refuses to delete a parameter group that is still attached to a live instance, so the destroy step errors and leaves the stack partially replaced.

Two changes fix this:

1. **`name` → `name_prefix`**: AWS appends a unique random suffix, eliminating name collision on replacement entirely.
2. **`lifecycle { create_before_destroy = true }`**: Terraform creates the new group first, updates the RDS instance to point to it, then destroys the old one — matching the same pattern already used by the security groups in the networking module.

Closes #108

## Changes
- `infra/modules/rds/main.tf` — switch `name` to `name_prefix`, add `lifecycle { create_before_destroy = true }`

## Testing
- `terraform validate` passes
- `terraform fmt -check` passes

## Risks / Notes
- `aws_db_instance.main` references `aws_db_parameter_group.postgres15.name` — Terraform resolves this to the actual generated name at plan time, so the reference remains valid after switching to `name_prefix`.
- No applied infrastructure changes — validate-only.
- If this were applied to a live stack, Terraform would create a new parameter group and associate it with the instance before destroying the old one — no downtime or data risk.

## Breaking Changes
None.