### PR TITLE
fix: database diagnostics — schema cleanup, migration ledger, compose split (MON-9..13, MON-62)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "CLAUDE.md",
         "hashed_secret": "ffddd4c9867f24ed207b1da5b50693e6d85a7889",
         "is_verified": false,
-        "line_number": 169
+        "line_number": 170
       }
     ],
     "README.md": [
@@ -159,24 +159,6 @@
         "hashed_secret": "09b30f6138f119acf5e4d3d7ad571e8c0b9f2059",
         "is_verified": false,
         "line_number": 176
-      }
-    ],
-    "scripts/setup_minio.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "scripts/setup_minio.py",
-        "hashed_secret": "bc565f6e909ec7d3c18e2ff5d9eeb2300ff20b7f",
-        "is_verified": false,
-        "line_number": 10
-      }
-    ],
-    "transform/package-lock.yml": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "transform/package-lock.yml",
-        "hashed_secret": "ca3d60af968149d3b440b2e576088ebfe7a4a5e4",
-        "is_verified": false,
-        "line_number": 5
       }
     ],
     "frontend/public/sw.js": [
@@ -250,7 +232,25 @@
         "is_verified": false,
         "line_number": 1
       }
+    ],
+    "scripts/setup_minio.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "scripts/setup_minio.py",
+        "hashed_secret": "bc565f6e909ec7d3c18e2ff5d9eeb2300ff20b7f",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "transform/package-lock.yml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "transform/package-lock.yml",
+        "hashed_secret": "ca3d60af968149d3b440b2e576088ebfe7a4a5e4",
+        "is_verified": false,
+        "line_number": 5
+      }
     ]
   },
-  "generated_at": "2026-06-02T20:22:59Z"
+  "generated_at": "2026-06-11T19:14:01Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Production API: https://monelu-production.up.railway.app
 | Transform layer | dbt (staging → intermediate → marts) | Runs against prod Supabase on merge to `master` |
 | RAG embeddings | OpenAI `text-embedding-3-small` | 1 536 dimensions, ~$0.006 per full re-index |
 | RAG inference | Groq `llama-3.3-70b-versatile` | temperature=0.2; free tier, faster than OpenAI |
-| Vector index | IVFFlat via pgvector (`<=>` cosine) | `ivfflat.probes=10`; notable-deputy pin for recall gaps |
+| Vector index | Exact cosine scan via pgvector (`<=>`) | ANN index dropped at ~3.7k chunks (migration 003) — exact scan is ms-fast with perfect recall |
 | CI/CD | GitHub Actions (5 workflows) | See Workflows section |
 | Experiment tracking | MLflow (local) | k=3 vs k=5 retrieval eval; baseline score 0.58 |
 | IaC | Terraform ~> 5.0 (AWS, validate-only) | `infra/` — not applied |
@@ -144,6 +144,7 @@ Assemblée Nationale Open Data (ZIPs)
 **`data/migrations/001_init.sql`** — Full schema
 - Four tables: `deputies`, `votes`, `vote_positions`, `document_chunks`
 - All `CREATE TABLE IF NOT EXISTS` — safe to re-run
+- `migrate.py` keeps a `schema_migrations` ledger: each file is applied once and skipped on later deploys
 
 ### Database
 
@@ -229,7 +230,9 @@ Key architectural choices made during the build and why. Consult this before pro
 
 ### 5. IVFFlat + notable-deputy pin for RAG retrieval
 
-**Decision:** pgvector uses IVFFlat (not HNSW) with `ivfflat.probes=10`. A hard-coded name list (Attal, Le Pen, etc.) pins the named deputy's chunk as the first result, bypassing the index.
+**Decision (revised 2026-06-11):** the IVFFlat index was dropped (migration 003) — it had been built on an empty table (degenerate clustering) and at ~3.7k chunks an exact cosine scan is faster *and* exact. The notable-deputy pin (hard-coded name list) remains for now; re-evaluating it is part of the RAG-axis remediation.
+
+**Original decision:** pgvector uses IVFFlat (not HNSW) with `ivfflat.probes=10`. A hard-coded name list (Attal, Le Pen, etc.) pins the named deputy's chunk as the first result, bypassing the index.
 
 **Why:** At 3 741 chunks, IVFFlat is fast enough and simpler to tune than HNSW. However, IVFFlat has known recall gaps for high-profile deputies whose names appear across many chunks — the index can return a generic vote chunk instead of the deputy profile. The pin is a targeted workaround: it adds one exact-match lookup before the vector search and is cheaper than retuning the entire index. This should be revisited if the corpus grows substantially or if HNSW becomes the default.
 

