### PR TITLE
chore: CI workflow cleanup — setup-python v5 and portable date command

### DIFF
--- a/.github/workflows/dbt_docs.yml
+++ b/.github/workflows/dbt_docs.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/ingest_prod.yml
+++ b/.github/workflows/ingest_prod.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           AN_API_BASE_URL: ${{ secrets.AN_API_BASE_URL }}
-        run: python scripts/run_ingestion_prod.py --since $(date -d '30 days ago' +%Y-%m-%d)
+        run: python scripts/run_ingestion_prod.py --since $(python3 -c "from datetime import date, timedelta; print(date.today() - timedelta(days=30))")
 
       - name: Install RAG dependencies
         if: steps.ingest.outputs.new_votes != '0'
@@ -58,7 +58,7 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-        run: python -m rag.pipeline.index_manager build --since $(date -d '30 days ago' +%Y-%m-%d)
+        run: python -m rag.pipeline.index_manager build --since $(python3 -c "from datetime import date, timedelta; print(date.today() - timedelta(days=30))")
 
       - name: Install dbt
         if: steps.ingest.outputs.new_votes != '0'


### PR DESCRIPTION
## What
Two small CI maintenance fixes bundled together — both are low-risk, one-line changes to GitHub Actions workflows.

## Why

**Issue #111 — `dbt_docs.yml` on `setup-python@v4`**
All other workflows (`ci.yml`, `deploy.yml`, `ingest_prod.yml`) already use `actions/setup-python@v5`. When GitHub deprecates v4, `dbt_docs.yml` would break in isolation. Aligning to v5 now eliminates the inconsistency and the future surprise.

**Issue #112 — `date -d '30 days ago'` is GNU-only**
`ingest_prod.yml` used `date -d '30 days ago' +%Y-%m-%d` in two places to compute the `--since` flag. This works fine on `ubuntu-latest` runners (GNU `date`) but fails with `date: illegal option -- d` on macOS. Replaced with a `python3` one-liner that is portable across Linux and macOS and already available in every environment that runs these workflows.

Closes #111
Closes #112

## Changes
- `.github/workflows/dbt_docs.yml` — `setup-python@v4` → `@v5`
- `.github/workflows/ingest_prod.yml` — `$(date -d '30 days ago' +%Y-%m-%d)` → `$(python3 -c "from datetime import date, timedelta; print(date.today() - timedelta(days=30))")` (two occurrences: ingestion step and RAG rebuild step)

## Testing
- Both YAML files pass `check yaml` pre-commit hook
- The Python one-liner produces identical output to the GNU `date` command: `YYYY-MM-DD` format, 30 days before today

## Risks / Notes
- No runtime behaviour change in CI — `ubuntu-latest` has both GNU `date` and `python3`, so both old and new commands produce the same date string.

## Breaking Changes
None.