### PR TITLE
frontend: pre-render detail pages and add on-demand cache revalidation

### DIFF
--- a/.github/workflows/ingest_prod.yml
+++ b/.github/workflows/ingest_prod.yml
@@ -112,5 +112,20 @@ jobs:
           dbt run --profiles-dir . --target prod
           dbt test --profiles-dir . --target prod
 
+      - name: Revalidate frontend cache
+        continue-on-error: true
+        env:
+          FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
+          REVALIDATE_SECRET: ${{ secrets.REVALIDATE_SECRET }}
+        run: |
+          if [ -n "$FRONTEND_URL" ] && [ -n "$REVALIDATE_SECRET" ]; then
+            curl -sf -X POST "$FRONTEND_URL/api/revalidate" \
+              -H "x-revalidate-secret: $REVALIDATE_SECRET" \
+              -H "Content-Type: application/json"
+            echo "Frontend cache revalidated."
+          else
+            echo "FRONTEND_URL or REVALIDATE_SECRET not set — skipping revalidation."
+          fi
+
       - name: Notify success
         run: echo "Ingestion completed at $(date)"

--- a/.github/workflows/ingest_prod.yml
+++ b/.github/workflows/ingest_prod.yml
@@ -113,6 +113,8 @@ jobs:
           dbt test --profiles-dir . --target prod
 
       - name: Revalidate frontend cache
+        # Runs unconditionally so deputy/party profile fixes (update_party.py)
+        # also trigger a cache purge, not just new-vote runs.
         continue-on-error: true
         env:
           FRONTEND_URL: ${{ secrets.FRONTEND_URL }}

--- a/frontend/src/app/api/revalidate/route.ts
+++ b/frontend/src/app/api/revalidate/route.ts
@@ -1,0 +1,15 @@
+import { revalidatePath } from 'next/cache'
+import { NextRequest } from 'next/server'
+
+export async function POST(req: NextRequest) {
+  if (req.headers.get('x-revalidate-secret') !== process.env.REVALIDATE_SECRET)
+    return new Response('Unauthorized', { status: 401 })
+
+  revalidatePath('/')
+  revalidatePath('/votes')
+  revalidatePath('/deputes')
+  revalidatePath('/deputes/[id]', 'page')
+  revalidatePath('/votes/[id]', 'page')
+
+  return Response.json({ revalidated: true, at: new Date().toISOString() })
+}

--- a/frontend/src/app/api/revalidate/route.ts
+++ b/frontend/src/app/api/revalidate/route.ts
@@ -1,6 +1,10 @@
 import { revalidatePath } from 'next/cache'
 import { NextRequest } from 'next/server'
 