--- a/Makefile
+++ b/Makefile
@@ -70,16 +70,16 @@ setup-minio:
 
 airflow-up:
 	@if [ -z "$$AIRFLOW_FERNET_KEY" ]; then echo "WARNING: AIRFLOW_FERNET_KEY is unset — using the public dev default. Set it in .env before deploying to production."; fi
-	docker compose up -d airflow-webserver airflow-scheduler
+	docker compose -f docker-compose.yml -f docker-compose.airflow.yml up -d airflow-webserver airflow-scheduler
 
 airflow-down:
-	docker compose stop airflow-webserver airflow-scheduler airflow-init postgres-airflow
+	docker compose -f docker-compose.yml -f docker-compose.airflow.yml stop airflow-webserver airflow-scheduler airflow-init postgres-airflow
 
 airflow-logs:
-	docker compose logs -f airflow-scheduler
+	docker compose -f docker-compose.yml -f docker-compose.airflow.yml logs -f airflow-scheduler
 
 minio-up:
-	docker compose up -d minio
+	docker compose -f docker-compose.yml -f docker-compose.airflow.yml up -d minio
 
 airflow-ui:
 	open http://localhost:8080
@@ -88,10 +88,10 @@ minio-ui:
 	open http://localhost:9001
 
 dag-deputies:
-	docker compose exec airflow-scheduler airflow dags trigger deputies_incremental
+	docker compose -f docker-compose.yml -f docker-compose.airflow.yml exec airflow-scheduler airflow dags trigger deputies_incremental
 
 dag-votes:
-	docker compose exec airflow-scheduler airflow dags trigger votes_batch
+	docker compose -f docker-compose.yml -f docker-compose.airflow.yml exec airflow-scheduler airflow dags trigger votes_batch
 
 venv:
 	python3.12 -m venv venv && venv/bin/pip install -r requirements.txt -r requirements-ingest.txt -r requirements-rag.txt

