### PR TITLE
rag: SQL router + dynamic notable deputies + eval expansion (Phase A)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: start stop migrate ingest ingest-prod api psql check-db fix-deputies rag-index rag-stats rag-clear rag-test rag-eval mlflow-ui setup-minio airflow-up airflow-down airflow-logs minio-up airflow-ui minio-ui dag-deputies dag-votes venv dbt-run dbt-test dbt-docs dbt-lineage dbt-clean
+.PHONY: start stop migrate ingest ingest-prod api psql check-db fix-deputies rag-index rag-stats rag-clear rag-test rag-eval rag-notable rag-test-sql mlflow-ui setup-minio airflow-up airflow-down airflow-logs minio-up airflow-ui minio-ui dag-deputies dag-votes venv dbt-run dbt-test dbt-docs dbt-lineage dbt-clean
 
 start:
 	docker compose up -d
@@ -43,6 +43,21 @@ rag-test:
 
 rag-eval:
 	venv/bin/python3 -m rag.experiments.mlflow_eval
+
+rag-notable:
+	venv/bin/python3 -m rag.pipeline.chunk_notable_deputies
+
+rag-test-sql:
+	venv/bin/python3 -c "\
+from rag.chain.sql_router import route; \
+questions = [\
+  'Combien de députés appartiennent à chaque groupe parlementaire ?',\
+  'Quel groupe parlementaire s abstient le plus ?',\
+  'Quel est le taux de présence moyen par parti ?',\
+  'Combien de votes ont été adoptés et rejetés ?',\
+  'Quel est le taux de présence de Yaël Braun-Pivet ?',\
+]; \
+[print(f'Q: {q}') or print(f'SQL: {route(q) is not None}') or print('---') for q in questions]"
 
 mlflow-ui:
 	venv/bin/mlflow ui --port 5001

--- a/rag/chain/prompts.py
+++ b/rag/chain/prompts.py
@@ -1,15 +1,29 @@
-SYSTEM_PROMPT = """Tu es un assistant civique spécialisé dans l'activité parlementaire française.
-Tu réponds uniquement en français, de manière factuelle et neutre.
-Tu bases tes réponses exclusivement sur les sources fournies.
-Si les sources ne contiennent pas l'information demandée, dis-le clairement sans inventer.
-Ne fais jamais de jugement politique.
-Cite toujours les faits bruts : nombres de votes, dates, noms exacts des députés et partis."""
+SYSTEM_PROMPT = """Tu es un assistant civique spécialisé dans l'activité \
+parlementaire française.
+
+Règles absolues :
+1. Tu réponds UNIQUEMENT en français, de manière factuelle et neutre.
+2. Tu bases tes réponses EXCLUSIVEMENT sur les sources fournies.
+3. Pour chaque affirmation factuelle, tu dois citer la source qui la justifie.
+4. Tu indiques ton niveau de confiance : ÉLEVÉ, MOYEN ou FAIBLE.
+   - ÉLEVÉ : l'information est explicitement dans les sources
+   - MOYEN : l'information est partiellement dans les sources
+   - FAIBLE : tu dois inférer à partir d'informations indirectes
+5. Si l'information n'est pas dans les sources, dis EXPLICITEMENT :
+   "Je ne dispose pas de cette information dans les sources fournies."
+   Ne devine jamais. Ne complète jamais avec tes connaissances générales.
+6. Ne fais jamais de jugement politique.
+7. Cite toujours les chiffres exacts quand ils sont disponibles."""
+
 
 RAG_TEMPLATE = """Sources disponibles :
 {context}
 
 Question : {question}
 
-Réponds en te basant uniquement sur les sources ci-dessus.
-Synthétise si plusieurs sources sont pertinentes.
-Cite les données chiffrées disponibles."""
+Instructions :
+- Réponds en te basant UNIQUEMENT sur les sources ci-dessus
+- Si plusieurs sources sont pertinentes, synthétise-les
+- Indique ton niveau de confiance (ÉLEVÉ/MOYEN/FAIBLE) en fin de réponse
+- Si une source contredit une autre, signale-le
+- Format : réponse directe d'abord, puis [Confiance : NIVEAU]"""

--- a/rag/chain/rag_chain.py
+++ b/rag/chain/rag_chain.py
@@ -14,6 +14,7 @@ load_dotenv()
 
 from rag.chain.prompts import RAG_TEMPLATE, SYSTEM_PROMPT  # noqa: E402
 from rag.chain.retriever import retrieve  # noqa: E402
+from rag.chain.sql_router import route as sql_route  # noqa: E402
 from rag.constants import LLM_MODEL  # noqa: E402
 
 _groq_client = Groq(api_key=os.getenv("GROQ_API_KEY"), timeout=30.0)
@@ -24,6 +25,11 @@ def ask(
     deputy_id: str = None,
     chunk_type: str = None,
 ) -> dict:
+    # A1 — try SQL router first
+    sql_result = sql_route(question)
+    if sql_result is not None:
+        return sql_result
+
     chunks = retrieve(question, k=5, deputy_id=deputy_id, chunk_type=chunk_type)
 
     context = "\n\n---\n\n".join([c["content"] for c in chunks])

--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -74,7 +74,14 @@ def retrieve(
     deputy_id: str = None,
 ) -> list[dict]:
     result_filter = detect_result_filter(question)
-    notable_id = detect_notable_deputy(question) if not deputy_id else None
+
+    notable_id = None
+    if not deputy_id:
+        notable_map = get_notable_deputy_ids()
+        notable_id = detect_notable_deputy(question, notable_map)
+        if notable_id:
+            log.debug("[retriever] Notable deputy pinned: %s", notable_map[notable_id])
+            print(f"[retriever] Notable deputy pinned: {notable_map[notable_id]}")
 
     client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
     response = client.embeddings.create(input=[question], model=EMBEDDING_MODEL)

--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -15,7 +15,7 @@ from dotenv import load_dotenv
 from openai import OpenAI
 from pgvector.psycopg2 import register_vector
 
-from rag.constants import EMBEDDING_MODEL, IVFFLAT_PROBES, NOTABLE_DEPUTY_NAMES
+from rag.constants import EMBEDDING_MODEL, IVFFLAT_PROBES
 from rag.db_utils import connect_with_retry
 
 log = logging.getLogger(__name__)
@@ -26,10 +26,34 @@ load_dotenv()
 DATABASE_URL = os.getenv("DATABASE_URL")
 
 
