### PR TITLE
rag: apostrophe normalisation, retrieval-based confidence, dynamic data horizon

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -48,11 +48,13 @@ _warn_if_placeholder("DATABASE_URL", os.getenv("DATABASE_URL"), context="the API
 
 from api.db import close_pool, get_conn, init_pool  # noqa: E402
 from api.limiter import limiter  # noqa: E402
+from rag.chain.sql_router import _get_pool as _warm_sql_pool  # noqa: E402
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     init_pool()
+    _warm_sql_pool()  # establish the SQL router connection pool at startup
     yield
     close_pool()
 

--- a/api/main.py
+++ b/api/main.py
@@ -48,7 +48,7 @@ _warn_if_placeholder("DATABASE_URL", os.getenv("DATABASE_URL"), context="the API
 
 from api.db import close_pool, get_conn, init_pool  # noqa: E402
 from api.limiter import limiter  # noqa: E402
-from rag.chain.sql_router import _get_pool as _warm_sql_pool  # noqa: E402
+from rag.chain.sql_router import warm_pool as _warm_sql_pool  # noqa: E402
 
 
 @asynccontextmanager

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -293,6 +293,26 @@ that Phase A + B don't cover.
 
 ---
 
+## ADR-015 — Confidence computed from retrieval quality, not LLM self-rating
+**Date:** RAG polish (2026-06-04)
+**Status:** Final
+
+**Decision:** The `confidence` field returned by `POST /search/` is computed from
+chunk similarity scores, not extracted from an LLM-generated `[Confiance]` tag.
+Thresholds: top similarity ≥ 0.65 AND ≥ 2 strong chunks → ÉLEVÉ; top ≥ 0.5 → MOYEN;
+otherwise → FAIBLE. The LLM tag is still stripped from the answer text but its value
+is discarded.
+
+**Reason:** Post-deploy testing showed the LLM always self-rated ÉLEVÉ regardless of
+answer quality, making the field meaningless as a reliability signal. Retrieval-based
+confidence is deterministic, requires no extra LLM call, and reflects actual evidence
+quality rather than LLM overconfidence.
+
+**Impact on `rag/chain/rag_chain.py`:** `compute_confidence(chunks)` replaces the
+`extract_confidence()` return value in the `ask()` response dict.
+
+---
+
 ## Rules for future development sessions
 
 1. Read this file before writing any code

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -293,7 +293,7 @@ that Phase A + B don't cover.
 
 ---
 
-## ADR-015 — Confidence computed from retrieval quality, not LLM self-rating
+## ADR-016 — Confidence computed from retrieval quality, not LLM self-rating
 **Date:** RAG polish (2026-06-04)
 **Status:** Final
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -313,6 +313,21 @@ quality rather than LLM overconfidence.
 
 ---
 
+## ADR-017 — High-profile deputies always indexed
+**Date:** RAG polish
+**Status:** Final
+
+**Decision:** ALWAYS_INCLUDE dict in chunk_notable_deputies.py forces
+indexing of high-profile deputies (Attal, Le Pen) regardless of vote
+count rank, since the production data window (July 2025+) doesn't rank
+them in the top 100 by vote count.
+
+**Reason:** These are the names users and journalists actually search.
+They must always have dedicated chunks even when their recent vote
+count is low.
+
+---
+
 ## Rules for future development sessions
 
 1. Read this file before writing any code

--- a/rag/chain/prompts.py
+++ b/rag/chain/prompts.py
@@ -15,8 +15,8 @@ def get_data_horizon() -> str:
                 lo, hi = cur.fetchone()
                 if lo and hi:
                     return f"du {lo} au {hi}"
-    except Exception:
-        pass
+    except Exception as exc:
+        print(f"[prompts] get_data_horizon failed, using fallback: {exc}")
     return "depuis juillet 2025"
 
 

--- a/rag/chain/prompts.py
+++ b/rag/chain/prompts.py
@@ -1,4 +1,28 @@
-SYSTEM_PROMPT = """Tu es un assistant civique spécialisé dans l'activité \
+import os
+
+import psycopg2
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def get_data_horizon() -> str:
+    """Return the actual min/max vote date range from the DB. Runs once at module load."""
+    try:
+        with psycopg2.connect(os.getenv("DATABASE_URL")) as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT MIN(voted_at)::date, MAX(voted_at)::date FROM votes")
+                lo, hi = cur.fetchone()
+                if lo and hi:
+                    return f"du {lo} au {hi}"
+    except Exception:
+        pass
+    return "depuis juillet 2025"
+
+
+_DATA_HORIZON = get_data_horizon()
+
+SYSTEM_PROMPT = f"""Tu es un assistant civique spécialisé dans l'activité \
 parlementaire française.
 
 Règles absolues :
@@ -13,7 +37,10 @@ Règles absolues :
    "Je ne dispose pas de cette information dans les sources fournies."
    Ne devine jamais. Ne complète jamais avec tes connaissances générales.
 6. Ne fais jamais de jugement politique.
-7. Cite toujours les chiffres exacts quand ils sont disponibles."""
+7. Cite toujours les chiffres exacts quand ils sont disponibles.
+8. Les données disponibles couvrent les votes de l'Assemblée Nationale \
+{_DATA_HORIZON}. Si une question porte sur une période antérieure, \
+indique que cette période n'est pas couverte par les données actuelles."""
 
 
 RAG_TEMPLATE = """Sources disponibles :

--- a/rag/chain/rag_chain.py
+++ b/rag/chain/rag_chain.py
@@ -24,14 +24,30 @@ _CONFIDENCE_PATTERN = re.compile(r"\[Confiance\s*:\s*(ÉLEVÉ|MOYEN|FAIBLE)\]", 
 
 
 def extract_confidence(answer: str) -> tuple[str, str]:
-    """Extract [Confiance : NIVEAU] tag from answer if present.
-    Returns (clean_answer, confidence_level)."""
+    """Strip any [Confiance : NIVEAU] tag the LLM emits. Returns (clean_answer, stripped_level)."""
     match = _CONFIDENCE_PATTERN.search(answer)
     if match:
         level = match.group(1).upper()
         clean = _CONFIDENCE_PATTERN.sub("", answer).strip()
         return clean, level
     return answer, "MEDIUM"
+
+
+def compute_confidence(chunks: list[dict]) -> str:
+    """
+    Compute confidence from retrieval quality, not LLM self-rating.
+    Based on top chunk similarity and number of supporting chunks.
+    """
+    if not chunks:
+        return "FAIBLE"
+    top_sim = chunks[0].get("similarity", 0)
+    strong_chunks = sum(1 for c in chunks if c.get("similarity", 0) >= 0.5)
+
+    if top_sim >= 0.65 and strong_chunks >= 2:
+        return "ÉLEVÉ"
+    if top_sim >= 0.5:
+        return "MOYEN"
+    return "FAIBLE"
 
 
 def ask(

--- a/rag/chain/rag_chain.py
+++ b/rag/chain/rag_chain.py
@@ -81,14 +81,16 @@ def ask(
         max_tokens=1024,
     )
 
-    clean_answer, confidence = extract_confidence(response.choices[0].message.content)
+    clean_answer, _llm_confidence = extract_confidence(response.choices[0].message.content)
+    computed_confidence = compute_confidence(chunks)
+
     return {
         "answer": clean_answer,
         "sources": chunks,
         "question": question,
         "chunks_retrieved": len(chunks),
         "query_type": "rag",
-        "confidence": confidence,
+        "confidence": computed_confidence,
         "data_source": "RAG",
         "caveat": None,
     }

--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -57,7 +57,7 @@ def detect_notable_deputy(question: str, notable_map: dict) -> str | None:
     q_lower = question.lower()
     for deputy_id, full_name in notable_map.items():
         last_name = full_name.lower().split()[-1]
-        if len(last_name) > 3 and last_name in q_lower:
+        if len(last_name) >= 3 and last_name in q_lower:
             return deputy_id
     return None
 

--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -7,6 +7,7 @@ via pgvector. The query is embedded with the same model used at index time.
 
 import logging
 import os
+import re
 from functools import lru_cache
 
 import numpy as np
@@ -57,7 +58,7 @@ def detect_notable_deputy(question: str, notable_map: dict) -> str | None:
     q_lower = question.lower()
     for deputy_id, full_name in notable_map.items():
         last_name = full_name.lower().split()[-1]
-        if len(last_name) >= 3 and last_name in q_lower:
+        if len(last_name) >= 3 and re.search(r"\b" + re.escape(last_name) + r"\b", q_lower):
             return deputy_id
     return None
 

--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -31,6 +31,11 @@ def _get_pool() -> psycopg2.pool.ThreadedConnectionPool:
     return _pool
 
 
+def warm_pool() -> None:
+    """Establish the connection pool at startup. Intended for app lifespan callers."""
+    _get_pool()
+
+
 # Department name keywords (lowercase) → numeric code stored in DB
 DEPT_NAME_TO_CODE = {
     "yvelines": "78",

--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -69,17 +69,21 @@ CODE_TO_DEPT_NAME: dict[str, str] = {
     "95": "Val-d'Oise",
 }
 
-_DEPT_PATTERN = re.compile(
-    r"\b(" + "|".join(re.escape(k) for k in DEPT_NAME_TO_CODE) + r")\b",
-    re.IGNORECASE,
-)
+
+def normalize_text(text: str) -> str:
+    """Normalize apostrophes and whitespace for pattern matching."""
+    for char in ["’", "`", "´", "‘"]:
+        text = text.replace(char, "'")
+    text = " ".join(text.split())
+    return text.lower().strip()
 
 
 def detect_department(question: str) -> str | None:
-    """Return the department code if a known department name appears in the question."""
-    m = _DEPT_PATTERN.search(question)
-    if m:
-        return DEPT_NAME_TO_CODE[m.group(1).lower()]
+    """Return the canonical department name if a known department appears in the question."""
+    q = normalize_text(question)
+    for dept_name, code in DEPT_NAME_TO_CODE.items():
+        if normalize_text(dept_name) in q:
+            return CODE_TO_DEPT_NAME[code]
     return None
 
 
@@ -277,7 +281,7 @@ FORMATTERS = {
 
 def detect_intent(question: str) -> str | None:
     """Return intent key if question matches an aggregation pattern."""
-    q = question.lower().strip()
+    q = normalize_text(question)
     for pattern, intent in PATTERNS:
         if re.search(pattern, q):
             return intent
@@ -319,10 +323,9 @@ def route(question: str) -> dict | None:
     # "deputies by department" question is better handled there than
     # with a broken or meaningless ranking.
     if intent == "deputy_by_department":
-        dept_code = detect_department(question)
-        if not dept_code:
+        dept_name = detect_department(question)
+        if not dept_name:
             return None
-        dept_name = CODE_TO_DEPT_NAME.get(dept_code, dept_code)
         rows = run_sql_query("deputy_by_department", {"dept": dept_name})
         formatter_key = "deputy_by_department"
     else:

--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -7,6 +7,7 @@ so the caller falls back to standard RAG.
 
 import os
 import re
+import threading
 
 import psycopg2
 import psycopg2.extras
@@ -17,7 +18,18 @@ load_dotenv()
 
 DATABASE_URL = os.getenv("DATABASE_URL")
 
-_pool = psycopg2.pool.ThreadedConnectionPool(1, 5, dsn=DATABASE_URL)
+_pool: psycopg2.pool.ThreadedConnectionPool | None = None
+_pool_lock = threading.Lock()
+
+
+def _get_pool() -> psycopg2.pool.ThreadedConnectionPool:
+    global _pool
+    if _pool is None:
+        with _pool_lock:
+            if _pool is None:
+                _pool = psycopg2.pool.ThreadedConnectionPool(1, 5, dsn=DATABASE_URL)
+    return _pool
+
 
 # Department name keywords (lowercase) → numeric code stored in DB
 DEPT_NAME_TO_CODE = {
@@ -82,7 +94,8 @@ def detect_department(question: str) -> str | None:
     """Return the canonical department name if a known department appears in the question."""
     q = normalize_text(question)
     for dept_name, code in DEPT_NAME_TO_CODE.items():
-        if normalize_text(dept_name) in q:
+        norm = normalize_text(dept_name)
+        if re.search(r"\b" + re.escape(norm) + r"\b", q):
             return CODE_TO_DEPT_NAME[code]
     return None
 
@@ -293,16 +306,17 @@ def run_sql_query(intent: str, params: dict | None = None) -> list[dict]:
     sql = SQL_QUERIES.get(intent)
     if not sql:
         return []
-    conn = _pool.getconn()
+    pool = _get_pool()
+    conn = pool.getconn()
     try:
         with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
             cur.execute(sql, params)
             rows = [dict(r) for r in cur.fetchall()]
-        _pool.putconn(conn)
+        pool.putconn(conn)
         return rows
     except Exception as exc:
         print(f"[SQL router] query failed for intent={intent}: {exc}")
-        _pool.putconn(conn, close=True)
+        pool.putconn(conn, close=True)
         return []
 
 

--- a/rag/pipeline/chunk_notable_deputies.py
+++ b/rag/pipeline/chunk_notable_deputies.py
@@ -105,9 +105,9 @@ def get_key_votes(deputy_id: str) -> list[dict]:
                   ORDER BY v.voted_at DESC LIMIT 3
                 )
                 ORDER BY voted_at DESC
-                LIMIT 20
+                LIMIT 25
             """,
-                (deputy_id, deputy_id),
+                (deputy_id, deputy_id, deputy_id),
             )
             return [dict(r) for r in cur.fetchall()]
 

--- a/rag/pipeline/chunk_notable_deputies.py
+++ b/rag/pipeline/chunk_notable_deputies.py
@@ -18,6 +18,14 @@ load_dotenv()
 DATABASE_URL = os.getenv("DATABASE_URL")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
+# Deputies guaranteed to be indexed regardless of vote-count rank.
+# Needed for high-profile figures whose vote counts in the production
+# date window (2025-07-01 onward) don't place them in the automatic top-N.
+ALWAYS_INCLUDE: dict[str, str] = {
+    "PA722190": "Gabriel Attal",
+    "PA720614": "Marine Le Pen",
+}
+
 
 def get_top_deputies(n: int = 100) -> list[dict]:
     """Get top N deputies by vote count."""
@@ -81,10 +89,20 @@ def get_key_votes(deputy_id: str) -> list[dict]:
                   AND (
                     v.vote_title ILIKE '%%PLFSS%%'
                     OR v.vote_title ILIKE '%%loi de finances%%'
+                    OR v.vote_title ILIKE '%%financement%%'
                     OR v.vote_title ILIKE '%%censure%%'
                     OR v.vote_title ILIKE '%%motion de rejet%%'
                   )
                   ORDER BY v.voted_at DESC LIMIT 10
+                )
+                UNION
+                (
+                  SELECT v.vote_title, v.voted_at, v.result, vp.position
+                  FROM vote_positions vp
+                  JOIN votes v ON vp.vote_id = v.vote_id
+                  WHERE vp.deputy_id = %s
+                  AND v.vote_title ILIKE '%%sécurité sociale%%'
+                  ORDER BY v.voted_at DESC LIMIT 3
                 )
                 ORDER BY voted_at DESC
                 LIMIT 20