--- a/data/migrations/001_init.sql
+++ b/data/migrations/001_init.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS deputies (
 
 CREATE TABLE IF NOT EXISTS votes (
     vote_id         TEXT PRIMARY KEY,           -- AN scrutin uid, e.g. "VTANR5L17V1234"
-    voted_at        TIMESTAMPTZ NOT NULL,
+    voted_at        TIMESTAMPTZ,                -- nullable: AN can omit dateScrutin (003)
     vote_title      TEXT NOT NULL,
     vote_type       TEXT,                       -- e.g. "SPO" (scrutin public ordinaire)
     result          TEXT,                       -- "adopté" | "rejeté"
@@ -40,14 +40,13 @@ CREATE TABLE IF NOT EXISTS vote_positions (
     UNIQUE (vote_id, deputy_id)                 -- one position per deputy per vote
 );
 
--- Indexes for common query patterns
+-- Indexes for common query patterns.
+-- Deliberately minimal: UNIQUE(vote_id, deputy_id) already serves vote_id
+-- lookups, and name/title searches are ILIKE '%…%' (btree-unusable) — see
+-- migration 003, which dropped the dead indexes this file used to create.
 CREATE INDEX IF NOT EXISTS idx_positions_deputy   ON vote_positions(deputy_id, vote_id);
-CREATE INDEX IF NOT EXISTS idx_positions_vote     ON vote_positions(vote_id);
-CREATE INDEX IF NOT EXISTS idx_vote_positions_pos ON vote_positions(position);
 CREATE INDEX IF NOT EXISTS idx_votes_voted_at     ON votes(voted_at DESC);
 CREATE INDEX IF NOT EXISTS idx_deputies_party     ON deputies(party_short);
-CREATE INDEX IF NOT EXISTS idx_deputies_full_name ON deputies(full_name);
-CREATE INDEX IF NOT EXISTS idx_votes_vote_title   ON votes(vote_title);
 
 -- ---------------------------------------------------------------------------
 -- Phase 2: semantic search via pgvector
@@ -63,19 +62,20 @@ CREATE TABLE IF NOT EXISTS document_chunks (
     content     TEXT NOT NULL,
     metadata    JSONB DEFAULT '{}',
     embedding   vector(1536),
-    created_at  TIMESTAMP DEFAULT NOW()
+    created_at  TIMESTAMPTZ DEFAULT NOW()
 );
 
-CREATE INDEX IF NOT EXISTS idx_chunks_embedding
-    ON document_chunks USING ivfflat (embedding vector_cosine_ops)
-    WITH (lists = 100);
-
-CREATE INDEX IF NOT EXISTS idx_chunks_created_at  ON document_chunks(created_at);
+-- No ANN index: at this corpus size (~3.7k chunks) an exact cosine scan is
+-- milliseconds with perfect recall. An IVFFlat index built at migration time
+-- (empty table) clusters degenerately — see migration 003 and the database
+-- diagnostic 2026-06-11 before reintroducing one.
 
 -- ---------------------------------------------------------------------------
 -- Row-Level Security
--- Affects direct Supabase REST API access only — psycopg2 (superuser role)
--- bypasses RLS entirely, so the FastAPI app is unaffected.
+-- Affects direct Supabase REST API access only. The FastAPI app connects as
+-- the table OWNER, which bypasses RLS by default (on Supabase the postgres
+-- role is not a superuser — owner bypass is what actually applies here).
+-- If a dedicated non-owner app role is ever created, it will need policies.
 -- ---------------------------------------------------------------------------
 
 ALTER TABLE deputies        ENABLE ROW LEVEL SECURITY;

--- a/data/migrations/002_vote_summaries.sql
+++ b/data/migrations/002_vote_summaries.sql
@@ -5,4 +5,7 @@ ALTER TABLE votes
   ADD COLUMN IF NOT EXISTS summary_plain TEXT,
   ADD COLUMN IF NOT EXISTS theme         TEXT;
 
--- theme is one of the 8 fixed LLM-classified categories, or NULL if not yet generated
+-- theme is one of the LLM-classified categories in VALID_THEMES
+-- (scripts/generate_vote_summaries.py — currently 10), or NULL if not yet
+-- generated. No CHECK constraint on purpose: the theme list is expected to
+-- evolve with the classifier prompt.

--- a/data/migrations/003_schema_cleanup.sql
+++ b/data/migrations/003_schema_cleanup.sql
@@ -1,0 +1,69 @@
+-- MonÉlu — schema cleanup (database diagnostic 2026-06-11)
+-- Idempotent: DROP IF EXISTS / guarded DO blocks — safe to re-run.
+
+-- ---------------------------------------------------------------------------
+-- 1. Drop dead indexes (MON-10)
+--    idx_positions_vote      — redundant: UNIQUE(vote_id, deputy_id) covers vote_id
+--    idx_vote_positions_pos  — 4 distinct values; planner never chooses it
+--    idx_votes_vote_title    — title lookups are ILIKE '%…%'; btree-unusable
+--    idx_deputies_full_name  — name lookups are ILIKE '%…%'; 577 rows seq-scan fine
+--    idx_chunks_created_at   — nothing queries chunks by created_at
+-- ---------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS idx_positions_vote;
+DROP INDEX IF EXISTS idx_vote_positions_pos;
+DROP INDEX IF EXISTS idx_votes_vote_title;
+DROP INDEX IF EXISTS idx_deputies_full_name;
+DROP INDEX IF EXISTS idx_chunks_created_at;
+
+-- ---------------------------------------------------------------------------
+-- 2. Drop the IVFFlat ANN index (MON-11)
+--    Built on an empty table at migration time → degenerate clustering and
+--    recall gaps. At ~3.7k chunks an exact cosine scan is milliseconds and
+--    has perfect recall; reintroduce ANN only if the corpus grows ~100×.
+-- ---------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS idx_chunks_embedding;
+
+-- ---------------------------------------------------------------------------
+-- 3. votes.voted_at: drop NOT NULL (MON-13)
+--    The AN parser can yield a scrutin without dateScrutin; NOT NULL would
+--    abort the whole execute_batch transaction on one bad record.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE votes ALTER COLUMN voted_at DROP NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- 4. document_chunks.created_at: TIMESTAMP → TIMESTAMPTZ (MON-13)
+--    Every other table uses TIMESTAMPTZ; align the one outlier.
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'document_chunks'
+          AND column_name = 'created_at'
+          AND data_type = 'timestamp without time zone'
+    ) THEN
+        ALTER TABLE document_chunks
+            ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC';
+    END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 5. CHECK constraint on vote_positions.position (MON-13)
+--    Catches upstream AN format drift at write time instead of letting
+--    unknown position strings through silently.
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'chk_position_domain'
+    ) THEN
+        ALTER TABLE vote_positions
+            ADD CONSTRAINT chk_position_domain
+            CHECK (position IN ('pour', 'contre', 'abstention', 'nonVotant'));
+    END IF;
+END $$;

