### PR TITLE
chore: remove unused vpc_id variable from EC2 and RDS modules

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -27,7 +27,6 @@ module "rds" {
   instance_class      = var.db_instance_class
   db_name             = var.db_name
   db_password         = var.db_password
-  vpc_id              = module.networking.vpc_id
   subnet_ids          = module.networking.private_subnet_ids
   security_group_ids  = [module.networking.db_security_group_id]
   multi_az            = var.db_multi_az
@@ -41,7 +40,6 @@ module "ec2" {
   name_prefix           = local.name_prefix
   airflow_instance_type = var.airflow_instance_type
   spark_instance_type   = var.spark_instance_type
-  vpc_id                = module.networking.vpc_id
   subnet_id             = module.networking.private_subnet_ids[0]
   security_group_ids    = [module.networking.app_security_group_id]
   s3_bucket_arns        = module.s3.bucket_arns

--- a/infra/modules/ec2/variables.tf
+++ b/infra/modules/ec2/variables.tf
@@ -13,11 +13,6 @@ variable "spark_instance_type" {
   type        = string
 }
 
-variable "vpc_id" {
-  description = "VPC ID where instances are deployed"
-  type        = string
-}
-
 variable "subnet_id" {
   description = "Public subnet ID for the EC2 instances"
   type        = string

--- a/infra/modules/rds/variables.tf
+++ b/infra/modules/rds/variables.tf
@@ -46,11 +46,6 @@ variable "deletion_protection" {
   default     = false
 }
 
-variable "vpc_id" {
-  description = "VPC ID where RDS is deployed"
-  type        = string
-}
-
 variable "subnet_ids" {
   description = "Private subnet IDs for the DB subnet group"
   type        = list(string)


### PR DESCRIPTION
## What
Removes the `vpc_id` input variable from both `modules/ec2` and `modules/rds`, and the corresponding `vpc_id = module.networking.vpc_id` lines from the module calls in `main.tf`.

## Why
`vpc_id` was declared in both module variable files and passed from `main.tf`, but neither module body ever referenced `var.vpc_id` in any resource. VPC membership is already enforced implicitly via `subnet_id`/`subnet_ids` and `security_group_ids`, both of which are VPC-scoped. The dead variable widened each module's public interface and misled readers into thinking VPC-level operations happened inside the modules.

Closes #110

## Changes
- `infra/modules/ec2/variables.tf` — remove `variable "vpc_id"`
- `infra/modules/rds/variables.tf` — remove `variable "vpc_id"`
- `infra/main.tf` — remove `vpc_id = module.networking.vpc_id` from both the `rds` and `ec2` module calls

## Testing
- `terraform validate` passes
- `terraform fmt -check` passes

## Risks / Notes
- No runtime impact — the variable was never used, so no behaviour changes.
- No applied infrastructure changes — validate-only.

## Breaking Changes
Any external caller of these modules that was passing `vpc_id` will get a Terraform error ("An argument named 'vpc_id' is not expected here"). There are no such callers in this repo.