+export async function GET() {
+  return new Response('Method Not Allowed', { status: 405 })
+}
+
 export async function POST(req: NextRequest) {
   if (req.headers.get('x-revalidate-secret') !== process.env.REVALIDATE_SECRET)
     return new Response('Unauthorized', { status: 401 })

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -4,7 +4,7 @@ import { api } from '@/lib/api'
 import { partyColor, getInitials } from '@/lib/utils'
 
 export const dynamicParams = true
-export const revalidate = 86400
+export const revalidate = 86400 // fallback if the /api/revalidate webhook is not called
 
 export async function generateStaticParams() {
   try {

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -3,6 +3,29 @@ import Link from 'next/link'
 import { api } from '@/lib/api'
 import { partyColor, getInitials } from '@/lib/utils'
 
+export const dynamicParams = true
+export const revalidate = 86400
+
+export async function generateStaticParams() {
+  try {
+    const first = await api.deputies.list({ limit: 200, offset: 0 })
+    const total = first.total
+    const items = [...first.items]
+    if (total > 200) {
+      const pages = Math.ceil((total - 200) / 200)
+      const rest = await Promise.all(
+        Array.from({ length: pages }, (_, i) =>
+          api.deputies.list({ limit: 200, offset: 200 + i * 200 })
+        )
+      )
+      items.push(...rest.flatMap(r => r.items))
+    }
+    return items.map(d => ({ id: d.deputy_id }))
+  } catch {
+    return []
+  }
+}
+
 export default async function DeputyPage({ params }: { params: { id: string } }) {
   const [deputy, scorecard] = await Promise.all([
     api.deputies.get(params.id).catch(() => null),

--- a/frontend/src/app/votes/[id]/page.tsx
+++ b/frontend/src/app/votes/[id]/page.tsx
@@ -4,7 +4,7 @@ import { api } from '@/lib/api'
 import { formatDate, partyShort, partyColor } from '@/lib/utils'
 
 export const dynamicParams = true
-export const revalidate = 86400
+export const revalidate = 86400 // fallback if the /api/revalidate webhook is not called
 
 export async function generateStaticParams() {
   try {

--- a/frontend/src/app/votes/[id]/page.tsx
+++ b/frontend/src/app/votes/[id]/page.tsx
@@ -3,6 +3,18 @@ import Link from 'next/link'
 import { api } from '@/lib/api'
 import { formatDate, partyShort, partyColor } from '@/lib/utils'
 
+export const dynamicParams = true
+export const revalidate = 86400
+
+export async function generateStaticParams() {
+  try {
+    const data = await api.votes.list({ limit: 100 })
+    return data.items.map(v => ({ id: v.vote_id }))
+  } catch {
+    return []
+  }
+}
+
 export default async function VoteDetailPage({ params }: { params: { id: string } }) {
   const vote = await api.votes.get(params.id).catch(() => null)
   if (!vote) notFound()


### PR DESCRIPTION
## What
Pre-renders all 577 deputy pages and the 100 most recent vote pages at build time (705 static pages total), and adds an on-demand cache revalidation webhook that the nightly ingestion workflow calls to flush stale pages as soon as new data lands.

## Why
Deputy and vote detail pages were fully dynamic — every visit triggered a live Railway API call. With 577 deputies that's 577 pages that could be served from Vercel's edge instead. The home-page and listing pages also used ISR with a 5-minute TTL, meaning newly ingested data could be stale for up to 5 minutes post-cron. The revalidation webhook closes that gap.

## Changes

**`frontend/src/app/deputes/[id]/page.tsx`**
- Added `generateStaticParams` — fetches all deputies in parallel batches of 200, returns all IDs for pre-rendering at build time
- `dynamicParams = true` — new deputies added after deploy are still served (SSR on first hit, then cached)
- `revalidate = 86400` — 24h background revalidation as a safety net

**`frontend/src/app/votes/[id]/page.tsx`**
- Added `generateStaticParams` — fetches the 100 most recent votes for pre-rendering
- Same `dynamicParams = true` and `revalidate = 86400` pattern

**`frontend/src/app/api/revalidate/route.ts`** (new)
- POST endpoint protected by `x-revalidate-secret` header
- Calls `revalidatePath` on `/`, `/votes`, `/deputes`, `/deputes/[id]` (page), `/votes/[id]` (page)
- Returns `{ revalidated: true, at: <timestamp> }` on success, `401` on bad/missing secret

**`.github/workflows/ingest_prod.yml`**
- New `Revalidate frontend cache` step added after dbt transformations
- `continue-on-error: true` — a failed revalidation does not fail the ingestion workflow
- Skips gracefully if `FRONTEND_URL` or `REVALIDATE_SECRET` secrets are not set

## Testing
- `npm run build` passes — 705/705 static pages generated, no type errors
- Deputy pages show as `● (SSG)` in build output, `/api/revalidate` shows as `ƒ (Dynamic)`
- Manual test: `curl -X POST <url>/api/revalidate -H "x-revalidate-secret: wrong"` should return 401

## Risks / Notes
- **Requires two new secrets before the revalidation step is active:**
  - `REVALIDATE_SECRET` — set in both Vercel env vars and GitHub Actions secrets (same value)
  - `FRONTEND_URL` — set in GitHub Actions secrets (e.g. `https://mon-elu.vercel.app`)
  - Without them the workflow step skips gracefully — no breakage
- Build time increases slightly: `generateStaticParams` makes 3–4 Railway API calls at deploy time; negligible at current scale
- Vote pages only pre-render the 100 most recent; older pages are SSR on first visit then cached 24h

## Breaking Changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)