### PR TITLE
fix: serialize dbt test execution to prevent concurrent deadlock

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
           cd transform
           dbt deps
           dbt run --profiles-dir . --target prod
-          dbt test --profiles-dir . --target prod
+          dbt test --profiles-dir . --target prod --threads 1
 
       - name: Deploy notification
         run: echo "✅ Deployed to master at $(date). Railway auto-deploys the API."


### PR DESCRIPTION
## What
Adds `--threads 1` to the `dbt test` step in `deploy.yml`.

## Why
The deploy job was failing with a PostgreSQL deadlock on the `int_party_vote_majority` intermediate view:

```
Database Error in test dbt_utils_unique_combination_of_columns_int_party_vote_majority_party__vote_id
  deadlock detected
  DETAIL: Process 1880637 waits for AccessShareLock on relation 87808; blocked by process 1880598.
           Process 1880598 waits for AccessExclusiveLock on relation 87823; blocked by process 1880637.
```

With `threads: 4`, dbt runs 4 test queries concurrently. The `dbt_utils_unique_combination_of_columns` macro creates a temporary relation during its test query (acquiring `AccessExclusiveLock`), while 3 other threads are concurrently reading the same `int_party_vote_majority` view (holding `AccessShareLock`). PostgreSQL detects the circular wait and kills one transaction. Because the deadlocked test rolled back, the view became inaccessible mid-run and 3 downstream `not_null` tests then failed with `relation does not exist`.

`dbt run` is not affected — model creation is dependency-ordered and doesn't produce this lock contention pattern. Only `dbt test` is serialized.

## Changes
- `.github/workflows/deploy.yml` — `dbt test` gets `--threads 1`

## Risks / Notes
- 58 tests run sequentially instead of 4 at a time. Based on the log each test takes ~1.5s, so total test time increases from ~25s to ~90s. Acceptable for a deploy workflow.
- `dbt run` keeps `threads: 4` (from `create_dbt_profile.py`) — no change to model build speed.