### PR TITLE
fix: derive EC2 IAM S3 policy ARNs from module.s3 output instead of re-interpolating

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -44,5 +44,6 @@ module "ec2" {
   vpc_id                = module.networking.vpc_id
   subnet_id             = module.networking.private_subnet_ids[0]
   security_group_ids    = [module.networking.app_security_group_id]
+  s3_bucket_arns        = module.s3.bucket_arns
   tags                  = local.common_tags
 }

--- a/infra/modules/ec2/main.tf
+++ b/infra/modules/ec2/main.tf
@@ -45,16 +45,7 @@ resource "aws_iam_role_policy" "s3_access" {
         "s3:DeleteObject",
         "s3:ListBucket",
       ]
-      Resource = [
-        "arn:aws:s3:::${var.name_prefix}-bronze",
-        "arn:aws:s3:::${var.name_prefix}-bronze/*",
-        "arn:aws:s3:::${var.name_prefix}-silver",
-        "arn:aws:s3:::${var.name_prefix}-silver/*",
-        "arn:aws:s3:::${var.name_prefix}-gold",
-        "arn:aws:s3:::${var.name_prefix}-gold/*",
-        "arn:aws:s3:::${var.name_prefix}-artifacts",
-        "arn:aws:s3:::${var.name_prefix}-artifacts/*",
-      ]
+      Resource = flatten([for arn in var.s3_bucket_arns : [arn, "${arn}/*"]])
     }]
   })
 }

--- a/infra/modules/ec2/variables.tf
+++ b/infra/modules/ec2/variables.tf
@@ -28,6 +28,11 @@ variable "security_group_ids" {
   type        = list(string)
 }
 
+variable "s3_bucket_arns" {
+  description = "ARNs of the S3 buckets the EC2 instances need read/write access to"
+  type        = list(string)
+}
+
 variable "tags" {
   description = "Common tags applied to all resources"
   type        = map(string)


### PR DESCRIPTION
## What
Replaces the hardcoded S3 bucket ARN interpolations in the EC2 IAM policy with a reference to the real ARNs exported by the S3 module, creating an explicit Terraform dependency between the two modules.

## Why
The IAM policy in `modules/ec2/main.tf` was re-deriving bucket ARNs by interpolating `var.name_prefix` directly (e.g. `arn:aws:s3:::${var.name_prefix}-bronze`). The S3 module derives the same names independently. There was no data dependency linking them — if the S3 module's naming ever changed, the IAM policy would silently target non-existent ARNs, causing `AccessDenied` on every S3 operation at runtime with no plan-time error.

Closes #109

## Changes
- `infra/modules/ec2/variables.tf` — add `s3_bucket_arns` input variable (`list(string)`)
- `infra/modules/ec2/main.tf` — replace 8 hardcoded ARN strings with `flatten([for arn in var.s3_bucket_arns : [arn, "${arn}/*"]])`, which expands each ARN into the bucket-level and object-level entries the policy needs
- `infra/main.tf` — pass `s3_bucket_arns = module.s3.bucket_arns` to the EC2 module call; `bucket_arns` is already exported by `modules/s3/outputs.tf`

## Testing
- `terraform validate` passes
- `terraform fmt -check` passes
- The `flatten` expression produces identical ARN pairs to the previous hardcoded list for any set of buckets; validated with the existing 4-bucket S3 module output

## Risks / Notes
- No applied infrastructure changes — validate-only.
- The `module.s3` → `module.ec2` dependency is now explicit in the Terraform graph; `terraform apply` will ensure S3 buckets are created before the EC2 IAM policy that references them.

## Breaking Changes
None — the generated IAM policy document is functionally identical to the previous version when the bucket names haven't changed.