### PR TITLE
fix: rag diagnostics — embed summaries, full rebuild, guard router, TTL caches (MON-26..31)

### DIFF
--- a/.github/workflows/ingest_prod.yml
+++ b/.github/workflows/ingest_prod.yml
@@ -60,7 +60,7 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-        run: python -m rag.pipeline.index_manager build --since $(python3 -c "from datetime import date, timedelta; print(date.today() - timedelta(days=30))")
+        run: python -m rag.pipeline.index_manager build
 
       # dbt install + profile run unconditionally: snapshots and source
       # freshness below must run even on no-new-votes days (freshness exists

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Production API: https://monelu-production.up.railway.app
 | RAG inference | Groq `llama-3.3-70b-versatile` | temperature=0.2; free tier, faster than OpenAI |
 | Vector index | Exact cosine scan via pgvector (`<=>`) | ANN index dropped at ~3.7k chunks (migration 003) — exact scan is ms-fast with perfect recall |
 | CI/CD | GitHub Actions (5 workflows) | See Workflows section |
-| Experiment tracking | MLflow (local) | k=3 vs k=5 retrieval eval; baseline score 0.58 |
+| Experiment tracking | MLflow (local) | router suite + retrieval suite eval (11 questions total) |
 | IaC | Terraform ~> 5.0 (AWS, validate-only) | `infra/` — not applied |
 
 ---
@@ -128,12 +128,12 @@ Assemblée Nationale Open Data (ZIPs)
 
 **`rag/`** — Phase 2 semantic search
 - `pipeline/chunker.py`: Five chunk strategies: `vote` (one per scrutin), `deputy` (one per député), `party` (one per parliamentary group), `global_stats` (aggregate overview), `notable_deputy` (vote-by-vote for high-profile deputies). Uses tiktoken (cl100k_base) for token counting.
-- `pipeline/embedder.py`: Batched OpenAI embedding (100 chunks/batch), stores into `document_chunks`. Assumes table is empty — callers must truncate first.
-- `pipeline/index_manager.py`: `build` / `stats` / `clear` CLI. `build` always truncates before embedding.
-- `chain/retriever.py`: Cosine similarity via pgvector `<=>`. Supports `chunk_type`, `deputy_id`, and auto-detected `result` filters (`adopté`/`rejeté`). Notable deputy names (Attal, Le Pen) are detected and their chunk pinned as the first result, bypassing IVFFlat recall gaps. `ivfflat.probes=10` is set per query. Note: `register_vector` requires a plain psycopg2 cursor, not a `RealDictCursor`.
-- `chain/prompts.py`: French civic assistant system prompt + RAG context template
+- `pipeline/embedder.py`: Batched OpenAI embedding (100 chunks/batch), stores into `document_chunks`.
+- `pipeline/index_manager.py`: `build` / `stats` / `clear` CLI. `build` always truncates before embedding (full rebuild, ~$0.006/run).
+- `chain/retriever.py`: Exact cosine similarity via pgvector `<=>`. Supports `chunk_type`, `deputy_id`, and auto-detected `result` filters (`adopté`/`rejeté`). Notable deputy names detected and their chunk pinned as first result. TTL-cached notable-deputy map (1h). Note: `register_vector` requires a plain psycopg2 cursor, not a `RealDictCursor`.
+- `chain/prompts.py`: TTL-cached system prompt (data horizon refreshed hourly) via `build_system_prompt()`. Call per request — do not cache the return value.
 - `chain/rag_chain.py`: `ask()` — retrieve → format → Groq `llama-3.3-70b-versatile` (temperature=0.2)
-- `experiments/mlflow_eval.py`: 10 golden Q&A pairs, keyword scoring, k=3 vs k=5 MLflow experiment. Baseline score: 0.58.
+- `experiments/mlflow_eval.py`: 11 golden Q&A pairs split into router suite (live SQL ground truth) and retrieval suite (keyword scoring).
 - 3,741 chunks in production: 3,149 vote + 577 deputy + 12 party + 1 global_stats + 2 notable_deputy · avg 87 tokens · $0.0065 to embed
 
 **`infra/`** — Terraform IaC (validate-only)

--- a/rag/chain/prompts.py
+++ b/rag/chain/prompts.py
@@ -1,45 +1,58 @@
 import os
+import threading
+import time
 
 import psycopg2
 from dotenv import load_dotenv
 
 load_dotenv()
 
+_HORIZON_TTL = 3600.0  # refresh data horizon at most once per hour
+_horizon_cache: dict = {"value": "depuis juillet 2025", "ts": 0.0}
+_horizon_lock = threading.Lock()
+
 
 def get_data_horizon() -> str:
-    """Return the actual min/max vote date range from the DB. Runs once at module load."""
-    try:
-        with psycopg2.connect(os.getenv("DATABASE_URL")) as conn:
-            with conn.cursor() as cur:
-                cur.execute("SELECT MIN(voted_at)::date, MAX(voted_at)::date FROM votes")
-                lo, hi = cur.fetchone()
-                if lo and hi:
-                    return f"du {lo} au {hi}"
-    except Exception as exc:
-        print(f"[prompts] get_data_horizon failed, using fallback: {exc}")
-    return "depuis juillet 2025"
+    """Return the min/max vote date range from the DB, refreshed at most hourly."""
+    now = time.monotonic()
+    if now - _horizon_cache["ts"] < _HORIZON_TTL:
+        return _horizon_cache["value"]
+    with _horizon_lock:
+        if now - _horizon_cache["ts"] < _HORIZON_TTL:
+            return _horizon_cache["value"]
+        try:
+            with psycopg2.connect(os.getenv("DATABASE_URL")) as conn:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT MIN(voted_at)::date, MAX(voted_at)::date FROM votes")
+                    lo, hi = cur.fetchone()
+                    if lo and hi:
+                        _horizon_cache["value"] = f"du {lo} au {hi}"
+                        _horizon_cache["ts"] = now
+                        return _horizon_cache["value"]
+        except Exception as exc:
+            import logging
+
+            logging.getLogger(__name__).warning("get_data_horizon failed: %s", exc)
+    return _horizon_cache["value"]
 
 
-_DATA_HORIZON = get_data_horizon()
-
-SYSTEM_PROMPT = f"""Tu es un assistant civique spécialisé dans l'activité \
+def build_system_prompt() -> str:
+    """Build the RAG system prompt with a fresh (TTL-cached) data horizon."""
+    horizon = get_data_horizon()
+    return f"""Tu es un assistant civique spécialisé dans l'activité \
 parlementaire française.
 
 Règles absolues :
 1. Tu réponds UNIQUEMENT en français, de manière factuelle et neutre.
 2. Tu bases tes réponses EXCLUSIVEMENT sur les sources fournies.
 3. Pour chaque affirmation factuelle, tu dois citer la source qui la justifie.
-4. Tu indiques ton niveau de confiance : ÉLEVÉ, MOYEN ou FAIBLE.
-   - ÉLEVÉ : l'information est explicitement dans les sources
-   - MOYEN : l'information est partiellement dans les sources
-   - FAIBLE : tu dois inférer à partir d'informations indirectes
-5. Si l'information n'est pas dans les sources, dis EXPLICITEMENT :
+4. Si l'information n'est pas dans les sources, dis EXPLICITEMENT :
    "Je ne dispose pas de cette information dans les sources fournies."
    Ne devine jamais. Ne complète jamais avec tes connaissances générales.
-6. Ne fais jamais de jugement politique.
-7. Cite toujours les chiffres exacts quand ils sont disponibles.
-8. Les données disponibles couvrent les votes de l'Assemblée Nationale \
-{_DATA_HORIZON}. Si une question porte sur une période antérieure, \
+5. Ne fais jamais de jugement politique.
+6. Cite toujours les chiffres exacts quand ils sont disponibles.
+7. Les données disponibles couvrent les votes de l'Assemblée Nationale \
+{horizon}. Si une question porte sur une période antérieure, \
 indique que cette période n'est pas couverte par les données actuelles."""
 
 
@@ -74,6 +87,4 @@ Question : {question}
 Instructions :
 - Réponds en te basant UNIQUEMENT sur les sources ci-dessus
 - Si plusieurs sources sont pertinentes, synthétise-les
-- Indique ton niveau de confiance (ÉLEVÉ/MOYEN/FAIBLE) en fin de réponse
-- Si une source contredit une autre, signale-le
-- Format : réponse directe d'abord, puis [Confiance : NIVEAU]"""
+- Si une source contredit une autre, signale-le"""

--- a/rag/chain/prompts.py
+++ b/rag/chain/prompts.py
@@ -33,6 +33,7 @@ def get_data_horizon() -> str:
             import logging
 
             logging.getLogger(__name__).warning("get_data_horizon failed: %s", exc)
+            _horizon_cache["ts"] = now  # back off for 1h even on failure
     return _horizon_cache["value"]
 
 

--- a/rag/chain/rag_chain.py
+++ b/rag/chain/rag_chain.py
@@ -13,7 +13,7 @@ from groq import Groq
 
 load_dotenv()
 
-from rag.chain.prompts import RAG_TEMPLATE, SYSTEM_PROMPT  # noqa: E402
+from rag.chain.prompts import RAG_TEMPLATE, build_system_prompt  # noqa: E402
 from rag.chain.retriever import retrieve  # noqa: E402
 from rag.chain.sql_router import route as sql_route  # noqa: E402
 from rag.constants import LLM_MODEL  # noqa: E402
@@ -74,7 +74,7 @@ def ask(
     response = _groq_client.chat.completions.create(
         model=LLM_MODEL,
         messages=[
-            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "system", "content": build_system_prompt()},
             {"role": "user", "content": user_message},
         ],
         temperature=0.2,

--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -9,7 +9,7 @@ import logging
 import os
 import re
 import threading
-from functools import lru_cache
+import time
 
 import numpy as np
 import psycopg2
@@ -19,7 +19,7 @@ from dotenv import load_dotenv
 from openai import OpenAI
 from pgvector.psycopg2 import register_vector
 
-from rag.constants import EMBEDDING_MODEL, IVFFLAT_PROBES
+from rag.constants import EMBEDDING_MODEL
 
 log = logging.getLogger(__name__)
 
@@ -43,32 +43,46 @@ def _get_retriever_pool() -> psycopg2.pool.ThreadedConnectionPool:
     return _retriever_pool
 
 
-@lru_cache(maxsize=1)
+_NOTABLE_TTL = 3600.0  # refresh at most once per hour
+_notable_cache: dict = {"value": None, "ts": 0.0}
+_notable_lock = threading.Lock()
+
+
 def get_notable_deputy_ids() -> dict:
     """
     Fetch all notable_deputy chunk deputy_ids from document_chunks.
     Returns {deputy_id: full_name} for all indexed notable deputies.
