### PR TITLE
frontend: render deputy photos with next/image and initials fallback

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -10,6 +10,15 @@ const withPWA = withPWAInit({
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'www.assemblee-nationale.fr',
+        pathname: '/dyn/static/tribun/photos/**',
+      },
+    ],
+  },
   async rewrites() {
     return []
   },

--- a/frontend/src/app/deputes/DeputiesClient.tsx
+++ b/frontend/src/app/deputes/DeputiesClient.tsx
@@ -3,7 +3,8 @@ import { useState } from 'react'
 import useSWR from 'swr'
 import Link from 'next/link'
 import { api, Deputy } from '@/lib/api'
-import { getInitials, partyShort, partyColor } from '@/lib/utils'
+import { partyShort, partyColor } from '@/lib/utils'
+import { DeputyAvatar } from '@/components/DeputyAvatar'
 
 const PARTIES = [
   'Rassemblement National',
@@ -111,9 +112,7 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
           {deputies.map(d => (
             <Link key={d.deputy_id} href={`/deputes/${d.deputy_id}`}
               className="bg-white border border-gray-border rounded-lg p-4 hover:border-navy/30 transition-colors flex items-center gap-3">
-              <div className="w-10 h-10 rounded-full bg-navy-muted flex items-center justify-center text-navy font-medium text-sm flex-shrink-0">
-                {getInitials(d.full_name)}
-              </div>
+              <DeputyAvatar name={d.full_name} photoUrl={d.photo_url} size="sm" />
               <div className="min-w-0 flex-1">
                 <p className="text-sm font-medium text-navy truncate">{d.full_name}</p>
                 <p className="text-xs text-gray-mid truncate">{d.department}</p>

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -26,7 +26,7 @@ export default async function DeputyPage({ params }: { params: { id: string } })
       {/* Header card */}
       <div className="bg-white border border-gray-border rounded-xl p-6 mb-4 mt-4">
         <div className="flex items-center gap-4 mb-2">
-          <DeputyAvatar name={deputy.full_name} photoUrl={deputy.photo_url} size="lg" />
+          <DeputyAvatar name={deputy.full_name} photoUrl={deputy.photo_url} size="lg" priority />
           <div className="min-w-0">
             <h1 className="font-serif text-2xl text-navy leading-tight">{deputy.full_name}</h1>
             <p className="text-sm text-gray-mid mt-0.5">{deputy.department}</p>

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -1,7 +1,8 @@
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { api } from '@/lib/api'
-import { partyColor, getInitials } from '@/lib/utils'
+import { partyColor } from '@/lib/utils'
+import { DeputyAvatar } from '@/components/DeputyAvatar'
 
 export default async function DeputyPage({ params }: { params: { id: string } }) {
   const [deputy, scorecard] = await Promise.all([
@@ -25,9 +26,7 @@ export default async function DeputyPage({ params }: { params: { id: string } })
       {/* Header card */}
       <div className="bg-white border border-gray-border rounded-xl p-6 mb-4 mt-4">
         <div className="flex items-center gap-4 mb-2">
-          <div className="w-16 h-16 rounded-full bg-navy-muted flex items-center justify-center text-navy font-medium text-xl flex-shrink-0">
-            {getInitials(deputy.full_name)}
-          </div>
+          <DeputyAvatar name={deputy.full_name} photoUrl={deputy.photo_url} size="lg" />
           <div className="min-w-0">
             <h1 className="font-serif text-2xl text-navy leading-tight">{deputy.full_name}</h1>
             <p className="text-sm text-gray-mid mt-0.5">{deputy.department}</p>

--- a/frontend/src/components/DeputyAvatar.tsx
+++ b/frontend/src/components/DeputyAvatar.tsx
@@ -1,0 +1,41 @@
+'use client'
+import { useState } from 'react'
+import Image from 'next/image'
+import { getInitials } from '@/lib/utils'
+
+type Props = {
+  name: string
+  photoUrl: string | null
+  size?: 'sm' | 'lg'
+}
+
+const sizes = {
+  sm: { px: 40, className: 'w-10 h-10 text-sm' },
+  lg: { px: 64, className: 'w-16 h-16 text-xl' },
+}
+
+export function DeputyAvatar({ name, photoUrl, size = 'sm' }: Props) {
+  const [imgError, setImgError] = useState(false)
+  const { px, className } = sizes[size]
+
+  if (photoUrl && !imgError) {
+    return (
+      <div className={`${className} rounded-full overflow-hidden flex-shrink-0 bg-navy-muted`}>
+        <Image
+          src={photoUrl}
+          alt={name}
+          width={px}
+          height={px}
+          className="object-cover w-full h-full"
+          onError={() => setImgError(true)}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className={`${className} rounded-full bg-navy-muted flex items-center justify-center text-navy font-medium flex-shrink-0`}>
+      {getInitials(name)}
+    </div>
+  )
+}

--- a/frontend/src/components/DeputyAvatar.tsx
+++ b/frontend/src/components/DeputyAvatar.tsx
@@ -7,6 +7,7 @@ type Props = {
   name: string
   photoUrl: string | null
   size?: 'sm' | 'lg'
+  priority?: boolean
 }
 
 const sizes = {
@@ -14,7 +15,7 @@ const sizes = {
   lg: { px: 64, className: 'w-16 h-16 text-xl' },
 }
 
-export function DeputyAvatar({ name, photoUrl, size = 'sm' }: Props) {
+export function DeputyAvatar({ name, photoUrl, size = 'sm', priority = false }: Props) {
   const [imgError, setImgError] = useState(false)
   const { px, className } = sizes[size]
 
@@ -26,7 +27,8 @@ export function DeputyAvatar({ name, photoUrl, size = 'sm' }: Props) {
           alt={name}
           width={px}
           height={px}
-          className="object-cover w-full h-full"
+          className="object-cover object-top w-full h-full"
+          priority={priority}
           onError={() => setImgError(true)}
         />
       </div>


### PR DESCRIPTION
## What
Renders official AN deputy portrait photos using `next/image` (Vercel edge-optimised WebP) across the deputies grid and detail page, with a graceful initials fallback for null URLs or failed loads.

## Why
`photo_url` has been returned by the API since Phase 1 but was never displayed — the UI showed initials placeholders everywhere. With `next/image` configured, Vercel serves WebP at the exact rendered size from its edge CDN, eliminating the cost of serving 577 full-size JPEGs directly from the AN server.

## Changes

**`frontend/src/components/DeputyAvatar.tsx`** (new)
- Client component (`'use client'`) with `useState` to catch image load errors
- Renders `<Image>` from `next/image` when `photo_url` is non-null and no error occurred
- Falls back to the initials `<div>` on `onError` or null `photo_url`
- Accepts `size` prop: `'sm'` (40×40, grid cards) or `'lg'` (64×64, detail header)

**`frontend/next.config.mjs`**
- Adds `images.remotePatterns` allowlisting `www.assemblee-nationale.fr/dyn/static/tribun/photos/**`

**`frontend/src/app/deputes/DeputiesClient.tsx`**
- Replaces the inline initials `<div>` in grid cards with `<DeputyAvatar size="sm" />`
- Removes unused `getInitials` import

**`frontend/src/app/deputes/[id]/page.tsx`**
- Replaces the inline initials `<div>` in the detail header with `<DeputyAvatar size="lg" />`
- Removes unused `getInitials` import

## Testing
- `npm run build` passes — 8/8 pages, no type errors
- Manual: visit `/deputes` and confirm photos load; visit a deputy detail page and confirm the larger photo renders
- Manual: disconnect network or use a non-existent deputy ID to confirm initials fallback renders correctly
- Verify no console errors for missing remotePatterns domain

## Risks / Notes
- The AN photo server (`www.assemblee-nationale.fr`) must remain accessible from Vercel's edge nodes. If the AN blocks external image requests, all photos will fall back to initials silently (the `onError` handler covers this)
- `next/image` requires a fixed `width` and `height`. Both are set to the actual rendered size (40 or 64px), so no layout shift occurs
- The `DeputyAvatar` component is `'use client'` solely because `onError` requires state. The rest of the component tree is unaffected

## Breaking Changes
None — initials are preserved as fallback for any deputy without a photo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)