@@ -189,6 +207,33 @@ def build_notable_deputy_index(n: int = 100) -> dict:
     client = OpenAI(api_key=OPENAI_API_KEY)
     deputies = get_top_deputies(n)
     already_indexed = get_already_indexed_ids()
+
+    # Prepend ALWAYS_INCLUDE deputies not already in the top-N list.
+    existing_ids = {d["deputy_id"] for d in deputies}
+    for deputy_id, _full_name in ALWAYS_INCLUDE.items():
+        if deputy_id not in existing_ids:
+            with psycopg2.connect(DATABASE_URL) as conn:
+                with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+                    cur.execute(
+                        """
+                        SELECT d.deputy_id, d.full_name, d.party, d.department,
+                               COUNT(vp.position_id) as total_votes,
+                               COUNT(vp.position_id) FILTER (WHERE vp.position='pour') as pour,
+                               COUNT(vp.position_id) FILTER (WHERE vp.position='contre') as contre,
+                               COUNT(vp.position_id) FILTER (WHERE vp.position='abstention') as abstention,
+                               ROUND(COUNT(vp.position_id) FILTER (
+                                   WHERE vp.position IN ('pour','contre','abstention')
+                               )::numeric / NULLIF((SELECT COUNT(*) FROM votes),0)*100,1) as presence_pct
+                        FROM deputies d
+                        LEFT JOIN vote_positions vp ON d.deputy_id = vp.deputy_id
+                        WHERE d.deputy_id = %s
+                        GROUP BY d.deputy_id
+                        """,
+                        (deputy_id,),
+                    )
+                    row = cur.fetchone()
+                    if row:
+                        deputies.insert(0, dict(row))
 
     stats = {"new": 0, "skipped": 0, "errors": 0}
     notable_map = {}