--- a/data/migrations/003_schema_cleanup.sql
+++ b/data/migrations/003_schema_cleanup.sql
@@ -55,6 +55,11 @@ END $$;
 -- 5. CHECK constraint on vote_positions.position (MON-13)
 --    Catches upstream AN format drift at write time instead of letting
 --    unknown position strings through silently.
+--    NOT VALID: enforced for new writes only — skips the full-table scan
+--    (ACCESS EXCLUSIVE over ~715k rows) inside the Railway start hook, and a
+--    surprise historical value can't fail the boot. Validate existing rows
+--    manually when convenient:  ALTER TABLE vote_positions
+--    VALIDATE CONSTRAINT chk_position_domain;
 -- ---------------------------------------------------------------------------
 
 DO $$
@@ -64,6 +69,7 @@ BEGIN
     ) THEN
         ALTER TABLE vote_positions
             ADD CONSTRAINT chk_position_domain
-            CHECK (position IN ('pour', 'contre', 'abstention', 'nonVotant'));
+            CHECK (position IN ('pour', 'contre', 'abstention', 'nonVotant'))
+            NOT VALID;
     END IF;
 END $$;

--- a/docker-compose.airflow.yml
+++ b/docker-compose.airflow.yml
@@ -1,0 +1,136 @@
+# Experimental Airflow + MinIO stack — NOT used by production (ingestion runs on
+# GitHub Actions cron; Phase 5 is deferred, see docs/decisions.md).
+# Kept for local orchestration experiments. Run together with the base file:
+#   docker compose -f docker-compose.yml -f docker-compose.airflow.yml up -d
+
+x-airflow-common: &airflow-common
+  image: apache/airflow:2.8.1-python3.11
+  environment:
+    AIRFLOW__CORE__EXECUTOR: LocalExecutor
+    AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:${AIRFLOW_POSTGRES_PASSWORD:-airflow_local_dev}@postgres-airflow/airflow
+    # dev-only Fernet key — set AIRFLOW_FERNET_KEY in .env to override in production
+    AIRFLOW__CORE__FERNET_KEY: ${AIRFLOW_FERNET_KEY:-WHXUzrK0dY11atB_ORjCHFQ2S9B4_4ovITdpye6T4t4=}
+    AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
+    AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
+    AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth'
+    PYTHONPATH: /opt/airflow
+    DATABASE_URL: postgresql://${POSTGRES_USER:-monelu}:${POSTGRES_PASSWORD:-monelu}@postgres:5432/${POSTGRES_DB:-monelu}
+    AN_API_BASE_URL: ${AN_API_BASE_URL}
+    MINIO_ENDPOINT: http://minio:9000
+    MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:-minioadmin}
+    MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-minioadmin}
+  volumes:
+    - ./ingestion/dags:/opt/airflow/dags
+    - ./ingestion:/opt/airflow/ingestion
+    - ./quality:/opt/airflow/quality
+    - ./scripts:/opt/airflow/scripts
+    - ./logs/airflow:/opt/airflow/logs
+    - ./data:/opt/airflow/data
+
+services:
+  postgres-airflow:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: airflow
+      POSTGRES_PASSWORD: ${AIRFLOW_POSTGRES_PASSWORD:-airflow_local_dev}
+      POSTGRES_DB: airflow
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "airflow"]
+      interval: 5s
+      retries: 5
+    volumes:
+      - postgres-airflow-data:/var/lib/postgresql/data
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.25"
+
+  airflow-init:
+    <<: *airflow-common
+    depends_on:
+      postgres-airflow:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+    entrypoint: /bin/bash
+    command: -c "airflow db migrate && (airflow users create --username admin --password ${AIRFLOW_ADMIN_PASSWORD:-airflow_local_dev} --firstname Admin --lastname Admin --role Admin --email admin@monelu.fr || true)"
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: "0.5"
+
+  airflow-webserver:
+    <<: *airflow-common
+    depends_on:
+      postgres-airflow:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      airflow-init:
+        condition: service_completed_successfully
+      minio:
+        condition: service_healthy
+    command: webserver
+    ports:
+      - "127.0.0.1:8080:8080"
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
+      interval: 30s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: "0.5"
+
+  airflow-scheduler:
+    <<: *airflow-common
+    build:
+      context: .
+      dockerfile: Dockerfile.airflow
+    depends_on:
+      postgres-airflow:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      airflow-init:
+        condition: service_completed_successfully
+      minio:
+        condition: service_healthy
+    command: scheduler
+    healthcheck:
+      test: ["CMD", "airflow", "jobs", "check", "--job-type", "SchedulerJob"]
+      interval: 30s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+          cpus: "1.0"
+
+  minio:
+    image: minio/minio:RELEASE.2024-01-28T22-35-53Z
+    command: server /data --console-address ":9001"
+    ports:
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9001:9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: "0.5"
+
+volumes:
+  postgres-airflow-data:
+  minio-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,9 @@
-x-airflow-common: &airflow-common
-  image: apache/airflow:2.8.1-python3.11
-  environment:
-    AIRFLOW__CORE__EXECUTOR: LocalExecutor
-    AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:${AIRFLOW_POSTGRES_PASSWORD:-airflow_local_dev}@postgres-airflow/airflow
-    # dev-only Fernet key — set AIRFLOW_FERNET_KEY in .env to override in production
-    AIRFLOW__CORE__FERNET_KEY: ${AIRFLOW_FERNET_KEY:-WHXUzrK0dY11atB_ORjCHFQ2S9B4_4ovITdpye6T4t4=}
-    AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
-    AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
-    AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth'
-    PYTHONPATH: /opt/airflow
-    DATABASE_URL: postgresql://${POSTGRES_USER:-monelu}:${POSTGRES_PASSWORD:-monelu}@postgres:5432/${POSTGRES_DB:-monelu}
-    AN_API_BASE_URL: ${AN_API_BASE_URL}
-    MINIO_ENDPOINT: http://minio:9000
-    MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:-minioadmin}
-    MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-minioadmin}
-  volumes:
-    - ./ingestion/dags:/opt/airflow/dags
-    - ./ingestion:/opt/airflow/ingestion
-    - ./quality:/opt/airflow/quality
-    - ./scripts:/opt/airflow/scripts
-    - ./logs/airflow:/opt/airflow/logs
-    - ./data:/opt/airflow/data
+# MonÉlu local infrastructure — Postgres 15 (pgvector) + pgAdmin 8 only.
+# Schema is applied by `make migrate` (scripts/migrate.py) — the same mechanism
+# production uses — not by the Postgres initdb hook.
+#
+# The experimental Airflow/MinIO stack lives in docker-compose.airflow.yml:
+#   docker compose -f docker-compose.yml -f docker-compose.airflow.yml up -d
 
 services:
   postgres:
@@ -34,7 +17,6 @@ services:
       - "127.0.0.1:5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./data/migrations:/docker-entrypoint-initdb.d
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-monelu}"]
       interval: 10s
@@ -65,111 +47,6 @@ services:
           memory: 256m
           cpus: "0.25"
 
-  postgres-airflow:
-    image: postgres:15
-    environment:
-      POSTGRES_USER: airflow
-      POSTGRES_PASSWORD: ${AIRFLOW_POSTGRES_PASSWORD:-airflow_local_dev}
-      POSTGRES_DB: airflow
-    healthcheck:
-      test: ["CMD", "pg_isready", "-U", "airflow"]
-      interval: 5s
-      retries: 5
-    volumes:
-      - postgres-airflow-data:/var/lib/postgresql/data
-    deploy:
-      resources:
-        limits:
-          memory: 256m
-          cpus: "0.25"
-
-  airflow-init:
-    <<: *airflow-common
-    depends_on:
-      postgres-airflow:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
-    entrypoint: /bin/bash
-    command: -c "airflow db migrate && (airflow users create --username admin --password ${AIRFLOW_ADMIN_PASSWORD:-airflow_local_dev} --firstname Admin --lastname Admin --role Admin --email admin@monelu.fr || true)"
-    deploy:
-      resources:
-        limits:
-          memory: 512m
-          cpus: "0.5"
-
-  airflow-webserver:
-    <<: *airflow-common
-    depends_on:
-      postgres-airflow:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
-      airflow-init:
-        condition: service_completed_successfully
-      minio:
-        condition: service_healthy
-    command: webserver
-    ports:
-      - "127.0.0.1:8080:8080"
-    healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
-      interval: 30s
-      retries: 3
-    deploy:
-      resources:
-        limits:
-          memory: 1g
-          cpus: "0.5"
-
-  airflow-scheduler:
-    <<: *airflow-common
-    build:
-      context: .
-      dockerfile: Dockerfile.airflow
-    depends_on:
-      postgres-airflow:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
-      airflow-init:
-        condition: service_completed_successfully
-      minio:
-        condition: service_healthy
-    command: scheduler
-    healthcheck:
-      test: ["CMD", "airflow", "jobs", "check", "--job-type", "SchedulerJob"]
-      interval: 30s
-      retries: 3
-    deploy:
-      resources:
-        limits:
-          memory: 2g
-          cpus: "1.0"
-
-  minio:
-    image: minio/minio:RELEASE.2024-01-28T22-35-53Z
-    command: server /data --console-address ":9001"
-    ports:
-      - "127.0.0.1:9000:9000"
-      - "127.0.0.1:9001:9001"
-    environment:
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
-    volumes:
-      - minio-data:/data
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      retries: 3
-    deploy:
-      resources:
-        limits:
-          memory: 1g
-          cpus: "0.5"
-
 volumes:
   postgres_data:
   pgadmin_data:
-  postgres-airflow-data:
-  minio-data:

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -1,7 +1,10 @@
 """
 migrate.py
-Applies all data/migrations/*.sql files (in order) against DATABASE_URL.
-Safe to run multiple times — all statements use CREATE TABLE/ALTER TABLE IF NOT EXISTS.
+Applies data/migrations/*.sql files (in order) against DATABASE_URL.
+
+A schema_migrations ledger records applied files so each migration runs
+exactly once — re-deploys skip them. Files should still be written
+idempotently as a safety net (the ledger row is only written on success).
 
 Usage:
     python scripts/migrate.py
@@ -25,6 +28,21 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MIGRATIONS_DIR = os.path.join(PROJECT_ROOT, "data", "migrations")
 
 
+def _applied_migrations(conn) -> set[str]:
+    """Ensure the ledger table exists and return the filenames already applied."""
+    with conn:
+        with conn.cursor() as cur:
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS schema_migrations (
+                    filename   TEXT PRIMARY KEY,
+                    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                )
+            """)
+    with conn.cursor() as cur:
+        cur.execute("SELECT filename FROM schema_migrations")
+        return {row["filename"] for row in cur.fetchall()}
+
+
 def main() -> None:
     database_url = os.getenv("DATABASE_URL")
     if not database_url:
@@ -38,14 +56,25 @@ def main() -> None:
     log.info("Connecting to database…")
     conn = psycopg2.connect(database_url, cursor_factory=psycopg2.extras.RealDictCursor)
     try:
+        applied = _applied_migrations(conn)
+
         for migration_file in migration_files:
             filename = os.path.basename(migration_file)
+            if filename in applied:
+                log.info("Skipped %s (already applied)", filename)
+                continue
             with open(migration_file) as f:
                 sql = f.read()
             try:
+                # One transaction per migration: the SQL and its ledger row
+                # commit together, so a failed file is retried next run.
                 with conn:
                     with conn.cursor() as cur:
                         cur.execute(sql)