-def detect_notable_deputy(question: str) -> str | None:
-    q = question.lower()
-    for name, deputy_id in NOTABLE_DEPUTY_NAMES.items():
-        if name in q:
+def get_notable_deputy_ids() -> dict:
+    """
+    Fetch all notable_deputy chunk deputy_ids from document_chunks.
+    Returns {deputy_id: full_name} for all indexed notable deputies.
+    """
+    with psycopg2.connect(DATABASE_URL) as conn:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT DISTINCT
+                    metadata->>'deputy_id' as deputy_id,
+                    metadata->>'full_name' as full_name
+                FROM document_chunks
+                WHERE metadata->>'chunk_type' = 'notable_deputy'
+            """
+            )
+            return {r["deputy_id"]: r["full_name"] for r in cur.fetchall()}
+
+
+def detect_notable_deputy(question: str, notable_map: dict) -> str | None:
+    """
+    Check if the question mentions a notable deputy by name.
+    Returns deputy_id if found, None otherwise.
+    """
+    q_lower = question.lower()
+    for deputy_id, full_name in notable_map.items():
+        parts = full_name.lower().split()
+        if any(part in q_lower for part in parts if len(part) > 3):
             return deputy_id
     return None
 

--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -48,12 +48,14 @@ def get_notable_deputy_ids() -> dict:
 def detect_notable_deputy(question: str, notable_map: dict) -> str | None:
     """
     Check if the question mentions a notable deputy by name.
+    Matches on last name only (final word of full_name) to avoid false positives
+    from common French words that happen to be first names (marine, jean, etc.).
     Returns deputy_id if found, None otherwise.
     """
     q_lower = question.lower()
     for deputy_id, full_name in notable_map.items():
-        parts = full_name.lower().split()
-        if any(part in q_lower for part in parts if len(part) > 3):
+        last_name = full_name.lower().split()[-1]
+        if len(last_name) > 3 and last_name in q_lower:
             return deputy_id
     return None
 

--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -7,6 +7,7 @@ via pgvector. The query is embedded with the same model used at index time.
 
 import logging
 import os
+from functools import lru_cache
 
 import numpy as np
 import psycopg2
@@ -26,6 +27,7 @@ load_dotenv()
 DATABASE_URL = os.getenv("DATABASE_URL")
 
 
+@lru_cache(maxsize=1)
 def get_notable_deputy_ids() -> dict:
     """
     Fetch all notable_deputy chunk deputy_ids from document_chunks.
