### PR TITLE
fix: isolate mart query in landing(), guard NULL result, fix pool double-putconn

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -905,6 +905,14 @@ def landing(request: Request) -> HTMLResponse:
                 n_votes = f"{cur.fetchone()['count']:,}"
                 cur.execute("SELECT COUNT(*) FROM vote_positions")
                 n_positions = f"{cur.fetchone()['count']:,}"
+        db_dot = "#4ade80"
+        db_label = "Base de données opérationnelle"
+    except Exception:
+        logger.warning("Landing page could not reach DB", exc_info=True)
+
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
                 cur.execute(
                     """
                     SELECT vote_title, result, voted_at,
@@ -917,10 +925,8 @@ def landing(request: Request) -> HTMLResponse:
                 rows = cur.fetchall()
                 if rows:
                     latest_votes_html = "".join(_build_vote_row(r) for r in rows)
-        db_dot = "#4ade80"
-        db_label = "Base de données opérationnelle"
     except Exception:
-        logger.warning("Landing page could not reach DB", exc_info=True)
+        logger.warning("Landing page could not fetch latest votes", exc_info=True)
 
     html = _LANDING_HTML.format(
         n_deputies=_compact(n_deputies),

--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -287,7 +287,9 @@ FORMATTERS = {
     ),
     "vote_result_count": lambda rows: (
         "Résultats des votes à l'Assemblée Nationale :\n"
-        + "\n".join(f"- {r['result'].capitalize()} : {r['count']} votes" for r in rows)
+        + "\n".join(
+            f"- {(r['result'] or 'inconnu').capitalize()} : {r['count']} votes" for r in rows
+        )
     ),
     "party_alignment": lambda rows: (
         "Discipline de vote par groupe parlementaire "
@@ -313,16 +315,18 @@ def run_sql_query(intent: str, params: dict | None = None) -> list[dict]:
         return []
     pool = _get_pool()
     conn = pool.getconn()
+    broken = False
     try:
         with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
             cur.execute(sql, params)
             rows = [dict(r) for r in cur.fetchall()]
-        pool.putconn(conn)
         return rows
     except Exception as exc:
         print(f"[SQL router] query failed for intent={intent}: {exc}")
-        pool.putconn(conn, close=True)
+        broken = True
         return []
+    finally:
+        pool.putconn(conn, close=broken)
 
 
 def route(question: str) -> dict | None:


### PR DESCRIPTION
## What
Fixes three confirmed correctness bugs in the landing page, the SQL router formatter, and the DB connection pool — all identified in code review (issue #125).

## Why
1. **Landing page false-negative**: `landing()` ran four queries (three `COUNT(*)` + mart query) inside a single `try/except`. On every fresh Railway deploy before dbt has run, `analytics_marts.mart_vote_summary` raises `UndefinedTable`, which fires before `db_dot` and `db_label` are set — making the page display a red "DB unavailable" indicator even though deputies/votes tables are fully populated.
2. **`capitalize()` on NULL**: The `vote_result_count` SQL formatter called `r['result'].capitalize()` directly. `votes.result` has no `NOT NULL` constraint, so a NULL group from `GROUP BY result` produces `None.capitalize()` → `AttributeError` → 500 returned to the caller.
3. **Double `pool.putconn`**: `run_sql_query` called `pool.putconn(conn)` inside the `try` block. If that call raised (e.g. pool closed during graceful shutdown), the `except` block called `pool.putconn(conn, close=True)` a second time — corrupting pool state and leaking the connection.

## Changes
- **`api/main.py`**: Split the mart query into its own `try/except` block so that an `UndefinedTable` error on fresh deploys no longer prevents `db_dot`/`db_label` from being set green.
- **`rag/chain/sql_router.py`** (formatter): Added `(r['result'] or 'inconnu')` guard before `.capitalize()` to handle NULL result groups.
- **`rag/chain/sql_router.py`** (`run_sql_query`): Replaced the split `putconn` calls with a `broken` flag and a single `finally: pool.putconn(conn, close=broken)`, matching the pattern in `api/db.py`.

## Testing
- Pre-commit hooks (ruff lint + format) pass on both changed files.
- Manual: the landing page pattern mirrors the existing `health()` split which is already tested in production.
- No new unit tests added — the NULL result condition requires a DB with dirty data; covered by the guard itself.

## Risks / Notes
- The landing page change is purely structural — same queries, same variables, same HTML output on the happy path. Only the failure mode changes (mart absent → counts still shown, latest votes section shows placeholder instead of all stats being blank).
- `run_sql_query` change is semantically equivalent on the happy path; `finally` is only exercised on pool errors (very rare, edge shutdown case).

## Breaking Changes
None.

Closes #125