### PR TITLE
fix: make Vercel build resilient to transient API errors

### DIFF
--- a/frontend/src/app/deputes/page.tsx
+++ b/frontend/src/app/deputes/page.tsx
@@ -3,7 +3,7 @@ import { DeputiesClient } from './DeputiesClient'
 import { api } from '@/lib/api'
 import type { Deputy } from '@/lib/api'
 
-export const revalidate = 3600
+export const dynamic = 'force-dynamic'
 
 async function fetchAllDeputies() {
   const first = await api.deputies.list({ limit: 200, offset: 0 })

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -77,12 +77,19 @@ export type SearchResult = {
 }
 
 async function apiFetch<T>(path: string): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`, {
-    headers: { 'Content-Type': 'application/json' },
-    next: { revalidate: 300 },
-  })
-  if (!res.ok) throw new Error(`API error: ${res.status}`)
-  return res.json()
+  const delays = [200, 400]
+  let lastStatus = 0
+  for (let attempt = 0; attempt <= delays.length; attempt++) {
+    const res = await fetch(`${API_BASE}${path}`, {
+      headers: { 'Content-Type': 'application/json' },
+      next: { revalidate: 300 },
+    })
+    if (res.ok) return res.json()
+    lastStatus = res.status
+    if (res.status < 500 || attempt === delays.length) break
+    await new Promise(r => setTimeout(r, delays[attempt]))
+  }
+  throw new Error(`API error: ${lastStatus}`)
 }
 
 export const api = {


### PR DESCRIPTION
## Problem

Production Vercel deploy `dpl_9JzSjYUyuiEvpMR23LyfpE3A85r3` failed during static generation of `/deputes`. Next.js prerendered 705 pages at build time; one transient HTTP 500 from the Railway API at page 528/705 killed the entire build.

Root error from build logs:
```
Error occurred prerendering page "/deputes". Read more: https://nextjs.org/docs/messages/prerender-error
Error: API error: 500
Export encountered an error on /deputes/page: /deputes, exiting the build.
```

## Fix

**`frontend/src/app/deputes/page.tsx`** — replace `revalidate = 3600` with `dynamic = 'force-dynamic'`

The `/deputes` page fetches ~600 deputies at build time, making it the most likely SSG failure point. Force-dynamic means it renders on the server per-request instead of at build time. The inner `apiFetch` calls still carry `next: { revalidate: 300 }` so Next.js caches API responses for 5 min — no extra load on Railway.

**`frontend/src/lib/api.ts`** — add retry-with-backoff in `apiFetch`

Retries up to 3 times with 200 ms / 400 ms delays on 5xx responses before throwing. Protects all 700+ prerendered detail pages from single-request blips during static generation.

## Test plan

- [ ] Vercel preview deploy on this PR succeeds
- [ ] `/deputes` page loads and shows deputies in the browser
- [ ] `/deputies/?limit=200` returns 200 in the Railway API

🤖 Generated with [Claude Code](https://claude.com/claude-code)