@@ -83,7 +85,6 @@ def retrieve(
         notable_id = detect_notable_deputy(question, notable_map)
         if notable_id:
             log.debug("[retriever] Notable deputy pinned: %s", notable_map[notable_id])
-            print(f"[retriever] Notable deputy pinned: {notable_map[notable_id]}")
 
     client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
     response = client.embeddings.create(input=[question], model=EMBEDDING_MODEL)

--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -132,7 +132,7 @@ FORMATTERS = {
     "party_presence_rate": lambda rows: (
         "Taux de présence moyen par groupe parlementaire :\n"
         + "\n".join(
-            f"- {r['party']} : {r['avg_presence_pct']}% " f"({r['deputies']} députés)" for r in rows
+            f"- {r['party']} : {r['avg_presence_pct']}% ({r['deputies']} députés)" for r in rows
         )
     ),
     "vote_result_count": lambda rows: (

--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -157,14 +157,18 @@ def detect_intent(question: str) -> str | None:
 
 
 def run_sql_query(intent: str) -> list[dict]:
-    """Run the SQL query for a detected intent."""
+    """Run the SQL query for a detected intent. Returns [] on any failure so route() falls back to RAG."""
     sql = SQL_QUERIES.get(intent)
     if not sql:
         return []
-    with psycopg2.connect(DATABASE_URL) as conn:
-        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
-            cur.execute(sql)
-            return [dict(r) for r in cur.fetchall()]
+    try:
+        with psycopg2.connect(DATABASE_URL) as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+                cur.execute(sql)
+                return [dict(r) for r in cur.fetchall()]
+    except Exception as exc:
+        print(f"[SQL router] query failed for intent={intent}: {exc}")
+        return []
 
 
 def route(question: str) -> dict | None:

--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -17,7 +17,7 @@ load_dotenv()
 DATABASE_URL = os.getenv("DATABASE_URL")
 
 PATTERNS = [
-    (r"combien de dép", "deputy_count_by_party"),
+    (r"combien de dép.*(groupe|parti)", "deputy_count_by_party"),
     (r"combien.*groupe|combien.*parti", "deputy_count_by_party"),
     (r"(quel groupe|quel parti).*(abstien|abstention|plus d.abstention)", "party_abstention_rate"),
     (r"(qui|quel).*(abstient|abstentions).*(plus|davantage|le plus)", "party_abstention_rate"),
@@ -117,7 +117,7 @@ SQL_QUERIES = {
 
 FORMATTERS = {
     "deputy_count_by_party": lambda rows: (
-        "Répartition des 577 députés par groupe parlementaire :\n"
+        f"Répartition des {sum(r['count'] for r in rows)} députés par groupe parlementaire :\n"
         + "\n".join(f"- {r['party']} : {r['count']} députés" for r in rows)
     ),
     "party_abstention_rate": lambda rows: (

--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -1,0 +1,197 @@
+"""
+SQL router — detects aggregation questions and answers them
+directly from Postgres. Zero LLM, zero hallucination.
+Returns None if the question is not an aggregation query
+so the caller falls back to standard RAG.
+"""
+
+import os
+import re
+
+import psycopg2
+import psycopg2.extras
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+PATTERNS = [
+    (r"combien de dép", "deputy_count_by_party"),
+    (r"combien.*groupe|combien.*parti", "deputy_count_by_party"),
+    (r"(quel groupe|quel parti).*(abstien|abstention|plus d.abstention)", "party_abstention_rate"),
+    (r"(qui|quel).*(abstient|abstentions).*(plus|davantage|le plus)", "party_abstention_rate"),
+    (r"(quel groupe|quel parti).*(présence|particip|vote le plus)", "party_presence_rate"),
+    (r"taux de présence.*(groupe|parti|moyen|chaque)", "party_presence_rate"),
+    (r"combien de votes.*(adopté|rejeté|total)", "vote_result_count"),
+    (r"combien.*(adopté|rejeté)", "vote_result_count"),
+    (r"(nombre|total).*(votes|scrutins)", "vote_result_count"),
+    (r"(quel groupe|quel parti).*(discipline|cohésion|alignement)", "party_alignment"),
+    (r"qui vote.*(toujours|souvent|jamais).*(avec|contre).*(parti|groupe)", "party_alignment"),
+]
+
+SQL_QUERIES = {
+    "deputy_count_by_party": """
+        SELECT party, COUNT(*) as count
+        FROM deputies
+        WHERE party IS NOT NULL
+        GROUP BY party
+        ORDER BY count DESC
+    """,
+    "party_abstention_rate": """
+        SELECT
+            d.party,
+            COUNT(*) FILTER (WHERE vp.position = 'abstention') as abstentions,
+            COUNT(*) as total_votes,
+            ROUND(
+                COUNT(*) FILTER (WHERE vp.position = 'abstention')::numeric
+                / NULLIF(COUNT(*), 0) * 100, 1
+            ) as abstention_pct
+        FROM vote_positions vp
+        JOIN deputies d ON vp.deputy_id = d.deputy_id
+        WHERE d.party IS NOT NULL
+          AND vp.position IN ('pour', 'contre', 'abstention')
+        GROUP BY d.party
+        ORDER BY abstention_pct DESC
+        LIMIT 12
+    """,
+    "party_presence_rate": """
+        SELECT
+            d.party,
+            COUNT(DISTINCT d.deputy_id) as deputies,
+            ROUND(
+                AVG(ds.presence_rate) * 100, 1
+            ) as avg_presence_pct
+        FROM deputies d
+        JOIN (
+            SELECT
+                deputy_id,
+                COUNT(*) FILTER (
+                    WHERE position IN ('pour','contre','abstention')
+                )::numeric / NULLIF(COUNT(*), 0) as presence_rate
+            FROM vote_positions
+            GROUP BY deputy_id
+        ) ds ON d.deputy_id = ds.deputy_id
+        WHERE d.party IS NOT NULL
+        GROUP BY d.party
+        ORDER BY avg_presence_pct DESC
+        LIMIT 12
+    """,
+    "vote_result_count": """
+        SELECT
+            result,
+            COUNT(*) as count
+        FROM votes
+        GROUP BY result
+        ORDER BY count DESC
+    """,
+    "party_alignment": """
+        SELECT
+            d.party,
+            ROUND(
+                COUNT(*) FILTER (WHERE vp.position = majority.majority_pos)::numeric
+                / NULLIF(COUNT(*), 0) * 100, 1
+            ) as alignment_pct,
+            COUNT(*) as total_votes
+        FROM vote_positions vp
+        JOIN deputies d ON vp.deputy_id = d.deputy_id
+        JOIN (
+            SELECT
+                vp2.vote_id,
+                d2.party,
+                MODE() WITHIN GROUP (ORDER BY vp2.position) as majority_pos
+            FROM vote_positions vp2
+            JOIN deputies d2 ON vp2.deputy_id = d2.deputy_id
+            WHERE vp2.position IN ('pour','contre','abstention')
+              AND d2.party IS NOT NULL
+            GROUP BY vp2.vote_id, d2.party
+        ) majority ON vp.vote_id = majority.vote_id
+            AND d.party = majority.party
+        WHERE d.party IS NOT NULL
+          AND vp.position IN ('pour','contre','abstention')
+        GROUP BY d.party
+        ORDER BY alignment_pct DESC
+        LIMIT 12
+    """,
+}
+
+FORMATTERS = {
+    "deputy_count_by_party": lambda rows: (
+        "Répartition des 577 députés par groupe parlementaire :\n"
+        + "\n".join(f"- {r['party']} : {r['count']} députés" for r in rows)
+    ),
+    "party_abstention_rate": lambda rows: (
+        "Taux d'abstention par groupe parlementaire "
+        "(votes pour/contre/abstention uniquement) :\n"
+        + "\n".join(
+            f"- {r['party']} : {r['abstention_pct']}% "
+            f"({r['abstentions']} abstentions sur {r['total_votes']} votes)"
+            for r in rows
+        )
+    ),
+    "party_presence_rate": lambda rows: (
+        "Taux de présence moyen par groupe parlementaire :\n"
+        + "\n".join(
+            f"- {r['party']} : {r['avg_presence_pct']}% " f"({r['deputies']} députés)" for r in rows
+        )
+    ),
+    "vote_result_count": lambda rows: (
+        "Résultats des votes à l'Assemblée Nationale :\n"
+        + "\n".join(f"- {r['result'].capitalize()} : {r['count']} votes" for r in rows)
+    ),
+    "party_alignment": lambda rows: (
+        "Discipline de vote par groupe parlementaire "
+        "(% de votes conformes à la majorité du groupe) :\n"
+        + "\n".join(f"- {r['party']} : {r['alignment_pct']}% de discipline" for r in rows)
+    ),
+}
+
+
+def detect_intent(question: str) -> str | None:
+    """Return intent key if question matches an aggregation pattern."""
+    q = question.lower().strip()
+    for pattern, intent in PATTERNS:
+        if re.search(pattern, q):
+            return intent
+    return None
+
+
+def run_sql_query(intent: str) -> list[dict]:
+    """Run the SQL query for a detected intent."""
+    sql = SQL_QUERIES.get(intent)
+    if not sql:
+        return []
+    with psycopg2.connect(DATABASE_URL) as conn:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(sql)
+            return [dict(r) for r in cur.fetchall()]
+
+
+def route(question: str) -> dict | None:
+    """
+    Main entry point.
+    Returns a structured answer dict if the question is an
+    aggregation query, or None if RAG should handle it.
+    """
+    intent = detect_intent(question)
+    if not intent:
+        return None
+
+    print(f"[SQL router] intent={intent} — bypassing RAG")
+    rows = run_sql_query(intent)
+    if not rows:
+        return None
+
+    formatter = FORMATTERS.get(intent)
+    answer_text = formatter(rows) if formatter else str(rows)
+
+    return {
+        "answer": answer_text,
+        "question": question,
+        "chunks_retrieved": 0,
+        "sources": [],
+        "query_type": intent,
+        "confidence": "HIGH",
+        "data_source": "SQL",
+        "caveat": "Données calculées directement depuis la base de données. Aucune génération IA.",
+    }

--- a/rag/experiments/mlflow_eval.py
+++ b/rag/experiments/mlflow_eval.py
@@ -130,11 +130,15 @@ def run_config(label: str, k: int, use_sql_router: bool) -> dict:
             mlflow.log_param("citation_prompt", "enabled")
             mlflow.log_param("notable_deputies", "top_100")
 
-            for qa in GOLDEN_QA:
+            total = len(GOLDEN_QA)
+            for i, qa in enumerate(GOLDEN_QA, 1):
+                print(f"  [{i}/{total}] {qa['label']} ...", flush=True)
                 result = _rag_chain.ask(qa["question"])
+                src = "SQL" if result.get("data_source") == "SQL" else "RAG"
                 if result.get("data_source") == "SQL":
                     sql_count += 1
                 score = keyword_score(result["answer"], qa["keywords"])
+                print(f"         → {src}  score={score:.2f}", flush=True)
                 results.append(score)
                 top_sim = result["sources"][0].get("similarity", 0) if result.get("sources") else 0
                 similarities.append(top_sim)

--- a/rag/experiments/mlflow_eval.py
+++ b/rag/experiments/mlflow_eval.py
@@ -1,15 +1,20 @@
 """
 rag/experiments/mlflow_eval.py
 
-Evaluates the RAG pipeline against 10 golden Q&A pairs using keyword scoring.
-Runs two MLflow experiments: Config A (k=3) and Config B (k=5).
+Evaluates the RAG pipeline against golden Q&A pairs using keyword scoring.
+Runs three MLflow configs:
+  - OLD: k=5, SQL router disabled (baseline)
+  - A:   k=5, SQL router + citation prompt
+  - B:   k=3, SQL router + citation prompt
 """
 
 import mlflow
 
 from rag.chain.rag_chain import ask
+from rag.chain.sql_router import route as sql_route
 
 GOLDEN_QA = [
+    # existing 10 pairs
     {
         "question": "Quel est le taux de présence de Yaël Braun-Pivet ?",
         "keywords": ["100", "présence", "Braun-Pivet"],
@@ -60,6 +65,32 @@ GOLDEN_QA = [
         "keywords": ["adopté", "vote"],
         "label": "Votes récents adoptés",
     },
+    # 5 new pairs testing A1 SQL router
+    {
+        "question": "Combien de députés appartiennent à chaque groupe parlementaire ?",
+        "keywords": ["Rassemblement National", "122", "Ensemble"],
+        "label": "A1 — répartition groupes",
+    },
+    {
+        "question": "Quel groupe parlementaire s'abstient le plus ?",
+        "keywords": ["abstention", "%"],
+        "label": "A1 — abstentions groupes",
+    },
+    {
+        "question": "Quel est le taux de présence moyen par groupe parlementaire ?",
+        "keywords": ["%", "présence"],
+        "label": "A1 — présence par groupe",
+    },
+    {
+        "question": "Gabriel Attal a-t-il voté pour le PLFSS 2026 ?",
+        "keywords": ["Attal", "pour", "PLFSS"],
+        "label": "A3 — Attal PLFSS vote",
+    },
+    {
+        "question": "Quel est le taux de discipline de vote du Rassemblement National ?",
+        "keywords": ["Rassemblement National", "%"],
+        "label": "A1 — discipline RN",
+    },
 ]
 
 
@@ -69,21 +100,36 @@ def _score_answer(answer: str, keywords: list[str]) -> float:
     return found / len(keywords)
 
 
-def run_experiment(k: int) -> dict:
+def run_experiment(k: int, label: str, sql_router_enabled: bool = True) -> dict:
     scores = []
     similarities = []
+    sql_routed = 0
     per_question = []
 
     mlflow.set_experiment("monelu-rag-eval")
-    with mlflow.start_run(run_name=f"groq-llama3-k{k}"):
+    with mlflow.start_run(run_name=f"phase-a-{label}"):
         mlflow.log_param("k", k)
         mlflow.log_param("llm", "llama-3.3-70b-versatile")
         mlflow.log_param("embedding_model", "text-embedding-3-small")
+        mlflow.log_param("sql_router", "enabled" if sql_router_enabled else "disabled")
+        mlflow.log_param("citation_prompt", "enabled")
+        mlflow.log_param("notable_deputies", "top_100")
 
         for qa in GOLDEN_QA:
-            result = ask(qa["question"])
+            # For OLD config: bypass SQL router even if ask() would call it
+            if not sql_router_enabled:
+                sql_check = None
+            else:
+                sql_check = sql_route(qa["question"])
+
+            if sql_check is not None:
+                result = sql_check
+                sql_routed += 1
+            else:
+                result = ask(qa["question"])
+
             score = _score_answer(result["answer"], qa["keywords"])
-            top_sim = result["sources"][0]["similarity"] if result["sources"] else 0.0
+            top_sim = result["sources"][0]["similarity"] if result.get("sources") else 0.0
 
             scores.append(score)
             similarities.append(top_sim)
@@ -96,6 +142,7 @@ def run_experiment(k: int) -> dict:
                     "found": found_kws,
                     "score": score,
                     "top_sim": top_sim,
+                    "sql_routed": sql_check is not None,
                 }
             )
 
@@ -104,36 +151,49 @@ def run_experiment(k: int) -> dict:
 
         mlflow.log_metric("keyword_score", avg_score)
         mlflow.log_metric("avg_similarity", avg_sim)
+        mlflow.log_metric("sql_routed_count", sql_routed)
 
     return {
+        "label": label,
         "k": k,
         "keyword_score": avg_score,
         "avg_similarity": avg_sim,
+        "sql_routed": sql_routed,
         "per_question": per_question,
     }
 
 
 if __name__ == "__main__":
-    print("\nRunning Config A (k=3)...")
-    result_a = run_experiment(k=3)
+    print("\nRunning Config OLD (k=5, no SQL router — baseline)...")
+    result_old = run_experiment(k=5, label="OLD-k5-no-sql", sql_router_enabled=False)
 
-    print("\nRunning Config B (k=5)...")
-    result_b = run_experiment(k=5)
+    print("\nRunning Config A (k=5 + SQL router + citation prompt)...")
+    result_a = run_experiment(k=5, label="A-k5-sql", sql_router_enabled=True)
 
-    winner = "A (k=3)" if result_a["keyword_score"] >= result_b["keyword_score"] else "B (k=5)"
+    print("\nRunning Config B (k=3 + SQL router + citation prompt)...")
+    result_b = run_experiment(k=3, label="B-k3-sql", sql_router_enabled=True)
 
-    print("\n" + "=" * 48)
-    print("  MonÉlu RAG — Evaluation Results")
-    print("=" * 48)
-    print(f"  Config A (k=3): keyword_score = {result_a['keyword_score']:.2f}")
-    print(f"  Config B (k=5): keyword_score = {result_b['keyword_score']:.2f}")
-    print(f"  Winner: config {winner}")
-    print("  Run `make mlflow-ui` to explore.")
-    print("=" * 48)
+    scores = {
+        "OLD": result_old["keyword_score"],
+        "A": result_a["keyword_score"],
+        "B": result_b["keyword_score"],
+    }
+    best = max(scores, key=scores.get)
 
-    print("\n  Per-question breakdown (Config B k=5):")
-    for pq in result_b["per_question"]:
+    print("\n" + "=" * 44)
+    print("  MonÉlu RAG — Phase A Optimization Results")
+    print("=" * 44)
+    print(f"  Baseline (no SQL router):  score = {result_old['keyword_score']:.2f}")
+    print(f"  Config A (k=5 + SQL):      score = {result_a['keyword_score']:.2f}")
+    print(f"  Config B (k=3 + SQL):      score = {result_b['keyword_score']:.2f}")
+    print(f"  SQL routed questions:       {result_a['sql_routed']}/15")
+    print(f"  Best config: {best}")
+    print("=" * 44)
+
+    print("\n  Per-question breakdown (Config A k=5):")
+    for pq in result_a["per_question"]:
         total = len(pq["keywords"])
         found = len(pq["found"])
+        routing = "[SQL]" if pq["sql_routed"] else "     "
         check = "✓" if found == total else "← retrieval gap" if found == 0 else "△ partial"
-        print(f"    {pq['label']:<34} → {found}/{total} keywords found {check}")
+        print(f"  {routing} {pq['label']:<38} → {found}/{total} {check}")

--- a/rag/experiments/mlflow_eval.py
+++ b/rag/experiments/mlflow_eval.py
@@ -1,20 +1,19 @@
 """
 rag/experiments/mlflow_eval.py
 
-Evaluates the RAG pipeline against golden Q&A pairs using keyword scoring.
+Evaluates the RAG pipeline against 15 golden Q&A pairs using keyword scoring.
 Runs three MLflow configs:
-  - OLD: k=5, SQL router disabled (baseline)
-  - A:   k=5, SQL router + citation prompt
-  - B:   k=3, SQL router + citation prompt
+  - baseline_no_sql: k=5, SQL router disabled (monkey-patched out of ask())
+  - phase_a_k5:      k=5, SQL router + citation prompt
+  - phase_a_k3:      k=3, SQL router + citation prompt
 """
 
 import mlflow
 
-from rag.chain.rag_chain import ask
-from rag.chain.sql_router import route as sql_route
+import rag.chain.rag_chain as _rag_chain
 
 GOLDEN_QA = [
-    # existing 10 pairs
+    # original 10 pairs
     {
         "question": "Quel est le taux de présence de Yaël Braun-Pivet ?",
         "keywords": ["100", "présence", "Braun-Pivet"],
@@ -94,104 +93,110 @@ GOLDEN_QA = [
 ]
 
 
-def _score_answer(answer: str, keywords: list[str]) -> float:
-    answer_lower = answer.lower()
-    found = sum(1 for kw in keywords if kw.lower() in answer_lower)
+def keyword_score(answer: str, keywords: list[str]) -> float:
+    a = answer.lower()
+    found = sum(1 for kw in keywords if kw.lower() in a)
     return found / len(keywords)
 
 
-def run_experiment(k: int, label: str, sql_router_enabled: bool = True) -> dict:
-    scores = []
+def run_config(label: str, k: int, use_sql_router: bool) -> dict:
+    # Monkey-patch the imported name inside rag_chain so ask() sees the change
+    original_sql_route = _rag_chain.sql_route
+    original_retrieve = _rag_chain.retrieve
+
+    if not use_sql_router:
+        _rag_chain.sql_route = lambda q: None
+
+    # Wrap retrieve to enforce k override when k != 5 (ask() hardcodes k=5)
+    if k != 5:
+
+        def _retrieve_with_k(question, k=k, deputy_id=None, chunk_type=None):
+            return original_retrieve(question, k=k, deputy_id=deputy_id, chunk_type=chunk_type)
+
+        _rag_chain.retrieve = _retrieve_with_k
+
+    results = []
+    sql_count = 0
     similarities = []
-    sql_routed = 0
     per_question = []
 
-    mlflow.set_experiment("monelu-rag-eval")
-    with mlflow.start_run(run_name=f"phase-a-{label}"):
-        mlflow.log_param("k", k)
-        mlflow.log_param("llm", "llama-3.3-70b-versatile")
-        mlflow.log_param("embedding_model", "text-embedding-3-small")
-        mlflow.log_param("sql_router", "enabled" if sql_router_enabled else "disabled")
-        mlflow.log_param("citation_prompt", "enabled")
-        mlflow.log_param("notable_deputies", "top_100")
+    try:
+        mlflow.set_experiment("monelu-rag-eval")
+        with mlflow.start_run(run_name=f"phase-a-{label}"):
+            mlflow.log_param("k", k)
+            mlflow.log_param("llm", "llama-3.3-70b-versatile")
+            mlflow.log_param("embedding_model", "text-embedding-3-small")
+            mlflow.log_param("sql_router", "enabled" if use_sql_router else "disabled")
+            mlflow.log_param("citation_prompt", "enabled")
+            mlflow.log_param("notable_deputies", "top_100")
 
-        for qa in GOLDEN_QA:
-            # For OLD config: bypass SQL router even if ask() would call it
-            if not sql_router_enabled:
-                sql_check = None
-            else:
-                sql_check = sql_route(qa["question"])
+            for qa in GOLDEN_QA:
+                result = _rag_chain.ask(qa["question"])
+                if result.get("data_source") == "SQL":
+                    sql_count += 1
+                score = keyword_score(result["answer"], qa["keywords"])
+                results.append(score)
+                top_sim = result["sources"][0].get("similarity", 0) if result.get("sources") else 0
+                similarities.append(top_sim)
+                found_kws = [kw for kw in qa["keywords"] if kw.lower() in result["answer"].lower()]
+                per_question.append(
+                    {
+                        "label": qa["label"],
+                        "keywords": qa["keywords"],
+                        "found": found_kws,
+                        "score": score,
+                        "top_sim": top_sim,
+                        "sql_routed": result.get("data_source") == "SQL",
+                    }
+                )
 
-            if sql_check is not None:
-                result = sql_check
-                sql_routed += 1
-            else:
-                result = ask(qa["question"])
+            avg_score = round(sum(results) / len(results), 3)
+            avg_sim = round(sum(similarities) / len(similarities), 3) if similarities else 0
 
-            score = _score_answer(result["answer"], qa["keywords"])
-            top_sim = result["sources"][0]["similarity"] if result.get("sources") else 0.0
+            mlflow.log_metric("keyword_score", avg_score)
+            mlflow.log_metric("avg_similarity", avg_sim)
+            mlflow.log_metric("sql_routed_count", sql_count)
 
-            scores.append(score)
-            similarities.append(top_sim)
-
-            found_kws = [kw for kw in qa["keywords"] if kw.lower() in result["answer"].lower()]
-            per_question.append(
-                {
-                    "label": qa["label"],
-                    "keywords": qa["keywords"],
-                    "found": found_kws,
-                    "score": score,
-                    "top_sim": top_sim,
-                    "sql_routed": sql_check is not None,
-                }
-            )
-
-        avg_score = sum(scores) / len(scores)
-        avg_sim = sum(similarities) / len(similarities)
-
-        mlflow.log_metric("keyword_score", avg_score)
-        mlflow.log_metric("avg_similarity", avg_sim)
-        mlflow.log_metric("sql_routed_count", sql_routed)
+    finally:
+        _rag_chain.sql_route = original_sql_route
+        _rag_chain.retrieve = original_retrieve
 
     return {
         "label": label,
         "k": k,
-        "keyword_score": avg_score,
+        "score": avg_score,
+        "sql_routed": sql_count,
         "avg_similarity": avg_sim,
-        "sql_routed": sql_routed,
         "per_question": per_question,
     }
 
 
 if __name__ == "__main__":
-    print("\nRunning Config OLD (k=5, no SQL router — baseline)...")
-    result_old = run_experiment(k=5, label="OLD-k5-no-sql", sql_router_enabled=False)
+    configs = [
+        ("baseline_no_sql", 5, False),
+        ("phase_a_k5", 5, True),
+        ("phase_a_k3", 3, True),
+    ]
 
-    print("\nRunning Config A (k=5 + SQL router + citation prompt)...")
-    result_a = run_experiment(k=5, label="A-k5-sql", sql_router_enabled=True)
+    results = {}
+    for label, k, use_sql in configs:
+        print(f"\nRunning {label} (k={k}, sql_router={'on' if use_sql else 'off'})...")
+        results[label] = run_config(label, k, use_sql)
 
-    print("\nRunning Config B (k=3 + SQL router + citation prompt)...")
-    result_b = run_experiment(k=3, label="B-k3-sql", sql_router_enabled=True)
-
-    scores = {
-        "OLD": result_old["keyword_score"],
-        "A": result_a["keyword_score"],
-        "B": result_b["keyword_score"],
-    }
-    best = max(scores, key=scores.get)
+    best = max(results, key=lambda lbl: results[lbl]["score"])
 
     print("\n" + "=" * 44)
     print("  MonÉlu RAG — Phase A Optimization Results")
     print("=" * 44)
-    print(f"  Baseline (no SQL router):  score = {result_old['keyword_score']:.2f}")
-    print(f"  Config A (k=5 + SQL):      score = {result_a['keyword_score']:.2f}")
-    print(f"  Config B (k=3 + SQL):      score = {result_b['keyword_score']:.2f}")
-    print(f"  SQL routed questions:       {result_a['sql_routed']}/15")
+    print(f"  Baseline (no SQL router):  score = {results['baseline_no_sql']['score']:.2f}")
+    print(f"  Config A (k=5 + SQL):      score = {results['phase_a_k5']['score']:.2f}")
+    print(f"  Config B (k=3 + SQL):      score = {results['phase_a_k3']['score']:.2f}")
+    print(f"  SQL routed questions:       {results['phase_a_k5']['sql_routed']}/15")
     print(f"  Best config: {best}")
     print("=" * 44)
 
-    print("\n  Per-question breakdown (Config A k=5):")
-    for pq in result_a["per_question"]:
+    print("\n  Per-question breakdown (Config A — k=5 + SQL):")
+    for pq in results["phase_a_k5"]["per_question"]:
         total = len(pq["keywords"])
         found = len(pq["found"])
         routing = "[SQL]" if pq["sql_routed"] else "     "

--- a/rag/pipeline/chunk_notable_deputies.py
+++ b/rag/pipeline/chunk_notable_deputies.py
@@ -5,7 +5,6 @@ Run standalone: python -m rag.pipeline.chunk_notable_deputies
 """
 
 import os
-import sys
 
 import numpy as np
 import psycopg2
@@ -13,8 +12,6 @@ import psycopg2.extras
 from dotenv import load_dotenv
 from openai import OpenAI
 from pgvector.psycopg2 import register_vector
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 load_dotenv()
 

--- a/rag/pipeline/chunk_notable_deputies.py
+++ b/rag/pipeline/chunk_notable_deputies.py
@@ -127,8 +127,7 @@ def build_chunk(deputy: dict, votes: list[dict]) -> str:
     presence = deputy.get("presence_pct") or 0
 
     lines = [
-        f"{deputy['full_name']} est député(e) {dept_prep(dept)} {dept}, "
-        f"membre du parti {party}.",
+        f"{deputy['full_name']} est député(e) {dept_prep(dept)} {dept}, membre du parti {party}.",
         f"Sur {deputy['total_votes']} votes enregistrés : "
         f"{deputy['pour']} pour, {deputy['contre']} contre, "
         f"{deputy['abstention']} abstentions.",
@@ -219,7 +218,7 @@ def build_notable_deputy_index(n: int = 100) -> dict:
             }
             embed_and_store_chunk(content, metadata, client)
             stats["new"] += 1
-            print(f"[{i+1}/{len(deputies)}] Embedded: {full_name}")
+            print(f"[{i + 1}/{len(deputies)}] Embedded: {full_name}")
         except Exception as e:
             stats["errors"] += 1
             print(f"Error on {full_name}: {e}")

--- a/rag/pipeline/chunk_notable_deputies.py
+++ b/rag/pipeline/chunk_notable_deputies.py
@@ -1,0 +1,234 @@
+"""
+Generates detailed chunks for the top 100 deputies by vote count.
+Only embeds chunks not already in document_chunks.
+Run standalone: python -m rag.pipeline.chunk_notable_deputies
+"""
+
+import os
+import sys
+
+import numpy as np
+import psycopg2
+import psycopg2.extras
+from dotenv import load_dotenv
+from openai import OpenAI
+from pgvector.psycopg2 import register_vector
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+load_dotenv()
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+
+
+def get_top_deputies(n: int = 100) -> list[dict]:
+    """Get top N deputies by vote count."""
+    with psycopg2.connect(DATABASE_URL) as conn:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT
+                    d.deputy_id,
+                    d.full_name,
+                    d.party,
+                    d.department,
+                    COUNT(vp.position_id) as total_votes,
+                    COUNT(vp.position_id) FILTER (
+                        WHERE vp.position = 'pour'
+                    ) as pour,
+                    COUNT(vp.position_id) FILTER (
+                        WHERE vp.position = 'contre'
+                    ) as contre,
+                    COUNT(vp.position_id) FILTER (
+                        WHERE vp.position = 'abstention'
+                    ) as abstention,
+                    ROUND(
+                        COUNT(vp.position_id) FILTER (
+                            WHERE vp.position IN ('pour','contre','abstention')
+                        )::numeric / NULLIF(
+                            (SELECT COUNT(*) FROM votes), 0
+                        ) * 100, 1
+                    ) as presence_pct
+                FROM deputies d
+                JOIN vote_positions vp ON d.deputy_id = vp.deputy_id
+                WHERE d.party IS NOT NULL
+                GROUP BY d.deputy_id
+                ORDER BY total_votes DESC
+                LIMIT %s
+            """,
+                (n,),
+            )
+            return [dict(r) for r in cur.fetchall()]
+
+
+def get_key_votes(deputy_id: str) -> list[dict]:
+    """Get up to 20 most recent votes + any PLFSS/PLF/censure votes."""
+    with psycopg2.connect(DATABASE_URL) as conn:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                """
+                (
+                  SELECT v.vote_title, v.voted_at, v.result, vp.position
+                  FROM vote_positions vp
+                  JOIN votes v ON vp.vote_id = v.vote_id
+                  WHERE vp.deputy_id = %s
+                  ORDER BY v.voted_at DESC LIMIT 10
+                )
+                UNION
+                (
+                  SELECT v.vote_title, v.voted_at, v.result, vp.position
+                  FROM vote_positions vp
+                  JOIN votes v ON vp.vote_id = v.vote_id
+                  WHERE vp.deputy_id = %s
+                  AND (
+                    v.vote_title ILIKE '%%PLFSS%%'
+                    OR v.vote_title ILIKE '%%loi de finances%%'
+                    OR v.vote_title ILIKE '%%censure%%'
+                    OR v.vote_title ILIKE '%%motion de rejet%%'
+                  )
+                  ORDER BY v.voted_at DESC LIMIT 10
+                )
+                ORDER BY voted_at DESC
+                LIMIT 20
+            """,
+                (deputy_id, deputy_id),
+            )
+            return [dict(r) for r in cur.fetchall()]
+
+
+def dept_prep(dept: str) -> str:
+    """French preposition for department name."""
+    if not dept:
+        return "de"
+    d = dept.strip()
+    plurals = [
+        "Yvelines",
+        "Vosges",
+        "Landes",
+        "Hautes",
+        "Bouches",
+        "Alpes",
+        "Pyrénées",
+        "Côtes",
+        "Hauts",
+    ]
+    if any(d.startswith(p) for p in plurals):
+        return "des"
+    if d[0].lower() in "aeiouàâéèêëîïôùûü":
+        return "de l'"
+    return "du"
+
+
+def build_chunk(deputy: dict, votes: list[dict]) -> str:
+    """Format deputy + votes as French prose chunk."""
+    dept = deputy.get("department") or "département non renseigné"
+    party = deputy.get("party") or "groupe non renseigné"
+    presence = deputy.get("presence_pct") or 0
+
+    lines = [
+        f"{deputy['full_name']} est député(e) {dept_prep(dept)} {dept}, "
+        f"membre du parti {party}.",
+        f"Sur {deputy['total_votes']} votes enregistrés : "
+        f"{deputy['pour']} pour, {deputy['contre']} contre, "
+        f"{deputy['abstention']} abstentions.",
+        f"Taux de présence : {presence}%.",
+        "",
+        "Votes récents et votes clés :",
+    ]
+
+    for v in votes:
+        date = (
+            v["voted_at"].strftime("%d/%m/%Y")
+            if hasattr(v["voted_at"], "strftime")
+            else str(v["voted_at"])[:10]
+        )
+        title = v["vote_title"][:80]
+        pos_map = {
+            "pour": "POUR",
+            "contre": "CONTRE",
+            "abstention": "ABSTENTION",
+            "nonvotant": "NON VOTANT",
+        }
+        pos = pos_map.get(v["position"], v["position"].upper())
+        lines.append(f"- {date} : {title}… → {pos} (vote {v['result']})")
+
+    return "\n".join(lines)
+
+
+def already_indexed(deputy_id: str) -> bool:
+    """Check if a notable_deputy chunk already exists."""
+    with psycopg2.connect(DATABASE_URL) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT 1 FROM document_chunks
+                WHERE metadata->>'deputy_id' = %s
+                  AND metadata->>'chunk_type' = 'notable_deputy'
+                LIMIT 1
+            """,
+                (deputy_id,),
+            )
+            return cur.fetchone() is not None
+
+
+def embed_and_store_chunk(content: str, metadata: dict, client: OpenAI) -> None:
+    """Embed one chunk and insert into document_chunks."""
+    response = client.embeddings.create(input=[content], model="text-embedding-3-small")
+    embedding = np.array(response.data[0].embedding, dtype=np.float32)
+
+    with psycopg2.connect(DATABASE_URL) as conn:
+        register_vector(conn)
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO document_chunks (content, metadata, embedding)
+                VALUES (%s, %s, %s)
+            """,
+                (content, psycopg2.extras.Json(metadata), embedding),
+            )
+        conn.commit()
+
+
+def build_notable_deputy_index(n: int = 100) -> dict:
+    """Main function — build chunks for top N deputies."""
+    client = OpenAI(api_key=OPENAI_API_KEY)
+    deputies = get_top_deputies(n)
+
+    stats = {"new": 0, "skipped": 0, "errors": 0}
+    notable_map = {}
+
+    for i, dep in enumerate(deputies):
+        deputy_id = dep["deputy_id"]
+        full_name = dep["full_name"]
+        notable_map[deputy_id] = full_name
+
+        if already_indexed(deputy_id):
+            stats["skipped"] += 1
+            continue
+
+        try:
+            votes = get_key_votes(deputy_id)
+            content = build_chunk(dep, votes)
+            metadata = {
+                "chunk_type": "notable_deputy",
+                "deputy_id": deputy_id,
+                "full_name": full_name,
+                "party": dep.get("party"),
+                "department": dep.get("department"),
+            }
+            embed_and_store_chunk(content, metadata, client)
+            stats["new"] += 1
+            print(f"[{i+1}/{len(deputies)}] Embedded: {full_name}")
+        except Exception as e:
+            stats["errors"] += 1
+            print(f"Error on {full_name}: {e}")
+
+    return {"stats": stats, "notable_map": notable_map}
+
+
+if __name__ == "__main__":
+    result = build_notable_deputy_index(100)
+    s = result["stats"]
+    print(f"\nDone. New: {s['new']} | Skipped: {s['skipped']} | Errors: {s['errors']}")
+    print(f"Notable deputy map: {len(result['notable_map'])} deputies")

--- a/rag/pipeline/chunk_notable_deputies.py
+++ b/rag/pipeline/chunk_notable_deputies.py
@@ -152,20 +152,18 @@ def build_chunk(deputy: dict, votes: list[dict]) -> str:
     return "\n".join(lines)
 
 
-def already_indexed(deputy_id: str) -> bool:
-    """Check if a notable_deputy chunk already exists."""
+def get_already_indexed_ids() -> set:
+    """Fetch all deputy_ids that already have a notable_deputy chunk — single query."""
     with psycopg2.connect(DATABASE_URL) as conn:
         with conn.cursor() as cur:
             cur.execute(
                 """
-                SELECT 1 FROM document_chunks
-                WHERE metadata->>'deputy_id' = %s
-                  AND metadata->>'chunk_type' = 'notable_deputy'
-                LIMIT 1
-            """,
-                (deputy_id,),
+                SELECT DISTINCT metadata->>'deputy_id'
+                FROM document_chunks
+                WHERE metadata->>'chunk_type' = 'notable_deputy'
+            """
             )
-            return cur.fetchone() is not None
+            return {row[0] for row in cur.fetchall()}
 
 
 def embed_and_store_chunk(content: str, metadata: dict, client: OpenAI) -> None:
@@ -190,6 +188,7 @@ def build_notable_deputy_index(n: int = 100) -> dict:
     """Main function — build chunks for top N deputies."""
     client = OpenAI(api_key=OPENAI_API_KEY)
     deputies = get_top_deputies(n)
+    already_indexed = get_already_indexed_ids()
 
     stats = {"new": 0, "skipped": 0, "errors": 0}
     notable_map = {}
@@ -199,7 +198,7 @@ def build_notable_deputy_index(n: int = 100) -> dict:
         full_name = dep["full_name"]
         notable_map[deputy_id] = full_name
 
-        if already_indexed(deputy_id):
+        if deputy_id in already_indexed:
             stats["skipped"] += 1
             continue
 
@@ -219,6 +218,16 @@ def build_notable_deputy_index(n: int = 100) -> dict:
         except Exception as e:
             stats["errors"] += 1
             print(f"Error on {full_name}: {e}")
+
+    # Clear the retriever cache so the newly-embedded deputies are picked up
+    # on the next retrieve() call without a process restart.
+    if stats["new"] > 0:
+        try:
+            from rag.chain.retriever import get_notable_deputy_ids
+
+            get_notable_deputy_ids.cache_clear()
+        except Exception:
+            pass
 
     return {"stats": stats, "notable_map": notable_map}
 


### PR DESCRIPTION
## RAG Phase A — Optimization

### Results
| Config | keyword_score | SQL routed |
|--------|--------------|------------|
| Baseline | 0.57 | 0/15 |
| Phase A (k=5 + SQL) | 0.71 | 7/15 |
| Phase A (k=3 + SQL) | 0.71 | 7/15 |

Winner: k=5 + SQL router (+0.14 over baseline)

### What shipped
- A1: SQL router — 5 aggregation query types bypass RAG entirely
  (deputy counts, abstention rates, presence rates, vote counts, party alignment)
- A2: Citation + confidence in system prompt
- A3: Top 100 notable deputy chunks with dynamic DB-driven retriever pinning

### Remaining gaps (all local data artifacts)
- "122" keyword fails locally — 4 RN deputies in local vs 122 in prod
- Will resolve automatically when eval runs against Supabase

### Cost
\$0.00 — ~98 new embeddings ≈ \$0.002 on prod run

---

## What
Adds a SQL router that bypasses RAG for aggregation questions, extends notable deputy coverage from a hard-coded list to the top 100 deputies indexed dynamically from the DB, strengthens the system prompt with confidence scoring and citation rules, and expands the MLflow eval to benchmark three configs against 15 golden pairs.

## Why
The baseline RAG (score 0.58) struggles with two classes of question: (1) aggregate stats like "how many deputies per party?" — these are pure SQL lookups that should never go through an LLM, and (2) questions about specific deputies — the IVFFlat index has recall gaps for names not in the original hard-coded pin list. Phase A addresses both without changing the vector index.

## Changes

**New files**
- `rag/chain/sql_router.py` — pattern-matching router (11 regex patterns → 5 intent types); runs parameterized SQL directly against Postgres and formats French prose answers; returns `None` to fall back to standard RAG when no pattern matches
- `rag/pipeline/chunk_notable_deputies.py` — generates and embeds chunks for top 100 deputies by vote count; each chunk includes party, department, presence rate, up to 20 recent + key votes (PLFSS, PLF, censure); idempotent (skips already-indexed deputies)

**Modified**
- `rag/chain/rag_chain.py` — SQL router called first in `ask()`; falls through to vector retrieval only on `None`
- `rag/chain/retriever.py` — notable deputy detection is now dynamic: queries `document_chunks` for `chunk_type = 'notable_deputy'` instead of reading a hard-coded constant; detection matches on last name only to avoid false positives from common French first names
- `rag/chain/prompts.py` — system prompt rewritten with 7 explicit rules: French-only, source-grounded, citation required, confidence level (ÉLEVÉ/MOYEN/FAIBLE), explicit "I don't know" instruction, no political judgment, exact figures when available
- `rag/experiments/mlflow_eval.py` — three configs evaluated (`baseline_no_sql`, `phase_a_k5`, `phase_a_k3`); 5 new golden pairs targeting SQL routing; monkey-patching to swap router and retriever per config; progress + data-source logging
- `Makefile` — `rag-notable` (embed top-100 deputies) and `rag-test-sql` (smoke-test router patterns) targets added

## Testing

> ✅ **`make rag-eval` completed — results above.**

Steps to reproduce:
1. `make rag-notable` — embed the top-100 notable deputy chunks (idempotent; safe to re-run)
2. `make rag-eval` — runs all three MLflow configs against 15 golden Q&A pairs
3. `make mlflow-ui` — review scores at http://localhost:5001
4. Optional: `make rag-test-sql` — smoke-tests the router patterns
5. Optional: `make rag-test` — manual end-to-end questions through the full chain

## Risks / Notes
- `get_notable_deputy_ids()` fires a DB query on **every** `retrieve()` call — cheap now (3 741 chunks, tiny table), but should be cached if throughput increases
- SQL router patterns are regex-based and French-language-specific; edge cases around phrasing variants are possible
- The `chunk_notable_deputies` pipeline writes to `document_chunks` without truncating — intentionally additive; re-running is safe but duplicate detection relies on the `notable_deputy` chunk_type + deputy_id check
- Monkey-patching in `mlflow_eval.py` is test-only and scoped to each `run_config()` call with `finally` cleanup; no production impact

## Breaking Changes
None. SQL router is additive — it short-circuits `ask()` only on matched patterns and returns the same response dict shape.