--- a/rag/pipeline/index_manager.py
+++ b/rag/pipeline/index_manager.py
@@ -21,7 +21,6 @@ from rag.pipeline.chunker import (  # noqa: E402
     chunk_all,
     chunk_deputies,
     chunk_global_stats,
-    chunk_notable_deputies,
     chunk_party_summaries,
     chunk_votes,
 )
@@ -108,11 +107,12 @@ def build_index(since: str | None = None) -> None:
     else:
         print(f"No new votes since {since} — skipping vote and deputy chunks.")
 
-    # Aggregate chunks are always small (~15 total) and always stale after a run
+    # Aggregate chunks are always small (~15 total) and always stale after a run.
+    # notable_deputy chunks are excluded — they are managed by make rag-notable
+    # (build_notable_deputy_index) which has its own already_indexed guard.
     _delete_aggregate_chunks()
     chunks += chunk_party_summaries()
     chunks += chunk_global_stats()
-    chunks += chunk_notable_deputies()
 
     if chunks:
         print(f"Embedding {len(chunks)} chunks...\n")
@@ -137,12 +137,16 @@ def _delete_chunks_by_ids(chunk_type: str, id_key: str, ids: set[str]) -> None:
 
 
 def _delete_aggregate_chunks() -> None:
+    # notable_deputy chunks are managed by chunk_notable_deputies.py
+    # (build_notable_deputy_index) and must not be wiped on incremental
+    # --since builds. Only party + global_stats are truly aggregate and
+    # always stale after a run.
     conn = _get_conn()
     try:
         with conn.cursor() as cur:
             cur.execute(
                 "DELETE FROM document_chunks WHERE metadata->>'chunk_type' = ANY(%s)",
-                (["party", "global_stats", "notable_deputy"],),
+                (["party", "global_stats"],),
             )
         conn.commit()
     finally:

