### PR TITLE
fix: ingestion diagnostics — single ZIP downloads, shared retry helper, workflow hygiene (MON-5..8, MON-61)

### DIFF
--- a/.github/workflows/ingest_prod.yml
+++ b/.github/workflows/ingest_prod.yml
@@ -108,8 +108,8 @@ jobs:
           dbt test --profiles-dir . --target prod
 
       - name: Revalidate frontend cache
-        # Runs unconditionally so deputy/party profile fixes (update_party.py)
-        # also trigger a cache purge, not just new-vote runs.
+        # Runs unconditionally so deputy/party profile fixes (update_party.py,
+        # run inside run_ingestion_prod.py) also purge the cache, not just new-vote runs.
         continue-on-error: true
         env:
           FRONTEND_URL: ${{ secrets.FRONTEND_URL }}

--- a/.github/workflows/ingest_prod.yml
+++ b/.github/workflows/ingest_prod.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   ingest:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -48,13 +49,6 @@ jobs:
           AN_API_BASE_URL: ${{ secrets.AN_API_BASE_URL }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
         run: python scripts/run_ingestion_prod.py --since $(python3 -c "from datetime import date, timedelta; print(date.today() - timedelta(days=30))")
-
-      - name: Fix party + department names
-        continue-on-error: true
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          AN_API_BASE_URL: ${{ secrets.AN_API_BASE_URL }}
-        run: python scripts/update_party.py
 
       - name: Install RAG dependencies
         if: steps.ingest.outputs.new_votes != '0'
@@ -132,3 +126,11 @@ jobs:
 
       - name: Notify success
         run: echo "Ingestion completed at $(date)"
+
+      - name: Notify failure
+        if: failure()
+        run: |
+          echo "::error::Daily ingestion failed — data will go stale until fixed."
+          echo "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo "## ❌ Ingestion failed" >> "$GITHUB_STEP_SUMMARY"
+          echo "See the failed step above. Data goes stale until this is fixed." >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/_http.py
+++ b/scripts/_http.py
@@ -23,6 +23,7 @@ BACKOFF_BASE = 2  # seconds
 
 def download_with_retry(url: str, timeout: int = 60) -> bytes:
     """GET with exponential backoff on 429 / 5xx / network errors; returns raw bytes."""
+    last_exc: Exception | None = None
     for attempt in range(MAX_RETRIES):
         last_attempt = attempt == MAX_RETRIES - 1
         try:
@@ -42,22 +43,25 @@ def download_with_retry(url: str, timeout: int = 60) -> bytes:
             resp.raise_for_status()
             return resp.content
         except requests.RequestException as exc:
+            last_exc = exc
             if not last_attempt:
                 wait = BACKOFF_BASE**attempt
                 log.warning("Request failed (%s). Retrying in %ss…", exc, wait)
                 time.sleep(wait)
-    raise RuntimeError(f"Failed to download {url} after {MAX_RETRIES} attempts")
+    raise RuntimeError(f"Failed to download {url} after {MAX_RETRIES} attempts") from last_exc
 
 
 def connect_with_retry(dsn: str | None = None) -> psycopg2.extensions.connection:
     """Connect to Postgres with exponential backoff (handles transient proxy drops)."""
     dsn = dsn or os.getenv("DATABASE_URL")
+    last_exc: Exception | None = None
     for attempt in range(MAX_RETRIES):
         try:
             return psycopg2.connect(dsn)
         except psycopg2.OperationalError as exc:
+            last_exc = exc
             if attempt < MAX_RETRIES - 1:
                 wait = BACKOFF_BASE**attempt
                 log.warning("DB connection failed (%s). Retrying in %ss…", exc, wait)
                 time.sleep(wait)
-    raise RuntimeError(f"Could not connect to DB after {MAX_RETRIES} attempts")
+    raise RuntimeError(f"Could not connect to DB after {MAX_RETRIES} attempts") from last_exc

--- a/scripts/_http.py
+++ b/scripts/_http.py
@@ -1,0 +1,63 @@
+"""
+scripts/_http.py
+Shared download / DB-connection helpers for the ingestion scripts.
+
+Single source of truth for the retry logic that was previously copy-pasted
+in ingest_deputies.py, ingest_votes.py and ingest_positions.py.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+import psycopg2
+import requests
+
+log = logging.getLogger(__name__)
+
+MAX_RETRIES = 5
+BACKOFF_BASE = 2  # seconds
+
+
+def download_with_retry(url: str, timeout: int = 60) -> bytes:
+    """GET with exponential backoff on 429 / 5xx / network errors; returns raw bytes."""
+    for attempt in range(MAX_RETRIES):
+        last_attempt = attempt == MAX_RETRIES - 1
+        try:
+            resp = requests.get(url, timeout=timeout)
+            if resp.status_code == 429:
+                if not last_attempt:
+                    wait = BACKOFF_BASE**attempt
+                    log.warning("Rate-limited (429). Retrying in %ss…", wait)
+                    time.sleep(wait)
+                continue
+            if resp.status_code >= 500:
+                if not last_attempt:
+                    wait = BACKOFF_BASE**attempt
+                    log.warning("Server error %s. Retrying in %ss…", resp.status_code, wait)
+                    time.sleep(wait)
+                continue
+            resp.raise_for_status()
+            return resp.content
+        except requests.RequestException as exc:
+            if not last_attempt:
+                wait = BACKOFF_BASE**attempt
+                log.warning("Request failed (%s). Retrying in %ss…", exc, wait)
+                time.sleep(wait)
+    raise RuntimeError(f"Failed to download {url} after {MAX_RETRIES} attempts")
+
+
+def connect_with_retry(dsn: str | None = None) -> psycopg2.extensions.connection:
+    """Connect to Postgres with exponential backoff (handles transient proxy drops)."""
+    dsn = dsn or os.getenv("DATABASE_URL")
+    for attempt in range(MAX_RETRIES):
+        try:
+            return psycopg2.connect(dsn)
+        except psycopg2.OperationalError as exc:
+            if attempt < MAX_RETRIES - 1:
+                wait = BACKOFF_BASE**attempt
+                log.warning("DB connection failed (%s). Retrying in %ss…", exc, wait)
+                time.sleep(wait)
+    raise RuntimeError(f"Could not connect to DB after {MAX_RETRIES} attempts")

--- a/scripts/generate_vote_summaries.py
+++ b/scripts/generate_vote_summaries.py
@@ -149,9 +149,7 @@ def process_batch(
             motion_type = _detect_motion_type(title)
             system = SUMMARY_PROMPT_PROCEDURAL
             user_msg = (
-                f"Type de motion : {motion_type}\n"
-                f'Titre : "{title}"\n'
-                f"Résultat du vote : {result}"
+                f'Type de motion : {motion_type}\nTitre : "{title}"\nRésultat du vote : {result}'
             )
         else:
             system = SUMMARY_PROMPT

--- a/scripts/ingest_deputies.py
+++ b/scripts/ingest_deputies.py
@@ -9,17 +9,21 @@ Usage:
 
 from __future__ import annotations
 
+import argparse
 import io
 import json
 import logging
 import os
-import time
 import zipfile
 
 import psycopg2
 import psycopg2.extras
-import requests
 from dotenv import load_dotenv
+
+try:
+    from scripts._http import download_with_retry
+except ImportError:  # running as a plain file: python scripts/ingest_deputies.py
+    from _http import download_with_retry
 
 load_dotenv()
 
@@ -39,47 +43,20 @@ DEPUTIES_ZIP_PATH = (
 )
 
 # ---------------------------------------------------------------------------
-# HTTP helpers
-# ---------------------------------------------------------------------------
-
-MAX_RETRIES = 5
-BACKOFF_BASE = 2  # seconds
-
-
-def download_with_retry(url: str) -> bytes:
-    """GET with exponential backoff on 429 / 5xx; returns raw bytes."""
-    for attempt in range(MAX_RETRIES):
-        try:
-            resp = requests.get(url, timeout=60)
-            if resp.status_code == 429:
-                wait = BACKOFF_BASE**attempt
-                log.warning("Rate-limited (429). Retrying in %ss…", wait)
-                time.sleep(wait)
-                continue
-            if resp.status_code >= 500:
-                wait = BACKOFF_BASE**attempt
-                log.warning("Server error %s. Retrying in %ss…", resp.status_code, wait)
-                time.sleep(wait)
-                continue
-            resp.raise_for_status()
-            return resp.content
-        except requests.RequestException as exc:
-            wait = BACKOFF_BASE**attempt
-            log.warning("Request failed (%s). Retrying in %ss…", exc, wait)
-            time.sleep(wait)
-    raise RuntimeError(f"Failed to download {url} after {MAX_RETRIES} attempts")
-
-
-# ---------------------------------------------------------------------------
 # Data fetch
 # ---------------------------------------------------------------------------
 
 
-def fetch_all_deputies() -> list[dict]:
-    """Download the ZIP export and return a list of raw acteur dicts."""
-    url = f"{AN_API_BASE_URL}{DEPUTIES_ZIP_PATH}"
-    log.info("Downloading deputies ZIP from %s…", url)
-    raw = download_with_retry(url)
+def fetch_all_deputies(zip_path: str | None = None) -> list[dict]:
+    """Load the ZIP export (local path or download) and return raw acteur dicts."""
+    if zip_path:
+        log.info("Reading deputies ZIP from %s…", zip_path)
+        with open(zip_path, "rb") as fh:
+            raw = fh.read()
+    else:
+        url = f"{AN_API_BASE_URL}{DEPUTIES_ZIP_PATH}"
+        log.info("Downloading deputies ZIP from %s…", url)
+        raw = download_with_retry(url)
 
     all_items = []
     with zipfile.ZipFile(io.BytesIO(raw)) as zf:
@@ -236,11 +213,19 @@ def upsert_deputies(raw_items: list[dict]) -> int:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Ingest AN deputies into MonÉlu DB")
+    parser.add_argument(
+        "--zip-path",
+        default=None,
+        help="Path to an already-downloaded AMO10 deputies ZIP (skips the download).",
+    )
+    args = parser.parse_args()
+
     if not DATABASE_URL:
         raise EnvironmentError("DATABASE_URL is not set. Copy .env.example to .env and fill it in.")
 
     log.info("=== Starting deputy ingestion ===")
-    raw_items = fetch_all_deputies()
+    raw_items = fetch_all_deputies(zip_path=args.zip_path)
     upsert_deputies(raw_items)
     log.info("=== Deputy ingestion finished ===")
 

--- a/scripts/ingest_organes.py
+++ b/scripts/ingest_organes.py
@@ -13,7 +13,10 @@ import io
 import json
 import zipfile
 
-import requests
+try:
+    from scripts._http import download_with_retry
+except ImportError:  # running as a plain file: python scripts/ingest_organes.py
+    from _http import download_with_retry
 
 AN_BASE = "https://data.assemblee-nationale.fr"
 ZIP_PATH = (
@@ -23,11 +26,16 @@ ZIP_PATH = (
 )
 
 
-def download_zip() -> zipfile.ZipFile:
-    url = AN_BASE + ZIP_PATH
-    print(f"Downloading {url} …")
-    raw = requests.get(url, timeout=120).content
-    print(f"  {len(raw):,} bytes downloaded.")
+def download_zip(zip_path: str | None = None) -> zipfile.ZipFile:
+    if zip_path:
+        print(f"Reading {zip_path} …")
+        with open(zip_path, "rb") as fh:
+            raw = fh.read()
+    else:
+        url = AN_BASE + ZIP_PATH
+        print(f"Downloading {url} …")
+        raw = download_with_retry(url, timeout=120)
+    print(f"  {len(raw):,} bytes loaded.")
     return zipfile.ZipFile(io.BytesIO(raw))
 
 

--- a/scripts/ingest_positions.py
+++ b/scripts/ingest_positions.py
@@ -15,13 +15,15 @@ import io
 import json
 import logging
 import os
-import time
 import zipfile
 
-import psycopg2
 import psycopg2.extras
-import requests
 from dotenv import load_dotenv
+
+try:
+    from scripts._http import connect_with_retry, download_with_retry
+except ImportError:  # running as a plain file: python scripts/ingest_positions.py
+    from _http import connect_with_retry, download_with_retry
 
 load_dotenv()
 
@@ -35,53 +37,6 @@ AN_BASE_URL = os.getenv("AN_API_BASE_URL", "https://data.assemblee-nationale.fr"
 DATABASE_URL = os.getenv("DATABASE_URL")
 
 SCRUTINS_ZIP_PATH = "/static/openData/repository/17/loi/scrutins/Scrutins.json.zip"
-
-MAX_RETRIES = 5
-BACKOFF_BASE = 2
-
-
-# ---------------------------------------------------------------------------
-# DB connection with retry (handles transient proxy drops on Railway)
-# ---------------------------------------------------------------------------
-
-
-def connect_with_retry() -> psycopg2.extensions.connection:
-    for attempt in range(MAX_RETRIES):
-        try:
-            return psycopg2.connect(DATABASE_URL)
-        except psycopg2.OperationalError as exc:
-            wait = BACKOFF_BASE**attempt
-            log.warning("DB connection failed (%s). Retrying in %ss…", exc, wait)
-            time.sleep(wait)
-    raise RuntimeError(f"Could not connect to DB after {MAX_RETRIES} attempts")
-
-
-# ---------------------------------------------------------------------------
-# HTTP helper (same pattern as ingest_deputies / ingest_votes)
-# ---------------------------------------------------------------------------
-
-
-def download_with_retry(url: str) -> bytes:
-    for attempt in range(MAX_RETRIES):
-        try:
-            resp = requests.get(url, timeout=60)
-            if resp.status_code == 429:
-                wait = BACKOFF_BASE**attempt
-                log.warning("Rate-limited (429). Retrying in %ss…", wait)
-                time.sleep(wait)
-                continue
-            if resp.status_code >= 500:
-                wait = BACKOFF_BASE**attempt
-                log.warning("Server error %s. Retrying in %ss…", resp.status_code, wait)
-                time.sleep(wait)
-                continue
-            resp.raise_for_status()
-            return resp.content
-        except requests.RequestException as exc:
-            wait = BACKOFF_BASE**attempt
-            log.warning("Request failed (%s). Retrying in %ss…", exc, wait)
-            time.sleep(wait)
-    raise RuntimeError(f"Failed to download {url} after {MAX_RETRIES} attempts")
 
 
 # ---------------------------------------------------------------------------
@@ -153,7 +108,11 @@ def extract_positions(scrutin: dict) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-def fetch_scrutin_zip() -> bytes:
+def fetch_scrutin_zip(zip_path: str | None = None) -> bytes:
+    if zip_path:
+        log.info("Reading scrutins ZIP from %s…", zip_path)
+        with open(zip_path, "rb") as fh:
+            return fh.read()
     url = f"{AN_BASE_URL}{SCRUTINS_ZIP_PATH}"
     log.info("Downloading scrutins ZIP from %s…", url)
     return download_with_retry(url)
@@ -195,6 +154,11 @@ def main() -> None:
         default=None,
         help="Only ingest positions for votes on/after this date (YYYY-MM-DD). Default: all known votes.",
     )
+    parser.add_argument(
+        "--zip-path",
+        default=None,
+        help="Path to an already-downloaded Scrutins.json.zip (skips the download).",
+    )
     args = parser.parse_args()
 
     if args.since:
@@ -205,10 +169,10 @@ def main() -> None:
         except ValueError:
             parser.error(f"--since must be YYYY-MM-DD, got: {args.since!r}")
 
-    run(since=args.since)
+    run(since=args.since, zip_path=args.zip_path)
 
 
-def run(since: str | None = None) -> None:
+def run(since: str | None = None, zip_path: str | None = None) -> None:
     """Programmatic entry point for Airflow — skips argparse."""
     if not DATABASE_URL:
         raise EnvironmentError("DATABASE_URL is not set. Copy .env.example to .env and fill it in.")
@@ -220,7 +184,7 @@ def run(since: str | None = None) -> None:
         except ValueError as exc:
             raise ValueError(f"since must be YYYY-MM-DD, got: {since!r}") from exc
 
-    raw = fetch_scrutin_zip()
+    raw = fetch_scrutin_zip(zip_path=zip_path)
 
     log.info("Loading known vote_ids and deputy_ids…")
     conn = connect_with_retry()

--- a/scripts/ingest_positions.py
+++ b/scripts/ingest_positions.py
@@ -108,7 +108,11 @@ def extract_positions(scrutin: dict) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-def fetch_scrutin_zip() -> bytes:
+def fetch_scrutin_zip(zip_path: str | None = None) -> bytes:
+    if zip_path:
+        log.info("Reading scrutins ZIP from %s…", zip_path)
+        with open(zip_path, "rb") as fh:
+            return fh.read()
     url = f"{AN_BASE_URL}{SCRUTINS_ZIP_PATH}"
     log.info("Downloading scrutins ZIP from %s…", url)
     return download_with_retry(url)
@@ -150,6 +154,11 @@ def main() -> None:
         default=None,
         help="Only ingest positions for votes on/after this date (YYYY-MM-DD). Default: all known votes.",
     )
+    parser.add_argument(
+        "--zip-path",
+        default=None,
+        help="Path to an already-downloaded Scrutins.json.zip (skips the download).",
+    )
     args = parser.parse_args()
 
     if args.since:
@@ -160,10 +169,10 @@ def main() -> None:
         except ValueError:
             parser.error(f"--since must be YYYY-MM-DD, got: {args.since!r}")
 
-    run(since=args.since)
+    run(since=args.since, zip_path=args.zip_path)
 
 
-def run(since: str | None = None) -> None:
+def run(since: str | None = None, zip_path: str | None = None) -> None:
     """Programmatic entry point for Airflow — skips argparse."""
     if not DATABASE_URL:
         raise EnvironmentError("DATABASE_URL is not set. Copy .env.example to .env and fill it in.")
@@ -175,7 +184,7 @@ def run(since: str | None = None) -> None:
         except ValueError as exc:
             raise ValueError(f"since must be YYYY-MM-DD, got: {since!r}") from exc
 
-    raw = fetch_scrutin_zip()
+    raw = fetch_scrutin_zip(zip_path=zip_path)
 
     log.info("Loading known vote_ids and deputy_ids…")
     conn = connect_with_retry()
@@ -208,6 +217,14 @@ def run(since: str | None = None) -> None:
             with zf.open(name) as f:
                 data = json.load(f)
             scrutin = data.get("scrutin") or data
+
+            # Cheap date guard: skip the ventilationVotes tree-walk for scrutins
+            # outside the window, regardless of DB state.
+            if since:
+                date_raw = (scrutin.get("dateScrutin") or "")[:10]
+                if date_raw and date_raw < since:
+                    total_skipped += 1
+                    continue
 
             vote_id = scrutin.get("uid") or ""
             if vote_id not in known_votes:

--- a/scripts/ingest_positions.py
+++ b/scripts/ingest_positions.py
@@ -108,11 +108,7 @@ def extract_positions(scrutin: dict) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-def fetch_scrutin_zip(zip_path: str | None = None) -> bytes:
-    if zip_path:
-        log.info("Reading scrutins ZIP from %s…", zip_path)
-        with open(zip_path, "rb") as fh:
-            return fh.read()
+def fetch_scrutin_zip() -> bytes:
     url = f"{AN_BASE_URL}{SCRUTINS_ZIP_PATH}"
     log.info("Downloading scrutins ZIP from %s…", url)
     return download_with_retry(url)
@@ -154,11 +150,6 @@ def main() -> None:
         default=None,
         help="Only ingest positions for votes on/after this date (YYYY-MM-DD). Default: all known votes.",
     )
-    parser.add_argument(
-        "--zip-path",
-        default=None,
-        help="Path to an already-downloaded Scrutins.json.zip (skips the download).",
-    )
     args = parser.parse_args()
 
     if args.since:
@@ -169,10 +160,10 @@ def main() -> None:
         except ValueError:
             parser.error(f"--since must be YYYY-MM-DD, got: {args.since!r}")
 
-    run(since=args.since, zip_path=args.zip_path)
+    run(since=args.since)
 
 
-def run(since: str | None = None, zip_path: str | None = None) -> None:
+def run(since: str | None = None) -> None:
     """Programmatic entry point for Airflow — skips argparse."""
     if not DATABASE_URL:
         raise EnvironmentError("DATABASE_URL is not set. Copy .env.example to .env and fill it in.")
@@ -184,7 +175,7 @@ def run(since: str | None = None, zip_path: str | None = None) -> None:
         except ValueError as exc:
             raise ValueError(f"since must be YYYY-MM-DD, got: {since!r}") from exc
 
-    raw = fetch_scrutin_zip(zip_path=zip_path)
+    raw = fetch_scrutin_zip()
 
     log.info("Loading known vote_ids and deputy_ids…")
     conn = connect_with_retry()

--- a/scripts/ingest_votes.py
+++ b/scripts/ingest_votes.py
@@ -16,14 +16,17 @@ import io
 import json
 import logging
 import os
-import time
 import zipfile
 from datetime import date, timedelta
 
 import psycopg2
 import psycopg2.extras
-import requests
 from dotenv import load_dotenv
+
+try:
+    from scripts._http import download_with_retry
+except ImportError:  # running as a plain file: python scripts/ingest_votes.py
+    from _http import download_with_retry
 
 load_dotenv()
 
@@ -38,48 +41,22 @@ DATABASE_URL = os.getenv("DATABASE_URL")
 
 SCRUTINS_ZIP_PATH = "/static/openData/repository/17/loi/scrutins/Scrutins.json.zip"
 
-MAX_RETRIES = 5
-BACKOFF_BASE = 2
-
-
-# ---------------------------------------------------------------------------
-# HTTP helper
-# ---------------------------------------------------------------------------
-
-
-def download_with_retry(url: str) -> bytes:
-    for attempt in range(MAX_RETRIES):
-        try:
-            resp = requests.get(url, timeout=60)
-            if resp.status_code == 429:
-                wait = BACKOFF_BASE**attempt
-                log.warning("Rate-limited (429). Retrying in %ss…", wait)
-                time.sleep(wait)
-                continue
-            if resp.status_code >= 500:
-                wait = BACKOFF_BASE**attempt
-                log.warning("Server error %s. Retrying in %ss…", resp.status_code, wait)
-                time.sleep(wait)
-                continue
-            resp.raise_for_status()
-            return resp.content
-        except requests.RequestException as exc:
-            wait = BACKOFF_BASE**attempt
-            log.warning("Request failed (%s). Retrying in %ss…", exc, wait)
-            time.sleep(wait)
-    raise RuntimeError(f"Failed to download {url} after {MAX_RETRIES} attempts")
-
 
 # ---------------------------------------------------------------------------
 # Fetch
 # ---------------------------------------------------------------------------
 
 
-def fetch_all_scrutins(since: str | None = None) -> list[dict]:
-    """Download ZIP and return scrutins, optionally filtered to dateScrutin >= since."""
-    url = f"{AN_BASE_URL}{SCRUTINS_ZIP_PATH}"
-    log.info("Downloading scrutins ZIP from %s…", url)
-    raw = download_with_retry(url)
+def fetch_all_scrutins(since: str | None = None, zip_path: str | None = None) -> list[dict]:
+    """Load scrutins from a local ZIP (zip_path) or download one, filtered to dateScrutin >= since."""
+    if zip_path:
+        log.info("Reading scrutins ZIP from %s…", zip_path)
+        with open(zip_path, "rb") as fh:
+            raw = fh.read()
+    else:
+        url = f"{AN_BASE_URL}{SCRUTINS_ZIP_PATH}"
+        log.info("Downloading scrutins ZIP from %s…", url)
+        raw = download_with_retry(url)
 
     items = []
     skipped = 0
@@ -236,13 +213,18 @@ def main() -> None:
         default=(date.today() - timedelta(days=365)).isoformat(),
         help="Only ingest votes on or after this date (YYYY-MM-DD). Default: rolling 12 months.",
     )
+    parser.add_argument(
+        "--zip-path",
+        default=None,
+        help="Path to an already-downloaded Scrutins.json.zip (skips the download).",
+    )
     args = parser.parse_args()
 
     if not DATABASE_URL:
         raise EnvironmentError("DATABASE_URL is not set. Copy .env.example to .env and fill it in.")
 
     log.info("=== Starting vote ingestion (since %s) ===", args.since)
-    raw_items = fetch_all_scrutins(since=args.since)
+    raw_items = fetch_all_scrutins(since=args.since, zip_path=args.zip_path)
     upsert_votes(raw_items)
     log.info("=== Vote ingestion finished ===")
 

--- a/scripts/run_ingestion_prod.py
+++ b/scripts/run_ingestion_prod.py
@@ -14,12 +14,18 @@ import logging
 import os
 import subprocess
 import sys
+import tempfile
 import time
 from datetime import date, timedelta
 
 import psycopg2
 from dotenv import load_dotenv
 from psycopg2 import sql
+
+try:
+    from scripts._http import download_with_retry
+except ImportError:  # running as a plain file: python scripts/run_ingestion_prod.py
+    from _http import download_with_retry
 
 load_dotenv()
 
@@ -36,6 +42,29 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _INGESTION_LOCK_KEY = 7_391_204
 
 _ALLOWED_TABLES = {"deputies", "votes", "vote_positions", "document_chunks"}
+
+AN_BASE_URL = os.getenv("AN_API_BASE_URL", "https://data.assemblee-nationale.fr")
+SCRUTINS_ZIP_PATH = "/static/openData/repository/17/loi/scrutins/Scrutins.json.zip"
+DEPUTIES_ZIP_PATH = (
+    "/static/openData/repository/17/amo/deputes_actifs_mandats_actifs_organes"
+    "/AMO10_deputes_actifs_mandats_actifs_organes.json.zip"
+)
+
+
+def _download_zips(tmp_dir: str) -> tuple[str, str]:
+    """Download each AN ZIP once; the steps read them via --zip-path."""
+    scrutins_path = os.path.join(tmp_dir, "Scrutins.json.zip")
+    deputies_path = os.path.join(tmp_dir, "AMO10_deputes.json.zip")
+
+    log.info("Downloading scrutins ZIP once for votes + positions…")
+    with open(scrutins_path, "wb") as fh:
+        fh.write(download_with_retry(f"{AN_BASE_URL}{SCRUTINS_ZIP_PATH}"))
+
+    log.info("Downloading deputies/organes ZIP once for deputies + party fix…")
+    with open(deputies_path, "wb") as fh:
+        fh.write(download_with_retry(f"{AN_BASE_URL}{DEPUTIES_ZIP_PATH}", timeout=120))
+
+    return scrutins_path, deputies_path
 
 
 def _try_acquire_lock(conn) -> bool:
@@ -95,10 +124,21 @@ def main() -> None:
     try:
         votes_before = row_count(lock_conn, "votes")
 
-        t_deputies = run_step("Deputies", "ingest_deputies.py")
-        t_votes = run_step("Votes", "ingest_votes.py", ["--since", args.since])
-        t_positions = run_step("Positions", "ingest_positions.py", ["--since", args.since])
-        t_party = run_step("Fix party + department names", "update_party.py")
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            scrutins_zip, deputies_zip = _download_zips(tmp_dir)
+
+            t_deputies = run_step("Deputies", "ingest_deputies.py", ["--zip-path", deputies_zip])
+            t_votes = run_step(
+                "Votes", "ingest_votes.py", ["--since", args.since, "--zip-path", scrutins_zip]
+            )
+            t_positions = run_step(
+                "Positions",
+                "ingest_positions.py",
+                ["--since", args.since, "--zip-path", scrutins_zip],
+            )
+            t_party = run_step(
+                "Fix party + department names", "update_party.py", ["--zip-path", deputies_zip]
+            )
 
         n_deputies = row_count(lock_conn, "deputies")
         n_votes = row_count(lock_conn, "votes")
@@ -107,15 +147,14 @@ def main() -> None:
         new_votes = n_votes - votes_before
         log.info("New votes ingested this run: %d", new_votes)
 
-        if new_votes > 0:
-            t_summaries = run_step(
-                "Vote summaries",
-                "generate_vote_summaries.py",
-                ["--since", args.since],
-            )
-        else:
-            t_summaries = 0.0
-            log.info("No new votes — skipping summary generation.")
+        # Always run summaries: the `summary_plain IS NULL` query no-ops when there is
+        # nothing to do, and this retries summaries that failed on a previous run
+        # instead of waiting for the next new vote.
+        t_summaries = run_step(
+            "Vote summaries",
+            "generate_vote_summaries.py",
+            ["--since", args.since],
+        )
 
         total_elapsed = time.perf_counter() - total_start
         log.info("New votes ingested this run: %d", new_votes)

--- a/scripts/run_ingestion_prod.py
+++ b/scripts/run_ingestion_prod.py
@@ -147,6 +147,13 @@ def main() -> None:
         new_votes = n_votes - votes_before
         log.info("New votes ingested this run: %d", new_votes)
 
+        # Write the output as soon as it is known — a summaries failure below must
+        # not lose the new_votes signal for downstream workflow steps.
+        github_output = os.getenv("GITHUB_OUTPUT")
+        if github_output:
+            with open(github_output, "a") as f:
+                f.write(f"new_votes={new_votes}\n")
+
         # Always run summaries: the `summary_plain IS NULL` query no-ops when there is
         # nothing to do, and this retries summaries that failed on a previous run
         # instead of waiting for the next new vote.
@@ -157,12 +164,6 @@ def main() -> None:
         )
 
         total_elapsed = time.perf_counter() - total_start
-        log.info("New votes ingested this run: %d", new_votes)
-
-        github_output = os.getenv("GITHUB_OUTPUT")
-        if github_output:
-            with open(github_output, "a") as f:
-                f.write(f"new_votes={new_votes}\n")
 
         log.info("")
         log.info("╔══════════════════════════════════════╗")

--- a/scripts/update_party.py
+++ b/scripts/update_party.py
@@ -5,7 +5,7 @@ Steps 3 + 4:
   - Updates deputies.party using the GP mapping from ingest_organes.py
   - Updates deputies.department codes → full French names
 
-Run: venv/bin/python3 scripts/update_party.py
+Run: venv/bin/python3 scripts/update_party.py [--zip-path /path/to/AMO10.json.zip]
 """
 
 import os

--- a/scripts/update_party.py
+++ b/scripts/update_party.py
@@ -204,13 +204,22 @@ def print_summary(conn) -> None:
 
 if __name__ == "__main__":
     # Import here so the ZIP is only downloaded once
+    import argparse
     import os
     import sys
 
     sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
     from scripts.ingest_organes import build_deputy_party_map, build_gp_map, download_zip
 
-    zf = download_zip()
+    parser = argparse.ArgumentParser(description="Resolve deputy party + department names")
+    parser.add_argument(
+        "--zip-path",
+        default=None,
+        help="Path to an already-downloaded AMO10 deputies ZIP (skips the download).",
+    )
+    args = parser.parse_args()
+
+    zf = download_zip(zip_path=args.zip_path)
     gp_map = build_gp_map(zf)
     deputy_map = build_deputy_party_map(zf, gp_map)
 


### PR DESCRIPTION
## Summary

Fixes all 5 ingestion findings from the 2026-06-11 diagnostic (`notes/dispatch/ingestion_diagnostic_2026-06-11.md`), tracked in Linear: **MON-5, MON-6, MON-7, MON-8, MON-61**.

### MON-7 — shared retry helper (`scripts/_http.py`)
`download_with_retry` and `connect_with_retry` were copy-pasted ×3 and slept 16s after the final failed attempt before raising anyway. Now one module, no sleep on the last attempt. `ingest_organes.py` (previously a plain `requests.get` with **zero** retries) now uses it too.

### MON-5 — each AN ZIP downloaded once per run
`run_ingestion_prod.py` now downloads `Scrutins.json.zip` and the AMO10 deputies ZIP once into a temp dir and passes `--zip-path` to the steps. Previously the Scrutins ZIP (tens of MB) was downloaded twice (votes + positions) and the AMO10 ZIP twice (deputies + party fix). Network work per run is roughly halved. All scripts still download themselves when run standalone.

### MON-6 — duplicate `update_party.py` run removed
The "Fix party + department names" workflow step duplicated the orchestrator's own step (incl. a second AMO10 download). Deleted.

### MON-8 — workflow hygiene (`ingest_prod.yml`)
- `timeout-minutes: 30` (was: 6h Actions default on a hung download)
- `if: failure()` notify step with run URL + job summary
- Summaries now run unconditionally in the orchestrator — the `summary_plain IS NULL` query no-ops when idle, and previously-failed summaries are retried instead of waiting for the next new vote. The `new_votes` output still gates RAG/dbt.

### MON-61 — skip tree-walk for out-of-window scrutins
`ingest_positions.py` now checks `dateScrutin` right after `json.load` and skips the `ventilationVotes` tree-walk for scrutins older than `--since`, independent of DB state.

### Ride-along
Deleted stray `scripts/generate_vote_summaries 2.py` (macOS duplicate of the real script).

## Testing
- `ruff check scripts/` clean; `tests/unit/` 10/10 pass
- `tests/test_bronze_writer.py` 10/10 pass (mocks the changed function signatures — confirms backward compat)
- `--help` smoke test on all 5 entry points (arg wiring)
- Remaining full-suite failures are pre-existing `psycopg2.OperationalError` (local DB not running) — unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)