### PR TITLE
chore: replace print() with structured logging in sql_router

### DIFF
--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -5,6 +5,7 @@ Returns None if the question is not an aggregation query
 so the caller falls back to standard RAG.
 """
 
+import logging
 import os
 import re
 import threading
@@ -15,6 +16,8 @@ import psycopg2.pool
 from dotenv import load_dotenv
 
 load_dotenv()
+
+log = logging.getLogger(__name__)
 
 DATABASE_URL = os.getenv("DATABASE_URL")
 
@@ -322,7 +325,7 @@ def run_sql_query(intent: str, params: dict | None = None) -> list[dict]:
             rows = [dict(r) for r in cur.fetchall()]
         return rows
     except Exception as exc:
-        print(f"[SQL router] query failed for intent={intent}: {exc}")
+        log.warning("SQL router query failed for intent=%s: %s", intent, exc)
         broken = True
         return []
     finally:
@@ -339,7 +342,7 @@ def route(question: str) -> dict | None:
     if not intent:
         return None
 
-    print(f"[SQL router] intent={intent} — bypassing RAG")
+    log.debug("SQL router intent=%s — bypassing RAG", intent)
 
     # Department queries need the detected code as a parameter.
     # If no department name is detected, fall back to RAG — a vague


### PR DESCRIPTION
## What
Replaces two bare `print()` calls in `rag/chain/sql_router.py` with structured `logging` calls so failures and routing decisions flow through the app's log configuration.

## Why
`sql_router.py` had no module-level logger and used `print()` for both a query failure message (line 325) and a routing decision message (line 342). On Railway, `print()` output lands in stdout without level, logger name, or timestamp metadata — making it invisible to any log filter set above INFO and unactionable in any log aggregator. A failing SQL router query was silently falling back to RAG with no observable alert.

Tracked in issue #126.

## Changes
- `rag/chain/sql_router.py`: added `import logging` and `log = logging.getLogger(__name__)` at module level.
- Query failure `print()` → `log.warning(...)` (surfaces in production monitoring).
- Routing decision `print()` → `log.debug(...)` (high-frequency, opt-in at DEBUG level).

## Testing
- Pre-commit hooks (ruff lint + format) pass.
- No logic changed — purely observability wiring.

## Risks / Notes
- Zero behaviour change on the happy path. The only observable difference is that these messages now carry log level, logger name (`rag.chain.sql_router`), and timestamp when the app's logging is configured.
- The `[SQL router]` prefix was dropped from the message strings — the logger name already provides that context.

## Breaking Changes
None.

Closes #126