### PR TITLE
fix: resolve ModuleNotFoundError for rag in prod ingestion

### DIFF
--- a/.github/workflows/ingest_prod.yml
+++ b/.github/workflows/ingest_prod.yml
@@ -43,8 +43,10 @@ jobs:
             requirements-ingest.txt
             requirements-rag.txt
 
-      - name: Install ingestion dependencies
-        run: pip install -r requirements-ingest.txt
+      - name: Install ingestion + RAG dependencies
+        run: |
+          pip install -r requirements-ingest.txt
+          pip install -r requirements-rag.txt
 
       - name: Run ingestion
         id: ingest
@@ -53,10 +55,6 @@ jobs:
           AN_API_BASE_URL: ${{ secrets.AN_API_BASE_URL }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
         run: python scripts/run_ingestion_prod.py --since $(python3 -c "from datetime import date, timedelta; print(date.today() - timedelta(days=30))")
-
-      - name: Install RAG dependencies
-        if: steps.ingest.outputs.new_votes != '0'
-        run: pip install -r requirements-rag.txt
 
       - name: Rebuild RAG index
         if: steps.ingest.outputs.new_votes != '0'

--- a/scripts/run_ingestion_prod.py
+++ b/scripts/run_ingestion_prod.py
@@ -87,7 +87,8 @@ def run_step(label: str, script: str, extra_args: list[str] | None = None) -> fl
     cmd = [sys.executable, script_path] + (extra_args or [])
     log.info("━━━ Starting: %s ━━━", label)
     t0 = time.perf_counter()
-    result = subprocess.run(cmd, cwd=PROJECT_ROOT, env={**os.environ})
+    env = {**os.environ, "PYTHONPATH": PROJECT_ROOT}
+    result = subprocess.run(cmd, cwd=PROJECT_ROOT, env=env)
     elapsed = time.perf_counter() - t0
     if result.returncode != 0:
         raise RuntimeError(f"{label} failed with exit code {result.returncode}")


### PR DESCRIPTION
## Summary

- **Root cause 1**: `run_step()` in `scripts/run_ingestion_prod.py` spawns subprocesses with `cwd=PROJECT_ROOT` but didn't set `PYTHONPATH`, so `import rag` failed inside child processes (the `rag/` package directory wasn't on `sys.path`).
- **Root cause 2**: `requirements-rag.txt` was installed *after* the ingest step (and only conditionally on `new_votes != 0`), but `generate_vote_summaries.py` imports `rag.chain.prompts` (which depends on `groq`) during the ingest step itself.

## Changes

- `scripts/run_ingestion_prod.py`: propagate `PYTHONPATH=PROJECT_ROOT` to all subprocess envs in `run_step()`
- `.github/workflows/ingest_prod.yml`: install both `requirements-ingest.txt` and `requirements-rag.txt` upfront (before the ingest step), remove the now-redundant conditional post-ingest RAG install step

## Test plan

- [ ] Trigger `workflow_dispatch` on this branch and confirm the "Vote summaries" step completes without `ModuleNotFoundError`
- [ ] Confirm CI passes (ruff + pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPyWEj1Ei5GNHmSfvZ9jDR