### PR TITLE
fix: deploy-config diagnostics — bloat, restart caps, env drift, pin alignment (MON-39, 40, 41, 42, 43, 45, 60)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,19 @@ AIRFLOW_FERNET_KEY=
 AIRFLOW_POSTGRES_PASSWORD=
 AIRFLOW_ADMIN_PASSWORD=
 
-# MinIO object storage (optional for local dev — defaults to minioadmin/minioadmin)
+# MinIO object storage (optional for local dev — defaults to minioadmin/minioadmin).
+# docker-compose.airflow.yml maps these into MINIO_ENDPOINT / MINIO_ACCESS_KEY /
+# MINIO_SECRET_KEY, which is what ingestion/utils/bronze_writer.py actually reads.
 MINIO_ROOT_USER=
 MINIO_ROOT_PASSWORD=
+
+# RAG retrieval — pgvector ivfflat probe count (optional, defaults set in rag/constants.py)
+IVFFLAT_PROBES=
+
+# dbt — required to generate transform/profiles.yml (scripts/create_dbt_profile.py),
+# used by CI and the deploy workflow against prod Supabase
+DBT_HOST=
+DBT_PORT=5432
+DBT_USER=
+DBT_PASSWORD=
+DBT_DBNAME=

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
 
   # Ruff — lint + format (replaces flake8, isort, black)
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.9
+    rev: v0.15.10
     hooks:
       - id: ruff                    # lint
         args: [--fix]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,9 +194,19 @@ Health check: `GET /health` — returns DB status, record counts, `last_ingestio
 
 Ruff is the single tool for lint and formatting (`ruff.toml`):
 - Line length: 100
-- `print()` allowed in `scripts/` and `rag/` (T201 ignored there), blocked elsewhere
+- `print()` allowed in `scripts/`, `rag/`, and `ingestion/` (T201 ignored there), blocked elsewhere
 - B008 ignored to allow FastAPI `Depends()` defaults
 - Pre-commit hooks run automatically on `git commit`
+
+### Dependency pinning convention
+
+Across `requirements*.txt`: exact-pin (`==`) packages with a history of breaking
+changes or where a newer version forced a downstream ceiling (e.g. `openai`,
+`tiktoken`, `pgvector`); range-pin (`>=`) everything else. The same package must
+use the same floor in every file it appears in (e.g. `groq>=0.11.0` everywhere) —
+a mismatched floor between `requirements.txt` and `requirements-ingest.txt` is a
+drift bug, not an intentional difference. No lockfiles are generated; each
+`requirements-*.txt` documents intent, not a fully resolved dependency graph.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ingest:
 	venv/bin/python3 scripts/ingest_positions.py
 
 ingest-prod:
-	venv/bin/python3 scripts/run_ingestion_prod.py --since 2025-01-01
+	venv/bin/python3 scripts/run_ingestion_prod.py --since $$(python3 -c "from datetime import date, timedelta; print(date.today() - timedelta(days=90))")
 
 api:
 	venv/bin/uvicorn api.main:app --reload

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: uvicorn api.main:app --host 0.0.0.0 --port $PORT

--- a/railway.json
+++ b/railway.json
@@ -4,6 +4,7 @@
   "deploy": {
     "startCommand": "python scripts/migrate.py && uvicorn api.main:app --host 0.0.0.0 --port $PORT --proxy-headers --forwarded-allow-ips='*'",
     "healthcheckPath": "/health",
-    "restartPolicyType": "ON_FAILURE"
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
   }
 }

--- a/requirements-airflow.txt
+++ b/requirements-airflow.txt
@@ -1,3 +1,7 @@
+# Installed into the local Airflow image only — see Dockerfile.airflow.
+# Not part of the Railway/prod deploy; do not delete as "unused" without
+# checking Dockerfile.airflow first (PR #145 deleted this file once already
+# and broke the Airflow image build as a result).
 pandas==2.2.2
 boto3>=1.34.0
 great-expectations>=1.0,<2.0

--- a/requirements-airflow.txt
+++ b/requirements-airflow.txt
@@ -1,0 +1,3 @@
+pandas==2.2.2
+boto3>=1.34.0
+great-expectations>=1.0,<2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pytest>=8.0.0
 detect-secrets==1.5.0
 dbt-core>=1.9,<1.10
 dbt-postgres>=1.9,<1.10
+mlflow==3.11.1

--- a/requirements-ingest.txt
+++ b/requirements-ingest.txt
@@ -1,4 +1,4 @@
 psycopg2-binary>=2.9.10
 requests==2.32.2
 python-dotenv==1.0.1
-groq>=0.9.0
+groq>=0.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,14 @@
 fastapi>=0.115.0
-aiofiles>=23.0.0
 slowapi==0.1.9
 uvicorn[standard]>=0.34.0
 psycopg2-binary>=2.9.10
 requests==2.32.2
 python-dotenv==1.0.1
-httpx==0.27.0
-pandas==2.2.2
+httpx>=0.23.0,<0.28.0
 # Phase 2 — RAG
 openai==1.40.0
 groq>=0.11.0
 tiktoken==0.7.0
-mlflow==3.11.1
 pgvector==0.3.2
 numpy>=1.26.0
 rank-bm25==0.2.2
-# Phase 3 — Orchestration
-boto3>=1.34.0
-great-expectations>=1.0,<2.0

--- a/ruff.toml
+++ b/ruff.toml
@@ -13,9 +13,9 @@ select = [
 ignore = [
     "E501", # line too long — handled by ruff-format
     "B008", # do not perform function calls in default args (FastAPI uses this pattern)
-    "T201", # print() allowed — scripts use it intentionally
 ]
 
 [lint.per-file-ignores]
-"scripts/*" = ["T201"]   # scripts print freely
-"rag/*"     = ["T201"]
+"scripts/*"   = ["T201"]   # scripts print freely
+"rag/*"       = ["T201"]
+"ingestion/*" = ["T201"]   # Airflow DAG path (Phase 5, deferred) — prints freely like scripts/


### PR DESCRIPTION
## Summary

Remediation for the **deploy-config** diagnostic axis (`notes/dispatch/deployment_config_diagnostic_2026-06-11.md`). Three cross-labeled issues (MON-44, MON-34, MON-15) were already fixed by merged PRs #145/#141 and are excluded here.

| Issue | Finding | Fix |
|---|---|---|
| MON-39 | Prod image ships ~500MB of unused deps (mlflow, pandas, boto3, great-expectations, aiofiles) | Stripped from `requirements.txt` (none imported by `api/` or `rag/`, the only Railway-deployed paths). `pandas`/`boto3`/`great-expectations` moved to a **restored** `requirements-airflow.txt` — `Dockerfile.airflow` still `COPY`s and installs this file, but PR #145 deleted it as "dead," silently breaking the Airflow image build. `mlflow` moved to `requirements-dev.txt` (only used by the local-only `rag/experiments/mlflow_eval.py`). `aiofiles` is unused anywhere and dropped entirely. |
| MON-40 | Procfile contradicts railway.json (skips `migrate.py`) | Deleted `Procfile`. `railway.json`'s `startCommand` already wins on Railway; the Procfile was a dangerous unused fallback. |
| MON-41 | Failed migration = unbounded restart loop | Added `"restartPolicyMaxRetries": 3` to `railway.json`. The migration ledger itself (MON-12) was already shipped in PR #140. Did **not** add `healthcheckTimeout` (also mentioned in the original finding) — judged a separate, lower-confidence change outside this finding's primary ask. |
| MON-42 | Env-var contract drifted both ways | Documented `IVFFLAT_PROBES` and `DBT_*` in `.env.example` (read by `rag/chain/hybrid_retriever.py` / `scripts/create_dbt_profile.py`, previously undocumented). Added a comment clarifying how `MINIO_ROOT_USER`/`PASSWORD` map to the `MINIO_ENDPOINT`/`ACCESS_KEY`/`SECRET_KEY` vars `bronze_writer.py` actually reads. |
| MON-43 | `ruff.toml`'s global T201 ignore contradicted CLAUDE.md's documented print() policy; pre-commit ruff pin 2 years stale | Removed the global T201 ignore, scoped it back to `per-file-ignores` (added `ingestion/*`, which also prints freely — same as `scripts/`/`rag/`). Bumped pre-commit's ruff `rev` from `v0.4.9` to `v0.15.10`, matching what CI's unpinned `pip install ruff` resolves to today. Did **not** bump `target-version` to py312 (the original finding asked for it) — CI's `setup-python` pins `python-version: "3.11"`, so `py311` is the correct target, not stale. |
| MON-45 | `ingest-prod` hardcodes `--since 2025-01-01`, contradicting CLAUDE.md's "last 3 months" | Makefile now computes `--since` as today minus 90 days at invocation time, matching the existing pattern already used in `ingest_prod.yml`. |
| MON-60 | Inconsistent version floors across requirements files; no documented pinning convention | Aligned `groq`'s floor to `>=0.11.0` everywhere (was `>=0.9.0` in `requirements-ingest.txt` only). Also relaxed `requirements.txt`'s `httpx==0.27.0` to `httpx>=0.23.0,<0.28.0` to match the range already used in `requirements-rag.txt`. Documented the pinning convention (exact-pin packages with breaking-change history, range-pin the rest, same floor everywhere) in CLAUDE.md. No lockfiles generated in this pass — confirmed with the user as out of scope. |

## Deploy-risk items (flagged explicitly per guard rails)

- **Procfile deletion** — low risk; `railway.json` already takes precedence, this just removes a dangerous dead fallback.
- **railway.json restartPolicyMaxRetries: 3** — changes Railway's restart behavior on failure from unlimited to capped at 3.

## Test plan

- [x] `venv/bin/python -m pytest tests/unit/ -q` — 10 passed, no new failures
- [x] `venv/bin/ruff check .` — clean repo-wide (confirmed the T201 ignore removal doesn't surface new violations outside `scripts/`, `rag/`, `ingestion/`)
- [x] `venv/bin/ruff format --check .` — clean repo-wide
- [x] `railway.json` JSON-validated after the edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