--- a/rag/pipeline/index_manager.py
+++ b/rag/pipeline/index_manager.py
@@ -38,7 +38,7 @@ def build_index(since: str | None = None) -> None:
 
     Without `since`: full rebuild (truncate + re-embed everything).
     With `since`: only embed new votes, refresh affected deputy chunks,
-    and always refresh the small aggregate chunks (party/global/notable).
+    and always refresh the small aggregate chunks (party/global).
     """
     if since is None:
         print("Clearing existing index...")


### PR DESCRIPTION
## What
A set of focused RAG and SQL-router reliability fixes discovered through live production testing: apostrophe normalisation, retrieval-based confidence scoring, dynamic data horizon in the system prompt, word-boundary protection for notable deputy and department detection, a guaranteed-indexing override for high-profile deputies, PLFSS vote coverage in key-vote queries, and a cron-safety fix that stops daily incremental builds from wiping the 102-chunk notable deputy index.

## Why
A full 30-test post-deploy API audit (2026-06-04/05) exposed six distinct failure modes:
1. Questions typed with curly apostrophes (`'`) silently fell back to RAG instead of routing to SQL.
2. Every `/search/` response returned `confidence: ÉLEVÉ` regardless of answer quality — the LLM always self-rates high; the field was meaningless.
3. The LLM had no knowledge of the data horizon (2025-07-01 onward), so it answered out-of-range questions with no explanation of why.
4. `detect_notable_deputy()` used a substring check with a `> 3` length gate — `"pen"` (3 chars) was blocked, and short names matched inside other words (e.g. `"pension"`).
5. Gabriel Attal and Marine Le Pen don't rank in the top-100 by vote count in the production date window (July 2025 onward) and lost their dedicated notable_deputy chunks.
6. The daily `--since` incremental cron build called `_delete_aggregate_chunks()` which deleted ALL `notable_deputy` chunks and rebuilt from a 2-entry JSON hardcoded list — wiping the 102-chunk index every night.

## Changes

**`rag/chain/sql_router.py`**
- Adds `normalize_text()`: collapses all apostrophe variants to straight `'`, normalises whitespace, lowercases. Applied in `detect_intent()` and `detect_department()`.
- Rewrites `detect_department()` to iterate over `DEPT_NAME_TO_CODE` with `\b` word-boundary regex (matching `detect_notable_deputy()`), returning the canonical display name directly. Fixes false positives where short names like `"var"` matched inside `"variantes"`, `"nord"` inside `"nordique"`, `"paris"` inside `"parisiens"`.
- Replaces eager module-level `ThreadedConnectionPool` with lazy double-checked locking (`_pool_lock` + `_get_pool()`) to avoid crashing CI where `DATABASE_URL` points to a non-existent localhost.

**`rag/chain/rag_chain.py`**
- Adds `compute_confidence(chunks)`: ÉLEVÉ if top similarity ≥ 0.65 AND ≥ 2 strong chunks; MOYEN if top ≥ 0.5; FAIBLE otherwise. LLM tag still stripped from answer text but its value is discarded.

**`rag/chain/retriever.py`**
- `detect_notable_deputy()`: `len(last_name) > 3` → `>= 3` (catches "Le Pen"), and substring `in` check → `\b` word-boundary regex (prevents `"pen"` matching inside `"pension"`).

**`rag/chain/prompts.py`**
- Adds `get_data_horizon()`: queries `MIN/MAX voted_at` once at module load; falls back to `"depuis juillet 2025"`. Rule 8 added to `SYSTEM_PROMPT` with actual date range.

**`rag/pipeline/chunk_notable_deputies.py`**
- Adds `ALWAYS_INCLUDE` dict (`{PA722190: Attal, PA720614: Le Pen}`) prepended to the top-N list regardless of vote-count rank.
- Adds dedicated `sécurité sociale` UNION arm (LIMIT 3) in `get_key_votes` so PLFSS votes are never crowded out by PLF amendments from a later month. Raises overall LIMIT 20 → 25.

**`rag/pipeline/index_manager.py`**
- Removes `"notable_deputy"` from `_delete_aggregate_chunks()` so daily `--since` cron no longer wipes the 102-chunk index. Notable deputy chunks are now managed exclusively by `make rag-notable`.
- Removes the now-unused `chunk_notable_deputies` import from `chunker.py`.
- Fixes stale docstring: `(party/global/notable)` → `(party/global)`.

**`api/main.py`**
- Calls `_warm_sql_pool()` in the lifespan startup hook so the first SQL-routed request doesn't pay the cold TLS handshake cost.

**`docs/decisions.md`**
- ADR-016: confidence computed from retrieval quality, not LLM self-rating.
- ADR-017: high-profile deputies always indexed via ALWAYS_INCLUDE.

## Testing
- `normalize_text` + apostrophe variants: all three forms of "Val-d'Oise" resolve correctly ✓
- `detect_department` false positives: "var/variantes", "nord/nordique", "paris/parisiens" all return None ✓
- `detect_notable_deputy`: Le Pen pinned, "pension de retraite" not pinned ✓
- `compute_confidence`: strong match → MOYEN/ÉLEVÉ; weak match → FAIBLE ✓
- Attal PLFSS answer: "a voté pour l'ensemble du projet de loi de financement…" ✓
- Le Pen voting pattern: specific vote counts and titles cited ✓
- `ruff check` + `ruff format` pass on all modified files.

## Risks / Notes
- After any full `make rag-index` rebuild, `make rag-notable` must be run separately to restore the 102-chunk index. The incremental cron (`--since`) no longer touches notable_deputy chunks.
- `get_data_horizon()` opens a DB connection at import time. Failure is caught silently (fallback string).
- `compute_confidence()` thresholds (0.65/0.5) were calibrated against local test data; production with notable_deputy pinning active will score higher for pinned deputies.

## Breaking Changes
The `confidence` field values (ÉLEVÉ/MOYEN/FAIBLE) are unchanged — only the source of the value changes from LLM self-rating to retrieval similarity score.