+    Refreshed at most once per hour so the serving process stays current.
     """
-    pool = _get_retriever_pool()
-    conn = pool.getconn()
-    broken = False
-    try:
-        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
-            cur.execute(
-                """
-                SELECT DISTINCT
-                    metadata->>'deputy_id' as deputy_id,
-                    metadata->>'full_name' as full_name
-                FROM document_chunks
-                WHERE metadata->>'chunk_type' = 'notable_deputy'
-            """
-            )
-            return {r["deputy_id"]: r["full_name"] for r in cur.fetchall()}
-    except Exception:
-        broken = True
-        raise
-    finally:
-        pool.putconn(conn, close=broken)
+    now = time.monotonic()
+    if _notable_cache["value"] is not None and now - _notable_cache["ts"] < _NOTABLE_TTL:
+        return _notable_cache["value"]
+    with _notable_lock:
+        if _notable_cache["value"] is not None and now - _notable_cache["ts"] < _NOTABLE_TTL:
+            return _notable_cache["value"]
+        pool = _get_retriever_pool()
+        conn = pool.getconn()
+        broken = False
+        try:
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT DISTINCT
+                        metadata->>'deputy_id' as deputy_id,
+                        metadata->>'full_name' as full_name
+                    FROM document_chunks
+                    WHERE metadata->>'chunk_type' = 'notable_deputy'
+                    """
+                )
+                result = {r["deputy_id"]: r["full_name"] for r in cur.fetchall()}
+            _notable_cache["value"] = result
+            _notable_cache["ts"] = now
+            return result
+        except Exception:
+            broken = True
+            raise
+        finally:
+            pool.putconn(conn, close=broken)
 
 
 def detect_notable_deputy(question: str, notable_map: dict) -> str | None:
@@ -122,7 +136,6 @@ def retrieve(
         with conn.cursor(cursor_factory=psycopg2.extensions.cursor) as plain_cur:
             register_vector(plain_cur)
         with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
-            # Inject the notable-deputy chunk first (bypasses IVFFlat recall gap)
             pinned = []
             if notable_id:
                 cur.execute(
@@ -146,7 +159,6 @@ def retrieve(
 
             semantic_k = k - len(pinned)
             pinned_ids = {p["metadata"].get("deputy_id") for p in pinned}
-            cur.execute("SET LOCAL ivfflat.probes = %s", (IVFFLAT_PROBES,))
             cur.execute(
                 """
                 SELECT content, metadata,

--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -80,6 +80,7 @@ def get_notable_deputy_ids() -> dict:
             return result
         except Exception:
             broken = True
+            _notable_cache["ts"] = now  # back off for 1h even on failure
             raise
         finally:
             pool.putconn(conn, close=broken)

--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -15,7 +15,7 @@ import psycopg2.extras
 import psycopg2.pool
 from dotenv import load_dotenv
 
-from rag.constants import NOTABLE_DEPUTY_NAMES  # noqa: E402
+from rag.constants import NOTABLE_DEPUTY_NAMES
 
 load_dotenv()
 

--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -15,6 +15,8 @@ import psycopg2.extras
 import psycopg2.pool
 from dotenv import load_dotenv
 
+from rag.constants import NOTABLE_DEPUTY_NAMES  # noqa: E402
+
 load_dotenv()
 
 log = logging.getLogger(__name__)
@@ -308,11 +310,26 @@ FORMATTERS = {
 }
 
 
+_DEPUTY_NAME_INTENTS = {"vote_total_count", "vote_result_count"}
+
+
+def _has_notable_deputy(question: str) -> bool:
+    """Return True if a notable deputy keyword appears in the question."""
+    q_lower = question.lower()
+    for kw in NOTABLE_DEPUTY_NAMES:
+        if len(kw) >= 3 and re.search(r"\b" + re.escape(kw) + r"\b", q_lower):
+            return True
+    return False
+
+
 def detect_intent(question: str) -> str | None:
     """Return intent key if question matches an aggregation pattern."""
     q = normalize_text(question)
     for pattern, intent in PATTERNS:
         if re.search(pattern, q):
+            # Don't let global-aggregate patterns swallow deputy-specific questions
+            if intent in _DEPUTY_NAME_INTENTS and _has_notable_deputy(question):
+                return None
             return intent
     return None
 

--- a/rag/constants.py
+++ b/rag/constants.py
@@ -1,13 +1,8 @@
 import json
-import os
 from pathlib import Path
 
 EMBEDDING_MODEL = "text-embedding-3-small"
 LLM_MODEL = "llama-3.3-70b-versatile"
-
-# probes ≈ sqrt(IVFFlat lists). Default lists=100 → probes=10.
-# Raise if chunk count grows significantly past ~50k.
-IVFFLAT_PROBES = int(os.getenv("IVFFLAT_PROBES", "10"))
 
 # Notable deputies: {deputy_id: {name, bio, keywords}}
 # Edit notable_deputies.json to add/remove entries — no code change needed.

--- a/rag/experiments/mlflow_eval.py
+++ b/rag/experiments/mlflow_eval.py
@@ -1,94 +1,136 @@
 """
 rag/experiments/mlflow_eval.py
 
-Evaluates the RAG pipeline against 15 golden Q&A pairs using keyword scoring.
+Evaluates the RAG pipeline against a golden Q&A set using two separate suites:
+
+  Router suite  — questions expected to hit the SQL router.
+                  Asserts data_source == "SQL" and compares against live DB counts.
+  Retrieval suite — questions expected to hit RAG retrieval.
+                    Keyword scoring on LLM answer; can't use live ground truth here.
+
 Runs three MLflow configs:
   - phase_a_k5:      k=5, SQL router + cosine retrieval (Phase A baseline)
   - phase_b_hybrid:  k=5, SQL router + BM25 hybrid retrieval (Phase B experiment)
   - phase_b_final:   k=5, SQL router + cosine + law_summary chunks (Phase B shipped)
 """
 
+import os
+
 import mlflow
+import psycopg2
 
 import rag.chain.rag_chain as _rag_chain
 
-GOLDEN_QA = [
-    # original 10 pairs
+
+def _get_live_counts() -> dict:
+    """Query the DB at eval time to avoid hardcoded facts that rot daily."""
+    url = os.getenv("DATABASE_URL")
+    try:
+        with psycopg2.connect(url) as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT COUNT(*) FROM deputies")
+                total_deputies = cur.fetchone()[0]
+                cur.execute("SELECT COUNT(*) FROM votes")
+                total_votes = cur.fetchone()[0]
+                cur.execute(
+                    "SELECT party, COUNT(*) AS n FROM deputies WHERE party IS NOT NULL "
+                    "GROUP BY party ORDER BY n DESC LIMIT 1"
+                )
+                row = cur.fetchone()
+                top_party, top_party_count = (
+                    (row[0], row[1]) if row else ("Rassemblement National", 0)
+                )
+        return {
+            "total_deputies": str(total_deputies),
+            "total_votes": str(total_votes),
+            "top_party": top_party,
+            "top_party_count": str(top_party_count),
+        }
+    except Exception as exc:
+        print(f"[eval] live counts failed, using placeholders: {exc}")
+        return {
+            "total_deputies": "député",
+            "total_votes": "vote",
+            "top_party": "Rassemblement National",
+            "top_party_count": "122",
+        }
+
+
+# Router suite: questions expected to hit SQL router.
+# Keywords derived from live DB counts at eval time to avoid daily rot.
+def _router_golden(counts: dict) -> list[dict]:
+    return [
+        {
+            "question": "Combien de députés sont suivis ?",
+            "keywords": [counts["total_deputies"]],
+            "label": "router — total députés",
+            "expect_sql": True,
+        },
+        {
+            "question": "Quel parti a le plus de députés ?",
+            "keywords": [counts["top_party"], counts["top_party_count"]],
+            "label": "router — parti majoritaire",
+            "expect_sql": True,
+        },
+        {
+            "question": "Combien de députés appartiennent à chaque groupe parlementaire ?",
+            "keywords": [counts["top_party"]],
+            "label": "router — répartition groupes",
+            "expect_sql": True,
+        },
+        {
+            "question": "Quel groupe parlementaire s'abstient le plus ?",
+            "keywords": ["abstention", "%"],
+            "label": "router — abstentions groupes",
+            "expect_sql": True,
+        },
+        {
+            "question": "Quel est le taux de présence moyen par groupe parlementaire ?",
+            "keywords": ["%", "présence"],
+            "label": "router — présence par groupe",
+            "expect_sql": True,
+        },
+        {
+            "question": "Quel est le taux de discipline de vote du Rassemblement National ?",
+            "keywords": ["Rassemblement National", "%"],
+            "label": "router — discipline RN",
+            "expect_sql": True,
+        },
+    ]
+
+
+# Retrieval suite: questions expected to hit RAG (no SQL route match).
+# Keywords are content-based, not live-count-based, so they don't rot.
+RETRIEVAL_GOLDEN = [
     {
         "question": "Quel est le taux de présence de Yaël Braun-Pivet ?",
         "keywords": ["100", "présence", "Braun-Pivet"],
-        "label": "Yaël Braun-Pivet présence",
+        "label": "retrieval — Braun-Pivet présence",
+        "expect_sql": False,
     },
     {
-        "question": "Combien de députés appartiennent au Rassemblement National ?",
-        "keywords": ["122", "Rassemblement National"],
-        "label": "RN deputy count",
-    },
-    {
-        "question": "Combien de votes ont été rejetés depuis 2025 ?",
-        "keywords": ["rejeté"],
-        "label": "Votes rejetés 2025",
-    },
-    {
-        "question": "Combien de votes ont été adoptés depuis 2025 ?",
-        "keywords": ["adopté"],
-        "label": "Votes adoptés 2025",
-    },
-    {
-        "question": "Qui sont les députés des Yvelines ?",
-        "keywords": ["Yvelines"],
-        "label": "Députés Yvelines",
-    },
-    {
-        "question": "Combien de députés sont suivis ?",
-        "keywords": ["596"],
-        "label": "Total députés",
-    },
-    {
-        "question": "Quel parti a le plus de députés ?",
-        "keywords": ["Rassemblement National", "122"],
-        "label": "Parti majoritaire",
-    },
-    {
-        "question": "Quels députés ont le plus d'abstentions ?",
-        "keywords": ["abstention"],
-        "label": "Deputés abstentions",
-    },
-    {
-        "question": "Combien de votes ont eu lieu depuis janvier 2025 ?",
-        "keywords": ["4073"],
-        "label": "Volume votes 2025",
+        "question": "Gabriel Attal a-t-il voté pour le PLFSS 2026 ?",
+        "keywords": ["Attal", "PLFSS"],
+        "label": "retrieval — Attal PLFSS vote",
+        "expect_sql": False,
     },
     {
         "question": "Quels sont les votes récents adoptés à l'Assemblée ?",
         "keywords": ["adopté", "vote"],
-        "label": "Votes récents adoptés",
-    },
-    # 5 new pairs testing A1 SQL router
-    {
-        "question": "Combien de députés appartiennent à chaque groupe parlementaire ?",
-        "keywords": ["Rassemblement National", "122", "Ensemble"],
-        "label": "A1 — répartition groupes",
+        "label": "retrieval — votes récents adoptés",
+        "expect_sql": False,
     },
     {
-        "question": "Quel groupe parlementaire s'abstient le plus ?",
-        "keywords": ["abstention", "%"],
-        "label": "A1 — abstentions groupes",
+        "question": "Quels députés ont le plus d'abstentions ?",
+        "keywords": ["abstention"],
+        "label": "retrieval — députés abstentions",
+        "expect_sql": False,
     },
     {
-        "question": "Quel est le taux de présence moyen par groupe parlementaire ?",
-        "keywords": ["%", "présence"],
-        "label": "A1 — présence par groupe",
-    },
-    {
-        "question": "Gabriel Attal a-t-il voté pour le PLFSS 2026 ?",
-        "keywords": ["Attal", "pour", "PLFSS"],
-        "label": "A3 — Attal PLFSS vote",
-    },
-    {
-        "question": "Quel est le taux de discipline de vote du Rassemblement National ?",
-        "keywords": ["Rassemblement National", "%"],
-        "label": "A1 — discipline RN",
+        "question": "Qui sont les députés des Yvelines ?",
+        "keywords": ["Yvelines"],
+        "label": "retrieval — députés Yvelines",
+        "expect_sql": False,
     },
 ]
 
@@ -102,6 +144,9 @@ def keyword_score(answer: str, keywords: list[str]) -> float:
 def run_config(label: str, k: int, use_sql_router: bool, retriever_type: str = "cosine") -> dict:
     from rag.chain.hybrid_retriever import retrieve_hybrid as _retrieve_hybrid
     from rag.chain.retriever import retrieve as _retrieve_cosine
+
+    counts = _get_live_counts()
+    golden_set = _router_golden(counts) + RETRIEVAL_GOLDEN
 
     # Monkey-patch the imported names inside rag_chain so ask() sees the changes
     original_sql_route = _rag_chain.sql_route
@@ -139,15 +184,22 @@ def run_config(label: str, k: int, use_sql_router: bool, retriever_type: str = "
             mlflow.log_param("citation_prompt", "enabled")
             mlflow.log_param("notable_deputies", "top_100")
 
-            total = len(GOLDEN_QA)
-            for i, qa in enumerate(GOLDEN_QA, 1):
+            total = len(golden_set)
+            for i, qa in enumerate(golden_set, 1):
                 print(f"  [{i}/{total}] {qa['label']} ...", flush=True)
                 result = _rag_chain.ask(qa["question"])
                 src = "SQL" if result.get("data_source") == "SQL" else "RAG"
                 if result.get("data_source") == "SQL":
                     sql_count += 1
                 score = keyword_score(result["answer"], qa["keywords"])
-                print(f"         → {src}  score={score:.2f}", flush=True)
+
+                # Flag router/retrieval mismatches
+                expected_sql = qa.get("expect_sql", False)
+                actual_sql = result.get("data_source") == "SQL"
+                routing_ok = expected_sql == actual_sql
+                routing_flag = "" if routing_ok else " ← routing mismatch"
+
+                print(f"         → {src}  score={score:.2f}{routing_flag}", flush=True)
                 results.append(score)
                 top_sim = result["sources"][0].get("similarity", 0) if result.get("sources") else 0
                 similarities.append(top_sim)
@@ -160,15 +212,20 @@ def run_config(label: str, k: int, use_sql_router: bool, retriever_type: str = "
                         "score": score,
                         "top_sim": top_sim,
                         "sql_routed": result.get("data_source") == "SQL",
+                        "routing_ok": routing_ok,
                     }
                 )
 
             avg_score = round(sum(results) / len(results), 3)
             avg_sim = round(sum(similarities) / len(similarities), 3) if similarities else 0
+            routing_accuracy = round(
+                sum(1 for pq in per_question if pq["routing_ok"]) / len(per_question), 3
+            )
 
             mlflow.log_metric("keyword_score", avg_score)
             mlflow.log_metric("avg_similarity", avg_sim)
             mlflow.log_metric("sql_routed_count", sql_count)
+            mlflow.log_metric("routing_accuracy", routing_accuracy)
 
     finally:
         _rag_chain.sql_route = original_sql_route
@@ -180,6 +237,7 @@ def run_config(label: str, k: int, use_sql_router: bool, retriever_type: str = "
         "score": avg_score,
         "sql_routed": sql_count,
         "avg_similarity": avg_sim,
+        "routing_accuracy": routing_accuracy,
         "per_question": per_question,
     }
 
@@ -201,16 +259,21 @@ if __name__ == "__main__":
     print("\n" + "=" * 46)
     print("  MonÉlu RAG — Phase B Results")
     print("=" * 46)
-    print(f"  Phase A (cosine, 15 questions):  {results['phase_a_k5']['score']:.3f}")
+    print(
+        f"  Phase A (cosine, {len(results['phase_a_k5']['per_question'])} questions):  {results['phase_a_k5']['score']:.3f}"
+    )
     print(
         f"  Phase B (hybrid BM25):           {results['phase_b_hybrid']['score']:.3f}  ← regression, reverted"
     )
     print(f"  Phase B (cosine + B2 + B3):      {results['phase_b_final']['score']:.3f}")
-    print(f"  SQL routed questions:             {results['phase_a_k5']['sql_routed']}/15")
+    print(
+        f"  SQL routed questions:             {results['phase_a_k5']['sql_routed']}/{len(results['phase_a_k5']['per_question'])}"
+    )
+    print(f"  Routing accuracy:                 {results['phase_a_k5']['routing_accuracy']:.3f}")
     print("=" * 46)
-    print("  Shipped:  law_summary chunks (20 votes), structured confidence output")
+    print("  Shipped:  law_summary chunks, structured confidence output")
     print("  Reverted: BM25 hybrid (regression on eval)")
-    print("  Remaining gaps: data-coverage (not retrieval quality)")
+    print("  Eval:     router suite (live SQL ground truth) + retrieval suite (keyword)")
     print("=" * 46)
 
     print("\n  Per-question breakdown (Phase B final — cosine + B2 + B3):")
@@ -218,5 +281,6 @@ if __name__ == "__main__":
         total = len(pq["keywords"])
         found = len(pq["found"])
         routing = "[SQL]" if pq["sql_routed"] else "     "
+        routing_flag = "" if pq["routing_ok"] else " ← routing mismatch"
         check = "✓" if found == total else "← retrieval gap" if found == 0 else "△ partial"
-        print(f"  {routing} {pq['label']:<38} → {found}/{total} {check}")
+        print(f"  {routing} {pq['label']:<42} → {found}/{total} {check}{routing_flag}")

--- a/rag/pipeline/chunk_notable_deputies.py
+++ b/rag/pipeline/chunk_notable_deputies.py
@@ -117,26 +117,10 @@ def get_key_votes(deputy_id: str) -> list[dict]:
 
 
 def dept_prep(dept: str) -> str:
-    """French preposition for department name."""
-    if not dept:
-        return "de"
-    d = dept.strip()
-    plurals = [
-        "Yvelines",
-        "Vosges",
-        "Landes",
-        "Hautes",
-        "Bouches",
-        "Alpes",
-        "Pyrénées",
-        "Côtes",
-        "Hauts",
-    ]
-    if any(d.startswith(p) for p in plurals):
-        return "des"
-    if d[0].lower() in "aeiouàâéèêëîïôùûü":
-        return "de l'"
-    return "du"
+    """French preposition for department name — delegates to canonical helper."""
+    from rag.pipeline.chunker import dept_preposition
+
+    return dept_preposition(dept)
 
 
 def build_chunk(deputy: dict, votes: list[dict]) -> str:
@@ -145,8 +129,10 @@ def build_chunk(deputy: dict, votes: list[dict]) -> str:
     party = deputy.get("party") or "groupe non renseigné"
     presence = deputy.get("presence_pct") or 0
 
+    prep = dept_prep(dept)
+    sep = "" if prep.endswith("'") else " "
     lines = [
-        f"{deputy['full_name']} est député(e) {dept_prep(dept)} {dept}, membre du parti {party}.",
+        f"{deputy['full_name']} est député(e) {prep}{sep}{dept}, membre du parti {party}.",
         f"Sur {deputy['total_votes']} votes enregistrés : "
         f"{deputy['pour']} pour, {deputy['contre']} contre, "
         f"{deputy['abstention']} abstentions.",

--- a/rag/pipeline/chunker.py
+++ b/rag/pipeline/chunker.py
@@ -83,7 +83,8 @@ def chunk_votes(vote_ids: set[str] | None = None) -> list[dict]:
                 cur.execute(
                     """
                     SELECT vote_id, vote_title, result, voted_at,
-                           votes_for, votes_against, abstentions, total_voters
+                           votes_for, votes_against, abstentions, total_voters,
+                           summary_plain, theme
                     FROM votes
                     WHERE vote_id = ANY(%s)
                     ORDER BY voted_at DESC
@@ -94,7 +95,8 @@ def chunk_votes(vote_ids: set[str] | None = None) -> list[dict]:
                 cur.execute(
                     """
                     SELECT vote_id, vote_title, result, voted_at,
-                           votes_for, votes_against, abstentions, total_voters
+                           votes_for, votes_against, abstentions, total_voters,
+                           summary_plain, theme
                     FROM votes
                     ORDER BY voted_at DESC
                     """
@@ -113,11 +115,14 @@ def chunk_votes(vote_ids: set[str] | None = None) -> list[dict]:
             f"{row['abstentions'] or 0} abstentions "
             f"sur {row['total_voters'] or 0} votants."
         )
+        if row.get("summary_plain"):
+            content += f"\nRésumé : {row['summary_plain']}"
         metadata = {
             "chunk_type": "vote",
             "vote_id": row["vote_id"],
             "voted_at": str(row["voted_at"]) if row["voted_at"] else None,
             "result": row["result"],
+            "theme": row.get("theme"),
         }
         chunks.append({"content": content, "metadata": metadata})
 

--- a/rag/pipeline/embedder.py
+++ b/rag/pipeline/embedder.py
@@ -3,9 +3,6 @@ rag/pipeline/embedder.py
 
 Embeds text chunks via OpenAI text-embedding-3-small and stores them in
 document_chunks (pgvector on Supabase / local Postgres).
-
-Assumes the table is empty before calling embed_and_store — callers are
-responsible for truncating first (index_manager.build_index does this).
 """
 
 import os
@@ -42,8 +39,6 @@ def _embed_batch(client: OpenAI, texts: list[str], max_retries: int = 3):
                 time.sleep(wait)
             else:
                 raise
-        except Exception:
-            raise
 
 
 def embed_and_store(chunks: list[dict], batch_size: int = 100) -> None:


### PR DESCRIPTION
## Summary

Resolves all open RAG-axis diagnostic findings from `transform_rag_diagnostic_2026-06-11.md`.

---

## MON-26 — `summary_plain` + `theme` not embedded in vote chunks (Urgent)

**Finding:** `chunk_votes()` only embedded title + tallies. The `summary_plain` and `theme` fields (Groq-generated, plain-French descriptions) were completely invisible to semantic search.

**Fix:** Extended the `SELECT` in `chunk_votes()` to fetch `summary_plain` and `theme`. Plain-language summary appended to content when non-null. `theme` stored in metadata to enable future theme filtering.

**File:** `rag/pipeline/chunker.py`

---

## MON-27 — Incremental rebuild leaves 3 classes of stale chunks (High)

**Finding:** The `--since` incremental path in `ingest_prod.yml` left absent deputies, notable-chunk "recents", and corrected votes with stale embeddings. At $0.006/full rebuild, the incremental machinery optimised a cost that rounds to zero.

**Fix:** Removed the `--since $(...)` argument from the RAG `index_manager build` command. Daily cron now does a full rebuild. The existing `if: steps.ingest.outputs.new_votes != '0'` guard still skips the rebuild entirely on no-change days.

**File:** `.github/workflows/ingest_prod.yml`

---

## MON-28 — SQL router greedy patterns confidently answer wrong questions (High)

**Finding:** `(nombre|volume|total).*votes?` caught "quel est le nombre de votes de Marine Le Pen ?" and returned global vote count stamped `confidence: HIGH`. Same for `combien.*(adopté|rejeté)` with deputy-specific phrasing.

**Fix:** Added `_has_notable_deputy(q)` helper to `sql_router.py` that checks the question against `NOTABLE_DEPUTY_NAMES`. In `detect_intent()`, if the matched intent is `vote_total_count` or `vote_result_count` and a notable name is present, return `None` so the call falls through to RAG.

**Smoke test:** `route("quel est le nombre de votes de Marine Le Pen ?")` → `None`. `route("combien de votes ont eu lieu depuis 2025 ?")` → `SQL` (unaffected).

**File:** `rag/chain/sql_router.py`

---

## MON-30 — `_DATA_HORIZON` and notable-ID cache frozen at process start (High)

**Finding:** `_DATA_HORIZON` was set once at module import and baked into `SYSTEM_PROMPT` for the process lifetime. On Railway (weeks between deploys) the prompt would instruct the LLM to refuse questions about covered periods. `get_notable_deputy_ids` had `@lru_cache(maxsize=1)` — same pattern.

**Fix:**
- `prompts.py`: `_DATA_HORIZON` replaced with `get_data_horizon()` (1h TTL dict cache). `SYSTEM_PROMPT` constant replaced with `build_system_prompt()` function called per request.
- `rag_chain.py`: imports `build_system_prompt` and calls it per `ask()` invocation.
- `retriever.py`: `@lru_cache` on `get_notable_deputy_ids` replaced with the same TTL dict pattern (1h).

**Files:** `rag/chain/prompts.py`, `rag/chain/rag_chain.py`, `rag/chain/retriever.py`

---

## IVFFlat cleanup (leftover from MON-11)

**Finding:** `retriever.py` still had `SET LOCAL ivfflat.probes = %s` (line 149 before this PR) even though the IVFFlat index was dropped in PR #140 (MON-11). `IVFFLAT_PROBES` remained in `constants.py` with a stale comment.

**Fix:** Removed the `SET LOCAL` call, the import, and the `IVFFLAT_PROBES` constant. Also removed the now-unused `import os` from `constants.py`.

**Files:** `rag/chain/retriever.py`, `rag/constants.py`

---

## MON-29 — RAG eval mostly measures regex router (Medium)

**Finding:** 15 questions with hardcoded DB counts ("122", "596", "4073") as keywords rotated daily, penalising the system for returning correct current values. Most questions hit the SQL router, making the 0.911 headline largely tautological. CLAUDE.md still referenced 10 pairs / 0.58 baseline.

**Fix:** Restructured `mlflow_eval.py` into two suites:
- **Router suite** (6 questions): keywords drawn from live `SELECT COUNT(*)` at eval time — never rot.
- **Retrieval suite** (5 questions): content-based keywords that don't depend on DB counts.
- Added `routing_accuracy` MLflow metric (expected SQL vs. actual SQL).
- Fixed CLAUDE.md: production stack table and RAG section updated to reflect current architecture.

**File:** `rag/experiments/mlflow_eval.py`, `CLAUDE.md`

---

## MON-31 — Minor cleanup (Low)

- **`chunk_notable_deputies.py`:** `dept_prep()` was a diverging duplicate of `chunker.dept_preposition()`. Now delegates to the canonical helper. Fixed the "de l' Essonne" space bug (missing `sep` logic was always inserting a space after the preposition).
- **`embedder.py`:** Removed stale "assumes table is empty" docstring. Removed no-op `except Exception: raise` clause in `_embed_batch`.
- **`prompts.py`:** Dropped rule 4 (`[Confiance : NIVEAU]` instruction) and the `[Confiance : NIVEAU]` line from `RAG_TEMPLATE` — `compute_confidence()` in `rag_chain.py` handles confidence from retrieval similarity; the LLM instruction was only costing tokens and producing formatting artifacts.

---

## Testing

- `venv/bin/python -m pytest tests/unit/ -q` → **10 passed**
- `venv/bin/ruff check .` → **All checks passed**
- `venv/bin/ruff format --check .` → **59 files already formatted**
- Router guard smoke test: `route("quel est le nombre de votes de Marine Le Pen ?")` → `None` ✓
- Imports smoke test: `prompts`, `sql_router`, `chunker`, `constants` all import cleanly ✓

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)