+                        cur.execute(
+                            "INSERT INTO schema_migrations (filename) VALUES (%s)",
+                            (filename,),
+                        )
             except psycopg2.Error as exc:
                 if "vector" in str(exc).lower():
                     log.error(

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -38,9 +38,8 @@ def _applied_migrations(conn) -> set[str]:
                     applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
                 )
             """)
-    with conn.cursor() as cur:
-        cur.execute("SELECT filename FROM schema_migrations")
-        return {row["filename"] for row in cur.fetchall()}
+            cur.execute("SELECT filename FROM schema_migrations")
+            return {row["filename"] for row in cur.fetchall()}
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

Fixes the 6 database findings from the 2026-06-11 diagnostic (`notes/dispatch/database_diagnostic_2026-06-11.md`), tracked in Linear: **MON-9, MON-10, MON-11, MON-12, MON-13, MON-62**.

### MON-9 — docker-compose split (decision: split, confirmed by owner)
`make start` booted 7 services (~5 GB of limits) — Airflow ×3, a second Postgres, MinIO — none used by production. `docker-compose.yml` now matches the docs: **postgres + pgadmin only**. The experimental stack moved intact to `docker-compose.airflow.yml`; Makefile `airflow-*`/`minio-*`/`dag-*` targets pass both `-f` files, so nothing is lost.

### MON-62 — single migration mechanism locally
The `data/migrations → /docker-entrypoint-initdb.d` mount made Postgres apply migrations at first boot *and* `make migrate` apply them again. The initdb mount is gone — `scripts/migrate.py` is the one mechanism, same as prod.

### MON-12 — `schema_migrations` ledger
`migrate.py` now records each applied file and skips it on later runs. SQL + ledger row commit in one transaction per file, so a failed migration is retried next deploy. First prod deploy re-runs 001/002 once (idempotent — same as every deploy today), records them, and from then on the per-boot `DROP/CREATE POLICY` churn (brief `ACCESS EXCLUSIVE` locks on all 4 tables) stops. This unblocks future non-idempotent migrations.

### MON-10 + MON-11 — `003_schema_cleanup.sql` drops 6 indexes (decision on ivfflat: drop, confirmed by owner)
- 5 dead indexes dropped (redundant `idx_positions_vote`, 4-value `idx_vote_positions_pos`, ILIKE-unusable `idx_votes_vote_title`/`idx_deputies_full_name`, unused `idx_chunks_created_at`) — frees space and write overhead on the 500 MB tier with zero query regression.
- The **IVFFlat ANN index dropped**: it was built on an empty table (degenerate centroids) and at ~3.7k chunks exact cosine scan is milliseconds with perfect recall. The retriever's `SET ivfflat.probes` remains (harmless GUC, no index to use it); the notable-deputy pin re-evaluation belongs to the RAG axis.
- `001_init.sql` no longer creates any of these for fresh installs.

### MON-13 — schema nits
- `votes.voted_at` **NOT NULL dropped** (003 + 001): the AN parser can emit a scrutin without `dateScrutin`; previously one bad record aborted the whole `execute_batch` transaction.
- `document_chunks.created_at` **TIMESTAMP → TIMESTAMPTZ** (guarded `DO` block), aligning with every other table.
- **CHECK constraint** on `vote_positions.position` (`pour/contre/abstention/nonVotant`) — upstream format drift now fails loudly at write time.
- 002 comment corrected (10 themes, not 8) with a note on why `theme` has no CHECK.
- RLS comment in 001 corrected: owner-bypass, not superuser-bypass (matters when a dedicated app role appears).
- *Not done:* dropping the `position_id` surrogate key — the diagnostic itself rates it "if/when free-tier pressure appears, not urgent"; left for then.

### Docs
CLAUDE.md updated: vector-index row, migration-ledger note, ADR-5 marked revised (index dropped, pin re-evaluation deferred to RAG axis).

## Deploy notes (flagged: migration + start-hook changes)
- `migrate.py` runs as the Railway start hook. First deploy: re-applies 001/002 (no-op, idempotent), creates the ledger, applies 003. Subsequent deploys skip all three.
- 003 is itself idempotent (`DROP IF EXISTS`, guarded DO blocks) — safe even if the ledger row write races a restart.
- Rollback: every dropped index can be recreated from git history; `DROP NOT NULL` and the TZ change are non-destructive.

## Testing
- `ruff check .` + `ruff format --check .` clean repo-wide; `tests/unit/` 10/10 pass
- Both compose files parse (YAML validated); Makefile targets updated and reviewed
- Local Docker daemon was down, so 003 was not executed against a live Postgres — it is `IF EXISTS`/`DO`-guarded throughout; first verification will be the Railway start hook on merge (watch the deploy logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)