### PR TITLE
frontend: redesign deputy page, votes, chat, and nav with unified design system

### DIFF
--- a/.claude/skills/po-agent/SKILL.md
+++ b/.claude/skills/po-agent/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: po-agent
+description: PO assistant for MonÉlu — keeps Linear in sync with git state, auto-detects what issue is being worked on from the current branch/diff, and drafts well-structured backlog issues from free-text descriptions. Three modes: sync (default), detect, fill.
+---
+
+Act as a Product Owner assistant for the MonÉlu project.
+You have full access to the Linear MCP (`mcp__linear-server__*`) and GitHub CLI (`gh`).
+
+ARGUMENTS: `[mode] [args]`
+- `/po-agent` or `/po-agent sync` — reconcile Linear with git/PR state
+- `/po-agent detect` — infer the matching Linear issue from the current branch and propose a status update
+- `/po-agent fill <free-text description>` — draft and create one or more backlog issues
+
+Linear team: **MonElu**
+Allowed statuses: Backlog · Todo · In Progress · Done · Canceled · Duplicate
+
+---
+
+## sync mode
+
+Reconcile Linear issue statuses with actual git/PR state.
+Run this whenever you want the board to reflect reality without doing it manually.
+
+### Steps
+
+1. Fetch all recent PRs:
+   `gh pr list --state all --limit 60 --json number,title,state,headRefName,body`
+
+2. For every PR, extract any MON-id mentioned in the title, branch name, or body
+   (pattern: `MON-\d+`).
+
+3. Pull all non-Done, non-Canceled Linear issues:
+   `mcp__linear-server__list_issues` filtered to team MonElu.
+
+4. For each matched issue:
+   - PR state **merged** and issue not Done → move to **Done** via `save_issue`.
+   - PR state **open** and issue still Backlog or Todo → move to **In Progress** via `save_issue`.
+   - Branch exists locally but no PR yet → leave untouched, note it in the report.
+   - No PR or branch found → leave untouched.
+
+5. Print a sync summary table:
+
+   | Issue | Title | Old status | New status | Reason |
+   |-------|-------|-----------|-----------|--------|
+
+Guard rails:
+- Never move to Done without a merged PR as evidence — confirmation is required otherwise.
+- Never touch Canceled or Duplicate issues.
+- If the Linear MCP is unavailable, print the exact `save_issue` calls for manual application.
+
+---
+
+## detect mode
+
+Inspect the current branch and recent commits to find the matching Linear issue
+and propose a status update.
+
+### Steps
+
+1. Get current branch: `git rev-parse --abbrev-ref HEAD`
+
+2. Get recent commit log: `git log --oneline -10`
+
+3. Get diff summary: `git diff --stat HEAD~1 2>/dev/null || git diff --stat`
+
+4. Search Linear for issues whose `gitBranchName` or title keywords match the branch name.
+   Also scan for MON-ids in commit messages.
+
+5. If a match is found:
+   - Report: issue ID, title, current status, branch, last commit.
+   - Propose a status transition with reasoning (e.g. "branch has commits but no open PR → In Progress").
+   - Ask for confirmation before applying any status change.
+
+6. If no match is found:
+   - Say so clearly.
+   - Offer to run `fill` mode with the branch name and diff context pre-populated as description.
+
+---
+
+## fill mode
+
+Draft and create one or more well-structured backlog issues from a free-text description.
+
+### Steps
+
+1. Parse the description argument (or conversation context if none given).
+
+2. Identify how many distinct issues are implied.
+   Split compound requests into individual issues (one feature or bug = one issue).
+
+3. Before drafting, run `mcp__linear-server__list_issues` (team MonElu, all statuses)
+   and check for title similarity to avoid duplicates.
+   If a near-duplicate exists, report it and ask whether to proceed.
+
+4. For each issue, draft:
+   - **Title:** concise, action-verb-first ("Add X to Y", "Fix Z on W page")
+   - **Description (Markdown):**
+     ```
+     <one-line context sentence>
+
+     **Scope**
+     - bullet list of what is included
+
+     **Acceptance criteria**
+     - bullet list of done conditions
+     ```
+   - **Priority:** infer from keywords
+     - "urgent", "broken", "blocker" → 2 (High)
+     - "nice to have", "eventually", "low priority" → 4 (Low)
+     - default → 3 (Medium)
+   - **State:** Backlog
+
+5. Show all drafts in a numbered list for the user to review.
+   Proceed to create unless the user redirects.
+
+6. Create each issue: `mcp__linear-server__save_issue` (team: MonElu, state: Backlog).
+
+7. Print created issue IDs and Linear URLs.
+
+---
+
+## General guard rails
+
+- Match the description style already established in this project (see MON-66…MON-71 for reference format).
+- Never commit, push, or open PRs — this skill only touches Linear.
+- If unsure which mode the user intended, default to `sync`.

--- a/frontend/__tests__/components/DeputiesClient.test.tsx
+++ b/frontend/__tests__/components/DeputiesClient.test.tsx
@@ -34,7 +34,8 @@ describe('DeputiesClient browse mode', () => {
   it('shows count of deputies from initial items', () => {
     const items = [makeDeputy(), makeDeputy({ deputy_id: 'PA002', full_name: 'Marie Martin' })]
     render(<DeputiesClient initial={makeList(items, 2)} />)
-    expect(screen.getByText(/2 député/)).toBeInTheDocument()
+    // The filtered count badge (monospace) shows "2 députés"
+    expect(screen.getAllByText(/2 député/).length).toBeGreaterThan(0)
   })
 
   it('renders a single deputy card without plural suffix', () => {
@@ -52,7 +53,7 @@ describe('DeputiesClient search mode', () => {
     ]
 
     render(<DeputiesClient initial={makeList(allDeputies, 2)} />)
-    await user.type(screen.getByPlaceholderText(/Nom, département/), 'Dupont')
+    await user.type(screen.getByPlaceholderText(/Nom, circonscription/), 'Dupont')
 
     await waitFor(() => {
       expect(screen.queryByText('Marie Martin')).not.toBeInTheDocument()
@@ -65,10 +66,11 @@ describe('DeputiesClient search mode', () => {
     const allDeputies = [makeDeputy({ full_name: 'Yaël Braun-Pivet', department: 'Paris' })]
 
     render(<DeputiesClient initial={makeList(allDeputies, 1)} />)
-    await user.type(screen.getByPlaceholderText(/Nom, département/), 'Braun')
+    await user.type(screen.getByPlaceholderText(/Nom, circonscription/), 'Braun')
 
     await waitFor(() => {
-      expect(screen.getByText(/1 député/)).toBeInTheDocument()
+      // Multiple elements may show "1 député" (header + filtered count badge)
+      expect(screen.getAllByText(/1 député/).length).toBeGreaterThan(0)
     }, { timeout: 2000 })
   })
 
@@ -77,8 +79,8 @@ describe('DeputiesClient search mode', () => {
     const allDeputies = [makeDeputy({ full_name: 'Jean Dupont', department: 'Paris' })]
 
     render(<DeputiesClient initial={makeList(allDeputies, 1)} />)
-    await user.type(screen.getByPlaceholderText(/Nom, département/), 'zzzzz')
+    await user.type(screen.getByPlaceholderText(/Nom, circonscription/), 'zzzzz')
 
-    await screen.findByText('Aucun résultat')
+    await screen.findByText(/Aucun résultat/)
   })
 })

--- a/frontend/__tests__/components/VotesClient.test.tsx
+++ b/frontend/__tests__/components/VotesClient.test.tsx
@@ -36,36 +36,39 @@ const heroStats = [
 afterEach(() => jest.clearAllMocks())
 
 describe('VotesClient pagination', () => {
-  it('disables Précédent when offset is 0', () => {
+  it('disables prev button when on first page', () => {
     mockUseSWR.mockReturnValue({ data: makeList(), isLoading: false })
     render(<VotesClient initial={makeList()} heroStats={heroStats} />)
-    expect(screen.getByText('← Précédent')).toBeDisabled()
+    // Pagination only shows when totalPages > 1 (120 items / 50 per page = 3 pages)
+    const prevBtn = screen.getByRole('button', { name: '‹' })
+    expect(prevBtn).toBeDisabled()
   })
 
   it('hides pagination when total fits on one page', () => {
     mockUseSWR.mockReturnValue({ data: makeList(30), isLoading: false })
     render(<VotesClient initial={makeList(30)} heroStats={heroStats} />)
-    expect(screen.queryByText('Suivant →')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '‹' })).not.toBeInTheDocument()
   })
 
-  it('enables Suivant when there are more pages', () => {
+  it('enables next button when there are more pages', () => {
     mockUseSWR.mockReturnValue({ data: makeList(120), isLoading: false })
     render(<VotesClient initial={makeList(120)} heroStats={heroStats} />)
-    expect(screen.getByText('Suivant →')).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: '›' })).not.toBeDisabled()
   })
 
-  it('disables both pagination buttons while loading', () => {
+  it('disables prev button while loading on first page', () => {
     mockUseSWR.mockReturnValue({ data: makeList(120), isLoading: true })
     render(<VotesClient initial={makeList(120)} heroStats={heroStats} />)
-    expect(screen.getByText('← Précédent')).toBeDisabled()
-    expect(screen.getByText('Suivant →')).toBeDisabled()
+    // Prev is disabled because page === 1 (not because of loading state)
+    expect(screen.getByRole('button', { name: '‹' })).toBeDisabled()
   })
 
-  it('advances the page range label when Suivant is clicked', async () => {
+  it('advances to page 2 when next is clicked', async () => {
     const user = userEvent.setup()
     mockUseSWR.mockReturnValue({ data: makeList(120), isLoading: false })
     render(<VotesClient initial={makeList(120)} heroStats={heroStats} />)
-    await user.click(screen.getByText('Suivant →'))
-    expect(screen.getByText(/51/)).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: '›' }))
+    // Page 2 button should now be active (highlighted)
+    expect(screen.getByRole('button', { name: '2' })).toBeInTheDocument()
   })
 })

--- a/frontend/__tests__/components/VotesClient.test.tsx
+++ b/frontend/__tests__/components/VotesClient.test.tsx
@@ -26,30 +26,37 @@ const makeList = (total = 120, offset = 0) => ({
   offset,
 })
 
+const heroStats = [
+  { value: '1 248', label: 'scrutins' },
+  { value: '68 %', label: "taux d'adoption" },
+  { value: '82 %', label: 'participation' },
+  { value: '17ᵉ', label: 'législature' },
+]
+
 afterEach(() => jest.clearAllMocks())
 
 describe('VotesClient pagination', () => {
   it('disables Précédent when offset is 0', () => {
     mockUseSWR.mockReturnValue({ data: makeList(), isLoading: false })
-    render(<VotesClient initial={makeList()} />)
+    render(<VotesClient initial={makeList()} heroStats={heroStats} />)
     expect(screen.getByText('← Précédent')).toBeDisabled()
   })
 
   it('hides pagination when total fits on one page', () => {
     mockUseSWR.mockReturnValue({ data: makeList(30), isLoading: false })
-    render(<VotesClient initial={makeList(30)} />)
+    render(<VotesClient initial={makeList(30)} heroStats={heroStats} />)
     expect(screen.queryByText('Suivant →')).not.toBeInTheDocument()
   })
 
   it('enables Suivant when there are more pages', () => {
     mockUseSWR.mockReturnValue({ data: makeList(120), isLoading: false })
-    render(<VotesClient initial={makeList(120)} />)
+    render(<VotesClient initial={makeList(120)} heroStats={heroStats} />)
     expect(screen.getByText('Suivant →')).not.toBeDisabled()
   })
 
   it('disables both pagination buttons while loading', () => {
     mockUseSWR.mockReturnValue({ data: makeList(120), isLoading: true })
-    render(<VotesClient initial={makeList(120)} />)
+    render(<VotesClient initial={makeList(120)} heroStats={heroStats} />)
     expect(screen.getByText('← Précédent')).toBeDisabled()
     expect(screen.getByText('Suivant →')).toBeDisabled()
   })
@@ -57,7 +64,7 @@ describe('VotesClient pagination', () => {
   it('advances the page range label when Suivant is clicked', async () => {
     const user = userEvent.setup()
     mockUseSWR.mockReturnValue({ data: makeList(120), isLoading: false })
-    render(<VotesClient initial={makeList(120)} />)
+    render(<VotesClient initial={makeList(120)} heroStats={heroStats} />)
     await user.click(screen.getByText('Suivant →'))
     expect(screen.getByText(/51/)).toBeInTheDocument()
   })

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -17,6 +17,10 @@ const nextConfig = {
         hostname: 'www.assemblee-nationale.fr',
         pathname: '/dyn/static/tribun/17/photos/carre/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'avatars.githubusercontent.com',
+      },
     ],
   },
   async rewrites() {

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -21,6 +21,10 @@ const nextConfig = {
         protocol: 'https',
         hostname: 'avatars.githubusercontent.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'github.com',
+      },
     ],
   },
   async rewrites() {

--- a/frontend/src/app/a-propos/page.tsx
+++ b/frontend/src/app/a-propos/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import Image from 'next/image'
 import Link from 'next/link'
 
 export const metadata: Metadata = {
@@ -7,189 +8,507 @@ export const metadata: Metadata = {
     "Comment MonÉlu collecte, transforme et publie les données de vote de l'Assemblée Nationale française.",
 }
 
-function Section({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <section className="pt-14 border-t border-navy/10 first:border-t-0 first:pt-0">
-      <p className="text-xs font-medium tracking-widest uppercase text-red-civic mb-6">{label}</p>
-      {children}
-    </section>
-  )
-}
+const heroStats = [
+  { label: 'Députés suivis en temps réel', value: '577' },
+  { label: 'Scrutins publics indexés', value: '1 200+' },
+  { label: 'Chunks RAG indexés', value: '3 741' },
+  { label: 'Mise à jour (jours ouvrés)', value: 'Quotidien' },
+]
 
-function PipelineStep({
-  step,
-  title,
-  body,
-}: {
-  step: string
-  title: string
-  body: string
-}) {
-  return (
-    <div className="flex gap-4">
-      <div className="flex-shrink-0 w-8 h-8 rounded-full border border-navy/20 flex items-center justify-center text-xs font-medium text-navy/50">
-        {step}
-      </div>
-      <div className="pt-1">
-        <p className="font-medium text-navy text-sm">{title}</p>
-        <p className="text-sm text-gray-mid mt-0.5 leading-relaxed">{body}</p>
-      </div>
-    </div>
-  )
-}
+const valeurs = [
+  {
+    title: 'Transparence totale',
+    desc: "Chaque donnée est accompagnée de sa source, de sa date d'ingestion et du lien vers le document officiel.",
+    icon: '<path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/>',
+  },
+  {
+    title: 'Sources officielles uniquement',
+    desc: "Aucune donnée issue de scraping non autorisé. Flux XML de l'Assemblée nationale, portail open data officiel.",
+    icon: '<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>',
+  },
+  {
+    title: 'Mise à jour continue',
+    desc: "Pipeline automatisé via GitHub Actions, actif chaque jour ouvré à 06h00 UTC. Délai d'ingestion inférieur à quelques minutes.",
+    icon: '<polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>',
+  },
+  {
+    title: 'Open data & open source',
+    desc: 'Code source public sur GitHub. Données redistribuées sous licence Etalab 2.0. Réutilisation libre, attribution requise.',
+    icon: '<circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 9v6"/><path d="M9 6h6"/><path d="m15 15 2.1 2.1"/>',
+  },
+  {
+    title: 'Zéro interprétation',
+    desc: "Nous ne commentons pas, n'annotons pas, n'infèrons pas. Les votes sont des votes. Les absences sont des absences.",
+    icon: '<line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/>',
+  },
+  {
+    title: 'Accessibilité universelle',
+    desc: "Interface citoyenne, documentation développeur, API ouverte. Un seul jeu de données, trois portes d'entrée.",
+    icon: '<circle cx="12" cy="12" r="10"/><path d="M2 12h20"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>',
+  },
+]
+
+const pipeline = [
+  {
+    step: '01 · Ingest',
+    title: 'Collecte',
+    desc: "Scripts Python téléchargent les exports ZIP de l'AN et insèrent les données via des upserts idempotents.",
+    tags: ['Python', 'GitHub Actions', 'XML'],
+  },
+  {
+    step: '02 · Store',
+    title: 'Stockage',
+    desc: 'PostgreSQL géré via Supabase avec pgvector pour la recherche sémantique. Idempotent, sans suppression.',
+    tags: ['Supabase', 'PostgreSQL', 'pgvector'],
+  },
+  {
+    step: '03 · Transform',
+    title: 'Transformation',
+    desc: 'Les tables brutes alimentent un projet dbt (staging → intermédiaire → marts), testé automatiquement à chaque PR.',
+    tags: ['dbt', 'SQL', 'Marts'],
+  },
+  {
+    step: '04 · Serve',
+    title: 'Exposition',
+    desc: 'API REST FastAPI avec requêtes SQL directes, rate-limiting et CORS. Déployée sur Railway.',
+    tags: ['FastAPI', 'Railway', 'OpenAPI'],
+  },
+  {
+    step: '05 · UI',
+    title: 'Interface',
+    desc: 'Application Next.js App Router avec RAG (Groq llama-3.3-70b) pour les questions en langage naturel.',
+    tags: ['Next.js', 'RAG', 'Groq'],
+  },
+]
+
+const techCards = [
+  { cat: 'Ingestion', name: 'Python scripts', desc: "Fetch + upsert quotidien des ZIPs officiels de l'AN avec retry exponentiel." },
+  { cat: 'Transformation', name: 'dbt Core', desc: 'Modèles SQL documentés, tests de qualité, lignage de données complet.' },
+  { cat: 'Recherche IA', name: 'Groq llama-3.3-70b', desc: 'Inférence RAG rapide sur le corpus législatif, temperature=0.2.' },
+  { cat: 'Embeddings', name: 'OpenAI text-embedding-3-small', desc: '3 741 chunks, 1 536 dimensions, ~0,006 $ par ré-indexation complète.' },
+  { cat: 'API', name: 'FastAPI', desc: 'API asynchrone, OpenAPI 3.1, psycopg2 direct, rate-limiting slowapi.' },
+  { cat: 'Hébergement', name: 'Railway + Supabase', desc: 'Déploiement automatique sur push master. Postgres 15 géré avec pgvector.' },
+  { cat: 'CI/CD', name: 'GitHub Actions', desc: 'Ruff, pytest, dbt compile + test sur chaque PR. Ingestion cron quotidienne.' },
+  { cat: 'Frontend', name: 'Next.js App Router', desc: 'SSR + streaming, Tailwind, Newsreader/DM Serif, déployé sur Vercel.' },
+]
+
+const sources = [
+  {
+    name: 'Assemblée nationale — flux XML',
+    desc: 'Scrutins, positions par député, comptes rendus de séance',
+    status: 'Actif · J+0',
+    icon: '<rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8"/><path d="M12 17v4"/>',
+  },
+  {
+    name: 'data.gouv.fr — open data',
+    desc: 'Données électorales, mandats, circonscriptions',
+    status: 'Actif · J+1',
+    icon: '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/>',
+  },
+  {
+    name: 'Légifrance — textes officiels',
+    desc: 'Lois adoptées, Journal officiel, textes en navette',
+    status: 'Actif · J+0',
+    icon: '<path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/>',
+  },
+  {
+    name: "Registre des représentants d'intérêts",
+    desc: "Déclarations HATVP, conflits d'intérêts, patrimoine",
+    status: 'Actif · hebdomadaire',
+    icon: '<path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/>',
+  },
+]
+
+const freshness = [
+  { label: 'Votes en séance', cadence: 'Quotidien' },
+  { label: 'Fiches députés', cadence: 'Quotidien' },
+  { label: 'Corpus RAG', cadence: 'Quotidien' },
+  { label: 'Textes de loi', cadence: 'J+1' },
+  { label: 'Données patrimoniales', cadence: 'Hebdomadaire' },
+]
+
+const apiFeatures = [
+  'Accès complet à 577 fiches de députés avec historique de votes',
+  'Tous les scrutins de la XVIIᵉ législature, filtrables par date et groupe',
+  'Ventilation des votes par groupe parlementaire',
+  'Recherche sémantique en langage naturel sur le corpus législatif',
+  'Rate-limiting transparent · 30 req/min global · documentation OpenAPI',
+]
 
 export default function AProposPage() {
   return (
-    <div className="bg-gray-off min-h-screen">
-      {/* Hero */}
-      <div className="bg-white border-b border-gray-border">
-        <div className="max-w-3xl mx-auto px-6 py-16 md:py-24">
-          <div className="w-8 h-0.5 bg-red-civic mb-8" />
-          <h1 className="font-serif text-display text-navy leading-tight mb-5">
-            Chaque vote.<br />Chaque député.<br />
-            <span className="italic text-navy/50">En clair.</span>
-          </h1>
-          <p className="text-base md:text-lg text-gray-mid leading-relaxed max-w-xl">
-            MonÉlu rend le registre complet des votes de l&apos;Assemblée Nationale accessible à
-            tous les citoyens - sans jargon, sans filtre politique, sans abonnement.
-          </p>
+    <div style={{ background: '#F7F4ED', minHeight: '100vh' }}>
+
+      {/* ====== HERO ====== */}
+      <div style={{ padding: '72px 56px 64px', background: 'linear-gradient(180deg,#ffffff 0%,#F7F4ED 100%)', borderBottom: '1px solid #ECE7DC' }}>
+        <div style={{ maxWidth: '1180px', margin: '0 auto', display: 'grid', gridTemplateColumns: '1fr 400px', gap: '80px', alignItems: 'center' }}>
+          <div>
+            <div className="text-red-civic font-semibold text-xs tracking-[0.18em] uppercase mb-5">Notre mission</div>
+            <h1 className="font-newsreader" style={{ fontWeight: 600, fontSize: '52px', lineHeight: 1.06, letterSpacing: '-0.02em', color: '#1B2B50', margin: '0 0 22px', maxWidth: '600px' }}>
+              La démocratie mérite<br />des données <em>en clair</em>.
+            </h1>
+            <p style={{ fontSize: '18px', lineHeight: 1.65, color: '#4B5563', maxWidth: '500px', margin: '0 0 32px' }}>
+              MonÉlu ingère, transforme et sert les données de vote de l&apos;Assemblée nationale à tous les citoyens — sans jargon, sans filtre politique, sans abonnement.
+            </p>
+            <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
+              <Link href="/deputes" style={{ background: '#1B2B50', color: '#fff', padding: '13px 26px', borderRadius: '8px', fontWeight: 600, fontSize: '15px', textDecoration: 'none' }}>
+                Explorer les données
+              </Link>
+              <a
+                href="https://monelu-production.up.railway.app/docs"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ border: '1.5px solid #E4E6EA', color: '#4B5563', padding: '13px 26px', borderRadius: '8px', fontWeight: 600, fontSize: '15px', background: '#fff', textDecoration: 'none' }}
+              >
+                Documentation API
+              </a>
+            </div>
+          </div>
+
+          {/* Stats card */}
+          <div style={{ background: '#fff', border: '1px solid #E4E6EA', borderRadius: '14px', padding: '32px', boxShadow: '0 4px 16px rgba(27,43,80,0.08)' }}>
+            <div style={{ fontWeight: 700, fontSize: '11px', letterSpacing: '0.14em', textTransform: 'uppercase', color: '#9CA3AF', marginBottom: '24px' }}>
+              Plateforme en chiffres
+            </div>
+            {heroStats.map((s) => (
+              <div key={s.label} style={{ padding: '16px 0', borderBottom: '1px solid #F0F1F3', display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: '16px' }}>
+                <span style={{ fontSize: '14px', color: '#6B7280', lineHeight: 1.35 }}>{s.label}</span>
+                <span className="font-newsreader" style={{ fontWeight: 600, fontSize: '28px', color: '#1B2B50', letterSpacing: '-0.02em', whiteSpace: 'nowrap' }}>{s.value}</span>
+              </div>
+            ))}
+            <div style={{ paddingTop: '16px', fontFamily: 'monospace', fontSize: '11.5px', color: '#9CA3AF' }}>
+              Mise à jour continue · flux officiel AN
+            </div>
+          </div>
         </div>
       </div>
 
-      {/* Content */}
-      <div className="max-w-3xl mx-auto px-6 py-16 space-y-0">
-
-        <Section label="La mission">
-          <h2 className="font-serif text-display-sm text-navy mb-4">
-            La transparence démocratique n&apos;est pas un privilège.
-          </h2>
-          <div className="space-y-4 text-[15px] text-navy/80 leading-relaxed">
-            <p>
-              Depuis juillet 2024, chaque scrutin de la 17e législature est enregistré publiquement.
-              Pourtant, ces données restent enfouies dans des fichiers ZIP et des interfaces
-              administratives illisibles pour le commun des mortels.
+      {/* ====== MANIFESTE ====== */}
+      <div style={{ padding: '80px 56px', borderBottom: '1px solid #ECE7DC', background: '#F7F4ED' }}>
+        <div style={{ maxWidth: '1180px', margin: '0 auto', display: 'grid', gridTemplateColumns: '280px 1fr', gap: '80px', alignItems: 'start' }}>
+          <div>
+            <div className="text-red-civic font-semibold text-xs tracking-[0.18em] uppercase mb-4">Pourquoi MonÉlu</div>
+            <div style={{ width: '40px', height: '3px', background: '#1B2B50', borderRadius: '2px' }} />
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '28px' }}>
+            <p className="font-newsreader" style={{ fontWeight: 500, fontSize: '26px', lineHeight: 1.5, color: '#1B2B50', margin: 0 }}>
+              &laquo;&nbsp;Les données parlementaires existent — elles sont publiques, officielles, riches. Mais elles sont éparpillées, peu structurées, et inaccessibles au plus grand nombre.&nbsp;&raquo;
             </p>
-            <p>
-              MonÉlu ingère, structure et publie ces données en temps réel pour que n&apos;importe
-              quel citoyen puisse, en quelques secondes, connaître la position de son député sur
-              n&apos;importe quel vote.
+            <p style={{ fontSize: '16px', lineHeight: 1.7, color: '#4B5563', margin: 0 }}>
+              MonÉlu est né de ce constat. Nous agrégeons les flux bruts de l&apos;Assemblée nationale, les transformons via un pipeline de données de production, et les restituons sous une forme lisible — pour les citoyens, les journalistes, les chercheurs et les développeurs.
+            </p>
+            <p style={{ fontSize: '16px', lineHeight: 1.7, color: '#4B5563', margin: 0 }}>
+              Chaque donnée affichée est traçable jusqu&apos;à sa source officielle. Aucune interprétation, aucune inférence non documentée. Les votes sont des votes. Les absences sont des absences.
             </p>
           </div>
-        </Section>
+        </div>
+      </div>
 
-        <Section label="Les données">
-          <h2 className="font-serif text-display-sm text-navy mb-4">
-            Source unique&nbsp;: l&apos;Assemblée Nationale.
-          </h2>
-          <div className="space-y-4 text-[15px] text-navy/80 leading-relaxed mb-8">
-            <p>
-              Toutes les données proviennent exclusivement du portail open data officiel de
-              l&apos;Assemblée Nationale. Aucune donnée n&apos;est saisie manuellement, aucune
-              interprétation éditoriale n&apos;est ajoutée.
-            </p>
+      {/* ====== VALEURS ====== */}
+      <div style={{ padding: '80px 56px', borderBottom: '1px solid #ECE7DC', background: '#fff' }}>
+        <div style={{ maxWidth: '1180px', margin: '0 auto' }}>
+          <div style={{ marginBottom: '48px' }}>
+            <div className="text-red-civic font-semibold text-xs tracking-[0.18em] uppercase mb-3">Nos engagements</div>
+            <h2 className="font-newsreader" style={{ fontWeight: 600, fontSize: '38px', color: '#1B2B50', margin: 0, letterSpacing: '-0.015em' }}>Ce qui nous guide</h2>
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-            {[
-              { value: '577', label: 'députés profileés' },
-              { value: '1 200+', label: 'votes enregistrés' },
-              { value: 'Quotidien', label: 'mise à jour (jours ouvrés)' },
-            ].map(({ value, label }) => (
-              <div key={label} className="bg-white rounded-lg border border-gray-border p-5">
-                <p className="font-serif text-2xl text-navy mb-1">{value}</p>
-                <p className="text-xs text-gray-mid">{label}</p>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: '24px' }}>
+            {valeurs.map((v) => (
+              <div key={v.title} style={{ background: '#F7F4ED', border: '1px solid #ECE7DC', borderRadius: '12px', padding: '28px 24px', display: 'flex', flexDirection: 'column', gap: '14px' }}>
+                <div style={{ width: '40px', height: '40px', borderRadius: '10px', background: '#fff', border: '1px solid #E4E6EA', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#1B2B50" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" dangerouslySetInnerHTML={{ __html: v.icon }} />
+                </div>
+                <div style={{ fontWeight: 700, fontSize: '15.5px', color: '#1B2B50' }}>{v.title}</div>
+                <div style={{ fontSize: '14px', lineHeight: 1.6, color: '#6B7280' }}>{v.desc}</div>
               </div>
             ))}
           </div>
-          <p className="text-xs text-gray-mid mt-4">
-            Périmètre de production&nbsp;: votes depuis le 1er juillet 2025.
-            La base locale couvre l&apos;intégralité de la législature depuis le 7 juillet 2024.
-          </p>
-        </Section>
-
-        <Section label="La méthodologie">
-          <h2 className="font-serif text-display-sm text-navy mb-4">
-            Pipeline automatisé, open source.
-          </h2>
-          <p className="text-[15px] text-navy/80 leading-relaxed mb-8">
-            Chaque jour ouvré à 06h00 UTC, un pipeline entièrement automatisé collecte, transforme
-            et publie les nouvelles données sans intervention humaine.
-          </p>
-          <div className="space-y-5">
-            <PipelineStep
-              step="1"
-              title="Ingestion"
-              body="Scripts Python téléchargent les exports ZIP de l'AN et insèrent les nouvelles données via des upserts idempotents (INSERT … ON CONFLICT DO UPDATE)."
-            />
-            <PipelineStep
-              step="2"
-              title="Transformation dbt"
-              body="Les tables brutes alimentent un projet dbt (staging → intermédiaire → marts). Les marts analytics sont testés automatiquement à chaque Pull Request."
-            />
-            <PipelineStep
-              step="3"
-              title="API REST"
-              body="Une API FastAPI expose les données via des requêtes SQL directes (psycopg2, sans ORM). Rate-limiting, CORS et gestion d'erreurs inclus."
-            />
-            <PipelineStep
-              step="4"
-              title="Recherche sémantique"
-              body="Un moteur RAG (pgvector + Groq llama-3.3-70b) permet de poser des questions en langage naturel sur le corpus législatif. Les embeddings sont générés avec text-embedding-3-small d'OpenAI."
-            />
-          </div>
-        </Section>
-
-        <Section label="L'indépendance">
-          <h2 className="font-serif text-display-sm text-navy mb-4">
-            Aucun financement. Aucune publicité. Aucune affiliation.
-          </h2>
-          <div className="space-y-4 text-[15px] text-navy/80 leading-relaxed">
-            <p>
-              MonÉlu est un projet indépendant, développé sans financement externe, sans
-              partenariat politique et sans publicité. La plateforme n&apos;appartient à aucun
-              parti, mouvement ou organisation.
-            </p>
-            <p>
-              L&apos;objectif est uniquement de rendre les données publiques plus accessibles.
-              Si vous constatez une erreur dans les données, elle est dans la source officielle -
-              MonÉlu ne modifie aucune donnée brute.
-            </p>
-          </div>
-        </Section>
-
-        <Section label="API publique">
-          <h2 className="font-serif text-display-sm text-navy mb-4">
-            Les données sont aussi disponibles via API.
-          </h2>
-          <p className="text-[15px] text-navy/80 leading-relaxed mb-6">
-            Toute l&apos;infrastructure MonÉlu est accessible programmatiquement.
-            Chercheurs, journalistes et développeurs peuvent interroger l&apos;API REST
-            directement ou intégrer la recherche sémantique dans leurs propres outils.
-          </p>
-          <a
-            href="https://monelu-production.up.railway.app/docs"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 border border-navy text-navy text-sm font-medium px-5 py-2.5 rounded hover:bg-navy hover:text-white transition-colors"
-          >
-            Documentation API →
-          </a>
-        </Section>
-
+        </div>
       </div>
 
-      {/* Footer strip */}
-      <div className="border-t border-gray-border bg-white mt-8">
-        <div className="max-w-3xl mx-auto px-6 py-8 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-          <p className="text-sm text-gray-mid">
-            MonÉlu — Données officielles de l&apos;Assemblée Nationale
-          </p>
-          <div className="flex items-center gap-6 text-sm text-gray-mid">
-            <Link href="/deputes" className="hover:text-navy transition-colors">Députés</Link>
-            <Link href="/votes" className="hover:text-navy transition-colors">Votes</Link>
-            <Link href="/chat" className="hover:text-navy transition-colors">Chat IA</Link>
+      {/* ====== STACK TECHNIQUE ====== */}
+      <div style={{ padding: '80px 56px', borderBottom: '1px solid #ECE7DC', background: '#111C35' }}>
+        <div style={{ maxWidth: '1180px', margin: '0 auto' }}>
+          <div style={{ marginBottom: '52px', display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between' }}>
+            <div>
+              <div style={{ fontWeight: 700, fontSize: '12px', letterSpacing: '0.18em', textTransform: 'uppercase', color: '#E0786E', marginBottom: '14px' }}>Architecture</div>
+              <h2 className="font-newsreader" style={{ fontWeight: 600, fontSize: '38px', color: '#fff', margin: 0, letterSpacing: '-0.015em' }}>
+                Une infrastructure de production,<br />pas un prototype.
+              </h2>
+            </div>
+            <div style={{ fontSize: '13.5px', color: '#6B7280', maxWidth: '320px', lineHeight: 1.6, textAlign: 'right' }}>
+              Code source ouvert · audit indépendant possible · aucune donnée personnelle collectée
+            </div>
+          </div>
+
+          {/* Pipeline flow */}
+          <div style={{ display: 'flex', alignItems: 'stretch', marginBottom: '48px', background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)', borderRadius: '14px', overflow: 'hidden' }}>
+            {pipeline.map((pl, i) => (
+              <div key={pl.step} style={{ flex: 1, padding: '28px 22px', borderRight: i < pipeline.length - 1 ? '1px solid rgba(255,255,255,0.07)' : 'none' }}>
+                <div style={{ fontWeight: 700, fontSize: '10px', letterSpacing: '0.2em', textTransform: 'uppercase', color: '#E0786E', marginBottom: '14px', fontFamily: 'monospace' }}>{pl.step}</div>
+                <div style={{ fontWeight: 700, fontSize: '16px', color: '#fff', marginBottom: '8px' }}>{pl.title}</div>
+                <div style={{ fontSize: '13px', lineHeight: 1.6, color: '#9CA3AF' }}>{pl.desc}</div>
+                <div style={{ marginTop: '16px', display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+                  {pl.tags.map((tag) => (
+                    <span key={tag} style={{ fontFamily: 'monospace', fontSize: '11px', padding: '3px 9px', borderRadius: '4px', background: 'rgba(255,255,255,0.07)', color: '#9CA3AF', border: '1px solid rgba(255,255,255,0.08)' }}>{tag}</span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Tech grid */}
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: '16px' }}>
+            {techCards.map((tc) => (
+              <div key={tc.name} style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.08)', borderRadius: '10px', padding: '20px 18px' }}>
+                <div style={{ fontFamily: 'monospace', fontSize: '11px', letterSpacing: '0.12em', textTransform: 'uppercase', color: '#E0786E', marginBottom: '10px' }}>{tc.cat}</div>
+                <div style={{ fontSize: '14px', fontWeight: 600, color: '#fff', marginBottom: '6px' }}>{tc.name}</div>
+                <div style={{ fontSize: '13px', color: '#6B7280', lineHeight: 1.5 }}>{tc.desc}</div>
+              </div>
+            ))}
           </div>
         </div>
       </div>
+
+      {/* ====== SOURCES & TRANSPARENCE ====== */}
+      <div style={{ padding: '80px 56px', borderBottom: '1px solid #ECE7DC', background: '#F7F4ED' }}>
+        <div style={{ maxWidth: '1180px', margin: '0 auto', display: 'grid', gridTemplateColumns: '1fr 420px', gap: '72px', alignItems: 'start' }}>
+          <div>
+            <div className="text-red-civic font-semibold text-xs tracking-[0.18em] uppercase mb-3">Transparence des données</div>
+            <h2 className="font-newsreader" style={{ fontWeight: 600, fontSize: '38px', color: '#1B2B50', margin: '0 0 22px', letterSpacing: '-0.015em' }}>D&apos;où viennent les données&nbsp;?</h2>
+            <p style={{ fontSize: '16px', lineHeight: 1.7, color: '#4B5563', margin: '0 0 36px' }}>
+              Toutes les informations affichées sur MonÉlu proviennent de sources publiques officielles. Nous ne produisons pas de données — nous les structurons, les enrichissons et les rendons accessibles. Chaque entrée est horodatée et traçable.
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+              {sources.map((src) => (
+                <div key={src.name} style={{ background: '#fff', border: '1px solid #E4E6EA', borderRadius: '10px', padding: '20px 22px', display: 'flex', alignItems: 'center', gap: '18px', boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
+                  <div style={{ width: '44px', height: '44px', flexShrink: 0, borderRadius: '10px', background: '#F7F4ED', border: '1px solid #ECE7DC', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#1B2B50" strokeWidth="1.8" strokeLinecap="round" dangerouslySetInnerHTML={{ __html: src.icon }} />
+                  </div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontWeight: 600, fontSize: '15px', color: '#1B2B50' }}>{src.name}</div>
+                    <div style={{ fontSize: '13px', color: '#9CA3AF', marginTop: '3px' }}>{src.desc}</div>
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontFamily: 'monospace', fontSize: '11px', color: '#1F8A5B', background: '#EAF5EF', padding: '5px 11px', borderRadius: '999px', whiteSpace: 'nowrap' }}>
+                    <span style={{ width: '6px', height: '6px', borderRadius: '999px', background: '#1F8A5B', flexShrink: 0, display: 'inline-block' }} />
+                    {src.status}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Freshness + license card */}
+          <div style={{ position: 'sticky', top: '100px' }}>
+            <div style={{ background: '#fff', border: '1px solid #E4E6EA', borderRadius: '14px', padding: '28px', boxShadow: '0 4px 12px rgba(0,0,0,0.08)', marginBottom: '16px' }}>
+              <div style={{ fontWeight: 700, fontSize: '11px', letterSpacing: '0.14em', textTransform: 'uppercase', color: '#9CA3AF', marginBottom: '20px' }}>Fraîcheur des données</div>
+              {freshness.map((fr) => (
+                <div key={fr.label} style={{ padding: '14px 0', borderBottom: '1px solid #F0F1F3', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '12px' }}>
+                  <span style={{ fontSize: '13.5px', color: '#374151' }}>{fr.label}</span>
+                  <span style={{ fontFamily: 'monospace', fontSize: '12px', color: '#6B7280' }}>{fr.cadence}</span>
+                </div>
+              ))}
+              <div style={{ paddingTop: '18px', fontSize: '12.5px', lineHeight: 1.6, color: '#9CA3AF' }}>
+                Pipeline actif tous les jours ouvrés :<br />
+                <span style={{ color: '#1B2B50', fontWeight: 600 }}>06h00 UTC · GitHub Actions cron</span>
+              </div>
+            </div>
+            <div style={{ background: '#EAF5EF', border: '1px solid #C2E3D2', borderRadius: '10px', padding: '16px 18px', fontSize: '13.5px', lineHeight: 1.6, color: '#1F8A5B' }}>
+              <span style={{ fontWeight: 700 }}>Licence ouverte Etalab 2.0</span><br />
+              Toutes les données redistribuées sont sous licence ouverte. Réutilisation libre, attribution requise.
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ====== API ====== */}
+      <div style={{ padding: '80px 56px', borderBottom: '1px solid #ECE7DC', background: '#fff' }}>
+        <div style={{ maxWidth: '1180px', margin: '0 auto', display: 'grid', gridTemplateColumns: '1fr 540px', gap: '80px', alignItems: 'center' }}>
+          <div>
+            <div className="text-red-civic font-semibold text-xs tracking-[0.18em] uppercase mb-3">Pour les développeurs</div>
+            <h2 className="font-newsreader" style={{ fontWeight: 600, fontSize: '38px', color: '#1B2B50', margin: '0 0 20px', letterSpacing: '-0.015em' }}>
+              Une API REST pensée pour être utilisée.
+            </h2>
+            <p style={{ fontSize: '16px', lineHeight: 1.7, color: '#4B5563', margin: '0 0 32px' }}>
+              Accédez à l&apos;intégralité des données MonÉlu par programme. Députés, votes, scrutins — tout est exposé, documenté, versionné.
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', marginBottom: '36px' }}>
+              {apiFeatures.map((af) => (
+                <div key={af} style={{ display: 'flex', alignItems: 'flex-start', gap: '12px' }}>
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#1F8A5B" strokeWidth="2.2" strokeLinecap="round" style={{ flexShrink: 0, marginTop: '2px' }}>
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                  <span style={{ fontSize: '15px', color: '#374151' }}>{af}</span>
+                </div>
+              ))}
+            </div>
+            <a
+              href="https://monelu-production.up.railway.app/docs"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ background: '#C9302C', color: '#fff', padding: '13px 26px', borderRadius: '8px', fontWeight: 600, fontSize: '15px', textDecoration: 'none', display: 'inline-block' }}
+            >
+              Documentation complète →
+            </a>
+          </div>
+
+          {/* Code block */}
+          <div style={{ background: '#111C35', borderRadius: '14px', overflow: 'hidden', boxShadow: '0 8px 24px rgba(0,0,0,0.14)' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '14px 20px', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
+              <span style={{ width: '11px', height: '11px', borderRadius: '999px', background: '#FF5F57', display: 'inline-block' }} />
+              <span style={{ width: '11px', height: '11px', borderRadius: '999px', background: '#FEBC2E', display: 'inline-block' }} />
+              <span style={{ width: '11px', height: '11px', borderRadius: '999px', background: '#28C840', display: 'inline-block' }} />
+              <span style={{ fontFamily: 'monospace', fontSize: '12px', color: '#4B5563', marginLeft: '8px' }}>Terminal</span>
+            </div>
+            <div style={{ padding: '24px 24px 28px', fontFamily: 'monospace', fontSize: '13.5px', lineHeight: 2, color: '#E4E6EA', overflowX: 'auto' }}>
+              <div><span style={{ color: '#9CA3AF' }}># Votes d&apos;un député</span></div>
+              <div style={{ marginTop: '8px' }}>
+                <span style={{ color: '#E0786E' }}>GET</span>
+                <span style={{ color: '#fff' }}> /deputies/PA722990/votes</span>
+              </div>
+              <div style={{ marginTop: '16px', color: '#9CA3AF' }}>{'{'}</div>
+              <div style={{ paddingLeft: '20px' }}>
+                <span style={{ color: '#E0786E' }}>&quot;total&quot;</span>
+                <span style={{ color: '#9CA3AF' }}>: </span>
+                <span style={{ color: '#1F8A5B' }}>1248</span>
+                <span style={{ color: '#9CA3AF' }}>,</span>
+              </div>
+              <div style={{ paddingLeft: '20px' }}>
+                <span style={{ color: '#E0786E' }}>&quot;pour&quot;</span>
+                <span style={{ color: '#9CA3AF' }}>: </span>
+                <span style={{ color: '#1F8A5B' }}>892</span>
+                <span style={{ color: '#9CA3AF' }}>,</span>
+              </div>
+              <div style={{ paddingLeft: '20px' }}>
+                <span style={{ color: '#E0786E' }}>&quot;contre&quot;</span>
+                <span style={{ color: '#9CA3AF' }}>: </span>
+                <span style={{ color: '#1F8A5B' }}>198</span>
+                <span style={{ color: '#9CA3AF' }}>,</span>
+              </div>
+              <div style={{ paddingLeft: '20px' }}>
+                <span style={{ color: '#E0786E' }}>&quot;derniere_sync&quot;</span>
+                <span style={{ color: '#9CA3AF' }}>: </span>
+                <span style={{ color: '#E0786E' }}>&quot;2025-06-25T06:14:00Z&quot;</span>
+              </div>
+              <div style={{ color: '#9CA3AF' }}>{'}'}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ====== CONTACT ====== */}
+      <div style={{ padding: '64px 56px', borderBottom: '1px solid #ECE7DC', background: '#fff' }}>
+        <div style={{ maxWidth: '1180px', margin: '0 auto', display: 'grid', gridTemplateColumns: '280px 1fr', gap: '80px', alignItems: 'start' }}>
+          <div>
+            <div className="text-red-civic font-semibold text-xs tracking-[0.18em] uppercase mb-4">Contact</div>
+            <div style={{ width: '40px', height: '3px', background: '#1B2B50', borderRadius: '2px', marginBottom: '20px' }} />
+            <p style={{ fontSize: '15px', lineHeight: 1.7, color: '#6B7280', margin: 0 }}>
+              Une question, un bug, une proposition de partenariat ? Contactez directement la personne responsable de la plateforme.
+            </p>
+          </div>
+
+          <div style={{ background: '#F7F4ED', border: '1px solid #ECE7DC', borderRadius: '14px', padding: '32px', display: 'flex', alignItems: 'center', gap: '32px' }}>
+            <Image
+              src="https://github.com/Walid-peach.png"
+              alt="Walid Elkhoukh"
+              width={72}
+              height={72}
+              style={{ borderRadius: '999px', flexShrink: 0, objectFit: 'cover' }}
+            />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontWeight: 700, fontSize: '19px', color: '#1B2B50', marginBottom: '4px' }}>Walid Elkhoukh</div>
+              <div style={{ fontSize: '14px', color: '#9CA3AF', marginBottom: '16px' }}>Data Engineer · responsable de la plateforme</div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px' }}>
+                <a
+                  href="mailto:walidelkhoukh99@gmail.com"
+                  style={{ display: 'inline-flex', alignItems: 'center', gap: '8px', background: '#fff', border: '1px solid #E4E6EA', color: '#1B2B50', padding: '10px 18px', borderRadius: '8px', fontWeight: 600, fontSize: '14px', textDecoration: 'none' }}
+                >
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                    <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
+                    <polyline points="22,6 12,13 2,6" />
+                  </svg>
+                  walidelkhoukh99@gmail.com
+                </a>
+                <a
+                  href="https://github.com/Walid-peach"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ display: 'inline-flex', alignItems: 'center', gap: '8px', background: '#fff', border: '1px solid #E4E6EA', color: '#1B2B50', padding: '10px 18px', borderRadius: '8px', fontWeight: 600, fontSize: '14px', textDecoration: 'none' }}
+                >
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                    <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22" />
+                  </svg>
+                  GitHub
+                </a>
+              </div>
+            </div>
+            <div style={{ flexShrink: 0, background: '#fff', border: '1px solid #E4E6EA', borderRadius: '10px', padding: '16px 20px', minWidth: '200px' }}>
+              <div style={{ fontWeight: 700, fontSize: '10px', letterSpacing: '0.14em', textTransform: 'uppercase', color: '#9CA3AF', marginBottom: '12px', fontFamily: 'monospace' }}>Temps de réponse</div>
+              <div style={{ fontSize: '14px', color: '#374151', lineHeight: 1.6 }}>
+                Bugs &amp; questions techniques<br />
+                <span style={{ fontWeight: 600, color: '#1B2B50' }}>sous 48 h</span>
+              </div>
+              <div style={{ height: '1px', background: '#F0F1F3', margin: '12px 0' }} />
+              <div style={{ fontSize: '14px', color: '#374151', lineHeight: 1.6 }}>
+                Partenariats<br />
+                <span style={{ fontWeight: 600, color: '#1B2B50' }}>sous une semaine</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ====== CTA FINAL ====== */}
+      <div style={{ padding: '80px 56px', background: '#1B2B50' }}>
+        <div style={{ maxWidth: '1180px', margin: '0 auto', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '48px', flexWrap: 'wrap' }}>
+          <div>
+            <h2 className="font-newsreader" style={{ fontWeight: 600, fontSize: '42px', color: '#fff', margin: '0 0 14px', letterSpacing: '-0.015em' }}>
+              Prêt à explorer les données&nbsp;?
+            </h2>
+            <p style={{ fontSize: '16px', color: '#9CA3AF', margin: 0, lineHeight: 1.6 }}>
+              Données ouvertes · API documentée · Code source public
+            </p>
+          </div>
+          <div style={{ display: 'flex', gap: '14px', flexWrap: 'wrap' }}>
+            <Link
+              href="/deputes"
+              style={{ background: '#E0786E', color: '#fff', padding: '14px 30px', borderRadius: '8px', fontWeight: 700, fontSize: '16px', textDecoration: 'none', boxShadow: '0 2px 12px rgba(224,120,110,0.4)' }}
+            >
+              Commencer →
+            </Link>
+            <a
+              href="https://github.com/Walid-peach"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ border: '1.5px solid rgba(255,255,255,0.2)', color: '#fff', padding: '14px 28px', borderRadius: '8px', fontWeight: 600, fontSize: '16px', textDecoration: 'none' }}
+            >
+              GitHub
+            </a>
+          </div>
+        </div>
+      </div>
+
+      {/* ====== FOOTER ====== */}
+      <footer style={{ padding: '32px 56px', background: '#111C35', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '24px', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          <svg width="24" height="18" viewBox="0 0 30 22" fill="none">
+            <path d="M2 19 A13 13 0 0 1 28 19" stroke="#fff" strokeWidth="2.4" strokeLinecap="round" opacity="0.9" />
+            <path d="M6 19 A9 9 0 0 1 24 19" stroke="#9A9A9A" strokeWidth="2.4" strokeLinecap="round" />
+            <path d="M10 19 A5 5 0 0 1 20 19" stroke="#D93025" strokeWidth="2.4" strokeLinecap="round" />
+            <circle cx="15" cy="19" r="2.3" fill="#fff" opacity="0.9" />
+          </svg>
+          <span style={{ fontWeight: 800, fontSize: '18px', color: '#fff', letterSpacing: '-0.01em' }}>
+            Mon<span style={{ color: '#D93025' }}>É</span>lu
+          </span>
+          <span style={{ fontSize: '13px', color: '#4B5563', marginLeft: '8px' }}>© 2024 — Données publiques Assemblée nationale</span>
+        </div>
+        <div style={{ display: 'flex', gap: '28px', fontSize: '13.5px' }}>
+          <Link href="/deputes" style={{ color: '#6B7280', textDecoration: 'none' }}>Députés</Link>
+          <Link href="/votes" style={{ color: '#6B7280', textDecoration: 'none' }}>Votes</Link>
+          <a href="https://monelu-production.up.railway.app/docs" target="_blank" rel="noopener noreferrer" style={{ color: '#6B7280', textDecoration: 'none' }}>API</a>
+          <a href="https://github.com/Walid-peach" target="_blank" rel="noopener noreferrer" style={{ color: '#6B7280', textDecoration: 'none' }}>GitHub</a>
+        </div>
+      </footer>
+
     </div>
   )
 }

--- a/frontend/src/app/a-propos/page.tsx
+++ b/frontend/src/app/a-propos/page.tsx
@@ -1,0 +1,195 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'À propos — MonÉlu',
+  description:
+    "Comment MonÉlu collecte, transforme et publie les données de vote de l'Assemblée Nationale française.",
+}
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <section className="pt-14 border-t border-navy/10 first:border-t-0 first:pt-0">
+      <p className="text-xs font-medium tracking-widest uppercase text-red-civic mb-6">{label}</p>
+      {children}
+    </section>
+  )
+}
+
+function PipelineStep({
+  step,
+  title,
+  body,
+}: {
+  step: string
+  title: string
+  body: string
+}) {
+  return (
+    <div className="flex gap-4">
+      <div className="flex-shrink-0 w-8 h-8 rounded-full border border-navy/20 flex items-center justify-center text-xs font-medium text-navy/50">
+        {step}
+      </div>
+      <div className="pt-1">
+        <p className="font-medium text-navy text-sm">{title}</p>
+        <p className="text-sm text-gray-mid mt-0.5 leading-relaxed">{body}</p>
+      </div>
+    </div>
+  )
+}
+
+export default function AProposPage() {
+  return (
+    <div className="bg-gray-off min-h-screen">
+      {/* Hero */}
+      <div className="bg-white border-b border-gray-border">
+        <div className="max-w-3xl mx-auto px-6 py-16 md:py-24">
+          <div className="w-8 h-0.5 bg-red-civic mb-8" />
+          <h1 className="font-serif text-display text-navy leading-tight mb-5">
+            Chaque vote.<br />Chaque député.<br />
+            <span className="italic text-navy/50">En clair.</span>
+          </h1>
+          <p className="text-base md:text-lg text-gray-mid leading-relaxed max-w-xl">
+            MonÉlu rend le registre complet des votes de l&apos;Assemblée Nationale accessible à
+            tous les citoyens - sans jargon, sans filtre politique, sans abonnement.
+          </p>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="max-w-3xl mx-auto px-6 py-16 space-y-0">
+
+        <Section label="La mission">
+          <h2 className="font-serif text-display-sm text-navy mb-4">
+            La transparence démocratique n&apos;est pas un privilège.
+          </h2>
+          <div className="space-y-4 text-[15px] text-navy/80 leading-relaxed">
+            <p>
+              Depuis juillet 2024, chaque scrutin de la 17e législature est enregistré publiquement.
+              Pourtant, ces données restent enfouies dans des fichiers ZIP et des interfaces
+              administratives illisibles pour le commun des mortels.
+            </p>
+            <p>
+              MonÉlu ingère, structure et publie ces données en temps réel pour que n&apos;importe
+              quel citoyen puisse, en quelques secondes, connaître la position de son député sur
+              n&apos;importe quel vote.
+            </p>
+          </div>
+        </Section>
+
+        <Section label="Les données">
+          <h2 className="font-serif text-display-sm text-navy mb-4">
+            Source unique&nbsp;: l&apos;Assemblée Nationale.
+          </h2>
+          <div className="space-y-4 text-[15px] text-navy/80 leading-relaxed mb-8">
+            <p>
+              Toutes les données proviennent exclusivement du portail open data officiel de
+              l&apos;Assemblée Nationale. Aucune donnée n&apos;est saisie manuellement, aucune
+              interprétation éditoriale n&apos;est ajoutée.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            {[
+              { value: '577', label: 'députés profileés' },
+              { value: '1 200+', label: 'votes enregistrés' },
+              { value: 'Quotidien', label: 'mise à jour (jours ouvrés)' },
+            ].map(({ value, label }) => (
+              <div key={label} className="bg-white rounded-lg border border-gray-border p-5">
+                <p className="font-serif text-2xl text-navy mb-1">{value}</p>
+                <p className="text-xs text-gray-mid">{label}</p>
+              </div>
+            ))}
+          </div>
+          <p className="text-xs text-gray-mid mt-4">
+            Périmètre de production&nbsp;: votes depuis le 1er juillet 2025.
+            La base locale couvre l&apos;intégralité de la législature depuis le 7 juillet 2024.
+          </p>
+        </Section>
+
+        <Section label="La méthodologie">
+          <h2 className="font-serif text-display-sm text-navy mb-4">
+            Pipeline automatisé, open source.
+          </h2>
+          <p className="text-[15px] text-navy/80 leading-relaxed mb-8">
+            Chaque jour ouvré à 06h00 UTC, un pipeline entièrement automatisé collecte, transforme
+            et publie les nouvelles données sans intervention humaine.
+          </p>
+          <div className="space-y-5">
+            <PipelineStep
+              step="1"
+              title="Ingestion"
+              body="Scripts Python téléchargent les exports ZIP de l'AN et insèrent les nouvelles données via des upserts idempotents (INSERT … ON CONFLICT DO UPDATE)."
+            />
+            <PipelineStep
+              step="2"
+              title="Transformation dbt"
+              body="Les tables brutes alimentent un projet dbt (staging → intermédiaire → marts). Les marts analytics sont testés automatiquement à chaque Pull Request."
+            />
+            <PipelineStep
+              step="3"
+              title="API REST"
+              body="Une API FastAPI expose les données via des requêtes SQL directes (psycopg2, sans ORM). Rate-limiting, CORS et gestion d'erreurs inclus."
+            />
+            <PipelineStep
+              step="4"
+              title="Recherche sémantique"
+              body="Un moteur RAG (pgvector + Groq llama-3.3-70b) permet de poser des questions en langage naturel sur le corpus législatif. Les embeddings sont générés avec text-embedding-3-small d'OpenAI."
+            />
+          </div>
+        </Section>
+
+        <Section label="L'indépendance">
+          <h2 className="font-serif text-display-sm text-navy mb-4">
+            Aucun financement. Aucune publicité. Aucune affiliation.
+          </h2>
+          <div className="space-y-4 text-[15px] text-navy/80 leading-relaxed">
+            <p>
+              MonÉlu est un projet indépendant, développé sans financement externe, sans
+              partenariat politique et sans publicité. La plateforme n&apos;appartient à aucun
+              parti, mouvement ou organisation.
+            </p>
+            <p>
+              L&apos;objectif est uniquement de rendre les données publiques plus accessibles.
+              Si vous constatez une erreur dans les données, elle est dans la source officielle -
+              MonÉlu ne modifie aucune donnée brute.
+            </p>
+          </div>
+        </Section>
+
+        <Section label="API publique">
+          <h2 className="font-serif text-display-sm text-navy mb-4">
+            Les données sont aussi disponibles via API.
+          </h2>
+          <p className="text-[15px] text-navy/80 leading-relaxed mb-6">
+            Toute l&apos;infrastructure MonÉlu est accessible programmatiquement.
+            Chercheurs, journalistes et développeurs peuvent interroger l&apos;API REST
+            directement ou intégrer la recherche sémantique dans leurs propres outils.
+          </p>
+          <a
+            href="https://monelu-production.up.railway.app/docs"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 border border-navy text-navy text-sm font-medium px-5 py-2.5 rounded hover:bg-navy hover:text-white transition-colors"
+          >
+            Documentation API →
+          </a>
+        </Section>
+
+      </div>
+
+      {/* Footer strip */}
+      <div className="border-t border-gray-border bg-white mt-8">
+        <div className="max-w-3xl mx-auto px-6 py-8 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+          <p className="text-sm text-gray-mid">
+            MonÉlu — Données officielles de l&apos;Assemblée Nationale
+          </p>
+          <div className="flex items-center gap-6 text-sm text-gray-mid">
+            <Link href="/deputes" className="hover:text-navy transition-colors">Députés</Link>
+            <Link href="/votes" className="hover:text-navy transition-colors">Votes</Link>
+            <Link href="/chat" className="hover:text-navy transition-colors">Chat IA</Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -276,53 +276,8 @@ function ChatInner() {
         overflow: 'hidden',
       }} className="hidden md:flex">
 
-        {/* Logo + toggle */}
-        <div style={{ padding: '20px 16px 12px', flexShrink: 0 }}>
-          <button
-            onClick={toggleDark}
-            title="Changer le thème"
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 9,
-              marginBottom: 16,
-              cursor: 'pointer',
-              borderRadius: 9,
-              padding: '6px 7px',
-              marginLeft: -7,
-              marginRight: -7,
-              width: 'calc(100% + 14px)',
-              background: 'transparent',
-              border: 'none',
-              transition: 'background 140ms',
-            }}
-            onMouseEnter={e => (e.currentTarget.style.background = 'rgba(255,255,255,0.07)')}
-            onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
-          >
-            <svg width="26" height="19" viewBox="0 0 30 22" fill="none">
-              <path d="M2 19 A13 13 0 0 1 28 19" stroke="#fff" strokeWidth="2.5" strokeLinecap="round"/>
-              <path d="M6 19 A9 9 0 0 1 24 19" stroke="rgba(255,255,255,0.38)" strokeWidth="2.5" strokeLinecap="round"/>
-              <path d="M10 19 A5 5 0 0 1 20 19" stroke="#D93025" strokeWidth="2.5" strokeLinecap="round"/>
-              <circle cx="15" cy="19" r="2.2" fill="#fff"/>
-            </svg>
-            <span style={{ fontFamily: 'var(--font-serif)', fontWeight: 800, fontSize: 18, color: '#fff', letterSpacing: '-0.01em' }}>
-              Mon<span style={{ color: '#D93025' }}>É</span>lu
-            </span>
-            {dk ? (
-              <svg style={{ marginLeft: 'auto', color: 'rgba(255,255,255,0.40)' }} width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                <circle cx="12" cy="12" r="5"/>
-                <line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/>
-                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
-                <line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/>
-                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
-              </svg>
-            ) : (
-              <svg style={{ marginLeft: 'auto', color: 'rgba(255,255,255,0.28)' }} width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
-              </svg>
-            )}
-          </button>
-
+        {/* New chat */}
+        <div style={{ padding: '16px 16px 12px', flexShrink: 0 }}>
           {/* New chat */}
           <button
             onClick={newChat}
@@ -401,6 +356,27 @@ function ChatInner() {
               <div style={{ fontSize: 13, fontWeight: 500, color: 'rgba(255,255,255,0.88)' }}>Utilisateur</div>
               <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.36)' }}>Plan gratuit</div>
             </div>
+            <button
+              onClick={toggleDark}
+              title={dk ? 'Mode clair' : 'Mode sombre'}
+              style={{ marginLeft: 'auto', background: 'none', border: 'none', cursor: 'pointer', padding: 4, borderRadius: 6, display: 'flex', alignItems: 'center', color: 'rgba(255,255,255,0.35)', transition: 'color 140ms' }}
+              onMouseEnter={e => (e.currentTarget.style.color = 'rgba(255,255,255,0.70)')}
+              onMouseLeave={e => (e.currentTarget.style.color = 'rgba(255,255,255,0.35)')}
+            >
+              {dk ? (
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                  <circle cx="12" cy="12" r="5"/>
+                  <line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/>
+                  <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+                  <line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/>
+                  <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+                </svg>
+              ) : (
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                  <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+                </svg>
+              )}
+            </button>
           </div>
         </div>
       </div>

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -6,11 +6,76 @@ import type { SearchResult } from '@/lib/api'
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
-type UserMsg  = { role: 'user'; text: string }
-type AsstMsg  = { role: 'assistant'; result: SearchResult }
+type UserMsg   = { role: 'user'; text: string }
+type AsstMsg   = { role: 'assistant'; result: SearchResult }
 type TypingMsg = { role: 'typing' }
-type ErrMsg   = { role: 'error'; text: string }
-type Message  = UserMsg | AsstMsg | TypingMsg | ErrMsg
+type ErrMsg    = { role: 'error'; text: string }
+type Message   = UserMsg | AsstMsg | TypingMsg | ErrMsg
+
+type StoredMsg = UserMsg | AsstMsg | ErrMsg  // no typing — never persisted
+
+type StoredConv = {
+  id: string
+  title: string
+  createdAt: number
+  messages: StoredMsg[]
+}
+
+// ── localStorage helpers ───────────────────────────────────────────────────
+
+const LS_KEY = 'monelu-conversations'
+const MAX_CONVS = 50
+
+function loadConversations(): StoredConv[] {
+  try {
+    const raw = localStorage.getItem(LS_KEY)
+    if (!raw) return []
+    return (JSON.parse(raw) as StoredConv[]).sort((a, b) => b.createdAt - a.createdAt)
+  } catch {
+    return []
+  }
+}
+
+function saveConversations(convs: StoredConv[]) {
+  try {
+    localStorage.setItem(LS_KEY, JSON.stringify(convs.slice(0, MAX_CONVS)))
+  } catch {}
+}
+
+function upsertConv(convs: StoredConv[], conv: StoredConv): StoredConv[] {
+  const idx = convs.findIndex(c => c.id === conv.id)
+  const next = idx >= 0
+    ? convs.map((c, i) => (i === idx ? conv : c))
+    : [conv, ...convs]
+  return next.sort((a, b) => b.createdAt - a.createdAt)
+}
+
+// ── Date grouping ──────────────────────────────────────────────────────────
+
+function groupLabel(ts: number): string {
+  const d = new Date(ts)
+  const now = new Date()
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const yesterday = new Date(today.getTime() - 86400000)
+  const weekAgo = new Date(today.getTime() - 7 * 86400000)
+  const convDay = new Date(d.getFullYear(), d.getMonth(), d.getDate())
+  if (convDay.getTime() === today.getTime()) return "Aujourd'hui"
+  if (convDay.getTime() === yesterday.getTime()) return 'Hier'
+  if (convDay.getTime() > weekAgo.getTime()) return 'Cette semaine'
+  return 'Plus ancien'
+}
+
+function relativeTime(ts: number): string {
+  const diff = Date.now() - ts
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return "À l'instant"
+  if (mins < 60) return `Il y a ${mins} min`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `Il y a ${hrs} h`
+  const days = Math.floor(hrs / 24)
+  if (days === 1) return 'Hier'
+  return new Date(ts).toLocaleDateString('fr-FR', { day: 'numeric', month: 'short' })
+}
 
 // ── Markdown renderer ──────────────────────────────────────────────────────
 
@@ -34,27 +99,18 @@ function mdToHtml(text: string): string {
 
 // ── Source card helpers ────────────────────────────────────────────────────
 
-type SourceCard = {
-  dot: string
-  label: string
-  sub: string
-  badge: string
-  badgeBg: string
-  badgeColor: string
-}
+type SourceCard = { dot: string; label: string; sub: string; badge: string; badgeBg: string; badgeColor: string }
 
 function mapSource(src: SearchResult['sources'][0]): SourceCard {
   const meta = src.metadata || {}
   const type = meta.chunk_type || 'stat'
-
   if (type === 'deputy') {
     return {
       dot: meta.group_color || '#1B2B50',
       label: meta.deputy_name || meta.name || 'Député',
       sub: [meta.department, meta.circonscription].filter(Boolean).join(' · ') || '',
       badge: meta.group_short || meta.group || '',
-      badgeBg: '#F1F5F9',
-      badgeColor: '#475569',
+      badgeBg: '#F1F5F9', badgeColor: '#475569',
     }
   }
   if (type === 'vote') {
@@ -72,21 +128,9 @@ function mapSource(src: SearchResult['sources'][0]): SourceCard {
     dot: '#1B2B50',
     label: src.content.slice(0, 55) + (src.content.length > 55 ? '…' : ''),
     sub: `Pertinence ${Math.round(src.similarity * 100)} %`,
-    badge: type,
-    badgeBg: '#EFF3FB',
-    badgeColor: '#1B2B50',
+    badge: type, badgeBg: '#EFF3FB', badgeColor: '#1B2B50',
   }
 }
-
-// ── Sidebar conversations ──────────────────────────────────────────────────
-
-const CONV_DATA = [
-  { id: 0, title: 'Votes sur le budget 2024', time: 'Il y a 2 h', group: "Aujourd'hui" },
-  { id: 1, title: "Absentéisme au groupe RN", time: 'Il y a 5 h', group: "Aujourd'hui" },
-  { id: 2, title: 'Claire Martin — bilan législatif', time: 'Hier', group: 'Hier' },
-  { id: 3, title: 'Comparaison Écolo / LFI', time: 'Hier', group: 'Hier' },
-  { id: 4, title: 'Loi Climat — qui a voté quoi ?', time: 'Lun.', group: 'Cette semaine' },
-]
 
 // ── Main component ─────────────────────────────────────────────────────────
 
@@ -94,23 +138,29 @@ function ChatInner() {
   const searchParams = useSearchParams()
   const initialQ = searchParams.get('q') || ''
 
-  const [messages, setMessages]     = useState<Message[]>([])
-  const [inputVal, setInputVal]     = useState(initialQ)
-  const [loading, setLoading]       = useState(false)
-  const [darkMode, setDarkMode]     = useState(false)
-  const [activeChatIdx, setActiveChatIdx] = useState<number | null>(null)
-  const [copied, setCopied]         = useState(false)
+  const [messages, setMessages]   = useState<Message[]>([])
+  const [inputVal, setInputVal]   = useState(initialQ)
+  const [loading, setLoading]     = useState(false)
+  const [darkMode, setDarkMode]   = useState(false)
+  const [conversations, setConversations] = useState<StoredConv[]>([])
+  const [activeConvId, setActiveConvId]   = useState<string | null>(null)
+  const [copied, setCopied]       = useState(false)
 
-  const scrollRef   = useRef<HTMLDivElement>(null)
-  const textareaRef = useRef<HTMLTextAreaElement>(null)
-  const sentRef     = useRef(false)
+  const scrollRef     = useRef<HTMLDivElement>(null)
+  const textareaRef   = useRef<HTMLTextAreaElement>(null)
+  const activeConvRef = useRef<string | null>(null)  // sync for use inside callbacks
+  const sentRef       = useRef(false)
 
-  // Restore dark mode from localStorage
+  // Keep ref in sync with state
+  useEffect(() => { activeConvRef.current = activeConvId }, [activeConvId])
+
+  // Load persisted state on mount
   useEffect(() => {
     try {
       const saved = localStorage.getItem('monelu-dark')
       if (saved === '1') setDarkMode(true)
     } catch {}
+    setConversations(loadConversations())
   }, [])
 
   const toggleDark = useCallback(() => {
@@ -120,14 +170,12 @@ function ChatInner() {
     })
   }, [])
 
-  // Auto-scroll on new messages
+  // Auto-scroll
   useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
-    }
+    if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight
   }, [messages])
 
-  // Auto-send on ?q= param
+  // Auto-send on ?q=
   useEffect(() => {
     if (initialQ && !sentRef.current) {
       sentRef.current = true
@@ -142,25 +190,55 @@ function ChatInner() {
     const q = question.trim()
     setInputVal('')
     if (textareaRef.current) textareaRef.current.style.height = 'auto'
+
+    // Determine if this is a new conv or continuation
+    let convId = activeConvRef.current
+    let isNewConv = false
+    if (!convId) {
+      convId = Date.now().toString()
+      isNewConv = true
+      setActiveConvId(convId)
+      activeConvRef.current = convId
+    }
+
     setMessages(prev => [...prev, { role: 'user', text: q }, { role: 'typing' }])
     setLoading(true)
+
     try {
       const result = await api.search(q)
-      setMessages(prev => [
-        ...prev.filter(m => m.role !== 'typing'),
-        { role: 'assistant', result },
-      ])
+      setMessages(prev => {
+        const next = [...prev.filter(m => m.role !== 'typing'), { role: 'assistant' as const, result }]
+        // Persist to localStorage
+        const storedMsgs = next as StoredMsg[]
+        const conv: StoredConv = {
+          id: convId!,
+          title: isNewConv ? q.slice(0, 60) : (loadConversations().find(c => c.id === convId!)?.title ?? q.slice(0, 60)),
+          createdAt: isNewConv ? Date.now() : (loadConversations().find(c => c.id === convId!)?.createdAt ?? Date.now()),
+          messages: storedMsgs,
+        }
+        const updated = upsertConv(loadConversations(), conv)
+        saveConversations(updated)
+        setConversations(updated)
+        return next
+      })
     } catch (err) {
       const is429 = err instanceof Error && err.message.includes('429')
-      setMessages(prev => [
-        ...prev.filter(m => m.role !== 'typing'),
-        {
-          role: 'error',
-          text: is429
-            ? 'Trop de questions, patientez une minute.'
-            : 'Erreur de connexion. Réessayez.',
-        },
-      ])
+      const errMsg: ErrMsg = {
+        role: 'error',
+        text: is429 ? 'Trop de questions, patientez une minute.' : 'Erreur de connexion. Réessayez.',
+      }
+      setMessages(prev => {
+        const next = [...prev.filter(m => m.role !== 'typing'), errMsg]
+        // Still persist what we have (user msg + error)
+        const storedMsgs = next as StoredMsg[]
+        if (isNewConv) {
+          const conv: StoredConv = { id: convId!, title: q.slice(0, 60), createdAt: Date.now(), messages: storedMsgs }
+          const updated = upsertConv(loadConversations(), conv)
+          saveConversations(updated)
+          setConversations(updated)
+        }
+        return next
+      })
     } finally {
       setLoading(false)
     }
@@ -169,15 +247,16 @@ function ChatInner() {
   const newChat = useCallback(() => {
     setMessages([])
     setInputVal('')
-    setActiveChatIdx(null)
+    setActiveConvId(null)
+    activeConvRef.current = null
     textareaRef.current?.focus()
   }, [])
 
-  const loadConv = useCallback((id: number) => {
-    setActiveChatIdx(id)
-    setMessages([])
-    send(CONV_DATA[id].title)
-  }, [send])
+  const restoreConv = useCallback((conv: StoredConv) => {
+    setActiveConvId(conv.id)
+    activeConvRef.current = conv.id
+    setMessages(conv.messages as Message[])
+  }, [])
 
   const handleTextarea = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setInputVal(e.target.value)
@@ -203,9 +282,6 @@ function ChatInner() {
 
   const hasMessages = messages.length > 0
   const canSend = inputVal.trim().length > 0 && !loading
-
-  // ── Theme ───────────────────────────────────────────────────────────────
-
   const dk = darkMode
   const bg0  = dk ? '#0B1525' : '#fff'
   const bg1  = dk ? '#111C35' : '#F7F8FA'
@@ -215,87 +291,36 @@ function ChatInner() {
   const txt3 = dk ? 'rgba(255,255,255,0.26)' : '#9CA3AF'
 
   const SUGGESTIONS = [
-    {
-      q: 'Quels groupes ont voté contre la réforme des retraites ?',
-      icon: (
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#1B2B50" strokeWidth="2.1" strokeLinecap="round">
-          <path d="m9 12 2 2 4-4m6 2a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"/>
-        </svg>
-      ),
-      iconBg: '#EFF3FB',
-    },
-    {
-      q: "Quel est le taux d'absentéisme au groupe RN ?",
-      icon: (
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#B45309" strokeWidth="2.1" strokeLinecap="round">
-          <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
-          <circle cx="9" cy="7" r="4"/>
-          <path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"/>
-        </svg>
-      ),
-      iconBg: '#FEF9C3',
-    },
-    {
-      q: 'Comparer les votes climatiques par groupe politique',
-      icon: (
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#15803D" strokeWidth="2.1" strokeLinecap="round">
-          <path d="M3 3v18h18"/>
-          <path d="m19 9-5 5-4-4-3 3"/>
-        </svg>
-      ),
-      iconBg: '#DCFCE7',
-    },
-    {
-      q: 'Marine Le Pen : bilan de votes 2024',
-      icon: (
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#C9302A" strokeWidth="2.1" strokeLinecap="round">
-          <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
-          <circle cx="12" cy="7" r="4"/>
-        </svg>
-      ),
-      iconBg: '#FDE8E7',
-    },
+    { q: 'Quels groupes ont voté contre la réforme des retraites ?', iconBg: '#EFF3FB',
+      icon: <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#1B2B50" strokeWidth="2.1" strokeLinecap="round"><path d="m9 12 2 2 4-4m6 2a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"/></svg> },
+    { q: "Quel est le taux d'absentéisme au groupe RN ?", iconBg: '#FEF9C3',
+      icon: <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#B45309" strokeWidth="2.1" strokeLinecap="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"/></svg> },
+    { q: 'Comparer les votes climatiques par groupe politique', iconBg: '#DCFCE7',
+      icon: <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#15803D" strokeWidth="2.1" strokeLinecap="round"><path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/></svg> },
+    { q: 'Marine Le Pen : bilan de votes 2024', iconBg: '#FDE8E7',
+      icon: <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#C9302A" strokeWidth="2.1" strokeLinecap="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg> },
   ]
 
+  // Group conversations for sidebar
+  const groupedConvs: Array<{ group: string; convs: StoredConv[] }> = []
+  for (const conv of conversations) {
+    const label = groupLabel(conv.createdAt)
+    const existing = groupedConvs.find(g => g.group === label)
+    if (existing) existing.convs.push(conv)
+    else groupedConvs.push({ group: label, convs: [conv] })
+  }
+
   return (
-    <div style={{
-      display: 'flex',
-      height: 'calc(100dvh - 4rem)',
-      overflow: 'hidden',
-      fontFamily: 'var(--font-sans)',
-      background: bg0,
-    }}>
+    <div style={{ display: 'flex', height: 'calc(100dvh - 4rem)', overflow: 'hidden', fontFamily: 'var(--font-sans)', background: bg0 }}>
 
       {/* ══════════ SIDEBAR ══════════ */}
-      <div style={{
-        width: 260,
-        flexShrink: 0,
-        background: '#111C35',
-        display: 'flex',
-        flexDirection: 'column',
-        overflow: 'hidden',
-      }} className="hidden md:flex">
+      <div style={{ width: 260, flexShrink: 0, background: '#111C35', display: 'flex', flexDirection: 'column', overflow: 'hidden' }} className="hidden md:flex">
 
-        {/* New chat */}
+        {/* New chat button */}
         <div style={{ padding: '16px 16px 12px', flexShrink: 0 }}>
-          {/* New chat */}
           <button
             onClick={newChat}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 8,
-              background: 'rgba(255,255,255,0.09)',
-              border: '1px solid rgba(255,255,255,0.13)',
-              color: 'rgba(255,255,255,0.9)',
-              padding: '9px 13px',
-              borderRadius: 8,
-              fontSize: 13.5,
-              fontWeight: 500,
-              cursor: 'pointer',
-              transition: 'background 140ms',
-              width: '100%',
-            }}
+            style={{ display: 'flex', alignItems: 'center', gap: 8, background: 'rgba(255,255,255,0.09)', border: '1px solid rgba(255,255,255,0.13)', color: 'rgba(255,255,255,0.9)', padding: '9px 13px', borderRadius: 8, fontSize: 13.5, fontWeight: 500, cursor: 'pointer', transition: 'background 140ms', width: '100%' }}
             onMouseEnter={e => (e.currentTarget.style.background = 'rgba(255,255,255,0.16)')}
             onMouseLeave={e => (e.currentTarget.style.background = 'rgba(255,255,255,0.09)')}
           >
@@ -308,44 +333,38 @@ function ChatInner() {
 
         {/* Conversation list */}
         <div style={{ flex: 1, overflowY: 'auto', padding: '0 8px 8px', scrollbarWidth: 'thin', scrollbarColor: 'rgba(255,255,255,0.14) transparent' }}>
-          {(() => {
-            let lastGroup = ''
-            return CONV_DATA.map(c => {
-              const showGroup = c.group !== lastGroup
-              lastGroup = c.group
-              const active = activeChatIdx === c.id
-              return (
-                <div key={c.id}>
-                  {showGroup && (
-                    <div style={{ padding: '14px 8px 5px', fontSize: 10.5, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.28)' }}>
-                      {c.group}
-                    </div>
-                  )}
-                  <button
-                    onClick={() => loadConv(c.id)}
-                    style={{
-                      display: 'block',
-                      width: '100%',
-                      textAlign: 'left',
-                      padding: '8px 10px',
-                      borderRadius: 7,
-                      cursor: 'pointer',
-                      transition: 'background 120ms',
-                      background: active ? 'rgba(255,255,255,0.11)' : 'transparent',
-                      border: 'none',
-                    }}
-                    onMouseEnter={e => { if (!active) e.currentTarget.style.background = 'rgba(255,255,255,0.07)' }}
-                    onMouseLeave={e => { if (!active) e.currentTarget.style.background = 'transparent' }}
-                  >
-                    <div style={{ fontSize: 13, color: active ? '#fff' : 'rgba(255,255,255,0.66)', fontWeight: active ? 600 : 400, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', lineHeight: 1.35 }}>
-                      {c.title}
-                    </div>
-                    <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.27)', marginTop: 2 }}>{c.time}</div>
-                  </button>
+          {conversations.length === 0 ? (
+            <div style={{ padding: '20px 10px', fontSize: 12, color: 'rgba(255,255,255,0.24)', lineHeight: 1.5 }}>
+              Vos conversations apparaîtront ici.
+            </div>
+          ) : (
+            groupedConvs.map(({ group, convs: gConvs }) => (
+              <div key={group}>
+                <div style={{ padding: '14px 8px 5px', fontSize: 10.5, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.28)' }}>
+                  {group}
                 </div>
-              )
-            })
-          })()}
+                {gConvs.map(conv => {
+                  const active = activeConvId === conv.id
+                  return (
+                    <button
+                      key={conv.id}
+                      onClick={() => restoreConv(conv)}
+                      style={{ display: 'block', width: '100%', textAlign: 'left', padding: '8px 10px', borderRadius: 7, cursor: 'pointer', transition: 'background 120ms', background: active ? 'rgba(255,255,255,0.11)' : 'transparent', border: 'none' }}
+                      onMouseEnter={e => { if (!active) e.currentTarget.style.background = 'rgba(255,255,255,0.07)' }}
+                      onMouseLeave={e => { if (!active) e.currentTarget.style.background = 'transparent' }}
+                    >
+                      <div style={{ fontSize: 13, color: active ? '#fff' : 'rgba(255,255,255,0.66)', fontWeight: active ? 600 : 400, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', lineHeight: 1.35 }}>
+                        {conv.title}
+                      </div>
+                      <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.27)', marginTop: 2 }}>
+                        {relativeTime(conv.createdAt)}
+                      </div>
+                    </button>
+                  )
+                })}
+              </div>
+            ))
+          )}
         </div>
 
         {/* User footer */}
@@ -423,31 +442,13 @@ function ChatInner() {
                   <button
                     key={i}
                     onClick={() => send(s.q)}
-                    style={{
-                      background: dk ? '#0F1929' : '#FAFAFA',
-                      border: `1.5px solid ${dk ? 'rgba(255,255,255,0.07)' : '#E8EAED'}`,
-                      borderRadius: 12,
-                      padding: '15px 16px',
-                      cursor: 'pointer',
-                      transition: 'border-color 150ms, box-shadow 150ms',
-                      textAlign: 'left',
-                    }}
-                    onMouseEnter={e => {
-                      e.currentTarget.style.borderColor = dk ? 'rgba(255,255,255,0.18)' : '#1B2B50'
-                      e.currentTarget.style.boxShadow = dk ? '0 2px 10px rgba(0,0,0,0.30)' : '0 2px 10px rgba(27,43,80,0.09)'
-                    }}
-                    onMouseLeave={e => {
-                      e.currentTarget.style.borderColor = dk ? 'rgba(255,255,255,0.07)' : '#E8EAED'
-                      e.currentTarget.style.boxShadow = 'none'
-                    }}
+                    style={{ background: dk ? '#0F1929' : '#FAFAFA', border: `1.5px solid ${dk ? 'rgba(255,255,255,0.07)' : '#E8EAED'}`, borderRadius: 12, padding: '15px 16px', cursor: 'pointer', transition: 'border-color 150ms, box-shadow 150ms', textAlign: 'left' }}
+                    onMouseEnter={e => { e.currentTarget.style.borderColor = dk ? 'rgba(255,255,255,0.18)' : '#1B2B50'; e.currentTarget.style.boxShadow = dk ? '0 2px 10px rgba(0,0,0,0.30)' : '0 2px 10px rgba(27,43,80,0.09)' }}
+                    onMouseLeave={e => { e.currentTarget.style.borderColor = dk ? 'rgba(255,255,255,0.07)' : '#E8EAED'; e.currentTarget.style.boxShadow = 'none' }}
                   >
                     <div style={{ display: 'flex', alignItems: 'flex-start', gap: 11 }}>
-                      <div style={{ width: 30, height: 30, borderRadius: 8, background: s.iconBg, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-                        {s.icon}
-                      </div>
-                      <span style={{ fontSize: 13, color: dk ? 'rgba(255,255,255,0.78)' : '#1B2B50', lineHeight: 1.55, fontWeight: 500 }}>
-                        {s.q}
-                      </span>
+                      <div style={{ width: 30, height: 30, borderRadius: 8, background: s.iconBg, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>{s.icon}</div>
+                      <span style={{ fontSize: 13, color: dk ? 'rgba(255,255,255,0.78)' : '#1B2B50', lineHeight: 1.55, fontWeight: 500 }}>{s.q}</span>
                     </div>
                   </button>
                 ))}
@@ -459,39 +460,31 @@ function ChatInner() {
           {hasMessages && (
             <div style={{ padding: '32px 32px 16px', maxWidth: 760, margin: '0 auto', width: '100%', boxSizing: 'border-box' }}>
               {messages.map((msg, i) => {
-                if (msg.role === 'user') {
-                  return (
-                    <div key={i} style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 28 }}>
-                      <div style={{ maxWidth: '74%', background: dk ? '#1E3360' : '#1B2B50', color: '#fff', padding: '13px 18px', borderRadius: '18px 18px 5px 18px', fontSize: 15, lineHeight: 1.65, fontWeight: 400 }}>
-                        {msg.text}
-                      </div>
+                if (msg.role === 'user') return (
+                  <div key={i} style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 28 }}>
+                    <div style={{ maxWidth: '74%', background: dk ? '#1E3360' : '#1B2B50', color: '#fff', padding: '13px 18px', borderRadius: '18px 18px 5px 18px', fontSize: 15, lineHeight: 1.65 }}>
+                      {msg.text}
                     </div>
-                  )
-                }
+                  </div>
+                )
 
-                if (msg.role === 'typing') {
-                  return (
-                    <div key={i} style={{ display: 'flex', gap: 13, marginBottom: 28, alignItems: 'flex-start' }}>
-                      <AiAvatar />
-                      <div style={{ background: bg1, border: `1px solid ${dk ? 'rgba(255,255,255,0.07)' : '#EDEEF0'}`, borderRadius: '5px 18px 18px 18px', padding: '15px 20px', display: 'flex', gap: 5, alignItems: 'center', marginTop: 2 }}>
-                        <Dot delay="0ms" color={dk ? 'rgba(255,255,255,0.28)' : '#C4C8CF'} />
-                        <Dot delay="180ms" color={dk ? 'rgba(255,255,255,0.28)' : '#C4C8CF'} />
-                        <Dot delay="360ms" color={dk ? 'rgba(255,255,255,0.28)' : '#C4C8CF'} />
-                      </div>
+                if (msg.role === 'typing') return (
+                  <div key={i} style={{ display: 'flex', gap: 13, marginBottom: 28, alignItems: 'flex-start' }}>
+                    <AiAvatar />
+                    <div style={{ background: bg1, border: `1px solid ${dk ? 'rgba(255,255,255,0.07)' : '#EDEEF0'}`, borderRadius: '5px 18px 18px 18px', padding: '15px 20px', display: 'flex', gap: 5, alignItems: 'center', marginTop: 2 }}>
+                      <Dot delay="0ms" color={dk ? 'rgba(255,255,255,0.28)' : '#C4C8CF'} />
+                      <Dot delay="180ms" color={dk ? 'rgba(255,255,255,0.28)' : '#C4C8CF'} />
+                      <Dot delay="360ms" color={dk ? 'rgba(255,255,255,0.28)' : '#C4C8CF'} />
                     </div>
-                  )
-                }
+                  </div>
+                )
 
-                if (msg.role === 'error') {
-                  return (
-                    <div key={i} style={{ display: 'flex', gap: 13, marginBottom: 28, alignItems: 'flex-start' }}>
-                      <AiAvatar />
-                      <div style={{ flex: 1, marginTop: 4, fontSize: 15, lineHeight: 1.75, color: '#DC2626' }}>
-                        {msg.text}
-                      </div>
-                    </div>
-                  )
-                }
+                if (msg.role === 'error') return (
+                  <div key={i} style={{ display: 'flex', gap: 13, marginBottom: 28, alignItems: 'flex-start' }}>
+                    <AiAvatar />
+                    <div style={{ flex: 1, marginTop: 4, fontSize: 15, lineHeight: 1.75, color: '#DC2626' }}>{msg.text}</div>
+                  </div>
+                )
 
                 if (msg.role === 'assistant') {
                   const sources = (msg.result.sources || []).slice(0, 3).map(mapSource)
@@ -499,33 +492,24 @@ function ChatInner() {
                     <div key={i} style={{ display: 'flex', gap: 13, marginBottom: 28, alignItems: 'flex-start' }}>
                       <AiAvatar />
                       <div style={{ flex: 1, minWidth: 0, marginTop: 4 }}>
-                        <div
-                          style={{ fontSize: 15, lineHeight: 1.75, color: dk ? 'rgba(255,255,255,0.85)' : '#1F2937' }}
-                          dangerouslySetInnerHTML={{ __html: mdToHtml(msg.result.answer) }}
-                        />
-
+                        <div style={{ fontSize: 15, lineHeight: 1.75, color: dk ? 'rgba(255,255,255,0.85)' : '#1F2937' }} dangerouslySetInnerHTML={{ __html: mdToHtml(msg.result.answer) }} />
                         {sources.length > 0 && (
                           <div style={{ marginTop: 18 }}>
                             <div style={{ fontSize: 10.5, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: txt3, marginBottom: 9 }}>Sources</div>
                             <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
                               {sources.map((src, si) => (
-                                <div key={si} style={{ display: 'flex', alignItems: 'center', gap: 10, background: dk ? '#162035' : '#fff', border: `1px solid ${dk ? 'rgba(255,255,255,0.08)' : '#E8EAED'}`, borderRadius: 9, padding: '9px 13px', maxWidth: 280, boxShadow: dk ? 'none' : '0 1px 3px rgba(0,0,0,0.05)', cursor: 'default' }}>
+                                <div key={si} style={{ display: 'flex', alignItems: 'center', gap: 10, background: dk ? '#162035' : '#fff', border: `1px solid ${dk ? 'rgba(255,255,255,0.08)' : '#E8EAED'}`, borderRadius: 9, padding: '9px 13px', maxWidth: 280, boxShadow: dk ? 'none' : '0 1px 3px rgba(0,0,0,0.05)' }}>
                                   <div style={{ width: 9, height: 9, borderRadius: 999, background: src.dot, flexShrink: 0 }} />
                                   <div style={{ minWidth: 0, flex: 1 }}>
                                     <div style={{ fontSize: 12.5, fontWeight: 600, color: txt1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{src.label}</div>
                                     {src.sub && <div style={{ fontSize: 11, color: txt3, marginTop: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{src.sub}</div>}
                                   </div>
-                                  {src.badge && (
-                                    <div style={{ flexShrink: 0, background: src.badgeBg, color: src.badgeColor, fontSize: 10, fontWeight: 700, padding: '3px 8px', borderRadius: 999, whiteSpace: 'nowrap', letterSpacing: '0.02em' }}>
-                                      {src.badge}
-                                    </div>
-                                  )}
+                                  {src.badge && <div style={{ flexShrink: 0, background: src.badgeBg, color: src.badgeColor, fontSize: 10, fontWeight: 700, padding: '3px 8px', borderRadius: 999, whiteSpace: 'nowrap', letterSpacing: '0.02em' }}>{src.badge}</div>}
                                 </div>
                               ))}
                             </div>
                           </div>
                         )}
-
                         <div style={{ display: 'flex', gap: 4, marginTop: 14 }}>
                           <ActionBtn onClick={copyLastAnswer} dark={dk}>
                             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
@@ -554,7 +538,7 @@ function ChatInner() {
         {/* Input bar */}
         <div style={{ flexShrink: 0, padding: '12px 28px 20px', background: bg0 }}>
           <div style={{ maxWidth: 760, margin: '0 auto' }}>
-            <div style={{ background: bg1, border: `1.5px solid ${dk ? 'rgba(255,255,255,0.10)' : '#E2E4E8'}`, borderRadius: 14, padding: '13px 14px 10px', transition: 'border-color 200ms' }}>
+            <div style={{ background: bg1, border: `1.5px solid ${dk ? 'rgba(255,255,255,0.10)' : '#E2E4E8'}`, borderRadius: 14, padding: '13px 14px 10px' }}>
               <textarea
                 ref={textareaRef}
                 value={inputVal}
@@ -562,63 +546,33 @@ function ChatInner() {
                 onKeyDown={handleKey}
                 placeholder="Posez une question sur vos élus…"
                 rows={1}
-                style={{
-                  resize: 'none',
-                  outline: 'none',
-                  border: 'none',
-                  background: 'transparent',
-                  fontFamily: 'var(--font-sans)',
-                  fontSize: 15,
-                  color: dk ? 'rgba(255,255,255,0.88)' : '#1B2B50',
-                  width: '100%',
-                  display: 'block',
-                  lineHeight: 1.6,
-                  maxHeight: 140,
-                  overflowY: 'auto',
-                }}
+                style={{ resize: 'none', outline: 'none', border: 'none', background: 'transparent', fontFamily: 'var(--font-sans)', fontSize: 15, color: dk ? 'rgba(255,255,255,0.88)' : '#1B2B50', width: '100%', display: 'block', lineHeight: 1.6, maxHeight: 140, overflowY: 'auto' }}
               />
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginTop: 8 }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                   <span style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 11.5, color: txt3 }}>
-                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                      <path d="m9 12 2 2 4-4m6 2a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"/>
-                    </svg>
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="m9 12 2 2 4-4m6 2a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"/></svg>
                     Données officielles
                   </span>
                   <span style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 11.5, color: txt3 }}>
-                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
-                    </svg>
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
                     XVII<sup style={{ fontSize: 9 }}>e</sup> législature
                   </span>
                 </div>
                 <button
                   onClick={() => send(inputVal)}
                   disabled={!canSend}
-                  style={{
-                    width: 34,
-                    height: 34,
-                    borderRadius: 9,
-                    background: canSend ? '#1B2B50' : (dk ? '#1E2D4A' : '#D1D5DB'),
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    cursor: canSend ? 'pointer' : 'default',
-                    transition: 'background 150ms',
-                    flexShrink: 0,
-                    border: 'none',
-                  }}
+                  style={{ width: 34, height: 34, borderRadius: 9, background: canSend ? '#1B2B50' : (dk ? '#1E2D4A' : '#D1D5DB'), display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: canSend ? 'pointer' : 'default', transition: 'background 150ms', flexShrink: 0, border: 'none' }}
                 >
                   <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="2.3" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M22 2L11 13"/>
-                    <path d="M22 2 15 22 11 13 2 9l20-7z"/>
+                    <path d="M22 2L11 13"/><path d="M22 2 15 22 11 13 2 9l20-7z"/>
                   </svg>
                 </button>
               </div>
             </div>
             <div style={{ textAlign: 'center', marginTop: 9, fontSize: 11.5, color: dk ? 'rgba(255,255,255,0.18)' : '#9CA3AF' }}>
               MonÉlu peut faire des erreurs. Vérifiez les informations importantes sur{' '}
-              <a href="https://assemblee-nationale.fr" target="_blank" rel="noopener noreferrer" style={{ color: dk ? '#F87167' : '#C9302A', cursor: 'pointer', textDecoration: 'none' }}>
+              <a href="https://assemblee-nationale.fr" target="_blank" rel="noopener noreferrer" style={{ color: dk ? '#F87167' : '#C9302A', textDecoration: 'none' }}>
                 assemblee-nationale.fr
               </a>
             </div>
@@ -629,7 +583,7 @@ function ChatInner() {
   )
 }
 
-// ── Small shared sub-components ────────────────────────────────────────────
+// ── Sub-components ─────────────────────────────────────────────────────────
 
 function AiAvatar() {
   return (
@@ -644,62 +598,26 @@ function AiAvatar() {
 }
 
 function Dot({ delay, color }: { delay: string; color: string }) {
-  return (
-    <span style={{
-      display: 'inline-block',
-      width: 7,
-      height: 7,
-      borderRadius: 999,
-      background: color,
-      animation: 'monelu-bounce 1.3s ease infinite',
-      animationDelay: delay,
-    }} />
-  )
+  return <span style={{ display: 'inline-block', width: 7, height: 7, borderRadius: 999, background: color, animation: 'monelu-bounce 1.3s ease infinite', animationDelay: delay }} />
 }
 
 function ActionBtn({ children, onClick, dark }: { children: React.ReactNode; onClick?: () => void; dark: boolean }) {
   const [hover, setHover] = useState(false)
-  const color = dark ? 'rgba(255,255,255,0.26)' : '#9CA3AF'
-  const hoverBg = dark ? 'rgba(255,255,255,0.06)' : '#F9FAFB'
-  const hoverColor = dark ? 'rgba(255,255,255,0.70)' : '#1B2B50'
   return (
     <button
       onClick={onClick}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 5,
-        fontSize: 12,
-        color: hover ? hoverColor : color,
-        cursor: 'pointer',
-        padding: '5px 9px',
-        borderRadius: 6,
-        transition: 'background 120ms, color 120ms',
-        background: hover ? hoverBg : 'transparent',
-        border: 'none',
-      }}
+      style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 12, color: hover ? (dark ? 'rgba(255,255,255,0.70)' : '#1B2B50') : (dark ? 'rgba(255,255,255,0.26)' : '#9CA3AF'), cursor: 'pointer', padding: '5px 9px', borderRadius: 6, transition: 'background 120ms, color 120ms', background: hover ? (dark ? 'rgba(255,255,255,0.06)' : '#F9FAFB') : 'transparent', border: 'none' }}
     >
       {children}
     </button>
   )
 }
 
-// ── Keyframe injection ─────────────────────────────────────────────────────
-
 function KeyframeStyle() {
-  return (
-    <style>{`
-      @keyframes monelu-bounce {
-        0%, 80%, 100% { transform: translateY(0); }
-        40% { transform: translateY(-5px); }
-      }
-    `}</style>
-  )
+  return <style>{`@keyframes monelu-bounce{0%,80%,100%{transform:translateY(0)}40%{transform:translateY(-5px)}}`}</style>
 }
-
-// ── Export ─────────────────────────────────────────────────────────────────
 
 export default function ChatPage() {
   return (

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -175,7 +175,7 @@ function ChatInner() {
   useEffect(() => {
     if (initialQ && !sentRef.current) {
       sentRef.current = true
-      // eslint-disable-next-line react-compiler/react-compiler
+      // eslint-disable-next-line react-hooks/immutability
       send(initialQ)
     } else if (!initialQ) {
       textareaRef.current?.focus()

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -1,54 +1,159 @@
 'use client'
-import { useState, useRef, useEffect, Suspense } from 'react'
+import { useState, useRef, useEffect, useCallback, Suspense } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { api } from '@/lib/api'
-import { CHAT_SUGGESTIONS } from '@/lib/chat-suggestions'
-import { UserBubble, AssistantBubble, ErrorBubble, TypingIndicator } from '@/components/chat/Bubbles'
 import type { SearchResult } from '@/lib/api'
 
-type Message =
-  | { role: 'user'; text: string }
-  | { role: 'assistant'; result: SearchResult }
-  | { role: 'error'; text: string }
+// ── Types ──────────────────────────────────────────────────────────────────
+
+type UserMsg  = { role: 'user'; text: string }
+type AsstMsg  = { role: 'assistant'; result: SearchResult }
+type TypingMsg = { role: 'typing' }
+type ErrMsg   = { role: 'error'; text: string }
+type Message  = UserMsg | AsstMsg | TypingMsg | ErrMsg
+
+// ── Markdown renderer ──────────────────────────────────────────────────────
+
+function mdToHtml(text: string): string {
+  let h = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  h = h.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+  const blocks = h.split('\n\n')
+  return blocks.map(block => {
+    const lines = block.split('\n')
+    if (lines.length > 1 && lines.every(l => /^- /.test(l))) {
+      const items = lines.map(l => `<li style="margin:5px 0">${l.slice(2)}</li>`).join('')
+      return `<ul style="margin:6px 0 12px 0;padding-left:22px">${items}</ul>`
+    }
+    if (lines.length > 1 && lines.every(l => /^\d+\. /.test(l))) {
+      const items = lines.map(l => `<li style="margin:5px 0">${l.replace(/^\d+\.\s/, '')}</li>`).join('')
+      return `<ol style="margin:6px 0 12px 0;padding-left:22px">${items}</ol>`
+    }
+    return `<p style="margin:0 0 14px 0">${lines.join('<br>')}</p>`
+  }).join('')
+}
+
+// ── Source card helpers ────────────────────────────────────────────────────
+
+type SourceCard = {
+  dot: string
+  label: string
+  sub: string
+  badge: string
+  badgeBg: string
+  badgeColor: string
+}
+
+function mapSource(src: SearchResult['sources'][0]): SourceCard {
+  const meta = src.metadata || {}
+  const type = meta.chunk_type || 'stat'
+
+  if (type === 'deputy') {
+    return {
+      dot: meta.group_color || '#1B2B50',
+      label: meta.deputy_name || meta.name || 'Député',
+      sub: [meta.department, meta.circonscription].filter(Boolean).join(' · ') || '',
+      badge: meta.group_short || meta.group || '',
+      badgeBg: '#F1F5F9',
+      badgeColor: '#475569',
+    }
+  }
+  if (type === 'vote') {
+    const adopted = (meta.result || '').toLowerCase().includes('adopt')
+    return {
+      dot: adopted ? '#15803D' : '#DC2626',
+      label: meta.title || src.content.slice(0, 60),
+      sub: meta.date || '',
+      badge: meta.result || '',
+      badgeBg: adopted ? '#DCFCE7' : '#FEE2E2',
+      badgeColor: adopted ? '#15803D' : '#DC2626',
+    }
+  }
+  return {
+    dot: '#1B2B50',
+    label: src.content.slice(0, 55) + (src.content.length > 55 ? '…' : ''),
+    sub: `Pertinence ${Math.round(src.similarity * 100)} %`,
+    badge: type,
+    badgeBg: '#EFF3FB',
+    badgeColor: '#1B2B50',
+  }
+}
+
+// ── Sidebar conversations ──────────────────────────────────────────────────
+
+const CONV_DATA = [
+  { id: 0, title: 'Votes sur le budget 2024', time: 'Il y a 2 h', group: "Aujourd'hui" },
+  { id: 1, title: "Absentéisme au groupe RN", time: 'Il y a 5 h', group: "Aujourd'hui" },
+  { id: 2, title: 'Claire Martin — bilan législatif', time: 'Hier', group: 'Hier' },
+  { id: 3, title: 'Comparaison Écolo / LFI', time: 'Hier', group: 'Hier' },
+  { id: 4, title: 'Loi Climat — qui a voté quoi ?', time: 'Lun.', group: 'Cette semaine' },
+]
+
+// ── Main component ─────────────────────────────────────────────────────────
 
 function ChatInner() {
   const searchParams = useSearchParams()
   const initialQ = searchParams.get('q') || ''
 
-  const [messages, setMessages] = useState<Message[]>([])
-  const [input, setInput] = useState(initialQ)
-  const [loading, setLoading] = useState(false)
-  const bottomRef = useRef<HTMLDivElement>(null)
-  const inputRef = useRef<HTMLInputElement>(null)
-  const sentInitialRef = useRef(false)
+  const [messages, setMessages]     = useState<Message[]>([])
+  const [inputVal, setInputVal]     = useState(initialQ)
+  const [loading, setLoading]       = useState(false)
+  const [darkMode, setDarkMode]     = useState(false)
+  const [activeChatIdx, setActiveChatIdx] = useState<number | null>(null)
+  const [copied, setCopied]         = useState(false)
 
-  // Auto-send when arriving with ?q=
+  const scrollRef   = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const sentRef     = useRef(false)
+
+  // Restore dark mode from localStorage
   useEffect(() => {
-    if (initialQ && !sentInitialRef.current) {
-      sentInitialRef.current = true
+    try {
+      const saved = localStorage.getItem('monelu-dark')
+      if (saved === '1') setDarkMode(true)
+    } catch {}
+  }, [])
+
+  const toggleDark = useCallback(() => {
+    setDarkMode(d => {
+      try { localStorage.setItem('monelu-dark', d ? '0' : '1') } catch {}
+      return !d
+    })
+  }, [])
+
+  // Auto-scroll on new messages
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+    }
+  }, [messages])
+
+  // Auto-send on ?q= param
+  useEffect(() => {
+    if (initialQ && !sentRef.current) {
+      sentRef.current = true
       send(initialQ)
     } else if (!initialQ) {
-      inputRef.current?.focus()
+      textareaRef.current?.focus()
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [messages])
-
-  async function send(question: string) {
+  const send = useCallback(async (question: string) => {
     if (!question.trim() || loading) return
     const q = question.trim()
-    setInput('')
-    setMessages(prev => [...prev, { role: 'user', text: q }])
+    setInputVal('')
+    if (textareaRef.current) textareaRef.current.style.height = 'auto'
+    setMessages(prev => [...prev, { role: 'user', text: q }, { role: 'typing' }])
     setLoading(true)
     try {
       const result = await api.search(q)
-      setMessages(prev => [...prev, { role: 'assistant', result }])
+      setMessages(prev => [
+        ...prev.filter(m => m.role !== 'typing'),
+        { role: 'assistant', result },
+      ])
     } catch (err) {
       const is429 = err instanceof Error && err.message.includes('429')
       setMessages(prev => [
-        ...prev,
+        ...prev.filter(m => m.role !== 'typing'),
         {
           role: 'error',
           text: is429
@@ -59,73 +164,574 @@ function ChatInner() {
     } finally {
       setLoading(false)
     }
+  }, [loading])
+
+  const newChat = useCallback(() => {
+    setMessages([])
+    setInputVal('')
+    setActiveChatIdx(null)
+    textareaRef.current?.focus()
+  }, [])
+
+  const loadConv = useCallback((id: number) => {
+    setActiveChatIdx(id)
+    setMessages([])
+    send(CONV_DATA[id].title)
+  }, [send])
+
+  const handleTextarea = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setInputVal(e.target.value)
+    e.target.style.height = 'auto'
+    e.target.style.height = Math.min(e.target.scrollHeight, 140) + 'px'
   }
 
-  return (
-    <div className="flex flex-col h-[calc(100vh-4rem)] max-w-2xl mx-auto">
-      {/* Header */}
-      <div className="px-4 md:px-8 pt-6 pb-3 border-b border-gray-border bg-white flex-shrink-0">
-        <h1 className="font-serif text-2xl text-navy">Chat IA</h1>
-        <p className="text-xs text-gray-mid mt-0.5">Posez vos questions sur les votes et les députés</p>
-      </div>
+  const handleKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      send(inputVal)
+    }
+  }
 
-      {/* Messages */}
-      <div className="flex-1 overflow-y-auto px-4 md:px-8 py-4 space-y-4">
-        {messages.length === 0 && (
-          <div className="pt-4">
-            <p className="text-sm text-gray-mid mb-4 text-center">Suggestions :</p>
-            <div className="flex flex-wrap gap-2 justify-center">
-              {CHAT_SUGGESTIONS.map(s => (
-                <button key={s}
-                  onClick={() => send(s)}
-                  disabled={loading}
-                  className="text-xs border border-gray-border rounded-full px-3 py-1.5 bg-white text-navy hover:border-navy/40 transition-colors disabled:opacity-40">
-                  {s}
-                </button>
-              ))}
+  const copyLastAnswer = useCallback(() => {
+    const last = [...messages].reverse().find(m => m.role === 'assistant') as AsstMsg | undefined
+    if (!last) return
+    navigator.clipboard.writeText(last.result.answer).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1800)
+    })
+  }, [messages])
+
+  const hasMessages = messages.length > 0
+  const canSend = inputVal.trim().length > 0 && !loading
+
+  // ── Theme ───────────────────────────────────────────────────────────────
+
+  const dk = darkMode
+  const bg0  = dk ? '#0B1525' : '#fff'
+  const bg1  = dk ? '#111C35' : '#F7F8FA'
+  const bdr  = dk ? 'rgba(255,255,255,0.07)' : '#F0F0F2'
+  const txt1 = dk ? 'rgba(255,255,255,0.90)' : '#1B2B50'
+  const txt2 = dk ? 'rgba(255,255,255,0.45)' : '#6B7280'
+  const txt3 = dk ? 'rgba(255,255,255,0.26)' : '#9CA3AF'
+
+  const SUGGESTIONS = [
+    {
+      q: 'Quels groupes ont voté contre la réforme des retraites ?',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#1B2B50" strokeWidth="2.1" strokeLinecap="round">
+          <path d="m9 12 2 2 4-4m6 2a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"/>
+        </svg>
+      ),
+      iconBg: '#EFF3FB',
+    },
+    {
+      q: "Quel est le taux d'absentéisme au groupe RN ?",
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#B45309" strokeWidth="2.1" strokeLinecap="round">
+          <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
+          <circle cx="9" cy="7" r="4"/>
+          <path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"/>
+        </svg>
+      ),
+      iconBg: '#FEF9C3',
+    },
+    {
+      q: 'Comparer les votes climatiques par groupe politique',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#15803D" strokeWidth="2.1" strokeLinecap="round">
+          <path d="M3 3v18h18"/>
+          <path d="m19 9-5 5-4-4-3 3"/>
+        </svg>
+      ),
+      iconBg: '#DCFCE7',
+    },
+    {
+      q: 'Marine Le Pen : bilan de votes 2024',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#C9302A" strokeWidth="2.1" strokeLinecap="round">
+          <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
+          <circle cx="12" cy="7" r="4"/>
+        </svg>
+      ),
+      iconBg: '#FDE8E7',
+    },
+  ]
+
+  return (
+    <div style={{
+      display: 'flex',
+      height: 'calc(100dvh - 4rem)',
+      overflow: 'hidden',
+      fontFamily: 'var(--font-sans)',
+      background: bg0,
+    }}>
+
+      {/* ══════════ SIDEBAR ══════════ */}
+      <div style={{
+        width: 260,
+        flexShrink: 0,
+        background: '#111C35',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }} className="hidden md:flex">
+
+        {/* Logo + toggle */}
+        <div style={{ padding: '20px 16px 12px', flexShrink: 0 }}>
+          <button
+            onClick={toggleDark}
+            title="Changer le thème"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 9,
+              marginBottom: 16,
+              cursor: 'pointer',
+              borderRadius: 9,
+              padding: '6px 7px',
+              marginLeft: -7,
+              marginRight: -7,
+              width: 'calc(100% + 14px)',
+              background: 'transparent',
+              border: 'none',
+              transition: 'background 140ms',
+            }}
+            onMouseEnter={e => (e.currentTarget.style.background = 'rgba(255,255,255,0.07)')}
+            onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
+          >
+            <svg width="26" height="19" viewBox="0 0 30 22" fill="none">
+              <path d="M2 19 A13 13 0 0 1 28 19" stroke="#fff" strokeWidth="2.5" strokeLinecap="round"/>
+              <path d="M6 19 A9 9 0 0 1 24 19" stroke="rgba(255,255,255,0.38)" strokeWidth="2.5" strokeLinecap="round"/>
+              <path d="M10 19 A5 5 0 0 1 20 19" stroke="#D93025" strokeWidth="2.5" strokeLinecap="round"/>
+              <circle cx="15" cy="19" r="2.2" fill="#fff"/>
+            </svg>
+            <span style={{ fontFamily: 'var(--font-serif)', fontWeight: 800, fontSize: 18, color: '#fff', letterSpacing: '-0.01em' }}>
+              Mon<span style={{ color: '#D93025' }}>É</span>lu
+            </span>
+            {dk ? (
+              <svg style={{ marginLeft: 'auto', color: 'rgba(255,255,255,0.40)' }} width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                <circle cx="12" cy="12" r="5"/>
+                <line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/>
+                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+                <line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/>
+                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+              </svg>
+            ) : (
+              <svg style={{ marginLeft: 'auto', color: 'rgba(255,255,255,0.28)' }} width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+              </svg>
+            )}
+          </button>
+
+          {/* New chat */}
+          <button
+            onClick={newChat}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              background: 'rgba(255,255,255,0.09)',
+              border: '1px solid rgba(255,255,255,0.13)',
+              color: 'rgba(255,255,255,0.9)',
+              padding: '9px 13px',
+              borderRadius: 8,
+              fontSize: 13.5,
+              fontWeight: 500,
+              cursor: 'pointer',
+              transition: 'background 140ms',
+              width: '100%',
+            }}
+            onMouseEnter={e => (e.currentTarget.style.background = 'rgba(255,255,255,0.16)')}
+            onMouseLeave={e => (e.currentTarget.style.background = 'rgba(255,255,255,0.09)')}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.3" strokeLinecap="round">
+              <path d="M12 5v14M5 12h14"/>
+            </svg>
+            Nouvelle conversation
+          </button>
+        </div>
+
+        {/* Conversation list */}
+        <div style={{ flex: 1, overflowY: 'auto', padding: '0 8px 8px', scrollbarWidth: 'thin', scrollbarColor: 'rgba(255,255,255,0.14) transparent' }}>
+          {(() => {
+            let lastGroup = ''
+            return CONV_DATA.map(c => {
+              const showGroup = c.group !== lastGroup
+              lastGroup = c.group
+              const active = activeChatIdx === c.id
+              return (
+                <div key={c.id}>
+                  {showGroup && (
+                    <div style={{ padding: '14px 8px 5px', fontSize: 10.5, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.28)' }}>
+                      {c.group}
+                    </div>
+                  )}
+                  <button
+                    onClick={() => loadConv(c.id)}
+                    style={{
+                      display: 'block',
+                      width: '100%',
+                      textAlign: 'left',
+                      padding: '8px 10px',
+                      borderRadius: 7,
+                      cursor: 'pointer',
+                      transition: 'background 120ms',
+                      background: active ? 'rgba(255,255,255,0.11)' : 'transparent',
+                      border: 'none',
+                    }}
+                    onMouseEnter={e => { if (!active) e.currentTarget.style.background = 'rgba(255,255,255,0.07)' }}
+                    onMouseLeave={e => { if (!active) e.currentTarget.style.background = 'transparent' }}
+                  >
+                    <div style={{ fontSize: 13, color: active ? '#fff' : 'rgba(255,255,255,0.66)', fontWeight: active ? 600 : 400, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', lineHeight: 1.35 }}>
+                      {c.title}
+                    </div>
+                    <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.27)', marginTop: 2 }}>{c.time}</div>
+                  </button>
+                </div>
+              )
+            })
+          })()}
+        </div>
+
+        {/* User footer */}
+        <div style={{ flexShrink: 0, padding: '12px 14px', borderTop: '1px solid rgba(255,255,255,0.07)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <div style={{ width: 30, height: 30, borderRadius: 999, background: '#E0786E', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 700, color: '#fff', flexShrink: 0 }}>U</div>
+            <div>
+              <div style={{ fontSize: 13, fontWeight: 500, color: 'rgba(255,255,255,0.88)' }}>Utilisateur</div>
+              <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.36)' }}>Plan gratuit</div>
             </div>
           </div>
-        )}
-
-        {messages.map((msg, i) => {
-          if (msg.role === 'user') return <UserBubble key={i} text={msg.text} />
-          if (msg.role === 'error') return <ErrorBubble key={i} text={msg.text} />
-          return <AssistantBubble key={i} result={msg.result} />
-        })}
-
-        {loading && <TypingIndicator />}
-
-        <div ref={bottomRef} />
+        </div>
       </div>
 
-      {/* Input */}
-      <div className="flex-shrink-0 border-t border-gray-border bg-white px-4 md:px-8 py-3">
-        <form onSubmit={e => { e.preventDefault(); send(input) }} className="flex gap-2">
-          <label htmlFor="chat-input" className="sr-only">Posez votre question</label>
-          <input
-            id="chat-input"
-            ref={inputRef}
-            type="text"
-            value={input}
-            onChange={e => setInput(e.target.value)}
-            placeholder="Posez votre question..."
-            disabled={loading}
-            className="flex-1 border border-gray-border rounded-xl px-4 py-2.5 text-sm bg-white focus:outline-none focus:border-navy disabled:opacity-50"
-          />
-          <button type="submit" disabled={loading || !input.trim()}
-            className="bg-navy text-white px-4 py-2.5 rounded-xl text-sm font-medium disabled:opacity-40 hover:bg-navy-light transition-colors">
-            →
-          </button>
-        </form>
+      {/* ══════════ MAIN ══════════ */}
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, background: bg0 }}>
+
+        {/* Top bar */}
+        <div style={{ height: 54, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 28px', borderBottom: `1px solid ${bdr}`, background: bg0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <span style={{ fontSize: 14, fontWeight: 600, color: txt1, letterSpacing: '-0.01em' }}>Chat IA</span>
+            <span style={{ background: dk ? 'rgba(255,255,255,0.08)' : '#EFF3FB', color: dk ? 'rgba(255,255,255,0.55)' : '#1B2B50', border: `1px solid ${dk ? 'rgba(255,255,255,0.10)' : 'rgba(27,43,80,0.12)'}`, fontSize: 11, fontWeight: 700, padding: '3px 9px', borderRadius: 999, letterSpacing: '0.03em' }}>
+              MonÉlu · Beta
+            </span>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12.5, color: txt3 }}>
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#15803D" strokeWidth="2.2" strokeLinecap="round">
+              <path d="m9 12 2 2 4-4m6 2a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"/>
+            </svg>
+            <span style={{ color: dk ? 'rgba(255,255,255,0.38)' : '#4B5563' }}>Données officielles · Assemblée nationale</span>
+          </div>
+        </div>
+
+        {/* Scroll area */}
+        <div ref={scrollRef} style={{ flex: 1, overflowY: 'auto', display: 'flex', flexDirection: 'column', scrollbarWidth: 'thin', scrollbarColor: dk ? 'rgba(255,255,255,0.09) transparent' : 'rgba(0,0,0,0.10) transparent' }}>
+
+          {/* Empty state */}
+          {!hasMessages && (
+            <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '48px 32px', minHeight: '100%' }}>
+              <svg width="56" height="40" viewBox="0 0 30 22" fill="none" style={{ marginBottom: 18 }}>
+                <path d="M2 19 A13 13 0 0 1 28 19" stroke={dk ? 'rgba(255,255,255,0.85)' : '#1B2B50'} strokeWidth="2.2" strokeLinecap="round"/>
+                <path d="M6 19 A9 9 0 0 1 24 19" stroke="#9CA3AF" strokeWidth="2.2" strokeLinecap="round"/>
+                <path d="M10 19 A5 5 0 0 1 20 19" stroke="#D93025" strokeWidth="2.2" strokeLinecap="round"/>
+                <circle cx="15" cy="19" r="2.3" fill={dk ? 'rgba(255,255,255,0.85)' : '#1B2B50'}/>
+              </svg>
+              <h2 style={{ fontFamily: 'var(--font-serif)', fontSize: 24, fontWeight: 800, color: txt1, margin: '0 0 10px', textAlign: 'center', letterSpacing: '-0.02em' }}>
+                Explorez les données de vos élus
+              </h2>
+              <p style={{ fontSize: 15, color: txt2, textAlign: 'center', maxWidth: 400, margin: '0 0 36px', lineHeight: 1.65 }}>
+                Posez une question sur les votes, l&apos;absentéisme ou le bilan de n&apos;importe quel député de la XVII<sup>e</sup> législature.
+              </p>
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10, width: '100%', maxWidth: 620 }}>
+                {SUGGESTIONS.map((s, i) => (
+                  <button
+                    key={i}
+                    onClick={() => send(s.q)}
+                    style={{
+                      background: dk ? '#0F1929' : '#FAFAFA',
+                      border: `1.5px solid ${dk ? 'rgba(255,255,255,0.07)' : '#E8EAED'}`,
+                      borderRadius: 12,
+                      padding: '15px 16px',
+                      cursor: 'pointer',
+                      transition: 'border-color 150ms, box-shadow 150ms',
+                      textAlign: 'left',
+                    }}
+                    onMouseEnter={e => {
+                      e.currentTarget.style.borderColor = dk ? 'rgba(255,255,255,0.18)' : '#1B2B50'
+                      e.currentTarget.style.boxShadow = dk ? '0 2px 10px rgba(0,0,0,0.30)' : '0 2px 10px rgba(27,43,80,0.09)'
+                    }}
+                    onMouseLeave={e => {
+                      e.currentTarget.style.borderColor = dk ? 'rgba(255,255,255,0.07)' : '#E8EAED'
+                      e.currentTarget.style.boxShadow = 'none'
+                    }}
+                  >
+                    <div style={{ display: 'flex', alignItems: 'flex-start', gap: 11 }}>
+                      <div style={{ width: 30, height: 30, borderRadius: 8, background: s.iconBg, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                        {s.icon}
+                      </div>
+                      <span style={{ fontSize: 13, color: dk ? 'rgba(255,255,255,0.78)' : '#1B2B50', lineHeight: 1.55, fontWeight: 500 }}>
+                        {s.q}
+                      </span>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Messages */}
+          {hasMessages && (
+            <div style={{ padding: '32px 32px 16px', maxWidth: 760, margin: '0 auto', width: '100%', boxSizing: 'border-box' }}>
+              {messages.map((msg, i) => {
+                if (msg.role === 'user') {
+                  return (
+                    <div key={i} style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 28 }}>
+                      <div style={{ maxWidth: '74%', background: dk ? '#1E3360' : '#1B2B50', color: '#fff', padding: '13px 18px', borderRadius: '18px 18px 5px 18px', fontSize: 15, lineHeight: 1.65, fontWeight: 400 }}>
+                        {msg.text}
+                      </div>
+                    </div>
+                  )
+                }
+
+                if (msg.role === 'typing') {
+                  return (
+                    <div key={i} style={{ display: 'flex', gap: 13, marginBottom: 28, alignItems: 'flex-start' }}>
+                      <AiAvatar />
+                      <div style={{ background: bg1, border: `1px solid ${dk ? 'rgba(255,255,255,0.07)' : '#EDEEF0'}`, borderRadius: '5px 18px 18px 18px', padding: '15px 20px', display: 'flex', gap: 5, alignItems: 'center', marginTop: 2 }}>
+                        <Dot delay="0ms" color={dk ? 'rgba(255,255,255,0.28)' : '#C4C8CF'} />
+                        <Dot delay="180ms" color={dk ? 'rgba(255,255,255,0.28)' : '#C4C8CF'} />
+                        <Dot delay="360ms" color={dk ? 'rgba(255,255,255,0.28)' : '#C4C8CF'} />
+                      </div>
+                    </div>
+                  )
+                }
+
+                if (msg.role === 'error') {
+                  return (
+                    <div key={i} style={{ display: 'flex', gap: 13, marginBottom: 28, alignItems: 'flex-start' }}>
+                      <AiAvatar />
+                      <div style={{ flex: 1, marginTop: 4, fontSize: 15, lineHeight: 1.75, color: '#DC2626' }}>
+                        {msg.text}
+                      </div>
+                    </div>
+                  )
+                }
+
+                if (msg.role === 'assistant') {
+                  const sources = (msg.result.sources || []).slice(0, 3).map(mapSource)
+                  return (
+                    <div key={i} style={{ display: 'flex', gap: 13, marginBottom: 28, alignItems: 'flex-start' }}>
+                      <AiAvatar />
+                      <div style={{ flex: 1, minWidth: 0, marginTop: 4 }}>
+                        <div
+                          style={{ fontSize: 15, lineHeight: 1.75, color: dk ? 'rgba(255,255,255,0.85)' : '#1F2937' }}
+                          dangerouslySetInnerHTML={{ __html: mdToHtml(msg.result.answer) }}
+                        />
+
+                        {sources.length > 0 && (
+                          <div style={{ marginTop: 18 }}>
+                            <div style={{ fontSize: 10.5, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: txt3, marginBottom: 9 }}>Sources</div>
+                            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                              {sources.map((src, si) => (
+                                <div key={si} style={{ display: 'flex', alignItems: 'center', gap: 10, background: dk ? '#162035' : '#fff', border: `1px solid ${dk ? 'rgba(255,255,255,0.08)' : '#E8EAED'}`, borderRadius: 9, padding: '9px 13px', maxWidth: 280, boxShadow: dk ? 'none' : '0 1px 3px rgba(0,0,0,0.05)', cursor: 'default' }}>
+                                  <div style={{ width: 9, height: 9, borderRadius: 999, background: src.dot, flexShrink: 0 }} />
+                                  <div style={{ minWidth: 0, flex: 1 }}>
+                                    <div style={{ fontSize: 12.5, fontWeight: 600, color: txt1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{src.label}</div>
+                                    {src.sub && <div style={{ fontSize: 11, color: txt3, marginTop: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{src.sub}</div>}
+                                  </div>
+                                  {src.badge && (
+                                    <div style={{ flexShrink: 0, background: src.badgeBg, color: src.badgeColor, fontSize: 10, fontWeight: 700, padding: '3px 8px', borderRadius: 999, whiteSpace: 'nowrap', letterSpacing: '0.02em' }}>
+                                      {src.badge}
+                                    </div>
+                                  )}
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+
+                        <div style={{ display: 'flex', gap: 4, marginTop: 14 }}>
+                          <ActionBtn onClick={copyLastAnswer} dark={dk}>
+                            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                              <rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+                            </svg>
+                            {copied ? 'Copié !' : 'Copier'}
+                          </ActionBtn>
+                          <ActionBtn dark={dk}>
+                            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                              <path d="M7 11 C7 7.13 10.13 4 14 4 C17.87 4 21 7.13 21 11 C21 14.87 17.87 18 14 18 L7 18 L3 22 L3 11 Z"/>
+                            </svg>
+                            Feedback
+                          </ActionBtn>
+                        </div>
+                      </div>
+                    </div>
+                  )
+                }
+
+                return null
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Input bar */}
+        <div style={{ flexShrink: 0, padding: '12px 28px 20px', background: bg0 }}>
+          <div style={{ maxWidth: 760, margin: '0 auto' }}>
+            <div style={{ background: bg1, border: `1.5px solid ${dk ? 'rgba(255,255,255,0.10)' : '#E2E4E8'}`, borderRadius: 14, padding: '13px 14px 10px', transition: 'border-color 200ms' }}>
+              <textarea
+                ref={textareaRef}
+                value={inputVal}
+                onChange={handleTextarea}
+                onKeyDown={handleKey}
+                placeholder="Posez une question sur vos élus…"
+                rows={1}
+                style={{
+                  resize: 'none',
+                  outline: 'none',
+                  border: 'none',
+                  background: 'transparent',
+                  fontFamily: 'var(--font-sans)',
+                  fontSize: 15,
+                  color: dk ? 'rgba(255,255,255,0.88)' : '#1B2B50',
+                  width: '100%',
+                  display: 'block',
+                  lineHeight: 1.6,
+                  maxHeight: 140,
+                  overflowY: 'auto',
+                }}
+              />
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginTop: 8 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 11.5, color: txt3 }}>
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                      <path d="m9 12 2 2 4-4m6 2a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"/>
+                    </svg>
+                    Données officielles
+                  </span>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 11.5, color: txt3 }}>
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+                    </svg>
+                    XVII<sup style={{ fontSize: 9 }}>e</sup> législature
+                  </span>
+                </div>
+                <button
+                  onClick={() => send(inputVal)}
+                  disabled={!canSend}
+                  style={{
+                    width: 34,
+                    height: 34,
+                    borderRadius: 9,
+                    background: canSend ? '#1B2B50' : (dk ? '#1E2D4A' : '#D1D5DB'),
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    cursor: canSend ? 'pointer' : 'default',
+                    transition: 'background 150ms',
+                    flexShrink: 0,
+                    border: 'none',
+                  }}
+                >
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="2.3" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M22 2L11 13"/>
+                    <path d="M22 2 15 22 11 13 2 9l20-7z"/>
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div style={{ textAlign: 'center', marginTop: 9, fontSize: 11.5, color: dk ? 'rgba(255,255,255,0.18)' : '#9CA3AF' }}>
+              MonÉlu peut faire des erreurs. Vérifiez les informations importantes sur{' '}
+              <a href="https://assemblee-nationale.fr" target="_blank" rel="noopener noreferrer" style={{ color: dk ? '#F87167' : '#C9302A', cursor: 'pointer', textDecoration: 'none' }}>
+                assemblee-nationale.fr
+              </a>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   )
 }
 
+// ── Small shared sub-components ────────────────────────────────────────────
+
+function AiAvatar() {
+  return (
+    <div style={{ width: 30, height: 30, borderRadius: 999, background: '#1B2B50', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, marginTop: 2 }}>
+      <svg width="15" height="11" viewBox="0 0 30 22" fill="none">
+        <path d="M2 19 A13 13 0 0 1 28 19" stroke="#fff" strokeWidth="2.4" strokeLinecap="round"/>
+        <path d="M6 19 A9 9 0 0 1 24 19" stroke="rgba(255,255,255,0.44)" strokeWidth="2.4" strokeLinecap="round"/>
+        <path d="M10 19 A5 5 0 0 1 20 19" stroke="#D93025" strokeWidth="2.4" strokeLinecap="round"/>
+      </svg>
+    </div>
+  )
+}
+
+function Dot({ delay, color }: { delay: string; color: string }) {
+  return (
+    <span style={{
+      display: 'inline-block',
+      width: 7,
+      height: 7,
+      borderRadius: 999,
+      background: color,
+      animation: 'monelu-bounce 1.3s ease infinite',
+      animationDelay: delay,
+    }} />
+  )
+}
+
+function ActionBtn({ children, onClick, dark }: { children: React.ReactNode; onClick?: () => void; dark: boolean }) {
+  const [hover, setHover] = useState(false)
+  const color = dark ? 'rgba(255,255,255,0.26)' : '#9CA3AF'
+  const hoverBg = dark ? 'rgba(255,255,255,0.06)' : '#F9FAFB'
+  const hoverColor = dark ? 'rgba(255,255,255,0.70)' : '#1B2B50'
+  return (
+    <button
+      onClick={onClick}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 5,
+        fontSize: 12,
+        color: hover ? hoverColor : color,
+        cursor: 'pointer',
+        padding: '5px 9px',
+        borderRadius: 6,
+        transition: 'background 120ms, color 120ms',
+        background: hover ? hoverBg : 'transparent',
+        border: 'none',
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
+// ── Keyframe injection ─────────────────────────────────────────────────────
+
+function KeyframeStyle() {
+  return (
+    <style>{`
+      @keyframes monelu-bounce {
+        0%, 80%, 100% { transform: translateY(0); }
+        40% { transform: translateY(-5px); }
+      }
+    `}</style>
+  )
+}
+
+// ── Export ─────────────────────────────────────────────────────────────────
+
 export default function ChatPage() {
   return (
-    <Suspense fallback={<div className="p-8 text-gray-mid text-sm">Chargement...</div>}>
-      <ChatInner />
-    </Suspense>
+    <>
+      <KeyframeStyle />
+      <Suspense fallback={<div style={{ padding: 32, color: '#9CA3AF', fontSize: 14 }}>Chargement…</div>}>
+        <ChatInner />
+      </Suspense>
+    </>
   )
 }

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -587,11 +587,12 @@ function ChatInner() {
 
 function AiAvatar() {
   return (
-    <div style={{ width: 30, height: 30, borderRadius: 999, background: '#1B2B50', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, marginTop: 2 }}>
-      <svg width="15" height="11" viewBox="0 0 30 22" fill="none">
-        <path d="M2 19 A13 13 0 0 1 28 19" stroke="#fff" strokeWidth="2.4" strokeLinecap="round"/>
-        <path d="M6 19 A9 9 0 0 1 24 19" stroke="rgba(255,255,255,0.44)" strokeWidth="2.4" strokeLinecap="round"/>
-        <path d="M10 19 A5 5 0 0 1 20 19" stroke="#D93025" strokeWidth="2.4" strokeLinecap="round"/>
+    <div style={{ width: 36, height: 36, borderRadius: 999, background: '#1B2B50', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, marginTop: 2 }}>
+      <svg width="22" height="16" viewBox="0 0 30 22" fill="none">
+        <path d="M2 19 A13 13 0 0 1 28 19" stroke="#fff" strokeWidth="2.6" strokeLinecap="round"/>
+        <path d="M6 19 A9 9 0 0 1 24 19" stroke="rgba(255,255,255,0.45)" strokeWidth="2.6" strokeLinecap="round"/>
+        <path d="M10 19 A5 5 0 0 1 20 19" stroke="#D93025" strokeWidth="2.6" strokeLinecap="round"/>
+        <circle cx="15" cy="19" r="2" fill="#fff"/>
       </svg>
     </div>
   )

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -186,6 +186,7 @@ function ChatInner() {
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
+  // eslint-disable-next-line react-hooks/preserve-manual-memoization
   const send = useCallback(async (question: string) => {
     if (!question.trim() || loading) return
     const q = question.trim()
@@ -262,7 +263,6 @@ function ChatInner() {
 
   const restoreConv = useCallback((conv: StoredConv) => {
     setActiveConvId(conv.id)
-    activeConvRef.current = conv.id
     setMessages(conv.messages as Message[])
   }, [])
 

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -141,8 +141,12 @@ function ChatInner() {
   const [messages, setMessages]   = useState<Message[]>([])
   const [inputVal, setInputVal]   = useState(initialQ)
   const [loading, setLoading]     = useState(false)
-  const [darkMode, setDarkMode]   = useState(false)
-  const [conversations, setConversations] = useState<StoredConv[]>([])
+  const [darkMode, setDarkMode]   = useState<boolean>(() => {
+    try { return localStorage.getItem('monelu-dark') === '1' } catch { return false }
+  })
+  const [conversations, setConversations] = useState<StoredConv[]>(() => {
+    try { return loadConversations() } catch { return [] }
+  })
   const [activeConvId, setActiveConvId]   = useState<string | null>(null)
   const [copied, setCopied]       = useState(false)
 
@@ -154,15 +158,6 @@ function ChatInner() {
 
   // Keep ref in sync with state
   useEffect(() => { activeConvRef.current = activeConvId }, [activeConvId])
-
-  // Load persisted state on mount
-  useEffect(() => {
-    try {
-      const saved = localStorage.getItem('monelu-dark')
-      if (saved === '1') setDarkMode(true)
-    } catch {}
-    setConversations(loadConversations())
-  }, [])
 
   const toggleDark = useCallback(() => {
     setDarkMode(d => {
@@ -180,6 +175,7 @@ function ChatInner() {
   useEffect(() => {
     if (initialQ && !sentRef.current) {
       sentRef.current = true
+      // eslint-disable-next-line react-compiler/react-compiler
       send(initialQ)
     } else if (!initialQ) {
       textareaRef.current?.focus()

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -149,6 +149,7 @@ function ChatInner() {
   const scrollRef     = useRef<HTMLDivElement>(null)
   const textareaRef   = useRef<HTMLTextAreaElement>(null)
   const activeConvRef = useRef<string | null>(null)  // sync for use inside callbacks
+  const isNewConvRef  = useRef(false)               // sync counterpart so setMessages updater never closes over stale value
   const sentRef       = useRef(false)
 
   // Keep ref in sync with state
@@ -191,14 +192,16 @@ function ChatInner() {
     setInputVal('')
     if (textareaRef.current) textareaRef.current.style.height = 'auto'
 
-    // Determine if this is a new conv or continuation
+    // Determine if this is a new conv or continuation — use refs so the
+    // setMessages updater below never closes over stale closure values.
     let convId = activeConvRef.current
-    let isNewConv = false
     if (!convId) {
       convId = Date.now().toString()
-      isNewConv = true
+      isNewConvRef.current = true
       setActiveConvId(convId)
       activeConvRef.current = convId
+    } else {
+      isNewConvRef.current = false
     }
 
     setMessages(prev => [...prev, { role: 'user', text: q }, { role: 'typing' }])
@@ -206,17 +209,21 @@ function ChatInner() {
 
     try {
       const result = await api.search(q)
+      // Read localStorage once, outside the updater, to avoid repeated I/O
+      // and to ensure the snapshot is consistent for title/createdAt lookups.
+      const id = activeConvRef.current!
+      const isNew = isNewConvRef.current
+      const existingConvs = loadConversations()
+      const existing = existingConvs.find(c => c.id === id)
       setMessages(prev => {
         const next = [...prev.filter(m => m.role !== 'typing'), { role: 'assistant' as const, result }]
-        // Persist to localStorage
-        const storedMsgs = next as StoredMsg[]
         const conv: StoredConv = {
-          id: convId!,
-          title: isNewConv ? q.slice(0, 60) : (loadConversations().find(c => c.id === convId!)?.title ?? q.slice(0, 60)),
-          createdAt: isNewConv ? Date.now() : (loadConversations().find(c => c.id === convId!)?.createdAt ?? Date.now()),
-          messages: storedMsgs,
+          id,
+          title: isNew ? q.slice(0, 60) : (existing?.title ?? q.slice(0, 60)),
+          createdAt: isNew ? Date.now() : (existing?.createdAt ?? Date.now()),
+          messages: next as StoredMsg[],
         }
-        const updated = upsertConv(loadConversations(), conv)
+        const updated = upsertConv(existingConvs, conv)
         saveConversations(updated)
         setConversations(updated)
         return next
@@ -227,13 +234,14 @@ function ChatInner() {
         role: 'error',
         text: is429 ? 'Trop de questions, patientez une minute.' : 'Erreur de connexion. Réessayez.',
       }
+      const id = activeConvRef.current!
+      const isNew = isNewConvRef.current
+      const existingConvs = isNew ? loadConversations() : null
       setMessages(prev => {
         const next = [...prev.filter(m => m.role !== 'typing'), errMsg]
-        // Still persist what we have (user msg + error)
-        const storedMsgs = next as StoredMsg[]
-        if (isNewConv) {
-          const conv: StoredConv = { id: convId!, title: q.slice(0, 60), createdAt: Date.now(), messages: storedMsgs }
-          const updated = upsertConv(loadConversations(), conv)
+        if (isNew && existingConvs) {
+          const conv: StoredConv = { id, title: q.slice(0, 60), createdAt: Date.now(), messages: next as StoredMsg[] }
+          const updated = upsertConv(existingConvs, conv)
           saveConversations(updated)
           setConversations(updated)
         }

--- a/frontend/src/app/deputes/DeputiesClient.tsx
+++ b/frontend/src/app/deputes/DeputiesClient.tsx
@@ -4,8 +4,10 @@ import { useSearchParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Deputy } from '@/lib/api'
 import { getInitials, partyHex } from '@/lib/utils'
+import { DeputyAvatar } from '@/components/DeputyAvatar'
 
 type DeputyList = { total: number; items: Deputy[]; limit: number; offset: number }
+type SortKey = 'nom' | 'region' | 'parti'
 
 const PAGE_SIZE = 10
 const NAVY = '#1B2B50'
@@ -18,20 +20,8 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
   const searchParams = useSearchParams()
 
   const [search, setSearch] = useState(() => searchParams.get('search') ?? '')
-  const [party, setParty]   = useState(() => searchParams.get('party') ?? '')
-  const [dept,  setDept]    = useState(() => searchParams.get('dept')   ?? '')
-  const [page,  setPage]    = useState(1)
-
-  const parties = useMemo(
-    () => [...new Set(initial.items.map(d => d.party).filter(Boolean))].sort() as string[],
-    [initial.items]
-  )
-
-  const departments = useMemo(
-    () => ([...new Set(initial.items.map(d => d.department).filter(Boolean))] as string[])
-      .sort((a, b) => a.localeCompare(b, 'fr')),
-    [initial.items]
-  )
+  const [sort,   setSort]   = useState<SortKey>('nom')
+  const [page,   setPage]   = useState(1)
 
   const [debouncedSearch, setDebouncedSearch] = useState(search)
   useEffect(() => {
@@ -44,39 +34,32 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
     if (skipFirstSync.current) { skipFirstSync.current = false; return }
     const p = new URLSearchParams()
     if (debouncedSearch) p.set('search', debouncedSearch)
-    if (party)           p.set('party',  party)
-    if (dept)            p.set('dept',   dept)
     const qs = p.toString()
     router.replace(`/deputes${qs ? `?${qs}` : ''}`, { scroll: false })
     setPage(1)
-  }, [debouncedSearch, party, dept, router])
+  }, [debouncedSearch, router])
 
   const filtered = useMemo(() => {
     const q = debouncedSearch.toLowerCase()
-    return initial.items
-      .filter(d => {
-        if (party && d.party !== party) return false
-        if (dept  && d.department !== dept) return false
-        if (q) return (
+    const items = q
+      ? initial.items.filter(d =>
           d.full_name.toLowerCase().includes(q) ||
           (d.department?.toLowerCase().includes(q) ?? false) ||
           (d.party?.toLowerCase().includes(q) ?? false)
         )
-        return true
-      })
-      .sort((a, b) => a.full_name.localeCompare(b.full_name, 'fr'))
-  }, [initial.items, party, dept, debouncedSearch])
+      : [...initial.items]
+
+    if (sort === 'nom')    return items.sort((a, b) => a.full_name.localeCompare(b.full_name, 'fr'))
+    if (sort === 'region') return items.sort((a, b) => (a.department ?? '').localeCompare(b.department ?? '', 'fr'))
+    if (sort === 'parti')  return items.sort((a, b) => (a.party ?? '').localeCompare(b.party ?? '', 'fr'))
+    return items
+  }, [initial.items, debouncedSearch, sort])
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))
   const safePage = Math.min(page, totalPages)
   const paginated = filtered.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE)
 
-  function clearAll() { setSearch(''); setParty(''); setDept(''); setPage(1) }
-
-  function selectParty(p: string) {
-    setParty(prev => prev === p ? '' : p)
-    setPage(1)
-  }
+  function clearSearch() { setSearch(''); setPage(1) }
 
   function getPageNumbers(): (number | '…')[] {
     if (totalPages <= 7) return Array.from({ length: totalPages }, (_, i) => i + 1)
@@ -144,7 +127,7 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
               />
               {search && (
                 <button
-                  onClick={() => setSearch('')}
+                  onClick={clearSearch}
                   aria-label="Effacer la recherche"
                   style={{ color: '#9CA3AF', cursor: 'pointer', background: 'none', border: 'none', padding: 0 }}
                 >
@@ -167,62 +150,25 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
             </button>
           </div>
 
-          {/* Filter chips */}
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 9, marginTop: 18, alignItems: 'center' }}>
-            <button
-              onClick={() => { setParty(''); setPage(1) }}
-              style={{
-                background: party === '' ? NAVY : '#fff',
-                color: party === '' ? '#fff' : '#4B5563',
-                border: '1px solid ' + (party === '' ? NAVY : LINE),
-                padding: '8px 16px', borderRadius: 999, fontSize: 13.5,
-                fontWeight: party === '' ? 600 : 400, cursor: 'pointer',
-              }}
-            >
-              Tous
-            </button>
-            {parties.map(p => (
+          {/* Sort pills */}
+          <div style={{ display: 'flex', gap: 9, marginTop: 18, alignItems: 'center' }}>
+            <span style={{ fontSize: 13.5, color: '#9CA3AF', marginRight: 4 }}>Trier par</span>
+            {([['nom', 'Nom'], ['region', 'Région'], ['parti', 'Groupe']] as const).map(([val, label]) => (
               <button
-                key={p}
-                onClick={() => selectParty(p)}
-                aria-pressed={party === p}
+                key={val}
+                onClick={() => { setSort(val); setPage(1) }}
+                aria-pressed={sort === val}
                 style={{
-                  background: party === p ? NAVY : '#fff',
-                  color: party === p ? '#fff' : '#4B5563',
-                  border: '1px solid ' + (party === p ? NAVY : LINE),
-                  padding: '8px 16px', borderRadius: 999, fontSize: 13.5,
-                  fontWeight: party === p ? 600 : 400, cursor: 'pointer',
+                  background: sort === val ? NAVY : '#fff',
+                  color: sort === val ? '#fff' : '#4B5563',
+                  border: '1px solid ' + (sort === val ? NAVY : LINE),
+                  padding: '8px 18px', borderRadius: 999, fontSize: 13.5,
+                  fontWeight: sort === val ? 600 : 400, cursor: 'pointer',
                 }}
               >
-                {p}
+                {label}
               </button>
             ))}
-            <div style={{ marginLeft: 'auto' }}>
-              <label htmlFor="filter-dept" className="sr-only">Région / département</label>
-              <div style={{
-                display: 'flex', alignItems: 'center', gap: 8,
-                background: '#fff', border: '1px solid ' + LINE,
-                padding: '8px 16px', borderRadius: 999, fontSize: 13.5,
-                color: '#4B5563', cursor: 'pointer',
-              }}>
-                <select
-                  id="filter-dept"
-                  value={dept}
-                  onChange={e => { setDept(e.target.value); setPage(1) }}
-                  style={{
-                    border: 'none', outline: 'none', background: 'transparent',
-                    fontSize: 13.5, color: '#4B5563', cursor: 'pointer',
-                    appearance: 'none', paddingRight: 4,
-                  }}
-                >
-                  <option value="">Toutes régions</option>
-                  {departments.map(d => <option key={d} value={d}>{d}</option>)}
-                </select>
-                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#9CA3AF" strokeWidth="2.4" strokeLinecap="round" aria-hidden="true">
-                  <path d="m5 9 7 7 7-7"/>
-                </svg>
-              </div>
-            </div>
           </div>
         </div>
       </div>
@@ -231,31 +177,29 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
       <div style={{ padding: '32px 56px 72px' }}>
         <div style={{ maxWidth: 1180, margin: '0 auto' }}>
 
-          {/* Count + sort row */}
+          {/* Count row */}
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 4px 14px' }}>
             <span style={{ fontFamily: 'monospace', fontSize: 13, color: '#6B7280' }}>
-              {filtered.length} député{filtered.length !== 1 ? 's' : ''} · triés par nom
+              {filtered.length} député{filtered.length !== 1 ? 's' : ''}
             </span>
-            <span style={{ fontSize: 13.5, color: '#6B7280', display: 'flex', alignItems: 'center', gap: 7 }}>
-              {(party || dept || debouncedSearch) && (
-                <button
-                  onClick={clearAll}
-                  style={{ color: '#C9302A', fontSize: 13, cursor: 'pointer', background: 'none', border: 'none', padding: 0 }}
-                >
-                  Effacer les filtres ×
-                </button>
-              )}
-            </span>
+            {debouncedSearch && (
+              <button
+                onClick={clearSearch}
+                style={{ color: '#C9302A', fontSize: 13, cursor: 'pointer', background: 'none', border: 'none', padding: 0 }}
+              >
+                Effacer la recherche ×
+              </button>
+            )}
           </div>
 
           {filtered.length === 0 ? (
             <div style={{ padding: '64px 0', textAlign: 'center' }}>
               <p style={{ color: '#6B7280', fontSize: 15, marginBottom: 12 }}>Aucun résultat pour cette recherche</p>
               <button
-                onClick={clearAll}
+                onClick={clearSearch}
                 style={{ fontSize: 14, color: NAVY, textDecoration: 'underline', background: 'none', border: 'none', cursor: 'pointer' }}
               >
-                Effacer les filtres
+                Effacer la recherche
               </button>
             </div>
           ) : (
@@ -282,17 +226,12 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
                 {/* Rows */}
                 {paginated.map(d => {
                   const hex = partyHex(d.party)
-                  const initials = getInitials(d.full_name)
                   return (
-                    <Link
-                      key={d.deputy_id}
-                      href={`/deputes/${d.deputy_id}`}
-                      style={{ textDecoration: 'none' }}
-                    >
+                    <Link key={d.deputy_id} href={`/deputes/${d.deputy_id}`} style={{ textDecoration: 'none' }}>
                       <div
                         style={{
                           display: 'grid', gridTemplateColumns: '1fr 260px 34px',
-                          gap: 18, padding: '15px 26px',
+                          gap: 18, padding: '13px 26px',
                           borderBottom: '1px solid #F0F1F3',
                           alignItems: 'center', cursor: 'pointer',
                           background: '#fff', transition: 'background 0.12s',
@@ -302,13 +241,7 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
                       >
                         {/* Deputy */}
                         <div style={{ display: 'flex', alignItems: 'center', gap: 14, minWidth: 0 }}>
-                          <span style={{
-                            width: 42, height: 42, flexShrink: 0, borderRadius: 999,
-                            display: 'flex', alignItems: 'center', justifyContent: 'center',
-                            fontWeight: 700, fontSize: 14, color: '#fff', background: hex,
-                          }}>
-                            {initials}
-                          </span>
+                          <DeputyAvatar name={d.full_name} photoUrl={d.photo_url} size="sm" />
                           <div style={{ minWidth: 0 }}>
                             <div style={{ fontWeight: 600, fontSize: 15.5, color: NAVY, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
                               {d.full_name}
@@ -345,12 +278,10 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
                     disabled={safePage === 1}
                     style={{
                       width: 34, height: 34, display: 'flex', alignItems: 'center', justifyContent: 'center',
-                      border: '1px solid ' + LINE, borderRadius: 8, background: '#fff', cursor: safePage === 1 ? 'default' : 'pointer',
-                      opacity: safePage === 1 ? 0.4 : 1,
+                      border: '1px solid ' + LINE, borderRadius: 8, background: '#fff',
+                      cursor: safePage === 1 ? 'default' : 'pointer', opacity: safePage === 1 ? 0.4 : 1,
                     }}
-                  >
-                    ‹
-                  </button>
+                  >‹</button>
                   {getPageNumbers().map((n, i) =>
                     n === '…' ? (
                       <span key={`ellipsis-${i}`} style={{ padding: '0 6px' }}>…</span>
@@ -366,9 +297,7 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
                           border: safePage === n ? 'none' : '1px solid ' + LINE,
                           fontWeight: safePage === n ? 600 : 400,
                         }}
-                      >
-                        {n}
-                      </button>
+                      >{n}</button>
                     )
                   )}
                   <button
@@ -376,12 +305,10 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
                     disabled={safePage === totalPages}
                     style={{
                       width: 34, height: 34, display: 'flex', alignItems: 'center', justifyContent: 'center',
-                      border: '1px solid ' + LINE, borderRadius: 8, background: '#fff', cursor: safePage === totalPages ? 'default' : 'pointer',
-                      opacity: safePage === totalPages ? 0.4 : 1,
+                      border: '1px solid ' + LINE, borderRadius: 8, background: '#fff',
+                      cursor: safePage === totalPages ? 'default' : 'pointer', opacity: safePage === totalPages ? 0.4 : 1,
                     }}
-                  >
-                    ›
-                  </button>
+                  >›</button>
                 </div>
               )}
             </>

--- a/frontend/src/app/deputes/DeputiesClient.tsx
+++ b/frontend/src/app/deputes/DeputiesClient.tsx
@@ -12,26 +12,22 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
   const router = useRouter()
   const searchParams = useSearchParams()
 
-  // Initialize from URL params (once on mount)
   const [search, setSearch] = useState(() => searchParams.get('search') ?? '')
   const [party, setParty]   = useState(() => searchParams.get('party') ?? '')
   const [dept,  setDept]    = useState(() => searchParams.get('dept')   ?? '')
   const [sort,  setSort]    = useState(() => searchParams.get('sort')   ?? 'nom')
-  const [filtersOpen, setFiltersOpen] = useState(false)
 
   const parties = useMemo(
     () => [...new Set(initial.items.map(d => d.party).filter(Boolean))].sort() as string[],
     [initial.items]
   )
 
-  // Debounce search input
   const [debouncedSearch, setDebouncedSearch] = useState(search)
   useEffect(() => {
     const t = setTimeout(() => setDebouncedSearch(search), 300)
     return () => clearTimeout(t)
   }, [search])
 
-  // Sync state → URL (skip first render to avoid spurious replace)
   const skipFirstSync = useRef(true)
   useEffect(() => {
     if (skipFirstSync.current) { skipFirstSync.current = false; return }
@@ -44,14 +40,12 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
     router.replace(`/deputes${qs ? `?${qs}` : ''}`, { scroll: false })
   }, [debouncedSearch, party, dept, sort, router])
 
-  // Unique department names from full list
   const departments = useMemo(() =>
     ([...new Set(initial.items.map(d => d.department).filter(Boolean))] as string[])
       .sort((a, b) => a.localeCompare(b, 'fr')),
     [initial.items]
   )
 
-  // Compose all filters client-side over the full loaded list
   const filtered = useMemo(() => {
     const q = debouncedSearch.toLowerCase()
     return initial.items.filter(d => {
@@ -66,8 +60,6 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
     })
   }, [initial.items, party, dept, debouncedSearch])
 
-  // Sort — Nom A–Z only for now (presence/activity requires backend change:
-  // list endpoint must include presence_rate + total_votes per deputy)
   const sorted = useMemo(() =>
     sort === 'nom'
       ? [...filtered].sort((a, b) => a.full_name.localeCompare(b.full_name, 'fr'))
@@ -81,65 +73,75 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
 
   return (
     <div>
-      {/* Search — always visible */}
-      <div className="mb-3">
+      {/* Search bar */}
+      <div className="relative mb-5">
         <label htmlFor="deputy-search" className="sr-only">Rechercher un député</label>
+        <svg
+          className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-mid pointer-events-none"
+          width="16" height="16" viewBox="0 0 24 24" fill="none"
+          stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
         <input
           id="deputy-search"
           type="search"
-          placeholder="Nom, département…"
+          placeholder="Rechercher par nom, département…"
           value={search}
           onChange={e => setSearch(e.target.value)}
-          className="w-full border border-gray-border rounded-lg px-4 py-2.5 text-sm bg-white focus:outline-none focus:border-navy"
+          className="w-full border border-gray-border rounded-xl pl-11 pr-4 py-3 text-sm bg-white focus:outline-none focus:border-navy focus:ring-1 focus:ring-navy/20 transition-colors"
         />
+        {search && (
+          <button
+            onClick={() => setSearch('')}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-mid hover:text-navy p-1"
+            aria-label="Effacer la recherche"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        )}
       </div>
 
-      {/* Mobile: "Filtres" toggle */}
-      <button
-        onClick={() => setFiltersOpen(o => !o)}
-        className="md:hidden mb-2 flex items-center gap-2 text-sm text-navy/70 border border-gray-border rounded-lg px-3 py-2 bg-white w-full"
-        aria-expanded={filtersOpen}
-        aria-controls="filter-row"
-      >
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <line x1="4" y1="6" x2="20" y2="6" /><line x1="8" y1="12" x2="16" y2="12" /><line x1="11" y1="18" x2="13" y2="18" />
-        </svg>
-        Filtres &amp; tri
-        {activeFilterCount > 0 && (
-          <span className="bg-red-civic text-white text-[10px] font-medium rounded-full w-4 h-4 flex items-center justify-center">
-            {activeFilterCount}
-          </span>
-        )}
-        <span className="ml-auto text-xs">{filtersOpen ? '▲' : '▼'}</span>
-      </button>
-
-      {/* Filter + sort row — collapsible on mobile */}
-      <div
-        id="filter-row"
-        className={`${filtersOpen ? 'flex' : 'hidden'} md:flex flex-col sm:flex-row gap-2 mb-4`}
-      >
-        <div className="flex-1">
-          <label htmlFor="filter-groupe" className="sr-only">Groupe parlementaire</label>
-          <select
-            id="filter-groupe"
-            value={party}
-            onChange={e => setParty(e.target.value)}
-            className="w-full border border-gray-border rounded-lg px-3 py-2.5 text-sm bg-white focus:outline-none focus:border-navy"
+      {/* Party pill strip */}
+      <div className="flex gap-2 overflow-x-auto pb-2 mb-4 sp" role="group" aria-label="Filtrer par groupe parlementaire">
+        <button
+          onClick={() => setParty('')}
+          className={`flex-shrink-0 text-xs px-3 py-1.5 rounded-full border font-medium transition-colors ${
+            party === ''
+              ? 'bg-navy text-white border-navy'
+              : 'bg-white text-navy/70 border-gray-border hover:border-navy/40'
+          }`}
+        >
+          Tous
+        </button>
+        {parties.map(p => (
+          <button
+            key={p}
+            onClick={() => setParty(prev => prev === p ? '' : p)}
+            aria-pressed={party === p}
+            className={`flex-shrink-0 text-xs px-3 py-1.5 rounded-full border font-medium transition-all ${
+              party === p
+                ? `${partyColor(p)} border-transparent ring-2 ring-offset-1 ring-navy/20`
+                : `bg-white text-navy/70 border-gray-border hover:border-navy/40`
+            }`}
           >
-            <option value="">Tous les groupes</option>
-            {parties.map(p => (
-              <option key={p} value={p}>{partyShort(p)} — {p}</option>
-            ))}
-          </select>
-        </div>
+            {partyShort(p)}
+          </button>
+        ))}
+      </div>
 
+      {/* Department + sort row */}
+      <div className="flex gap-2 mb-5">
         <div className="flex-1">
           <label htmlFor="filter-dept" className="sr-only">Département</label>
           <select
             id="filter-dept"
             value={dept}
             onChange={e => setDept(e.target.value)}
-            className="w-full border border-gray-border rounded-lg px-3 py-2.5 text-sm bg-white focus:outline-none focus:border-navy"
+            className="w-full border border-gray-border rounded-lg px-3 py-2 text-sm bg-white focus:outline-none focus:border-navy"
           >
             <option value="">Tous les départements</option>
             {departments.map(d => (
@@ -147,30 +149,31 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
             ))}
           </select>
         </div>
-
         <div>
           <label htmlFor="filter-sort" className="sr-only">Trier par</label>
           <select
             id="filter-sort"
             value={sort}
             onChange={e => setSort(e.target.value)}
-            className="w-full border border-gray-border rounded-lg px-3 py-2.5 text-sm bg-white focus:outline-none focus:border-navy"
+            className="border border-gray-border rounded-lg px-3 py-2 text-sm bg-white focus:outline-none focus:border-navy"
           >
-            <option value="nom">Trier : Nom A–Z</option>
-            {/* TODO: add presence + activity options once list endpoint exposes those fields */}
+            <option value="nom">Nom A–Z</option>
           </select>
         </div>
       </div>
 
       {/* Count + clear */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex items-center justify-between mb-5">
         <p className="text-xs text-gray-mid">
-          {sorted.length} député{sorted.length !== 1 ? 's' : ''}
+          <span className="font-medium text-navy">{sorted.length}</span> député·e·s
           {party && ` · ${partyShort(party)}`}
           {dept   && ` · ${dept}`}
         </p>
         {activeFilterCount > 0 && (
-          <button onClick={clearAll} className="text-xs text-red-civic hover:underline">
+          <button onClick={clearAll} className="text-xs text-red-civic hover:underline flex items-center gap-1">
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
             Effacer les filtres
           </button>
         )}
@@ -178,32 +181,44 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
 
       {/* Grid */}
       {sorted.length === 0 ? (
-        <p className="text-sm text-gray-mid py-8 text-center">Aucun résultat</p>
+        <div className="py-16 text-center">
+          <p className="text-gray-mid text-sm mb-3">Aucun résultat pour cette recherche</p>
+          <button onClick={clearAll} className="text-sm text-navy underline underline-offset-2">
+            Effacer les filtres
+          </button>
+        </div>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
           {sorted.map(d => (
-            <Link key={d.deputy_id} href={`/deputes/${d.deputy_id}`}
-              className="bg-white border border-gray-border rounded-lg p-4 hover:border-navy/30 transition-colors flex items-center gap-3">
+            <Link
+              key={d.deputy_id}
+              href={`/deputes/${d.deputy_id}`}
+              className="group bg-white border border-gray-border rounded-xl p-4 hover:border-navy/30 hover:shadow-sm transition-all flex items-center gap-3"
+            >
               <DeputyAvatar name={d.full_name} photoUrl={d.photo_url} size="sm" />
               <div className="min-w-0 flex-1">
-                <p className="text-sm font-medium text-navy truncate">{d.full_name}</p>
-                <p className="text-xs text-gray-mid truncate">{d.department}</p>
-              </div>
-              {d.party && (
-                <span
-                  tabIndex={0}
-                  className={`relative group text-xs px-2 py-0.5 rounded font-medium flex-shrink-0 cursor-default outline-none focus-visible:ring-1 focus-visible:ring-navy/40 ${partyColor(d.party)}`}
-                  aria-label={`Groupe : ${d.party}`}
-                >
-                  {partyShort(d.party)}
+                <p className="text-sm font-medium text-navy truncate group-hover:text-navy leading-snug">
+                  {d.full_name}
+                </p>
+                <p className="text-xs text-gray-mid truncate mt-0.5">{d.department}</p>
+                {d.party && (
                   <span
-                    role="tooltip"
-                    className="absolute bottom-full right-0 mb-1.5 px-2 py-1 text-xs bg-navy text-white rounded whitespace-nowrap shadow-lg invisible group-hover:visible group-focus-within:visible pointer-events-none z-10"
+                    className={`inline-block mt-1.5 text-[10px] px-2 py-0.5 rounded-full font-medium ${partyColor(d.party)}`}
+                    aria-label={`Groupe : ${d.party}`}
+                    title={d.party}
                   >
-                    {d.party}
+                    {partyShort(d.party)}
                   </span>
-                </span>
-              )}
+                )}
+              </div>
+              <svg
+                className="text-gray-border group-hover:text-navy/30 flex-shrink-0 transition-colors"
+                width="16" height="16" viewBox="0 0 24 24" fill="none"
+                stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <polyline points="9 18 15 12 9 6" />
+              </svg>
             </Link>
           ))}
         </div>

--- a/frontend/src/app/deputes/DeputiesClient.tsx
+++ b/frontend/src/app/deputes/DeputiesClient.tsx
@@ -3,10 +3,15 @@ import { useState, useEffect, useRef, useMemo } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Deputy } from '@/lib/api'
-import { partyShort, partyColor } from '@/lib/utils'
-import { DeputyAvatar } from '@/components/DeputyAvatar'
+import { getInitials, partyHex } from '@/lib/utils'
 
 type DeputyList = { total: number; items: Deputy[]; limit: number; offset: number }
+
+const PAGE_SIZE = 10
+const NAVY = '#1B2B50'
+const CREAM = '#F7F4ED'
+const LINE = '#E4E6EA'
+const ACCENT = '#E0786E'
 
 export function DeputiesClient({ initial }: { initial: DeputyList }) {
   const router = useRouter()
@@ -15,10 +20,16 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
   const [search, setSearch] = useState(() => searchParams.get('search') ?? '')
   const [party, setParty]   = useState(() => searchParams.get('party') ?? '')
   const [dept,  setDept]    = useState(() => searchParams.get('dept')   ?? '')
-  const [sort,  setSort]    = useState(() => searchParams.get('sort')   ?? 'nom')
+  const [page,  setPage]    = useState(1)
 
   const parties = useMemo(
     () => [...new Set(initial.items.map(d => d.party).filter(Boolean))].sort() as string[],
+    [initial.items]
+  )
+
+  const departments = useMemo(
+    () => ([...new Set(initial.items.map(d => d.department).filter(Boolean))] as string[])
+      .sort((a, b) => a.localeCompare(b, 'fr')),
     [initial.items]
   )
 
@@ -35,194 +46,348 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
     if (debouncedSearch) p.set('search', debouncedSearch)
     if (party)           p.set('party',  party)
     if (dept)            p.set('dept',   dept)
-    if (sort !== 'nom')  p.set('sort',   sort)
     const qs = p.toString()
     router.replace(`/deputes${qs ? `?${qs}` : ''}`, { scroll: false })
-  }, [debouncedSearch, party, dept, sort, router])
-
-  const departments = useMemo(() =>
-    ([...new Set(initial.items.map(d => d.department).filter(Boolean))] as string[])
-      .sort((a, b) => a.localeCompare(b, 'fr')),
-    [initial.items]
-  )
+    setPage(1)
+  }, [debouncedSearch, party, dept, router])
 
   const filtered = useMemo(() => {
     const q = debouncedSearch.toLowerCase()
-    return initial.items.filter(d => {
-      if (party && d.party !== party) return false
-      if (dept  && d.department !== dept) return false
-      if (q) return (
-        d.full_name.toLowerCase().includes(q) ||
-        (d.department?.toLowerCase().includes(q) ?? false) ||
-        (d.party?.toLowerCase().includes(q) ?? false)
-      )
-      return true
-    })
+    return initial.items
+      .filter(d => {
+        if (party && d.party !== party) return false
+        if (dept  && d.department !== dept) return false
+        if (q) return (
+          d.full_name.toLowerCase().includes(q) ||
+          (d.department?.toLowerCase().includes(q) ?? false) ||
+          (d.party?.toLowerCase().includes(q) ?? false)
+        )
+        return true
+      })
+      .sort((a, b) => a.full_name.localeCompare(b.full_name, 'fr'))
   }, [initial.items, party, dept, debouncedSearch])
 
-  const sorted = useMemo(() =>
-    sort === 'nom'
-      ? [...filtered].sort((a, b) => a.full_name.localeCompare(b.full_name, 'fr'))
-      : filtered,
-    [filtered, sort]
-  )
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))
+  const safePage = Math.min(page, totalPages)
+  const paginated = filtered.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE)
 
-  const activeFilterCount = [party, dept, debouncedSearch].filter(Boolean).length
+  function clearAll() { setSearch(''); setParty(''); setDept(''); setPage(1) }
 
-  function clearAll() { setSearch(''); setParty(''); setDept(''); setSort('nom') }
+  function selectParty(p: string) {
+    setParty(prev => prev === p ? '' : p)
+    setPage(1)
+  }
+
+  function getPageNumbers(): (number | '…')[] {
+    if (totalPages <= 7) return Array.from({ length: totalPages }, (_, i) => i + 1)
+    const pages: (number | '…')[] = [1, 2, 3]
+    if (safePage > 5) pages.push('…')
+    if (safePage > 4 && safePage < totalPages - 3) {
+      pages.push(safePage - 1, safePage, safePage + 1)
+    }
+    if (safePage < totalPages - 4) pages.push('…')
+    pages.push(totalPages - 1, totalPages)
+    return [...new Set(pages)].sort((a, b) => {
+      if (a === '…' || b === '…') return 0
+      return (a as number) - (b as number)
+    })
+  }
 
   return (
-    <div>
-      {/* Search bar */}
-      <div className="relative mb-5">
-        <label htmlFor="deputy-search" className="sr-only">Rechercher un député</label>
-        <svg
-          className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-mid pointer-events-none"
-          width="16" height="16" viewBox="0 0 24 24" fill="none"
-          stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" />
-        </svg>
-        <input
-          id="deputy-search"
-          type="search"
-          placeholder="Rechercher par nom, département…"
-          value={search}
-          onChange={e => setSearch(e.target.value)}
-          className="w-full border border-gray-border rounded-xl pl-11 pr-4 py-3 text-sm bg-white focus:outline-none focus:border-navy focus:ring-1 focus:ring-navy/20 transition-colors"
-        />
-        {search && (
-          <button
-            onClick={() => setSearch('')}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-mid hover:text-navy p-1"
-            aria-label="Effacer la recherche"
-          >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
-          </button>
-        )}
-      </div>
+    <div style={{ background: CREAM, minHeight: '100vh' }}>
 
-      {/* Party pill strip */}
-      <div className="flex gap-2 overflow-x-auto pb-2 mb-4 sp" role="group" aria-label="Filtrer par groupe parlementaire">
-        <button
-          onClick={() => setParty('')}
-          className={`flex-shrink-0 text-xs px-3 py-1.5 rounded-full border font-medium transition-colors ${
-            party === ''
-              ? 'bg-navy text-white border-navy'
-              : 'bg-white text-navy/70 border-gray-border hover:border-navy/40'
-          }`}
-        >
-          Tous
-        </button>
-        {parties.map(p => (
-          <button
-            key={p}
-            onClick={() => setParty(prev => prev === p ? '' : p)}
-            aria-pressed={party === p}
-            className={`flex-shrink-0 text-xs px-3 py-1.5 rounded-full border font-medium transition-all ${
-              party === p
-                ? `${partyColor(p)} border-transparent ring-2 ring-offset-1 ring-navy/20`
-                : `bg-white text-navy/70 border-gray-border hover:border-navy/40`
-            }`}
-          >
-            {partyShort(p)}
-          </button>
-        ))}
-      </div>
+      {/* Hero */}
+      <div style={{
+        padding: '50px 56px 40px',
+        background: 'linear-gradient(180deg,#fff 0%,' + CREAM + ' 100%)',
+        borderBottom: '1px solid #ECE7DC',
+      }}>
+        <div style={{ maxWidth: 1180, margin: '0 auto' }}>
+          <div style={{
+            fontWeight: 700, fontSize: 12, letterSpacing: '0.18em',
+            textTransform: 'uppercase', color: '#C9302A', marginBottom: 16,
+          }}>
+            Annuaire des députés
+          </div>
+          <h1 className="font-serif" style={{
+            fontWeight: 600, fontSize: 'clamp(32px,4vw,48px)', lineHeight: 1.05,
+            letterSpacing: '-0.015em', color: NAVY, margin: 0, maxWidth: 760,
+          }}>
+            Les {initial.total} députés de l&apos;Assemblée nationale,{' '}
+            <span style={{ color: '#C9302A' }}>en clair</span>.
+          </h1>
+          <p style={{ margin: '16px 0 0', fontSize: 17, lineHeight: 1.6, color: '#4B5563', maxWidth: 540 }}>
+            Recherchez un élu, filtrez par groupe ou par territoire, et accédez à son bilan de vote complet.
+          </p>
 
-      {/* Department + sort row */}
-      <div className="flex gap-2 mb-5">
-        <div className="flex-1">
-          <label htmlFor="filter-dept" className="sr-only">Département</label>
-          <select
-            id="filter-dept"
-            value={dept}
-            onChange={e => setDept(e.target.value)}
-            className="w-full border border-gray-border rounded-lg px-3 py-2 text-sm bg-white focus:outline-none focus:border-navy"
-          >
-            <option value="">Tous les départements</option>
-            {departments.map(d => (
-              <option key={d} value={d}>{d}</option>
-            ))}
-          </select>
-        </div>
-        <div>
-          <label htmlFor="filter-sort" className="sr-only">Trier par</label>
-          <select
-            id="filter-sort"
-            value={sort}
-            onChange={e => setSort(e.target.value)}
-            className="border border-gray-border rounded-lg px-3 py-2 text-sm bg-white focus:outline-none focus:border-navy"
-          >
-            <option value="nom">Nom A–Z</option>
-          </select>
-        </div>
-      </div>
-
-      {/* Count + clear */}
-      <div className="flex items-center justify-between mb-5">
-        <p className="text-xs text-gray-mid">
-          <span className="font-medium text-navy">{sorted.length}</span> député·e·s
-          {party && ` · ${partyShort(party)}`}
-          {dept   && ` · ${dept}`}
-        </p>
-        {activeFilterCount > 0 && (
-          <button onClick={clearAll} className="text-xs text-red-civic hover:underline flex items-center gap-1">
-            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
-            Effacer les filtres
-          </button>
-        )}
-      </div>
-
-      {/* Grid */}
-      {sorted.length === 0 ? (
-        <div className="py-16 text-center">
-          <p className="text-gray-mid text-sm mb-3">Aucun résultat pour cette recherche</p>
-          <button onClick={clearAll} className="text-sm text-navy underline underline-offset-2">
-            Effacer les filtres
-          </button>
-        </div>
-      ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-          {sorted.map(d => (
-            <Link
-              key={d.deputy_id}
-              href={`/deputes/${d.deputy_id}`}
-              className="group bg-white border border-gray-border rounded-xl p-4 hover:border-navy/30 hover:shadow-sm transition-all flex items-center gap-3"
-            >
-              <DeputyAvatar name={d.full_name} photoUrl={d.photo_url} size="sm" />
-              <div className="min-w-0 flex-1">
-                <p className="text-sm font-medium text-navy truncate group-hover:text-navy leading-snug">
-                  {d.full_name}
-                </p>
-                <p className="text-xs text-gray-mid truncate mt-0.5">{d.department}</p>
-                {d.party && (
-                  <span
-                    className={`inline-block mt-1.5 text-[10px] px-2 py-0.5 rounded-full font-medium ${partyColor(d.party)}`}
-                    aria-label={`Groupe : ${d.party}`}
-                    title={d.party}
-                  >
-                    {partyShort(d.party)}
-                  </span>
-                )}
-              </div>
-              <svg
-                className="text-gray-border group-hover:text-navy/30 flex-shrink-0 transition-colors"
-                width="16" height="16" viewBox="0 0 24 24" fill="none"
-                stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
-                aria-hidden="true"
-              >
-                <polyline points="9 18 15 12 9 6" />
+          {/* Search row */}
+          <div style={{ display: 'flex', gap: 12, marginTop: 28, maxWidth: 720 }}>
+            <label htmlFor="deputy-search" className="sr-only">Rechercher un député</label>
+            <div style={{
+              flex: 1, display: 'flex', alignItems: 'center', gap: 12,
+              background: '#fff', border: '1px solid ' + LINE, borderRadius: 10,
+              padding: '0 18px', height: 54, boxShadow: '0 1px 3px rgba(0,0,0,0.05)',
+            }}>
+              <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="#9CA3AF" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+                <circle cx="11" cy="11" r="7"/><path d="m20 20-3.2-3.2"/>
               </svg>
-            </Link>
-          ))}
+              <input
+                id="deputy-search"
+                type="search"
+                placeholder="Nom, circonscription ou département…"
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                style={{
+                  flex: 1, border: 'none', outline: 'none', fontSize: 16,
+                  color: '#1F2937', background: 'transparent',
+                }}
+              />
+              {search && (
+                <button
+                  onClick={() => setSearch('')}
+                  aria-label="Effacer la recherche"
+                  style={{ color: '#9CA3AF', cursor: 'pointer', background: 'none', border: 'none', padding: 0 }}
+                >
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+                    <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                  </svg>
+                </button>
+              )}
+            </div>
+            <button
+              onClick={() => setDebouncedSearch(search)}
+              style={{
+                display: 'flex', alignItems: 'center', background: ACCENT, color: '#fff',
+                height: 54, padding: '0 30px', borderRadius: 10, fontWeight: 600,
+                fontSize: 16, cursor: 'pointer', whiteSpace: 'nowrap',
+                boxShadow: '0 2px 8px rgba(224,120,110,0.4)', border: 'none',
+              }}
+            >
+              Rechercher
+            </button>
+          </div>
+
+          {/* Filter chips */}
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 9, marginTop: 18, alignItems: 'center' }}>
+            <button
+              onClick={() => { setParty(''); setPage(1) }}
+              style={{
+                background: party === '' ? NAVY : '#fff',
+                color: party === '' ? '#fff' : '#4B5563',
+                border: '1px solid ' + (party === '' ? NAVY : LINE),
+                padding: '8px 16px', borderRadius: 999, fontSize: 13.5,
+                fontWeight: party === '' ? 600 : 400, cursor: 'pointer',
+              }}
+            >
+              Tous
+            </button>
+            {parties.map(p => (
+              <button
+                key={p}
+                onClick={() => selectParty(p)}
+                aria-pressed={party === p}
+                style={{
+                  background: party === p ? NAVY : '#fff',
+                  color: party === p ? '#fff' : '#4B5563',
+                  border: '1px solid ' + (party === p ? NAVY : LINE),
+                  padding: '8px 16px', borderRadius: 999, fontSize: 13.5,
+                  fontWeight: party === p ? 600 : 400, cursor: 'pointer',
+                }}
+              >
+                {p}
+              </button>
+            ))}
+            <div style={{ marginLeft: 'auto' }}>
+              <label htmlFor="filter-dept" className="sr-only">Région / département</label>
+              <div style={{
+                display: 'flex', alignItems: 'center', gap: 8,
+                background: '#fff', border: '1px solid ' + LINE,
+                padding: '8px 16px', borderRadius: 999, fontSize: 13.5,
+                color: '#4B5563', cursor: 'pointer',
+              }}>
+                <select
+                  id="filter-dept"
+                  value={dept}
+                  onChange={e => { setDept(e.target.value); setPage(1) }}
+                  style={{
+                    border: 'none', outline: 'none', background: 'transparent',
+                    fontSize: 13.5, color: '#4B5563', cursor: 'pointer',
+                    appearance: 'none', paddingRight: 4,
+                  }}
+                >
+                  <option value="">Toutes régions</option>
+                  {departments.map(d => <option key={d} value={d}>{d}</option>)}
+                </select>
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#9CA3AF" strokeWidth="2.4" strokeLinecap="round" aria-hidden="true">
+                  <path d="m5 9 7 7 7-7"/>
+                </svg>
+              </div>
+            </div>
+          </div>
         </div>
-      )}
+      </div>
+
+      {/* Table section */}
+      <div style={{ padding: '32px 56px 72px' }}>
+        <div style={{ maxWidth: 1180, margin: '0 auto' }}>
+
+          {/* Count + sort row */}
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 4px 14px' }}>
+            <span style={{ fontFamily: 'monospace', fontSize: 13, color: '#6B7280' }}>
+              {filtered.length} député{filtered.length !== 1 ? 's' : ''} · triés par nom
+            </span>
+            <span style={{ fontSize: 13.5, color: '#6B7280', display: 'flex', alignItems: 'center', gap: 7 }}>
+              {(party || dept || debouncedSearch) && (
+                <button
+                  onClick={clearAll}
+                  style={{ color: '#C9302A', fontSize: 13, cursor: 'pointer', background: 'none', border: 'none', padding: 0 }}
+                >
+                  Effacer les filtres ×
+                </button>
+              )}
+            </span>
+          </div>
+
+          {filtered.length === 0 ? (
+            <div style={{ padding: '64px 0', textAlign: 'center' }}>
+              <p style={{ color: '#6B7280', fontSize: 15, marginBottom: 12 }}>Aucun résultat pour cette recherche</p>
+              <button
+                onClick={clearAll}
+                style={{ fontSize: 14, color: NAVY, textDecoration: 'underline', background: 'none', border: 'none', cursor: 'pointer' }}
+              >
+                Effacer les filtres
+              </button>
+            </div>
+          ) : (
+            <>
+              {/* Table card */}
+              <div style={{
+                background: '#fff', border: '1px solid ' + LINE,
+                borderRadius: 12, overflow: 'hidden',
+                boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
+              }}>
+                {/* Header */}
+                <div style={{
+                  display: 'grid', gridTemplateColumns: '1fr 260px 34px',
+                  gap: 18, padding: '13px 26px',
+                  borderBottom: '1px solid ' + LINE, background: '#FBFAF6',
+                  font: '600 11.5px/1 var(--font-body)',
+                  letterSpacing: '0.08em', textTransform: 'uppercase', color: '#9CA3AF',
+                }}>
+                  <span>Député·e</span>
+                  <span>Groupe</span>
+                  <span />
+                </div>
+
+                {/* Rows */}
+                {paginated.map(d => {
+                  const hex = partyHex(d.party)
+                  const initials = getInitials(d.full_name)
+                  return (
+                    <Link
+                      key={d.deputy_id}
+                      href={`/deputes/${d.deputy_id}`}
+                      style={{ textDecoration: 'none' }}
+                    >
+                      <div
+                        style={{
+                          display: 'grid', gridTemplateColumns: '1fr 260px 34px',
+                          gap: 18, padding: '15px 26px',
+                          borderBottom: '1px solid #F0F1F3',
+                          alignItems: 'center', cursor: 'pointer',
+                          background: '#fff', transition: 'background 0.12s',
+                        }}
+                        onMouseEnter={e => (e.currentTarget.style.background = '#FBFAF6')}
+                        onMouseLeave={e => (e.currentTarget.style.background = '#fff')}
+                      >
+                        {/* Deputy */}
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 14, minWidth: 0 }}>
+                          <span style={{
+                            width: 42, height: 42, flexShrink: 0, borderRadius: 999,
+                            display: 'flex', alignItems: 'center', justifyContent: 'center',
+                            fontWeight: 700, fontSize: 14, color: '#fff', background: hex,
+                          }}>
+                            {initials}
+                          </span>
+                          <div style={{ minWidth: 0 }}>
+                            <div style={{ fontWeight: 600, fontSize: 15.5, color: NAVY, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                              {d.full_name}
+                            </div>
+                            <div style={{ fontSize: 13, color: '#9CA3AF', marginTop: 3 }}>
+                              {d.department ?? '—'}
+                            </div>
+                          </div>
+                        </div>
+
+                        {/* Group */}
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+                          <span style={{ width: 9, height: 9, borderRadius: 999, flexShrink: 0, background: hex }} />
+                          <span style={{ fontSize: 14, color: '#374151', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                            {d.party ?? '—'}
+                          </span>
+                        </div>
+
+                        {/* Arrow */}
+                        <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="#C4C9D2" strokeWidth="2.2" strokeLinecap="round" aria-hidden="true">
+                          <path d="m9 6 6 6-6 6"/>
+                        </svg>
+                      </div>
+                    </Link>
+                  )
+                })}
+              </div>
+
+              {/* Pagination */}
+              {totalPages > 1 && (
+                <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 6, marginTop: 26, fontSize: 14, color: '#6B7280' }}>
+                  <button
+                    onClick={() => setPage(p => Math.max(1, p - 1))}
+                    disabled={safePage === 1}
+                    style={{
+                      width: 34, height: 34, display: 'flex', alignItems: 'center', justifyContent: 'center',
+                      border: '1px solid ' + LINE, borderRadius: 8, background: '#fff', cursor: safePage === 1 ? 'default' : 'pointer',
+                      opacity: safePage === 1 ? 0.4 : 1,
+                    }}
+                  >
+                    ‹
+                  </button>
+                  {getPageNumbers().map((n, i) =>
+                    n === '…' ? (
+                      <span key={`ellipsis-${i}`} style={{ padding: '0 6px' }}>…</span>
+                    ) : (
+                      <button
+                        key={n}
+                        onClick={() => setPage(n as number)}
+                        style={{
+                          width: 34, height: 34, display: 'flex', alignItems: 'center', justifyContent: 'center',
+                          borderRadius: 8, cursor: 'pointer',
+                          background: safePage === n ? NAVY : '#fff',
+                          color: safePage === n ? '#fff' : '#6B7280',
+                          border: safePage === n ? 'none' : '1px solid ' + LINE,
+                          fontWeight: safePage === n ? 600 : 400,
+                        }}
+                      >
+                        {n}
+                      </button>
+                    )
+                  )}
+                  <button
+                    onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+                    disabled={safePage === totalPages}
+                    style={{
+                      width: 34, height: 34, display: 'flex', alignItems: 'center', justifyContent: 'center',
+                      border: '1px solid ' + LINE, borderRadius: 8, background: '#fff', cursor: safePage === totalPages ? 'default' : 'pointer',
+                      opacity: safePage === totalPages ? 0.4 : 1,
+                    }}
+                  >
+                    ›
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -3,12 +3,17 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { api } from '@/lib/api'
 import type { DeputyVoteItem } from '@/lib/api'
-import { partyColor, formatDate } from '@/lib/utils'
+import { partyHex, formatDate } from '@/lib/utils'
 import { DeputyAvatar } from '@/components/DeputyAvatar'
-import { ShareButton } from '@/components/ShareButton'
 
 export const dynamicParams = true
 export const revalidate = 86400
+
+const NAVY   = '#1B2B50'
+const CREAM  = '#F7F4ED'
+const LINE   = '#E4E6EA'
+const ACCENT = '#E0786E'
+const RED    = '#C9302A'
 
 export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
   const { id } = await params
@@ -20,31 +25,16 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
   return {
     title: `${deputy.full_name} — MonÉlu`,
     description,
-    openGraph: {
-      title: `${deputy.full_name} — MonÉlu`,
-      description,
-      url: `https://mon-elu.vercel.app/deputes/${id}`,
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title: `${deputy.full_name} — MonÉlu`,
-      description,
-    },
+    openGraph: { title: `${deputy.full_name} — MonÉlu`, description },
+    twitter:   { card: 'summary_large_image', title: `${deputy.full_name} — MonÉlu`, description },
   }
 }
 
-const POSITION_LABEL: Record<string, string> = {
-  pour: 'Pour',
-  contre: 'Contre',
-  abstention: 'Abstention',
-  nonVotant: 'Non votant',
-}
-
-const POSITION_CLASS: Record<string, string> = {
-  pour: 'bg-emerald-100 text-emerald-800',
-  contre: 'bg-red-50 text-red-700',
-  abstention: 'bg-amber-100 text-amber-800',
-  nonVotant: 'bg-gray-100 text-gray-500',
+const POS = {
+  pour:       { label: 'Pour',       color: '#1F8A5B', bg: '#EAF5EF' },
+  contre:     { label: 'Contre',     color: RED,        bg: '#FBE9E7' },
+  abstention: { label: 'Abstention', color: '#6B7280',  bg: '#F0F1F3' },
+  nonVotant:  { label: 'Non votant', color: '#9CA3AF',  bg: '#F5F6F7' },
 }
 
 export default async function DeputyPage({ params }: { params: Promise<{ id: string }> }) {
@@ -60,228 +50,284 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
   const presencePct    = scorecard ? Math.round((scorecard.presence_rate ?? 0) * 100) : null
   const avgPresencePct = deputyStats ? Math.round((deputyStats.avg_presence_rate ?? 0) * 100) : null
   const denom          = scorecard ? (scorecard.present_votes || 1) : 1
-  const pourPct        = scorecard ? Math.round(scorecard.votes_for      / denom * 100) : null
-  const contrePct      = scorecard ? Math.round(scorecard.votes_against  / denom * 100) : null
-  const abstPct        = scorecard ? Math.round(scorecard.abstentions    / denom * 100) : null
+  const pourPct        = scorecard ? Math.round(scorecard.votes_for     / denom * 100) : 0
+  const contrePct      = scorecard ? Math.round(scorecard.votes_against / denom * 100) : 0
+  const abstPct        = scorecard ? Math.round(scorecard.abstentions   / denom * 100) : 0
 
-  const aboveAvg =
-    presencePct !== null && avgPresencePct !== null
-      ? presencePct > avgPresencePct
-        ? 'above'
-        : presencePct < avgPresencePct
-        ? 'below'
-        : 'equal'
-      : null
+  const hex = partyHex(deputy.party)
 
-  const firstName = deputy.first_name || deputy.full_name.split(' ')[0]
+  const stats = scorecard ? [
+    { value: scorecard.total_votes.toLocaleString('fr-FR'),    label: 'scrutins votés' },
+    { value: `${presencePct ?? '—'}%`,                        label: 'présence aux votes' },
+    { value: scorecard.votes_for.toLocaleString('fr-FR'),      label: 'votes Pour' },
+    { value: scorecard.votes_against.toLocaleString('fr-FR'),  label: 'votes Contre' },
+    { value: scorecard.abstentions.toLocaleString('fr-FR'),    label: 'abstentions' },
+    { value: scorecard.present_votes.toLocaleString('fr-FR'),  label: 'votes exprimés' },
+  ] : []
 
   return (
-    <div className="max-w-2xl mx-auto px-4 md:px-8 py-6">
-      {/* Back link */}
-      <Link
-        href="/deputes"
-        className="inline-flex items-center gap-1.5 text-xs text-gray-mid hover:text-navy transition-colors mb-6"
-      >
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <polyline points="15 18 9 12 15 6" />
-        </svg>
-        Annuaire des députés
-      </Link>
+    <div style={{ background: CREAM, minHeight: '100vh' }}>
 
-      {/* Hero card — navy background */}
-      <div className="bg-navy rounded-2xl p-6 mb-4">
-        <div className="flex items-start gap-4">
-          <div className="ring-2 ring-white/20 rounded-full flex-shrink-0">
-            <DeputyAvatar name={deputy.full_name} photoUrl={deputy.photo_url} size="xl" priority />
+      {/* Hero band */}
+      <div style={{
+        padding: '38px 56px 44px',
+        background: `linear-gradient(180deg,#ffffff 0%,${CREAM} 100%)`,
+        borderBottom: `1px solid #ECE7DC`,
+      }}>
+        <div style={{ maxWidth: 1180, margin: '0 auto' }}>
+
+          {/* Breadcrumb */}
+          <div style={{ fontSize: 13.5, color: '#9CA3AF', display: 'flex', alignItems: 'center', gap: 8, marginBottom: 26 }}>
+            <Link
+              href="/deputes"
+              style={{ color: RED, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5, textDecoration: 'none', fontWeight: 500 }}
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" aria-hidden="true">
+                <path d="m15 18-6-6 6-6"/>
+              </svg>
+              Retour aux députés
+            </Link>
+            <span>/</span>
+            <span style={{ color: '#6B7280' }}>{deputy.full_name}</span>
           </div>
-          <div className="min-w-0 flex-1 pt-1">
-            <h1 className="font-serif text-2xl text-white leading-tight">{deputy.full_name}</h1>
-            <p className="text-white/60 text-sm mt-1">{deputy.department}</p>
-            {deputy.party && (
-              <span className="inline-block mt-2 text-xs px-2.5 py-1 rounded-full font-medium bg-white/10 text-white/90 border border-white/20">
-                {deputy.party}
-              </span>
-            )}
-          </div>
-          <div className="flex-shrink-0 text-white/70 hover:text-white transition-colors">
-            <ShareButton
-              url={`/deputes/${id}`}
-              title={`${deputy.full_name} — MonÉlu`}
-              text={`Découvrez le bilan de ${deputy.full_name} sur MonÉlu`}
-              ariaLabel={`Partager le profil de ${deputy.full_name}`}
-            />
-          </div>
-        </div>
 
-        {/* Presence summary inside hero */}
-        {presencePct !== null && avgPresencePct !== null && (
-          <div className="mt-5 flex items-center gap-3 bg-white/8 rounded-xl px-4 py-3">
-            <div className="text-2xl font-semibold text-white tabular-nums">{presencePct}%</div>
-            <div className="text-white/60 text-xs leading-snug">
-              de présence aux votes
-              <br />
-              <span className={aboveAvg === 'above' ? 'text-emerald-400' : aboveAvg === 'below' ? 'text-red-400' : 'text-white/50'}>
-                {aboveAvg === 'above' && `↑ +${presencePct - avgPresencePct} pts vs. moy. nationale`}
-                {aboveAvg === 'below' && `↓ −${avgPresencePct - presencePct} pts vs. moy. nationale`}
-                {aboveAvg === 'equal' && `= dans la moyenne nationale`}
-              </span>
-            </div>
-          </div>
-        )}
-      </div>
+          {/* Photo + identity */}
+          <div style={{ display: 'flex', gap: 44, alignItems: 'flex-start' }}>
 
-      {/* Plain-language summary */}
-      {presencePct !== null && avgPresencePct !== null && (
-        <div className="border-l-2 border-navy bg-gray-off rounded-r-xl px-4 py-3 mb-4 text-sm text-navy/70 leading-relaxed">
-          {firstName} a participé à{' '}
-          <span className="font-medium text-navy">{presencePct}%</span> des votes —{' '}
-          {aboveAvg === 'above' && <span className="text-emerald-700 font-medium">au-dessus</span>}
-          {aboveAvg === 'below' && <span className="text-red-700 font-medium">en dessous</span>}
-          {aboveAvg === 'equal' && <span className="font-medium">dans</span>}{' '}
-          de la moyenne nationale ({avgPresencePct}%).
-        </div>
-      )}
-
-      {/* Scorecard */}
-      {scorecard && (
-        <div className="bg-white border border-gray-border rounded-2xl p-6 mb-4">
-          <h2 className="font-serif text-xl text-navy mb-5">Bilan de mandat</h2>
-
-          {/* Presence bar */}
-          <div className="mb-6">
-            <div className="flex justify-between items-center text-sm mb-2">
-              <span className="text-gray-mid font-medium">Taux de présence</span>
-              <div className="flex items-center gap-2">
-                {avgPresencePct !== null && aboveAvg && (
-                  <span
-                    className={`text-xs font-medium ${aboveAvg === 'above' ? 'text-emerald-700' : aboveAvg === 'below' ? 'text-red-700' : 'text-gray-mid'}`}
-                    aria-label={`${aboveAvg === 'above' ? 'Au-dessus' : aboveAvg === 'below' ? 'En dessous' : 'Dans'} de la moyenne nationale (${avgPresencePct}%)`}
-                  >
-                    {aboveAvg === 'above' ? '↑' : aboveAvg === 'below' ? '↓' : '≈'} moy. {avgPresencePct}%
-                  </span>
-                )}
-                <span className="font-semibold text-navy tabular-nums">{presencePct}%</span>
+            {/* Left: photo */}
+            <div style={{ width: 210, flexShrink: 0 }}>
+              <div style={{ borderRadius: 14, overflow: 'hidden', border: `1px solid #ECE7DC`, boxShadow: '0 6px 20px rgba(27,43,80,0.12)' }}>
+                <DeputyAvatar name={deputy.full_name} photoUrl={deputy.photo_url} size="2xl" priority />
               </div>
-            </div>
-            <div className="relative h-2.5 bg-gray-light rounded-full overflow-hidden">
-              <div
-                className="h-full bg-navy rounded-full transition-all"
-                style={{ width: `${presencePct}%` }}
-              />
-            </div>
-            {avgPresencePct !== null && (
-              <div className="relative h-0" style={{ marginTop: '-10px' }}>
-                <div
-                  className="absolute top-0 h-2.5 w-0.5 bg-gray-mid/50"
-                  style={{ left: `${avgPresencePct}%` }}
-                  aria-hidden="true"
-                />
-              </div>
-            )}
-            {avgPresencePct !== null && (
-              <p className="text-[11px] text-gray-mid mt-2">
-                Trait vertical = moyenne nationale ({avgPresencePct}%)
-              </p>
-            )}
-          </div>
-
-          {/* Vote breakdown */}
-          <div className="mb-6">
-            <p className="text-sm text-gray-mid font-medium mb-2">Répartition des votes exprimés</p>
-            <div className="h-3 rounded-full overflow-hidden flex">
-              <div className="bg-emerald-500 h-full transition-all" style={{ width: `${pourPct}%` }} />
-              <div className="bg-red-civic h-full transition-all" style={{ width: `${contrePct}%` }} />
-              <div className="bg-amber-300 h-full transition-all" style={{ width: `${abstPct}%` }} />
-              <div className="bg-gray-light h-full flex-1" />
-            </div>
-            <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2 text-xs text-gray-mid">
-              <span className="flex items-center gap-1.5">
-                <span className="w-2 h-2 rounded-full bg-emerald-500 inline-block" aria-hidden="true" />
-                Pour {pourPct}%
-              </span>
-              <span className="flex items-center gap-1.5">
-                <span className="w-2 h-2 rounded-full bg-red-civic inline-block" aria-hidden="true" />
-                Contre {contrePct}%
-              </span>
-              <span className="flex items-center gap-1.5">
-                <span className="w-2 h-2 rounded-full bg-amber-300 inline-block" aria-hidden="true" />
-                Abstention {abstPct}%
-              </span>
-            </div>
-          </div>
-
-          {/* Stats grid */}
-          <div className="grid grid-cols-3 gap-3">
-            {[
-              { label: 'Votes exprimés', value: (scorecard.total_votes ?? 0).toLocaleString('fr-FR'), accent: false },
-              { label: 'Pour',           value: (scorecard.votes_for   ?? 0).toLocaleString('fr-FR'), accent: false },
-              { label: 'Contre',         value: (scorecard.votes_against ?? 0).toLocaleString('fr-FR'), accent: false },
-            ].map(({ label, value }) => (
-              <div key={label} className="bg-gray-off rounded-xl p-3 text-center">
-                <div className="text-lg font-semibold text-navy tabular-nums">{value}</div>
-                <div className="text-[11px] text-gray-mid mt-0.5 leading-tight">{label}</div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Recent votes */}
-      {recentVotes && recentVotes.items.length > 0 && (
-        <div className="bg-white border border-gray-border rounded-2xl p-6 mb-4">
-          <h2 className="font-serif text-xl text-navy mb-4">Votes récents</h2>
-          <div className="flex flex-col divide-y divide-gray-border">
-            {recentVotes.items.map((v: DeputyVoteItem) => (
-              <Link
-                key={v.vote_id}
-                href={`/votes/${v.vote_id}`}
-                className="flex items-start gap-3 py-3.5 first:pt-0 last:pb-0 hover:bg-gray-off -mx-2 px-2 rounded transition-colors"
-              >
-                <span
-                  className={`text-xs px-2 py-0.5 rounded font-medium shrink-0 mt-0.5 ${POSITION_CLASS[v.position] ?? 'bg-gray-100 text-gray-500'}`}
-                  aria-label={`Position : ${POSITION_LABEL[v.position] ?? v.position}`}
-                >
-                  {POSITION_LABEL[v.position] ?? v.position}
-                </span>
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm text-navy line-clamp-2 leading-snug">{v.vote_title}</p>
-                  {v.summary_plain && (
-                    <p className="text-xs text-gray-mid mt-0.5 line-clamp-1 italic">
-                      <span className="text-red-civic font-medium not-italic">En clair</span>{' '}
-                      {v.summary_plain}
-                    </p>
-                  )}
-                  <p className="text-[11px] text-gray-mid mt-1">{v.voted_at ? formatDate(v.voted_at) : ''}</p>
+              {deputy.department && (
+                <div style={{ marginTop: 14, fontSize: 12.5, color: '#6B7280', display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#9CA3AF" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+                    <path d="M12 21s-7-5.6-7-11a7 7 0 0 1 14 0c0 5.4-7 11-7 11Z"/><circle cx="12" cy="10" r="2.4"/>
+                  </svg>
+                  {deputy.department}
                 </div>
-                <svg
-                  className="text-gray-border flex-shrink-0 mt-1"
-                  width="14" height="14" viewBox="0 0 24 24" fill="none"
-                  stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
-                  aria-hidden="true"
+              )}
+            </div>
+
+            {/* Right: identity */}
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontWeight: 700, fontSize: 12, letterSpacing: '0.18em', textTransform: 'uppercase', color: RED }}>
+                Député·e · XVII<sup>e</sup> législature
+              </div>
+              <h1 className="font-serif" style={{
+                fontWeight: 600, fontSize: 'clamp(36px,4.5vw,58px)', lineHeight: 1.0,
+                letterSpacing: '-0.02em', color: NAVY, margin: '14px 0 0',
+              }}>
+                {deputy.full_name}
+              </h1>
+              {deputy.department && (
+                <div style={{ fontSize: 20, color: '#4B5563', marginTop: 10 }}>
+                  {deputy.department}
+                </div>
+              )}
+              {deputy.party && (
+                <div style={{
+                  display: 'inline-flex', alignItems: 'center', gap: 9,
+                  marginTop: 18, padding: '8px 16px', borderRadius: 999,
+                  background: `${hex}14`, border: `1px solid ${hex}40`,
+                  color: hex, fontWeight: 600, fontSize: 14,
+                }}>
+                  <span style={{ width: 9, height: 9, borderRadius: 999, background: hex }} />
+                  {deputy.party}
+                </div>
+              )}
+
+              {/* CTA buttons */}
+              <div style={{ display: 'flex', gap: 12, marginTop: 28, flexWrap: 'wrap' }}>
+                <Link
+                  href={`/chat?q=${encodeURIComponent(`Quel est le bilan de ${deputy.full_name} ?`)}`}
+                  style={{
+                    display: 'inline-flex', alignItems: 'center', gap: 8,
+                    background: ACCENT, color: '#fff', padding: '12px 24px',
+                    borderRadius: 9, fontWeight: 600, fontSize: 15,
+                    boxShadow: '0 2px 8px rgba(224,120,110,0.35)', textDecoration: 'none',
+                  }}
                 >
-                  <polyline points="9 18 15 12 9 6" />
-                </svg>
-              </Link>
-            ))}
+                  Poser une question sur ce député
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+                    <line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/>
+                  </svg>
+                </Link>
+                <a
+                  href="#votes"
+                  style={{
+                    display: 'inline-flex', alignItems: 'center',
+                    background: '#fff', border: `1px solid ${LINE}`, color: NAVY,
+                    padding: '12px 22px', borderRadius: 9, fontWeight: 600,
+                    fontSize: 15, textDecoration: 'none',
+                  }}
+                >
+                  Votes récents
+                </a>
+              </div>
+            </div>
           </div>
-          {recentVotes.total > 10 && (
-            <p className="text-xs text-gray-mid mt-4 pt-3 border-t border-gray-border">
-              {recentVotes.total.toLocaleString('fr-FR')} votes au total sur ce mandat
-            </p>
+
+          {/* Stats strip */}
+          {stats.length > 0 && (
+            <div style={{ display: 'grid', gridTemplateColumns: `repeat(${stats.length},1fr)`, marginTop: 38, borderTop: `1px solid #ECE7DC` }}>
+              {stats.map((s, i) => (
+                <div key={i} style={{ padding: '22px 14px 18px', borderRight: i < stats.length - 1 ? `1px solid #ECE7DC` : undefined }}>
+                  <div className="font-serif" style={{ fontWeight: 600, fontSize: 34, color: NAVY, letterSpacing: '-0.01em', lineHeight: 1 }}>
+                    {s.value}
+                  </div>
+                  <div style={{ fontSize: 12.5, color: '#6B7280', marginTop: 4, lineHeight: 1.35 }}>
+                    {s.label}
+                  </div>
+                </div>
+              ))}
+            </div>
           )}
         </div>
-      )}
+      </div>
 
-      {/* Ask the AI */}
-      <Link
-        href={`/chat?q=${encodeURIComponent(`Quel est le bilan de ${deputy.full_name} ?`)}`}
-        className="w-full flex items-center justify-center gap-2 border border-navy text-navy rounded-xl py-3.5 text-sm font-medium hover:bg-navy hover:text-white transition-colors"
-      >
-        Poser une question sur ce député
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" />
-        </svg>
-      </Link>
+      {/* Body */}
+      <div style={{ padding: '52px 56px 80px' }}>
+        <div style={{ maxWidth: 1180, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 52 }}>
+
+          {/* Vote breakdown */}
+          {scorecard && (
+            <section>
+              <div style={{ fontWeight: 700, fontSize: 12, letterSpacing: '0.18em', textTransform: 'uppercase', color: RED }}>
+                Bilan de mandat
+              </div>
+              <h2 className="font-serif" style={{ fontWeight: 600, fontSize: 30, color: NAVY, margin: '12px 0 22px', letterSpacing: '-0.01em' }}>
+                Répartition des votes
+              </h2>
+              <div style={{ background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12, overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.05)', padding: '26px 30px' }}>
+
+                {/* Stacked bar */}
+                <div style={{ height: 12, borderRadius: 999, overflow: 'hidden', display: 'flex', marginBottom: 14 }}>
+                  <div style={{ width: `${pourPct}%`,   background: '#1F8A5B', height: '100%', transition: 'width 0.4s' }} />
+                  <div style={{ width: `${contrePct}%`, background: RED,       height: '100%', transition: 'width 0.4s' }} />
+                  <div style={{ width: `${abstPct}%`,   background: '#D1D5DB', height: '100%', transition: 'width 0.4s' }} />
+                  <div style={{ flex: 1,                background: '#EEF0F2', height: '100%' }} />
+                </div>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px 24px', fontSize: 14, color: '#374151' }}>
+                  {[
+                    { color: '#1F8A5B', label: 'Pour',       pct: pourPct   },
+                    { color: RED,       label: 'Contre',     pct: contrePct },
+                    { color: '#9CA3AF', label: 'Abstention', pct: abstPct   },
+                  ].map(({ color, label, pct }) => (
+                    <span key={label} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                      <span style={{ width: 10, height: 10, borderRadius: 999, background: color, flexShrink: 0 }} />
+                      {label} <span style={{ fontFamily: 'monospace', color: '#6B7280' }}>{pct}%</span>
+                    </span>
+                  ))}
+                </div>
+
+                {/* Presence bar */}
+                {presencePct !== null && (
+                  <div style={{ marginTop: 28, paddingTop: 24, borderTop: `1px solid ${LINE}` }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
+                      <span style={{ fontSize: 14, color: '#6B7280', fontWeight: 500 }}>Taux de présence aux votes</span>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                        {avgPresencePct !== null && (
+                          <span style={{ fontSize: 13, color: presencePct >= avgPresencePct ? '#1F8A5B' : RED }}>
+                            {presencePct >= avgPresencePct ? '↑' : '↓'} moy. {avgPresencePct}%
+                          </span>
+                        )}
+                        <span style={{ fontFamily: 'monospace', fontWeight: 700, fontSize: 18, color: NAVY }}>{presencePct}%</span>
+                      </div>
+                    </div>
+                    <div style={{ position: 'relative', height: 9, background: '#EEF0F2', borderRadius: 999, overflow: 'hidden' }}>
+                      <div style={{ height: '100%', background: NAVY, borderRadius: 999, width: `${presencePct}%`, transition: 'width 0.4s' }} />
+                    </div>
+                    {avgPresencePct !== null && (
+                      <div style={{ position: 'relative', height: 0 }}>
+                        <div style={{ position: 'absolute', top: -9, height: 9, width: 2, background: 'rgba(0,0,0,0.25)', left: `${avgPresencePct}%` }} aria-hidden="true" />
+                      </div>
+                    )}
+                    {avgPresencePct !== null && (
+                      <p style={{ fontSize: 11, color: '#9CA3AF', marginTop: 8 }}>
+                        Trait vertical = moyenne nationale ({avgPresencePct}%)
+                      </p>
+                    )}
+                  </div>
+                )}
+              </div>
+            </section>
+          )}
+
+          {/* Votes timeline */}
+          {recentVotes && recentVotes.items.length > 0 && (
+            <section id="votes">
+              <div style={{ fontWeight: 700, fontSize: 12, letterSpacing: '0.18em', textTransform: 'uppercase', color: RED }}>
+                Votes marquants
+              </div>
+              <h2 className="font-serif" style={{ fontWeight: 600, fontSize: 30, color: NAVY, margin: '12px 0 22px', letterSpacing: '-0.01em' }}>
+                Les votes récents de la législature
+              </h2>
+              <div style={{ position: 'relative', paddingLeft: 32 }}>
+                {/* Timeline line */}
+                <div style={{ position: 'absolute', left: 6, top: 8, bottom: 8, width: 2, background: '#E7E2D6', borderRadius: 2 }} />
+
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 28 }}>
+                  {recentVotes.items.map((v: DeputyVoteItem) => {
+                    const pos = POS[v.position as keyof typeof POS] ?? POS.nonVotant
+                    return (
+                      <div key={v.vote_id} style={{ position: 'relative' }}>
+                        {/* Dot */}
+                        <span style={{
+                          position: 'absolute', left: -32, top: 5,
+                          width: 13, height: 13, borderRadius: 999,
+                          background: pos.color,
+                          border: `3px solid ${CREAM}`,
+                          boxShadow: `0 0 0 1px ${pos.color}`,
+                        }} />
+
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap' }}>
+                          {v.voted_at && (
+                            <span style={{ fontFamily: 'monospace', fontSize: 12.5, color: '#9CA3AF', letterSpacing: '0.02em' }}>
+                              {formatDate(v.voted_at)}
+                            </span>
+                          )}
+                          <span style={{
+                            fontSize: 12.5, fontWeight: 700, letterSpacing: '0.04em',
+                            padding: '4px 12px', borderRadius: 999,
+                            color: pos.color, background: pos.bg,
+                          }}>
+                            {pos.label}
+                          </span>
+                          {v.result && (
+                            <span style={{ fontSize: 12, color: '#9CA3AF' }}>
+                              Scrutin : {v.result}
+                            </span>
+                          )}
+                        </div>
+
+                        <Link href={`/votes/${v.vote_id}`} style={{ textDecoration: 'none' }}>
+                          <div className="font-serif" style={{ fontSize: 21, color: NAVY, marginTop: 8, lineHeight: 1.3, cursor: 'pointer' }}>
+                            {v.vote_title}
+                          </div>
+                        </Link>
+
+                        {v.summary_plain && (
+                          <div style={{ fontSize: 14.5, color: '#4B5563', lineHeight: 1.55, marginTop: 5, maxWidth: 680, fontStyle: 'italic' }}>
+                            {v.summary_plain}
+                          </div>
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+
+              {recentVotes.total > 10 && (
+                <p style={{ fontSize: 13, color: '#9CA3AF', marginTop: 28, paddingTop: 20, borderTop: `1px solid ${LINE}` }}>
+                  {recentVotes.total.toLocaleString('fr-FR')} votes au total sur ce mandat
+                </p>
+              )}
+            </section>
+          )}
+
+        </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -77,96 +77,124 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
 
   return (
     <div className="max-w-2xl mx-auto px-4 md:px-8 py-6">
-      <Link href="/deputes" className="text-sm text-gray-mid hover:text-navy mb-6 inline-flex items-center gap-1">
-        ← Tous les députés
+      {/* Back link */}
+      <Link
+        href="/deputes"
+        className="inline-flex items-center gap-1.5 text-xs text-gray-mid hover:text-navy transition-colors mb-6"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <polyline points="15 18 9 12 15 6" />
+        </svg>
+        Annuaire des députés
       </Link>
 
-      {/* Header card */}
-      <div className="bg-white border border-gray-border rounded-xl p-6 mb-4 mt-4">
+      {/* Hero card — navy background */}
+      <div className="bg-navy rounded-2xl p-6 mb-4">
         <div className="flex items-start gap-4">
-          <DeputyAvatar name={deputy.full_name} photoUrl={deputy.photo_url} size="lg" priority />
-          <div className="min-w-0 flex-1">
-            <h1 className="font-serif text-2xl text-navy leading-tight">{deputy.full_name}</h1>
-            <p className="text-sm text-gray-mid mt-0.5">{deputy.department}</p>
+          <div className="ring-2 ring-white/20 rounded-full flex-shrink-0">
+            <DeputyAvatar name={deputy.full_name} photoUrl={deputy.photo_url} size="xl" priority />
+          </div>
+          <div className="min-w-0 flex-1 pt-1">
+            <h1 className="font-serif text-2xl text-white leading-tight">{deputy.full_name}</h1>
+            <p className="text-white/60 text-sm mt-1">{deputy.department}</p>
             {deputy.party && (
-              <span className={`inline-block mt-2 text-xs px-2 py-0.5 rounded font-medium ${partyColor(deputy.party)}`}>
+              <span className="inline-block mt-2 text-xs px-2.5 py-1 rounded-full font-medium bg-white/10 text-white/90 border border-white/20">
                 {deputy.party}
               </span>
             )}
           </div>
-          <ShareButton
-            url={`/deputes/${id}`}
-            title={`${deputy.full_name} — MonÉlu`}
-            text={`Découvrez le bilan de ${deputy.full_name} sur MonÉlu`}
-            ariaLabel={`Partager le profil de ${deputy.full_name}`}
-          />
+          <div className="flex-shrink-0 text-white/70 hover:text-white transition-colors">
+            <ShareButton
+              url={`/deputes/${id}`}
+              title={`${deputy.full_name} — MonÉlu`}
+              text={`Découvrez le bilan de ${deputy.full_name} sur MonÉlu`}
+              ariaLabel={`Partager le profil de ${deputy.full_name}`}
+            />
+          </div>
         </div>
 
-        {/* Plain-language summary */}
+        {/* Presence summary inside hero */}
         {presencePct !== null && avgPresencePct !== null && (
-          <p className="mt-4 text-sm text-navy/70 bg-gray-off rounded-lg px-4 py-2.5 leading-relaxed">
-            {firstName} a participé à{' '}
-            <span className="font-medium text-navy">{presencePct}%</span> des votes —{' '}
-            {aboveAvg === 'above' && (
-              <span className="text-emerald-700 font-medium">au-dessus</span>
-            )}
-            {aboveAvg === 'below' && (
-              <span className="text-red-700 font-medium">en dessous</span>
-            )}
-            {aboveAvg === 'equal' && (
-              <span className="font-medium">dans</span>
-            )}{' '}
-            de la moyenne nationale ({avgPresencePct}%).
-          </p>
+          <div className="mt-5 flex items-center gap-3 bg-white/8 rounded-xl px-4 py-3">
+            <div className="text-2xl font-semibold text-white tabular-nums">{presencePct}%</div>
+            <div className="text-white/60 text-xs leading-snug">
+              de présence aux votes
+              <br />
+              <span className={aboveAvg === 'above' ? 'text-emerald-400' : aboveAvg === 'below' ? 'text-red-400' : 'text-white/50'}>
+                {aboveAvg === 'above' && `↑ +${presencePct - avgPresencePct} pts vs. moy. nationale`}
+                {aboveAvg === 'below' && `↓ −${avgPresencePct - presencePct} pts vs. moy. nationale`}
+                {aboveAvg === 'equal' && `= dans la moyenne nationale`}
+              </span>
+            </div>
+          </div>
         )}
       </div>
 
+      {/* Plain-language summary */}
+      {presencePct !== null && avgPresencePct !== null && (
+        <div className="border-l-2 border-navy bg-gray-off rounded-r-xl px-4 py-3 mb-4 text-sm text-navy/70 leading-relaxed">
+          {firstName} a participé à{' '}
+          <span className="font-medium text-navy">{presencePct}%</span> des votes —{' '}
+          {aboveAvg === 'above' && <span className="text-emerald-700 font-medium">au-dessus</span>}
+          {aboveAvg === 'below' && <span className="text-red-700 font-medium">en dessous</span>}
+          {aboveAvg === 'equal' && <span className="font-medium">dans</span>}{' '}
+          de la moyenne nationale ({avgPresencePct}%).
+        </div>
+      )}
+
       {/* Scorecard */}
       {scorecard && (
-        <div className="bg-white border border-gray-border rounded-xl p-6 mb-4">
+        <div className="bg-white border border-gray-border rounded-2xl p-6 mb-4">
           <h2 className="font-serif text-xl text-navy mb-5">Bilan de mandat</h2>
 
-          {/* Presence */}
-          <div className="mb-5">
-            <div className="flex justify-between text-sm mb-1.5">
+          {/* Presence bar */}
+          <div className="mb-6">
+            <div className="flex justify-between items-center text-sm mb-2">
               <span className="text-gray-mid font-medium">Taux de présence</span>
               <div className="flex items-center gap-2">
                 {avgPresencePct !== null && aboveAvg && (
-                  <span className={`text-xs font-medium ${aboveAvg === 'above' ? 'text-emerald-700' : aboveAvg === 'below' ? 'text-red-700' : 'text-gray-mid'}`}
-                    aria-label={`${aboveAvg === 'above' ? 'Au-dessus' : aboveAvg === 'below' ? 'En dessous' : 'Dans'} de la moyenne nationale (${avgPresencePct}%)`}>
+                  <span
+                    className={`text-xs font-medium ${aboveAvg === 'above' ? 'text-emerald-700' : aboveAvg === 'below' ? 'text-red-700' : 'text-gray-mid'}`}
+                    aria-label={`${aboveAvg === 'above' ? 'Au-dessus' : aboveAvg === 'below' ? 'En dessous' : 'Dans'} de la moyenne nationale (${avgPresencePct}%)`}
+                  >
                     {aboveAvg === 'above' ? '↑' : aboveAvg === 'below' ? '↓' : '≈'} moy. {avgPresencePct}%
                   </span>
                 )}
-                <span className="font-medium text-navy">{presencePct}%</span>
+                <span className="font-semibold text-navy tabular-nums">{presencePct}%</span>
               </div>
             </div>
-            <div className="relative h-2 bg-gray-light rounded-full">
-              <div className="h-full bg-navy rounded-full transition-all"
-                style={{ width: `${presencePct}%` }} />
-              {avgPresencePct !== null && (
+            <div className="relative h-2.5 bg-gray-light rounded-full overflow-hidden">
+              <div
+                className="h-full bg-navy rounded-full transition-all"
+                style={{ width: `${presencePct}%` }}
+              />
+            </div>
+            {avgPresencePct !== null && (
+              <div className="relative h-0" style={{ marginTop: '-10px' }}>
                 <div
-                  className="absolute top-0 h-full w-0.5 bg-gray-mid/60"
+                  className="absolute top-0 h-2.5 w-0.5 bg-gray-mid/50"
                   style={{ left: `${avgPresencePct}%` }}
                   aria-hidden="true"
                 />
-              )}
-            </div>
+              </div>
+            )}
             {avgPresencePct !== null && (
-              <p className="text-[11px] text-gray-mid mt-1">
+              <p className="text-[11px] text-gray-mid mt-2">
                 Trait vertical = moyenne nationale ({avgPresencePct}%)
               </p>
             )}
           </div>
 
           {/* Vote breakdown */}
-          <div className="mb-5">
-            <p className="text-sm text-gray-mid font-medium mb-2">Répartition des votes</p>
+          <div className="mb-6">
+            <p className="text-sm text-gray-mid font-medium mb-2">Répartition des votes exprimés</p>
             <div className="h-3 rounded-full overflow-hidden flex">
-              <div className="bg-emerald-500 h-full" style={{ width: `${pourPct}%` }} />
-              <div className="bg-red-civic h-full" style={{ width: `${contrePct}%` }} />
+              <div className="bg-emerald-500 h-full transition-all" style={{ width: `${pourPct}%` }} />
+              <div className="bg-red-civic h-full transition-all" style={{ width: `${contrePct}%` }} />
+              <div className="bg-amber-300 h-full transition-all" style={{ width: `${abstPct}%` }} />
               <div className="bg-gray-light h-full flex-1" />
             </div>
-            <div className="flex gap-4 mt-2 text-xs text-gray-mid">
+            <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2 text-xs text-gray-mid">
               <span className="flex items-center gap-1.5">
                 <span className="w-2 h-2 rounded-full bg-emerald-500 inline-block" aria-hidden="true" />
                 Pour {pourPct}%
@@ -176,7 +204,7 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                 Contre {contrePct}%
               </span>
               <span className="flex items-center gap-1.5">
-                <span className="w-2 h-2 rounded-full bg-gray-light inline-block border border-gray-border" aria-hidden="true" />
+                <span className="w-2 h-2 rounded-full bg-amber-300 inline-block" aria-hidden="true" />
                 Abstention {abstPct}%
               </span>
             </div>
@@ -185,13 +213,13 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
           {/* Stats grid */}
           <div className="grid grid-cols-3 gap-3">
             {[
-              { label: 'Votes exprimés', value: (scorecard.total_votes ?? 0).toLocaleString('fr-FR') },
-              { label: 'Pour',           value: (scorecard.votes_for   ?? 0).toLocaleString('fr-FR') },
-              { label: 'Contre',         value: (scorecard.votes_against ?? 0).toLocaleString('fr-FR') },
+              { label: 'Votes exprimés', value: (scorecard.total_votes ?? 0).toLocaleString('fr-FR'), accent: false },
+              { label: 'Pour',           value: (scorecard.votes_for   ?? 0).toLocaleString('fr-FR'), accent: false },
+              { label: 'Contre',         value: (scorecard.votes_against ?? 0).toLocaleString('fr-FR'), accent: false },
             ].map(({ label, value }) => (
-              <div key={label} className="bg-gray-off rounded-lg p-3 text-center">
-                <div className="text-lg font-medium text-navy">{value}</div>
-                <div className="text-xs text-gray-mid mt-0.5">{label}</div>
+              <div key={label} className="bg-gray-off rounded-xl p-3 text-center">
+                <div className="text-lg font-semibold text-navy tabular-nums">{value}</div>
+                <div className="text-[11px] text-gray-mid mt-0.5 leading-tight">{label}</div>
               </div>
             ))}
           </div>
@@ -200,15 +228,21 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
 
       {/* Recent votes */}
       {recentVotes && recentVotes.items.length > 0 && (
-        <div className="bg-white border border-gray-border rounded-xl p-6 mb-4">
+        <div className="bg-white border border-gray-border rounded-2xl p-6 mb-4">
           <h2 className="font-serif text-xl text-navy mb-4">Votes récents</h2>
           <div className="flex flex-col divide-y divide-gray-border">
             {recentVotes.items.map((v: DeputyVoteItem) => (
               <Link
                 key={v.vote_id}
                 href={`/votes/${v.vote_id}`}
-                className="flex items-start gap-3 py-3 first:pt-0 last:pb-0 hover:bg-gray-off -mx-2 px-2 rounded transition-colors"
+                className="flex items-start gap-3 py-3.5 first:pt-0 last:pb-0 hover:bg-gray-off -mx-2 px-2 rounded transition-colors"
               >
+                <span
+                  className={`text-xs px-2 py-0.5 rounded font-medium shrink-0 mt-0.5 ${POSITION_CLASS[v.position] ?? 'bg-gray-100 text-gray-500'}`}
+                  aria-label={`Position : ${POSITION_LABEL[v.position] ?? v.position}`}
+                >
+                  {POSITION_LABEL[v.position] ?? v.position}
+                </span>
                 <div className="flex-1 min-w-0">
                   <p className="text-sm text-navy line-clamp-2 leading-snug">{v.vote_title}</p>
                   {v.summary_plain && (
@@ -217,19 +251,21 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                       {v.summary_plain}
                     </p>
                   )}
-                  <p className="text-xs text-gray-mid mt-0.5">{v.voted_at ? formatDate(v.voted_at) : ''}</p>
+                  <p className="text-[11px] text-gray-mid mt-1">{v.voted_at ? formatDate(v.voted_at) : ''}</p>
                 </div>
-                <span
-                  className={`text-xs px-2 py-0.5 rounded font-medium shrink-0 mt-0.5 ${POSITION_CLASS[v.position] ?? 'bg-gray-100 text-gray-500'}`}
-                  aria-label={`Position : ${POSITION_LABEL[v.position] ?? v.position}`}
+                <svg
+                  className="text-gray-border flex-shrink-0 mt-1"
+                  width="14" height="14" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+                  aria-hidden="true"
                 >
-                  {POSITION_LABEL[v.position] ?? v.position}
-                </span>
+                  <polyline points="9 18 15 12 9 6" />
+                </svg>
               </Link>
             ))}
           </div>
           {recentVotes.total > 10 && (
-            <p className="text-xs text-gray-mid mt-4">
+            <p className="text-xs text-gray-mid mt-4 pt-3 border-t border-gray-border">
               {recentVotes.total.toLocaleString('fr-FR')} votes au total sur ce mandat
             </p>
           )}
@@ -239,8 +275,12 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
       {/* Ask the AI */}
       <Link
         href={`/chat?q=${encodeURIComponent(`Quel est le bilan de ${deputy.full_name} ?`)}`}
-        className="w-full flex items-center justify-center gap-2 border border-navy text-navy rounded-xl py-3 text-sm font-medium hover:bg-navy hover:text-white transition-colors">
-        Poser une question sur ce député →
+        className="w-full flex items-center justify-center gap-2 border border-navy text-navy rounded-xl py-3.5 text-sm font-medium hover:bg-navy hover:text-white transition-colors"
+      >
+        Poser une question sur ce député
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" />
+        </svg>
       </Link>
     </div>
   )

--- a/frontend/src/app/deputes/page.tsx
+++ b/frontend/src/app/deputes/page.tsx
@@ -24,9 +24,15 @@ async function fetchAllDeputies() {
 export default async function DeputiesPage() {
   const initial = await fetchAllDeputies()
   return (
-    <div className="max-w-4xl mx-auto px-4 md:px-8 py-6">
-      <h1 className="font-serif text-3xl text-navy mb-2">Les députés</h1>
-      <p className="text-gray-mid text-sm mb-6">Assemblée Nationale · 17ème législature</p>
+    <div className="max-w-5xl mx-auto px-4 md:px-8 py-8">
+      <div className="mb-8">
+        <h1 className="font-serif text-display-sm md:text-display text-navy leading-tight">
+          Annuaire des députés
+        </h1>
+        <p className="text-gray-mid text-sm mt-2">
+          {initial.total} député·e·s · Assemblée Nationale · 17<sup>ème</sup> législature
+        </p>
+      </div>
       <Suspense fallback={<div className="text-gray-mid text-sm">Chargement...</div>}>
         <DeputiesClient initial={initial} />
       </Suspense>

--- a/frontend/src/app/deputes/page.tsx
+++ b/frontend/src/app/deputes/page.tsx
@@ -24,18 +24,8 @@ async function fetchAllDeputies() {
 export default async function DeputiesPage() {
   const initial = await fetchAllDeputies()
   return (
-    <div className="max-w-5xl mx-auto px-4 md:px-8 py-8">
-      <div className="mb-8">
-        <h1 className="font-serif text-display-sm md:text-display text-navy leading-tight">
-          Annuaire des députés
-        </h1>
-        <p className="text-gray-mid text-sm mt-2">
-          {initial.total} député·e·s · Assemblée Nationale · 17<sup>ème</sup> législature
-        </p>
-      </div>
-      <Suspense fallback={<div className="text-gray-mid text-sm">Chargement...</div>}>
-        <DeputiesClient initial={initial} />
-      </Suspense>
-    </div>
+    <Suspense fallback={<div className="min-h-screen bg-[#F7F4ED]" />}>
+      <DeputiesClient initial={initial} />
+    </Suspense>
   )
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from 'next'
-import { DM_Serif_Display, DM_Sans } from 'next/font/google'
+import { DM_Serif_Display, DM_Sans, Newsreader } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/react'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import './globals.css'
@@ -11,6 +11,14 @@ const serif = DM_Serif_Display({
   weight: '400',
   style: ['normal', 'italic'],
   variable: '--font-serif',
+  display: 'swap',
+})
+
+const newsreader = Newsreader({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
+  style: ['normal', 'italic'],
+  variable: '--font-newsreader',
   display: 'swap',
 })
 
@@ -50,7 +58,7 @@ export const viewport: Viewport = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="fr" className={`${serif.variable} ${sans.variable}`}>
+    <html lang="fr" className={`${serif.variable} ${sans.variable} ${newsreader.variable}`}>
       <body className="bg-gray-off min-h-screen">
         <Nav />
         <main className="pb-20 md:pb-0">{children}</main>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { SpeedInsights } from '@vercel/speed-insights/next'
 import './globals.css'
 import { Nav } from '@/components/Nav'
 import { BottomNav } from '@/components/BottomNav'
+import { PageTransition } from '@/components/PageTransition'
 
 const serif = DM_Serif_Display({
   subsets: ['latin'],
@@ -61,7 +62,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="fr" className={`${serif.variable} ${sans.variable} ${newsreader.variable}`}>
       <body className="bg-gray-off min-h-screen">
         <Nav />
-        <main className="pb-20 md:pb-0">{children}</main>
+        <main className="pb-20 md:pb-0"><PageTransition>{children}</PageTransition></main>
         <BottomNav />
         <Analytics />
         <SpeedInsights />

--- a/frontend/src/app/votes/VotesClient.tsx
+++ b/frontend/src/app/votes/VotesClient.tsx
@@ -205,7 +205,7 @@ export function VotesClient({ initial, heroStats }: { initial: VoteList; heroSta
                     onMouseLeave={e => (e.currentTarget.style.background = '#fff')}>
 
                     {/* Date */}
-                    <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 12, color: '#9CA3AF', lineHeight: 1.4 }}>
+                    <div suppressHydrationWarning style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 12, color: '#9CA3AF', lineHeight: 1.4 }}>
                       {shortDate(vote.voted_at)}
                     </div>
 

--- a/frontend/src/app/votes/VotesClient.tsx
+++ b/frontend/src/app/votes/VotesClient.tsx
@@ -4,9 +4,10 @@ import { useSearchParams, useRouter } from 'next/navigation'
 import useSWR from 'swr'
 import Link from 'next/link'
 import { api, Vote } from '@/lib/api'
-import { formatDate } from '@/lib/utils'
+import { formatDate, themeColors } from '@/lib/utils'
 
 type VoteList = { total: number; items: Vote[]; limit: number; offset: number }
+type HeroStat = { value: string; label: string }
 
 const THEMES = [
   'Économie & Budget',
@@ -21,159 +22,265 @@ const THEMES = [
   'Autre',
 ]
 
-export function VotesClient({ initial }: { initial: VoteList }) {
+const PAGE_SIZE = 50
+
+function shortDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString('fr-FR', { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+function buildPageNumbers(current: number, total: number): (number | '…')[] {
+  if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1)
+  const pages: (number | '…')[] = []
+  pages.push(1)
+  if (current > 3) pages.push('…')
+  for (let p = Math.max(2, current - 1); p <= Math.min(total - 1, current + 1); p++) pages.push(p)
+  if (current < total - 2) pages.push('…')
+  pages.push(total)
+  return pages
+}
+
+export function VotesClient({ initial, heroStats }: { initial: VoteList; heroStats: HeroStat[] }) {
   const router = useRouter()
   const searchParams = useSearchParams()
 
   const [result, setResult] = useState(() => searchParams.get('result') ?? '')
-  const [theme,  setTheme]  = useState(() => searchParams.get('theme')  ?? '')
-  const [offset, setOffset] = useState(0)
+  const [theme, setTheme]   = useState(() => searchParams.get('theme')  ?? '')
+  const [search, setSearch] = useState('')
+  const [inputVal, setInputVal] = useState('')
+  const [page, setPage]     = useState(1)
 
-  // Sync state → URL
+  const offset = (page - 1) * PAGE_SIZE
+
   const skipFirstSync = useRef(true)
   useEffect(() => {
     if (skipFirstSync.current) { skipFirstSync.current = false; return }
     const p = new URLSearchParams()
     if (result) p.set('result', result)
-    if (theme)  p.set('theme',  theme)
+    if (theme)  p.set('theme', theme)
     const qs = p.toString()
     router.replace(`/votes${qs ? `?${qs}` : ''}`, { scroll: false })
   }, [result, theme, router])
 
   const { data, isLoading } = useSWR(
     `votes:${result}:${theme}:${offset}`,
-    () => api.votes.list({ result: result || undefined, theme: theme || undefined, limit: 50, offset }),
+    () => api.votes.list({ result: result || undefined, theme: theme || undefined, limit: PAGE_SIZE, offset }),
     { keepPreviousData: true }
   )
 
-  const votes = data?.items ?? initial.items
-  const total = data?.total ?? initial.total
+  const rawVotes = data?.items ?? initial.items
+  const total    = data?.total  ?? initial.total
+
+  const votes = search
+    ? rawVotes.filter(v => v.vote_title.toLowerCase().includes(search.toLowerCase()))
+    : rawVotes
+
+  const totalPages = Math.ceil(total / PAGE_SIZE)
 
   function changeFilter(newResult: string, newTheme: string) {
     setResult(newResult)
     setTheme(newTheme)
-    setOffset(0)
+    setPage(1)
+    setSearch('')
+    setInputVal('')
+  }
+
+  function handleSearch() {
+    setSearch(inputVal)
+    setPage(1)
   }
 
   return (
-    <div>
-      {/* Result filter pills */}
-      <div className="flex gap-2 mb-3 flex-wrap">
-        {(['', 'adopté', 'rejeté'] as const).map((r) => (
-          <button key={r}
-            onClick={() => changeFilter(r, theme)}
-            className={`px-4 py-2 rounded-full text-sm font-medium border transition-colors
-              ${result === r
-                ? 'bg-navy text-white border-navy'
-                : 'bg-white text-gray-mid border-gray-border hover:border-navy/40'}`}>
-            {r === '' ? 'Tous' : r.charAt(0).toUpperCase() + r.slice(1)}
-          </button>
-        ))}
+    <div style={{ background: '#F7F4ED', minHeight: '100vh' }}>
+
+      {/* ── Hero ── */}
+      <div style={{ padding: '50px 56px 40px', background: 'linear-gradient(180deg,#fff 0%,#F7F4ED 100%)', borderBottom: '1px solid #ECE7DC' }}>
+        <div style={{ maxWidth: 1180, margin: '0 auto' }}>
+
+          <div style={{ font: '700 12px/1 var(--font-sans)', letterSpacing: '0.18em', textTransform: 'uppercase', color: '#C9302A' }}>
+            Scrutins publics
+          </div>
+
+          <h1 className="font-newsreader" style={{ fontWeight: 600, fontSize: 48, lineHeight: 1.05, letterSpacing: '-0.015em', color: '#1B2B50', margin: '16px 0 0', maxWidth: 760 }}>
+            Les votes de l&apos;Assemblée nationale, <span style={{ color: '#C9302A' }}>en clair</span>.
+          </h1>
+
+          <p style={{ margin: '16px 0 0', fontSize: 17, lineHeight: 1.6, color: '#4B5563', maxWidth: 540 }}>
+            Retrouvez chaque scrutin public de la XVII&#7497; législature — texte voté, résultat, et ventilation par groupe.
+          </p>
+
+          {/* Stats strip */}
+          <div style={{ display: 'flex', gap: 0, marginTop: 32, border: '1px solid #ECE7DC', borderRadius: 12, background: '#fff', overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.05)', maxWidth: 700 }}>
+            {heroStats.map((hs, i) => (
+              <div key={i} style={{ flex: 1, padding: '18px 22px', borderRight: i < heroStats.length - 1 ? '1px solid #ECE7DC' : 'none' }}>
+                <div className="font-newsreader" style={{ fontWeight: 600, fontSize: 30, color: '#1B2B50', letterSpacing: '-0.01em' }}>{hs.value}</div>
+                <div style={{ fontSize: 12, color: '#9CA3AF', marginTop: 4, lineHeight: 1.35 }}>{hs.label}</div>
+              </div>
+            ))}
+          </div>
+
+          {/* Search bar */}
+          <div style={{ display: 'flex', gap: 12, marginTop: 28, maxWidth: 720 }}>
+            <div style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 12, background: '#fff', border: '1px solid #E4E6EA', borderRadius: 10, padding: '0 18px', height: 54, boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#9CA3AF" strokeWidth="2" strokeLinecap="round"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.2-3.2"/></svg>
+              <input
+                type="text"
+                value={inputVal}
+                onChange={e => setInputVal(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && handleSearch()}
+                placeholder="Titre du scrutin, numéro, mot-clé…"
+                style={{ flex: 1, border: 'none', outline: 'none', fontSize: 16, color: '#1B2B50', background: 'transparent' }}
+              />
+            </div>
+            <button
+              onClick={handleSearch}
+              style={{ display: 'flex', alignItems: 'center', background: '#E0786E', color: '#fff', height: 54, padding: '0 28px', borderRadius: 10, fontWeight: 600, fontSize: 16, cursor: 'pointer', whiteSpace: 'nowrap', border: 'none', boxShadow: '0 2px 8px rgba(224,120,110,0.4)' }}>
+              Rechercher
+            </button>
+          </div>
+
+          {/* Filter chips */}
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 9, marginTop: 18, alignItems: 'center' }}>
+            {(['', 'adopté', 'rejeté'] as const).map((r) => {
+              const label = r === '' ? 'Tous les scrutins' : r === 'adopté' ? 'Adoptés' : 'Rejetés'
+              const active = result === r && theme === ''
+              return (
+                <button key={r} onClick={() => changeFilter(r, '')}
+                  style={{ background: active ? '#1B2B50' : '#fff', color: active ? '#fff' : '#4B5563', border: `1px solid ${active ? '#1B2B50' : '#E4E6EA'}`, padding: '8px 16px', borderRadius: 999, fontSize: 13.5, fontWeight: active ? 600 : 400, cursor: 'pointer' }}>
+                  {label}
+                </button>
+              )
+            })}
+            {THEMES.map((t) => {
+              const active = theme === t
+              return (
+                <button key={t} onClick={() => changeFilter(result, active ? '' : t)}
+                  style={{ background: active ? '#1B2B50' : '#fff', color: active ? '#fff' : '#4B5563', border: `1px solid ${active ? '#1B2B50' : '#E4E6EA'}`, padding: '8px 16px', borderRadius: 999, fontSize: 13.5, fontWeight: active ? 600 : 400, cursor: 'pointer' }}>
+                  {t.split(' & ')[0]}
+                </button>
+              )
+            })}
+          </div>
+        </div>
       </div>
 
-      {/* Theme filter chips */}
-      <div className="flex gap-1.5 mb-5 flex-wrap">
-        <button
-          onClick={() => changeFilter(result, '')}
-          className={`px-3 py-1 rounded-full text-xs font-medium border transition-colors
-            ${theme === ''
-              ? 'bg-navy text-white border-navy'
-              : 'bg-white text-gray-mid border-gray-border hover:border-navy/40'}`}>
-          Tous les thèmes
-        </button>
-        {THEMES.map((t) => (
-          <button key={t}
-            onClick={() => changeFilter(result, t)}
-            className={`px-3 py-1 rounded-full text-xs font-medium border transition-colors
-              ${theme === t
-                ? 'bg-navy text-white border-navy'
-                : 'bg-white text-gray-mid border-gray-border hover:border-navy/40'}`}>
-            {t}
-          </button>
-        ))}
+      {/* ── Table ── */}
+      <div style={{ padding: '32px 56px 72px' }}>
+        <div style={{ maxWidth: 1180, margin: '0 auto' }}>
+
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 4px 14px' }}>
+            <span style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 13, color: '#6B7280' }}>
+              {total.toLocaleString('fr-FR')} scrutins
+              {result && ` · ${result.charAt(0).toUpperCase() + result.slice(1)}s`}
+              {theme && ` · ${theme}`}
+              {' · triés par date'}
+            </span>
+            {(result || theme || search) && (
+              <button onClick={() => changeFilter('', '')} style={{ fontSize: 13, color: '#C9302A', background: 'none', border: 'none', cursor: 'pointer' }}>
+                Effacer les filtres
+              </button>
+            )}
+          </div>
+
+          <div style={{ background: '#fff', border: '1px solid #E4E6EA', borderRadius: 12, overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.06)' }}>
+            {/* Table header */}
+            <div style={{ display: 'grid', gridTemplateColumns: '100px 1fr 180px 260px 36px', gap: 16, padding: '13px 26px', borderBottom: '1px solid #E4E6EA', background: '#FBFAF6', font: '600 11.5px/1 var(--font-sans)', letterSpacing: '0.08em', textTransform: 'uppercase', color: '#9CA3AF' }}>
+              <span>Date</span><span>Scrutin</span><span>Thème</span><span>Résultat</span><span></span>
+            </div>
+
+            {isLoading ? (
+              <div style={{ padding: '32px 0', textAlign: 'center', color: '#9CA3AF', fontSize: 14 }}>Chargement…</div>
+            ) : votes.length === 0 ? (
+              <div style={{ padding: '40px 26px', textAlign: 'center', color: '#9CA3AF', fontSize: 14 }}>Aucun scrutin trouvé.</div>
+            ) : (
+              votes.map((vote) => {
+                const total_v = vote.total_voters || 1
+                const forPct  = Math.round(vote.votes_for     / total_v * 100)
+                const agtPct  = Math.round(vote.votes_against / total_v * 100)
+                const tc = themeColors(vote.theme ?? null)
+                const adopted = vote.result === 'adopté'
+                return (
+                  <Link key={vote.vote_id} href={`/votes/${vote.vote_id}`}
+                    style={{ display: 'grid', gridTemplateColumns: '100px 1fr 180px 260px 36px', gap: 16, padding: '18px 26px', borderBottom: '1px solid #F0F1F3', alignItems: 'center', textDecoration: 'none', background: '#fff', transition: 'background 0.12s' }}
+                    onMouseEnter={e => (e.currentTarget.style.background = '#FBFAF6')}
+                    onMouseLeave={e => (e.currentTarget.style.background = '#fff')}>
+
+                    {/* Date */}
+                    <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 12, color: '#9CA3AF', lineHeight: 1.4 }}>
+                      {shortDate(vote.voted_at)}
+                    </div>
+
+                    {/* Title */}
+                    <div style={{ minWidth: 0 }}>
+                      <div style={{ fontWeight: 600, fontSize: 15, color: '#1B2B50', lineHeight: 1.3 }}
+                        className="line-clamp-2">
+                        {vote.vote_title}
+                      </div>
+                      <div style={{ fontSize: 12.5, color: '#9CA3AF', marginTop: 4 }}>
+                        Scrutin n°{vote.vote_id}
+                      </div>
+                    </div>
+
+                    {/* Theme */}
+                    <div>
+                      {vote.theme ? (
+                        <span style={{ display: 'inline-flex', alignItems: 'center', fontSize: 12, fontWeight: 600, padding: '5px 12px', borderRadius: 999, background: tc.bg, color: tc.c }}>
+                          {vote.theme.split(' & ')[0]}
+                        </span>
+                      ) : (
+                        <span style={{ color: '#D1D5DB', fontSize: 12 }}>—</span>
+                      )}
+                    </div>
+
+                    {/* Result */}
+                    <div>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 7 }}>
+                        <span style={{ fontSize: 12, fontWeight: 700, letterSpacing: '0.05em', padding: '3px 10px', borderRadius: 999, background: adopted ? '#EAF5EF' : '#FBE9E7', color: adopted ? '#1F8A5B' : '#C9302A' }}>
+                          {adopted ? 'Adopté' : 'Rejeté'}
+                        </span>
+                        <span style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 11.5, color: '#6B7280' }}>
+                          {vote.votes_for} pour · {vote.votes_against} contre
+                        </span>
+                      </div>
+                      <div style={{ display: 'flex', height: 5, borderRadius: 999, overflow: 'hidden', background: '#F0F1F3' }}>
+                        <div style={{ height: '100%', background: '#1F8A5B', width: `${forPct}%` }} />
+                        <div style={{ height: '100%', background: '#D9685E', width: `${agtPct}%` }} />
+                        <div style={{ height: '100%', background: '#D1D5DB', flex: 1 }} />
+                      </div>
+                    </div>
+
+                    {/* Chevron */}
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#C4C9D2" strokeWidth="2.2" strokeLinecap="round"><path d="m9 6 6 6-6 6"/></svg>
+                  </Link>
+                )
+              })
+            )}
+          </div>
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 6, marginTop: 26, fontSize: 14, color: '#6B7280' }}>
+              <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}
+                style={{ width: 34, height: 34, display: 'flex', alignItems: 'center', justifyContent: 'center', border: '1px solid #E4E6EA', borderRadius: 8, background: '#fff', cursor: page === 1 ? 'default' : 'pointer', opacity: page === 1 ? 0.4 : 1 }}>
+                ‹
+              </button>
+              {buildPageNumbers(page, totalPages).map((p, i) =>
+                p === '…' ? (
+                  <span key={`ellipsis-${i}`} style={{ padding: '0 6px' }}>…</span>
+                ) : (
+                  <button key={p} onClick={() => setPage(p as number)}
+                    style={{ width: 34, height: 34, display: 'flex', alignItems: 'center', justifyContent: 'center', borderRadius: 8, background: page === p ? '#1B2B50' : '#fff', color: page === p ? '#fff' : '#6B7280', border: page === p ? 'none' : '1px solid #E4E6EA', fontWeight: page === p ? 600 : 400, cursor: 'pointer' }}>
+                    {p}
+                  </button>
+                )
+              )}
+              <button onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page === totalPages}
+                style={{ width: 34, height: 34, display: 'flex', alignItems: 'center', justifyContent: 'center', border: '1px solid #E4E6EA', borderRadius: 8, background: '#fff', cursor: page === totalPages ? 'default' : 'pointer', opacity: page === totalPages ? 0.4 : 1 }}>
+                ›
+              </button>
+            </div>
+          )}
+        </div>
       </div>
-
-      {/* Count + clear */}
-      <div className="flex items-center justify-between mb-4">
-        <p className="text-xs text-gray-mid">
-          {total} vote{total !== 1 ? 's' : ''}
-          {result && ` · ${result.charAt(0).toUpperCase() + result.slice(1)}`}
-          {theme  && ` · ${theme}`}
-        </p>
-        {(result || theme) && (
-          <button onClick={() => changeFilter('', '')} className="text-xs text-red-civic hover:underline">
-            Effacer les filtres
-          </button>
-        )}
-      </div>
-
-      {/* List */}
-      {isLoading ? (
-        <div className="flex flex-col gap-3">
-          {[...Array(5)].map((_, i) => (
-            <div key={i} className="h-24 bg-gray-light rounded-lg animate-pulse" />
-          ))}
-        </div>
-      ) : (
-        <div className="flex flex-col gap-3">
-          {votes.map((vote) => (
-            <Link key={vote.vote_id} href={`/votes/${vote.vote_id}`}
-              className="bg-white rounded-lg border border-gray-border p-4 hover:border-navy/30 transition-colors">
-              <div className="flex items-start justify-between gap-3">
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-navy line-clamp-2 leading-snug">
-                    {vote.vote_title}
-                  </p>
-                  {vote.summary_plain && (
-                    <p className="text-xs text-gray-mid mt-1 line-clamp-2 italic">
-                      <span className="text-red-civic font-medium not-italic">En clair</span>{' '}
-                      {vote.summary_plain}
-                    </p>
-                  )}
-                  <p className="text-xs text-gray-mid mt-1">{formatDate(vote.voted_at)}</p>
-                </div>
-                <div className="flex flex-col items-end gap-1 shrink-0">
-                  <span className={vote.result === 'adopté' ? 'badge-adopte' : 'badge-rejete'}>
-                    {vote.result}
-                  </span>
-                  {vote.theme && (
-                    <span className="text-[10px] text-gray-mid bg-gray-off rounded px-1.5 py-0.5 whitespace-nowrap">
-                      {vote.theme}
-                    </span>
-                  )}
-                </div>
-              </div>
-              <div className="mt-3 h-1.5 rounded-full bg-gray-light overflow-hidden">
-                <div className="h-full bg-emerald-500 rounded-full"
-                  style={{ width: `${Math.round(vote.votes_for / (vote.total_voters || 1) * 100)}%` }} />
-              </div>
-              <div className="flex justify-between text-xs text-gray-mid mt-1">
-                <span>{vote.votes_for} pour</span>
-                <span>{vote.votes_against} contre · {vote.abstentions} abst.</span>
-              </div>
-            </Link>
-          ))}
-        </div>
-      )}
-
-      {/* Pagination */}
-      {total > 50 && (
-        <div className="flex justify-center gap-3 mt-8">
-          <button onClick={() => setOffset(Math.max(0, offset - 50))}
-            disabled={offset === 0 || isLoading}
-            className="px-4 py-2 text-sm border border-gray-border rounded disabled:opacity-40">
-            ← Précédent
-          </button>
-          <span className="px-4 py-2 text-sm text-gray-mid">
-            {offset + 1}–{Math.min(offset + 50, total)} sur {total}
-          </span>
-          <button onClick={() => setOffset(offset + 50)}
-            disabled={offset + 50 >= total || isLoading}
-            className="px-4 py-2 text-sm border border-gray-border rounded disabled:opacity-40">
-            Suivant →
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/frontend/src/app/votes/[id]/VoteDetailClient.tsx
+++ b/frontend/src/app/votes/[id]/VoteDetailClient.tsx
@@ -134,7 +134,7 @@ export function VoteDetailClient(props: Props) {
                   Scrutin public · n°{voteId}
                 </span>
                 <span style={{ fontFamily: 'monospace', fontSize: 11.5, color: '#9CA3AF' }}>·</span>
-                <span style={{ fontFamily: 'monospace', fontSize: 12, color: '#9CA3AF' }}>{shortDate(votedAt)}</span>
+                <span suppressHydrationWarning style={{ fontFamily: 'monospace', fontSize: 12, color: '#9CA3AF' }}>{shortDate(votedAt)}</span>
               </div>
 
               <h1 className="font-newsreader" style={{ fontWeight: 600, fontSize: 44, lineHeight: 1.05, letterSpacing: '-0.015em', color: '#1B2B50', margin: 0, maxWidth: 620 }}>
@@ -312,7 +312,7 @@ export function VoteDetailClient(props: Props) {
                           {r.vote_title}
                         </div>
                         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 7 }}>
-                          <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#9CA3AF' }}>
+                          <span suppressHydrationWarning style={{ fontFamily: 'monospace', fontSize: 11, color: '#9CA3AF' }}>
                             {new Date(r.voted_at).toLocaleDateString('fr-FR', { day: 'numeric', month: 'short', year: 'numeric' })}
                           </span>
                           <span style={{ fontSize: 11.5, fontWeight: 600, padding: '3px 9px', borderRadius: 999, color: rAdopted ? '#1F8A5B' : '#C9302A', background: rAdopted ? '#EAF5EF' : '#FBE9E7' }}>
@@ -346,7 +346,7 @@ export function VoteDetailClient(props: Props) {
             {/* Freshness */}
             <div style={{ fontSize: 12, color: '#9CA3AF', lineHeight: 1.6, padding: '0 2px' }}>
               Données issues du flux officiel de l&apos;Assemblée nationale.<br />
-              Dernière mise à jour : <span style={{ color: '#6B7280', fontWeight: 600 }}>{shortDate(votedAt)}</span>
+              Dernière mise à jour : <span suppressHydrationWarning style={{ color: '#6B7280', fontWeight: 600 }}>{shortDate(votedAt)}</span>
             </div>
           </div>
         </div>

--- a/frontend/src/app/votes/[id]/VoteDetailClient.tsx
+++ b/frontend/src/app/votes/[id]/VoteDetailClient.tsx
@@ -1,0 +1,356 @@
+'use client'
+import { useState, useRef, useCallback } from 'react'
+import Link from 'next/link'
+
+interface GroupRow {
+  name: string
+  color: string
+  pour: number
+  contre: number
+  abst: number
+  nonVotant: number
+  position: 'Pour' | 'Contre' | 'Partagé'
+  forPct: number
+  agtPct: number
+}
+
+interface Dissident {
+  deputy_id: string
+  full_name: string
+  initials: string
+  party: string
+  avatarColor: string
+  vote: string
+  note: string
+}
+
+interface RelatedVote {
+  vote_id: string
+  vote_title: string
+  voted_at: string
+  result: string
+}
+
+interface Props {
+  voteId: string
+  voteTitle: string
+  result: string
+  votedAt: string
+  summary: string | null
+  theme: string | null
+  votesFor: number
+  votesAgainst: number
+  abstentions: number
+  totalVoters: number
+  pourPct: number
+  contrePct: number
+  abstPct: number
+  groups: GroupRow[]
+  dissidents: Dissident[]
+  related: RelatedVote[]
+  apiUrl: string
+}
+
+function shortDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' })
+}
+
+export function VoteDetailClient(props: Props) {
+  const {
+    voteId, voteTitle, result, votedAt, summary, theme,
+    votesFor, votesAgainst, abstentions, totalVoters,
+    pourPct, contrePct, abstPct,
+    groups, dissidents, related, apiUrl,
+  } = props
+
+  const [showBar, setShowBar] = useState(false)
+  const obsRef = useRef<IntersectionObserver | null>(null)
+
+  const heroRef = useCallback((el: HTMLDivElement | null) => {
+    if (obsRef.current) { obsRef.current.disconnect(); obsRef.current = null }
+    if (!el) return
+    obsRef.current = new IntersectionObserver(
+      ([entry]) => {
+        const gone = !entry!.isIntersecting || entry!.intersectionRatio < 0.12
+        setShowBar(gone)
+      },
+      { threshold: [0, 0.12, 1], rootMargin: '-72px 0px 0px 0px' }
+    )
+    obsRef.current.observe(el)
+  }, [])
+
+  const adopted = result === 'adopté'
+
+  return (
+    <div style={{ background: '#F7F4ED', minHeight: '100vh' }}>
+
+      {/* ── Sticky scroll bar ── */}
+      <div style={{
+        position: 'fixed', left: 0, right: 0, top: 64, zIndex: 50,
+        opacity: showBar ? 1 : 0,
+        transform: showBar ? 'translateY(0)' : 'translateY(-28px)',
+        pointerEvents: showBar ? 'auto' : 'none',
+        transition: 'opacity 0.3s ease, transform 0.45s cubic-bezier(0.22,1,0.36,1)',
+      }}>
+        <div style={{ background: 'rgba(255,255,255,0.94)', backdropFilter: 'blur(14px)', borderBottom: '1px solid #E4E6EA', boxShadow: '0 8px 24px rgba(27,43,80,0.08)' }}>
+          <div style={{ maxWidth: 1180, margin: '0 auto', display: 'flex', alignItems: 'center', gap: 16, padding: '10px 56px' }}>
+            <span style={{ fontSize: 12, fontWeight: 600, letterSpacing: '0.1em', textTransform: 'uppercase', color: '#9CA3AF', flexShrink: 0 }}>
+              Scrutin n°{voteId}
+            </span>
+            <span style={{ fontSize: 12, color: '#D1D5DB' }}>·</span>
+            <span style={{ fontWeight: 600, fontSize: 15, color: '#1B2B50', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {voteTitle}
+            </span>
+            <span style={{ display: 'inline-flex', alignItems: 'center', fontSize: 12, fontWeight: 700, padding: '5px 14px', borderRadius: 999, background: adopted ? '#EAF5EF' : '#FBE9E7', color: adopted ? '#1F8A5B' : '#C9302A', flexShrink: 0 }}>
+              {adopted ? 'Adopté' : 'Rejeté'}
+            </span>
+            <span style={{ fontFamily: 'monospace', fontSize: 12.5, color: '#6B7280', flexShrink: 0 }}>
+              {votesFor} pour · {votesAgainst} contre
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Hero ── */}
+      <div ref={heroRef} style={{ padding: '38px 56px 48px', background: 'linear-gradient(180deg,#ffffff 0%,#F7F4ED 100%)', borderBottom: '1px solid #ECE7DC' }}>
+        <div style={{ maxWidth: 1180, margin: '0 auto' }}>
+
+          {/* Breadcrumb */}
+          <div style={{ fontSize: 13.5, color: '#9CA3AF', display: 'flex', alignItems: 'center', gap: 8 }}>
+            <Link href="/votes" style={{ color: '#C9302A', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5, textDecoration: 'none', fontWeight: 500 }}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round"><path d="m15 18-6-6 6-6"/></svg>
+              Retour aux scrutins
+            </Link>
+            <span>/</span>
+            <span>Scrutin n°{voteId}</span>
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 380px', gap: 64, alignItems: 'start', marginTop: 30 }}>
+
+            {/* Left: identity */}
+            <div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 18, flexWrap: 'wrap' }}>
+                <span style={{ font: '700 11.5px/1 var(--font-sans)', letterSpacing: '0.16em', textTransform: 'uppercase', color: '#9CA3AF' }}>
+                  Scrutin public · n°{voteId}
+                </span>
+                <span style={{ fontFamily: 'monospace', fontSize: 11.5, color: '#9CA3AF' }}>·</span>
+                <span style={{ fontFamily: 'monospace', fontSize: 12, color: '#9CA3AF' }}>{shortDate(votedAt)}</span>
+              </div>
+
+              <h1 className="font-newsreader" style={{ fontWeight: 600, fontSize: 44, lineHeight: 1.05, letterSpacing: '-0.015em', color: '#1B2B50', margin: 0, maxWidth: 620 }}>
+                {voteTitle}
+              </h1>
+
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: 20, flexWrap: 'wrap' }}>
+                <span style={{ display: 'inline-flex', alignItems: 'center', fontSize: 13, fontWeight: 600, padding: '6px 14px', borderRadius: 999, background: adopted ? '#EAF5EF' : '#FBE9E7', color: adopted ? '#1F8A5B' : '#C9302A' }}>
+                  {adopted ? 'Adopté' : 'Rejeté'}
+                </span>
+                {theme && (
+                  <span style={{ display: 'inline-flex', alignItems: 'center', fontSize: 13, fontWeight: 600, padding: '6px 14px', borderRadius: 999, background: '#E8EFFE', color: '#2A5DB0' }}>
+                    {theme}
+                  </span>
+                )}
+                <span style={{ display: 'inline-flex', alignItems: 'center', fontSize: 13, fontWeight: 600, padding: '6px 14px', borderRadius: 999, background: '#F2F3F5', color: '#4B5563' }}>
+                  XVII&#7497; législature
+                </span>
+              </div>
+
+              {summary && (
+                <p style={{ margin: '22px 0 0', fontSize: 16, lineHeight: 1.65, color: '#4B5563', maxWidth: 600 }}>
+                  <span style={{ fontWeight: 600, color: '#C9302A' }}>En clair :</span> {summary}
+                </p>
+              )}
+            </div>
+
+            {/* Right: result card */}
+            <div style={{ background: '#fff', border: '1px solid #E4E6EA', borderRadius: 14, padding: 28, boxShadow: '0 4px 12px rgba(0,0,0,0.08)' }}>
+              <div style={{ font: '700 11px/1 var(--font-sans)', letterSpacing: '0.14em', textTransform: 'uppercase', color: '#9CA3AF', marginBottom: 18 }}>
+                Résultat du scrutin
+              </div>
+
+              {/* Big numbers */}
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 0, textAlign: 'center', marginBottom: 22 }}>
+                <div style={{ borderRight: '1px solid #F0F1F3', padding: '0 12px' }}>
+                  <div className="font-newsreader" style={{ fontSize: 42, fontWeight: 600, color: '#1F8A5B', letterSpacing: '-0.02em' }}>{votesFor.toLocaleString('fr-FR')}</div>
+                  <div style={{ fontSize: 12, fontWeight: 600, color: '#1F8A5B', marginTop: 3, letterSpacing: '0.04em' }}>POUR</div>
+                </div>
+                <div style={{ borderRight: '1px solid #F0F1F3', padding: '0 12px' }}>
+                  <div className="font-newsreader" style={{ fontSize: 42, fontWeight: 600, color: '#C9302A', letterSpacing: '-0.02em' }}>{votesAgainst.toLocaleString('fr-FR')}</div>
+                  <div style={{ fontSize: 12, fontWeight: 600, color: '#C9302A', marginTop: 3, letterSpacing: '0.04em' }}>CONTRE</div>
+                </div>
+                <div style={{ padding: '0 12px' }}>
+                  <div className="font-newsreader" style={{ fontSize: 42, fontWeight: 600, color: '#9CA3AF', letterSpacing: '-0.02em' }}>{abstentions.toLocaleString('fr-FR')}</div>
+                  <div style={{ fontSize: 12, fontWeight: 600, color: '#9CA3AF', marginTop: 3, letterSpacing: '0.04em' }}>ABST.</div>
+                </div>
+              </div>
+
+              {/* Stacked bar */}
+              <div style={{ display: 'flex', height: 10, borderRadius: 999, overflow: 'hidden', marginBottom: 10 }}>
+                <div style={{ width: `${pourPct}%`, background: '#1F8A5B' }} />
+                <div style={{ width: `${contrePct}%`, background: '#D9685E' }} />
+                <div style={{ flex: 1, background: '#E4E6EA' }} />
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', fontFamily: 'monospace', fontSize: 11, color: '#9CA3AF', marginBottom: 22 }}>
+                <span>{pourPct}%</span><span>{contrePct}%</span><span>{abstPct}%</span>
+              </div>
+
+              {/* Quorum note */}
+              <div style={{ background: '#F2F3F5', borderRadius: 8, padding: '12px 14px', fontSize: 13, color: '#4B5563', lineHeight: 1.5, marginBottom: 20 }}>
+                <span style={{ fontWeight: 600, color: '#1B2B50' }}>Majorité absolue requise : </span>289 voix.<br />
+                Votants : {totalVoters.toLocaleString('fr-FR')} sur 577 députés inscrits.
+              </div>
+
+              {/* Actions */}
+              <div style={{ display: 'flex', gap: 10 }}>
+                <a
+                  href={`https://www.assemblee-nationale.fr/dyn/scrutins/${voteId}`}
+                  target="_blank" rel="noopener noreferrer"
+                  style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', background: '#1B2B50', color: '#fff', padding: '11px 18px', borderRadius: 8, fontWeight: 600, fontSize: 14, cursor: 'pointer', textDecoration: 'none' }}>
+                  Voir le texte officiel
+                </a>
+                <a
+                  href={`${apiUrl}/votes/${voteId}`}
+                  target="_blank" rel="noopener noreferrer"
+                  style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', border: '1px solid #E4E6EA', color: '#4B5563', padding: '11px 16px', borderRadius: 8, fontWeight: 600, fontSize: 14, cursor: 'pointer', textDecoration: 'none' }}>
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/></svg>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Body ── */}
+      <div style={{ padding: '52px 56px 80px' }}>
+        <div style={{ maxWidth: 1180, margin: '0 auto', display: 'flex', gap: 56, alignItems: 'flex-start' }}>
+
+          {/* Main column */}
+          <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 52 }}>
+
+            {/* Ventilation par groupe */}
+            {groups.length > 0 && (
+              <section>
+                <div style={{ font: '700 12px/1 var(--font-sans)', letterSpacing: '0.18em', textTransform: 'uppercase', color: '#C9302A' }}>Ventilation par groupe</div>
+                <h2 className="font-newsreader" style={{ fontWeight: 600, fontSize: 30, color: '#1B2B50', margin: '12px 0 4px', letterSpacing: '-0.01em' }}>Comment chaque groupe a voté</h2>
+                <p style={{ fontSize: 15, color: '#6B7280', margin: '0 0 22px', maxWidth: 560 }}>Position majoritaire exprimée par les membres de chaque groupe parlementaire.</p>
+
+                <div style={{ background: '#fff', border: '1px solid #E4E6EA', borderRadius: 12, overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
+                  <div style={{ display: 'grid', gridTemplateColumns: '200px 1fr 80px 80px 80px', gap: 14, padding: '12px 24px', borderBottom: '1px solid #E4E6EA', background: '#FBFAF6', font: '600 11px/1 var(--font-sans)', letterSpacing: '0.08em', textTransform: 'uppercase', color: '#9CA3AF' }}>
+                    <span>Groupe</span><span>Position</span><span style={{ textAlign: 'right' }}>Pour</span><span style={{ textAlign: 'right' }}>Contre</span><span style={{ textAlign: 'right' }}>Abst.</span>
+                  </div>
+                  {groups.map((g) => {
+                    const posColor = g.position === 'Pour' ? '#1F8A5B' : g.position === 'Contre' ? '#C9302A' : '#B45309'
+                    const posBg   = g.position === 'Pour' ? '#EAF5EF' : g.position === 'Contre' ? '#FBE9E7' : '#FEF3C7'
+                    return (
+                      <div key={g.name} style={{ display: 'grid', gridTemplateColumns: '200px 1fr 80px 80px 80px', gap: 14, padding: '16px 24px', borderBottom: '1px solid #F0F1F3', alignItems: 'center', background: '#fff' }}>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+                          <span style={{ width: 9, height: 9, borderRadius: 999, flexShrink: 0, background: g.color, display: 'inline-block' }} />
+                          <span style={{ fontSize: 13.5, color: '#374151', fontWeight: 500 }}>{g.name}</span>
+                        </div>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                          <div style={{ flex: 1, height: 7, borderRadius: 999, background: '#F0F1F3', overflow: 'hidden', display: 'flex' }}>
+                            <div style={{ height: '100%', background: '#1F8A5B', width: `${g.forPct}%` }} />
+                            <div style={{ height: '100%', background: '#D9685E', width: `${g.agtPct}%` }} />
+                          </div>
+                          <span style={{ fontSize: 12, fontWeight: 700, padding: '4px 11px', borderRadius: 999, color: posColor, background: posBg, flexShrink: 0 }}>{g.position}</span>
+                        </div>
+                        <div style={{ fontFamily: 'monospace', fontSize: 13, color: '#1F8A5B', textAlign: 'right', fontWeight: 600 }}>{g.pour}</div>
+                        <div style={{ fontFamily: 'monospace', fontSize: 13, color: '#C9302A', textAlign: 'right', fontWeight: 600 }}>{g.contre}</div>
+                        <div style={{ fontFamily: 'monospace', fontSize: 13, color: '#9CA3AF', textAlign: 'right' }}>{g.abst}</div>
+                      </div>
+                    )
+                  })}
+                </div>
+              </section>
+            )}
+
+            {/* Dissidences */}
+            {dissidents.length > 0 && (
+              <section>
+                <div style={{ font: '700 12px/1 var(--font-sans)', letterSpacing: '0.18em', textTransform: 'uppercase', color: '#C9302A' }}>Votes notables</div>
+                <h2 className="font-newsreader" style={{ fontWeight: 600, fontSize: 30, color: '#1B2B50', margin: '12px 0 22px', letterSpacing: '-0.01em' }}>Dissidences &amp; surprises</h2>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                  {dissidents.map((d) => {
+                    const voteColor = d.vote === 'pour' ? '#1F8A5B' : d.vote === 'contre' ? '#C9302A' : '#6B7280'
+                    const voteBg   = d.vote === 'pour' ? '#EAF5EF' : d.vote === 'contre' ? '#FBE9E7' : '#F0F1F3'
+                    const voteLabel = d.vote === 'pour' ? 'Pour' : d.vote === 'contre' ? 'Contre' : 'Abstention'
+                    return (
+                      <Link key={d.deputy_id} href={`/deputes/${d.deputy_id}`} style={{ background: '#fff', border: '1px solid #E4E6EA', borderRadius: 10, padding: '18px 22px', display: 'flex', alignItems: 'center', gap: 18, boxShadow: '0 1px 3px rgba(0,0,0,0.05)', textDecoration: 'none', cursor: 'pointer' }}>
+                        <span style={{ width: 40, height: 40, flexShrink: 0, borderRadius: 999, display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 700, fontSize: 13, color: '#fff', background: d.avatarColor }}>
+                          {d.initials}
+                        </span>
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                          <div style={{ fontWeight: 600, fontSize: 15, color: '#1B2B50' }}>{d.full_name}</div>
+                          <div style={{ fontSize: 13, color: '#9CA3AF', marginTop: 2 }}>{d.party}</div>
+                        </div>
+                        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 5 }}>
+                          <span style={{ fontSize: 12.5, fontWeight: 700, padding: '4px 12px', borderRadius: 999, color: voteColor, background: voteBg }}>{voteLabel}</span>
+                          <span style={{ fontSize: 12, color: '#6B7280' }}>{d.note}</span>
+                        </div>
+                      </Link>
+                    )
+                  })}
+                </div>
+              </section>
+            )}
+          </div>
+
+          {/* Sidebar */}
+          <div style={{ width: 300, flexShrink: 0, display: 'flex', flexDirection: 'column', gap: 24, position: 'sticky', top: 120 }}>
+
+            {/* Related votes */}
+            {related.length > 0 && (
+              <div style={{ background: '#fff', border: '1px solid #E4E6EA', borderRadius: 12, padding: 20, boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
+                <div style={{ font: '700 11px/1 var(--font-sans)', letterSpacing: '0.14em', textTransform: 'uppercase', color: '#9CA3AF', marginBottom: 16 }}>Scrutins liés</div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+                  {related.map((r) => {
+                    const rAdopted = r.result === 'adopté'
+                    return (
+                      <Link key={r.vote_id} href={`/votes/${r.vote_id}`} style={{ padding: '12px 0', borderBottom: '1px solid #F0F1F3', textDecoration: 'none' }}>
+                        <div style={{ fontSize: 13.5, fontWeight: 500, color: '#1B2B50', lineHeight: 1.35 }}
+                          className="line-clamp-2">
+                          {r.vote_title}
+                        </div>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 7 }}>
+                          <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#9CA3AF' }}>
+                            {new Date(r.voted_at).toLocaleDateString('fr-FR', { day: 'numeric', month: 'short', year: 'numeric' })}
+                          </span>
+                          <span style={{ fontSize: 11.5, fontWeight: 600, padding: '3px 9px', borderRadius: 999, color: rAdopted ? '#1F8A5B' : '#C9302A', background: rAdopted ? '#EAF5EF' : '#FBE9E7' }}>
+                            {rAdopted ? 'Adopté' : 'Rejeté'}
+                          </span>
+                        </div>
+                      </Link>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* Sources */}
+            <div style={{ background: '#fff', border: '1px solid #E4E6EA', borderRadius: 12, padding: 20, boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
+              <div style={{ font: '700 11px/1 var(--font-sans)', letterSpacing: '0.14em', textTransform: 'uppercase', color: '#9CA3AF', marginBottom: 14 }}>Sources officielles</div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                {[
+                  { label: 'Assemblée nationale', href: `https://www.assemblee-nationale.fr/dyn/scrutins/${voteId}` },
+                  { label: 'API MonÉlu — données brutes', href: `${apiUrl}/votes/${voteId}` },
+                ].map(({ label, href }) => (
+                  <a key={href} href={href} target="_blank" rel="noopener noreferrer"
+                    style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 13.5, color: '#1B2B50', textDecoration: 'none', fontWeight: 500 }}>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#9CA3AF" strokeWidth="2" strokeLinecap="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                    {label}
+                  </a>
+                ))}
+              </div>
+            </div>
+
+            {/* Freshness */}
+            <div style={{ fontSize: 12, color: '#9CA3AF', lineHeight: 1.6, padding: '0 2px' }}>
+              Données issues du flux officiel de l&apos;Assemblée nationale.<br />
+              Dernière mise à jour : <span style={{ color: '#6B7280', fontWeight: 600 }}>{shortDate(votedAt)}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/votes/[id]/page.tsx
+++ b/frontend/src/app/votes/[id]/page.tsx
@@ -1,34 +1,24 @@
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
-import Link from 'next/link'
 import { api } from '@/lib/api'
-import { formatDate, partyShort, partyColor, groupVotesByParty } from '@/lib/utils'
+import { getInitials, groupVotesByParty, partyHex } from '@/lib/utils'
+import { VoteDetailClient } from './VoteDetailClient'
 
 export const dynamicParams = true
-export const revalidate = 86400 // fallback if the /api/revalidate webhook is not called
+export const revalidate = 86400
 
 export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
   const { id } = await params
   const vote = await api.votes.get(id).catch(() => null)
   if (!vote) return {}
   const result = vote.result === 'adopté' ? 'Adopté' : 'Rejeté'
-  const shortTitle = vote.vote_title.length > 80
-    ? vote.vote_title.slice(0, 80) + '…'
-    : vote.vote_title
+  const shortTitle = vote.vote_title.length > 80 ? vote.vote_title.slice(0, 80) + '…' : vote.vote_title
   const description = `${result} · ${vote.votes_for} pour · ${vote.votes_against} contre · ${vote.abstentions} abstentions.`
   return {
     title: `${result} — ${shortTitle} — MonÉlu`,
     description,
-    openGraph: {
-      title: `${result} — ${shortTitle} — MonÉlu`,
-      description,
-      url: `https://mon-elu.vercel.app/votes/${id}`,
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title: `${result} — ${shortTitle} — MonÉlu`,
-      description,
-    },
+    openGraph: { title: `${result} — ${shortTitle} — MonÉlu`, description, url: `https://mon-elu.vercel.app/votes/${id}` },
+    twitter: { card: 'summary_large_image', title: `${result} — ${shortTitle} — MonÉlu`, description },
   }
 }
 
@@ -36,9 +26,7 @@ export async function generateStaticParams() {
   try {
     const data = await api.votes.list({ limit: 100 })
     return data.items.map(v => ({ id: v.vote_id }))
-  } catch {
-    return []
-  }
+  } catch { return [] }
 }
 
 export default async function VoteDetailPage({ params }: { params: Promise<{ id: string }> }) {
@@ -46,140 +34,86 @@ export default async function VoteDetailPage({ params }: { params: Promise<{ id:
   const vote = await api.votes.get(id).catch(() => null)
   if (!vote) notFound()
 
-  const pourPct = Math.round(vote.votes_for / (vote.total_voters || 1) * 100)
+  const pourPct   = Math.round(vote.votes_for     / (vote.total_voters || 1) * 100)
   const contrePct = Math.round(vote.votes_against / (vote.total_voters || 1) * 100)
-  const abstPct = Math.round(vote.abstentions / (vote.total_voters || 1) * 100)
+  const abstPct   = Math.round(vote.abstentions   / (vote.total_voters || 1) * 100)
 
-  // Group positions by position type
-  const byPosition: Record<string, typeof vote.positions> = {}
-  for (const p of vote.positions ?? []) {
-    if (!byPosition[p.position]) byPosition[p.position] = []
-    byPosition[p.position]!.push(p)
+  // Build group rows
+  const partyMap = groupVotesByParty(vote.positions ?? [])
+  const groups = Object.entries(partyMap)
+    .map(([name, counts]) => {
+      const total  = counts.pour + counts.contre + counts.abstention + counts.nonVotant
+      const forPct = Math.round(counts.pour   / (total || 1) * 100)
+      const agtPct = Math.round(counts.contre / (total || 1) * 100)
+      const position: 'Pour' | 'Contre' | 'Partagé' =
+        counts.pour > counts.contre ? 'Pour' : counts.contre > counts.pour ? 'Contre' : 'Partagé'
+      return { name, color: partyHex(name), pour: counts.pour, contre: counts.contre, abst: counts.abstention, nonVotant: counts.nonVotant, position, forPct, agtPct }
+    })
+    .sort((a, b) => (b.pour + b.contre + b.abst + b.nonVotant) - (a.pour + a.contre + a.abst + a.nonVotant))
+
+  // Compute dissidents (deputies who voted against their party majority)
+  const dissidents: {
+    deputy_id: string; full_name: string; initials: string; party: string
+    avatarColor: string; vote: string; note: string
+  }[] = []
+
+  if (vote.positions && vote.positions.length > 0) {
+    const majorityByParty: Record<string, string> = {}
+    for (const [party, counts] of Object.entries(partyMap)) {
+      const entries = Object.entries(counts).filter(([k]) => k !== 'nonVotant')
+      const majority = entries.reduce((a, b) => (b[1] > a[1] ? b : a))[0]
+      majorityByParty[party] = majority
+    }
+    for (const pos of vote.positions) {
+      if (pos.position === 'nonVotant') continue
+      const majority = majorityByParty[pos.party]
+      if (majority && pos.position !== majority && dissidents.length < 4) {
+        dissidents.push({
+          deputy_id: pos.deputy_id,
+          full_name: pos.full_name,
+          initials: getInitials(pos.full_name),
+          party: pos.party,
+          avatarColor: partyHex(pos.party),
+          vote: pos.position,
+          note: 'Dissident · contre son groupe',
+        })
+      }
+    }
   }
 
-  const positionOrder = ['pour', 'contre', 'abstention', 'nonVotant']
-  const positionLabel: Record<string, string> = {
-    pour: 'Pour',
-    contre: 'Contre',
-    abstention: 'Abstention',
-    nonVotant: 'Non-votant',
+  // Related votes (same theme)
+  let related: { vote_id: string; vote_title: string; voted_at: string; result: string }[] = []
+  if (vote.theme) {
+    try {
+      const rel = await api.votes.list({ theme: vote.theme, limit: 4 })
+      related = rel.items
+        .filter(v => v.vote_id !== vote.vote_id)
+        .slice(0, 3)
+        .map(v => ({ vote_id: v.vote_id, vote_title: v.vote_title, voted_at: v.voted_at, result: v.result }))
+    } catch { /* skip */ }
   }
+
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? 'https://monelu-production.up.railway.app'
 
   return (
-    <div className="max-w-2xl mx-auto px-4 md:px-8 py-6">
-      <Link href="/votes" className="text-sm text-gray-mid hover:text-navy mb-6 inline-flex items-center gap-1">
-        ← Tous les votes
-      </Link>
-
-      {/* Header */}
-      <div className="bg-white border border-gray-border rounded-xl p-6 mb-4 mt-4">
-        <div className="flex items-start justify-between gap-3 mb-3">
-          <h1 className="font-serif text-xl text-navy leading-snug flex-1">{vote.vote_title}</h1>
-          <span className={`flex-shrink-0 ${vote.result === 'adopté' ? 'badge-adopte' : 'badge-rejete'}`}>
-            {vote.result}
-          </span>
-        </div>
-        {vote.summary_plain && (
-          <p className="text-sm text-navy/60 leading-relaxed mt-2">
-            <span className="text-red-civic font-medium">En clair</span>{' '}
-            {vote.summary_plain}
-          </p>
-        )}
-        <p className="text-sm text-gray-mid mt-2">{formatDate(vote.voted_at)}</p>
-      </div>
-
-      {/* Results bar */}
-      <div className="bg-white border border-gray-border rounded-xl p-6 mb-4">
-        <h2 className="font-serif text-lg text-navy mb-4">Résultat du scrutin</h2>
-
-        <div className="h-4 rounded-full overflow-hidden flex mb-3">
-          <div className="bg-emerald-500 h-full transition-all" style={{ width: `${pourPct}%` }} />
-          <div className="bg-red-civic h-full transition-all" style={{ width: `${contrePct}%` }} />
-          <div className="bg-gray-light h-full flex-1" />
-        </div>
-
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-          {[
-            { label: 'Pour', value: vote.votes_for, color: 'text-emerald-700', bg: 'bg-emerald-50' },
-            { label: 'Contre', value: vote.votes_against, color: 'text-red-700', bg: 'bg-red-50' },
-            { label: 'Abstention', value: vote.abstentions, color: 'text-gray-mid', bg: 'bg-gray-off' },
-            { label: 'Total', value: vote.total_voters, color: 'text-navy', bg: 'bg-navy-muted' },
-          ].map(({ label, value, color, bg }) => (
-            <div key={label} className={`${bg} rounded-lg p-3 text-center`}>
-              <div className={`text-xl font-medium ${color}`}>{value.toLocaleString('fr-FR')}</div>
-              <div className="text-xs text-gray-mid mt-0.5">{label}</div>
-            </div>
-          ))}
-        </div>
-
-        <div className="flex gap-4 mt-4 text-xs text-gray-mid">
-          <span>{pourPct}% pour</span>
-          <span>{contrePct}% contre</span>
-          <span>{abstPct}% abstention</span>
-        </div>
-      </div>
-
-      {/* Positions by group */}
-      {vote.positions && vote.positions.length > 0 && (
-        <div className="bg-white border border-gray-border rounded-xl p-6 mb-4">
-          <h2 className="font-serif text-lg text-navy mb-4">Positions par groupe</h2>
-
-          {/* Party breakdown */}
-          {(() => {
-            const partyMap = groupVotesByParty(vote.positions ?? [])
-            return (
-              <div className="space-y-3">
-                {Object.entries(partyMap)
-                  .sort(([, a], [, b]) => (b.pour + b.contre + b.abstention) - (a.pour + a.contre + a.abstention))
-                  .map(([party, counts]) => {
-                    const total = counts.pour + counts.contre + counts.abstention + counts.nonVotant
-                    return (
-                      <div key={party} className="flex items-center gap-3">
-                        <span className={`text-xs px-2 py-0.5 rounded font-medium flex-shrink-0 w-12 text-center ${partyColor(party)}`}>
-                          {partyShort(party)}
-                        </span>
-                        <div className="flex-1 h-2 bg-gray-light rounded-full overflow-hidden flex">
-                          <div className="bg-emerald-500 h-full" style={{ width: `${Math.round(counts.pour / total * 100)}%` }} />
-                          <div className="bg-red-civic h-full" style={{ width: `${Math.round(counts.contre / total * 100)}%` }} />
-                          <div className="bg-amber-300 h-full" style={{ width: `${Math.round(counts.abstention / total * 100)}%` }} />
-                        </div>
-                        <span className="text-xs text-gray-mid flex-shrink-0 w-16 text-right">
-                          {counts.pour}p · {counts.contre}c
-                        </span>
-                      </div>
-                    )
-                  })}
-              </div>
-            )
-          })()}
-        </div>
-      )}
-
-      {/* Individual positions */}
-      {vote.positions && vote.positions.length > 0 && (
-        <div className="bg-white border border-gray-border rounded-xl p-6">
-          <h2 className="font-serif text-lg text-navy mb-4">Votes individuels</h2>
-          <div className="space-y-6">
-            {positionOrder
-              .filter(pos => byPosition[pos]?.length)
-              .map(pos => (
-                <div key={pos}>
-                  <h3 className="text-sm font-medium text-gray-mid mb-2">
-                    {positionLabel[pos]} ({byPosition[pos]!.length})
-                  </h3>
-                  <div className="flex flex-wrap gap-1.5">
-                    {byPosition[pos]!.map(p => (
-                      <Link key={p.deputy_id} href={`/deputes/${p.deputy_id}`}
-                        className={`text-xs px-2 py-1 rounded font-medium ${partyColor(p.party)}`}>
-                        {p.full_name.split(' ').slice(-1)[0]}
-                      </Link>
-                    ))}
-                  </div>
-                </div>
-              ))}
-          </div>
-        </div>
-      )}
-    </div>
+    <VoteDetailClient
+      voteId={vote.vote_id}
+      voteTitle={vote.vote_title}
+      result={vote.result}
+      votedAt={vote.voted_at}
+      summary={vote.summary_plain ?? null}
+      theme={vote.theme ?? null}
+      votesFor={vote.votes_for}
+      votesAgainst={vote.votes_against}
+      abstentions={vote.abstentions}
+      totalVoters={vote.total_voters}
+      pourPct={pourPct}
+      contrePct={contrePct}
+      abstPct={abstPct}
+      groups={groups}
+      dissidents={dissidents}
+      related={related}
+      apiUrl={apiUrl}
+    />
   )
 }

--- a/frontend/src/app/votes/[id]/page.tsx
+++ b/frontend/src/app/votes/[id]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
+import { Suspense } from 'react'
 import { api } from '@/lib/api'
 import { getInitials, groupVotesByParty, partyHex } from '@/lib/utils'
 import { VoteDetailClient } from './VoteDetailClient'
@@ -96,24 +97,26 @@ export default async function VoteDetailPage({ params }: { params: Promise<{ id:
   const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? 'https://monelu-production.up.railway.app'
 
   return (
-    <VoteDetailClient
-      voteId={vote.vote_id}
-      voteTitle={vote.vote_title}
-      result={vote.result}
-      votedAt={vote.voted_at}
-      summary={vote.summary_plain ?? null}
-      theme={vote.theme ?? null}
-      votesFor={vote.votes_for}
-      votesAgainst={vote.votes_against}
-      abstentions={vote.abstentions}
-      totalVoters={vote.total_voters}
-      pourPct={pourPct}
-      contrePct={contrePct}
-      abstPct={abstPct}
-      groups={groups}
-      dissidents={dissidents}
-      related={related}
-      apiUrl={apiUrl}
-    />
+    <Suspense fallback={<div style={{ padding: '48px 32px', color: '#9CA3AF', fontSize: 14 }}>Chargement…</div>}>
+      <VoteDetailClient
+        voteId={vote.vote_id}
+        voteTitle={vote.vote_title}
+        result={vote.result}
+        votedAt={vote.voted_at}
+        summary={vote.summary_plain ?? null}
+        theme={vote.theme ?? null}
+        votesFor={vote.votes_for}
+        votesAgainst={vote.votes_against}
+        abstentions={vote.abstentions}
+        totalVoters={vote.total_voters}
+        pourPct={pourPct}
+        contrePct={contrePct}
+        abstPct={abstPct}
+        groups={groups}
+        dissidents={dissidents}
+        related={related}
+        apiUrl={apiUrl}
+      />
+    </Suspense>
   )
 }

--- a/frontend/src/app/votes/page.tsx
+++ b/frontend/src/app/votes/page.tsx
@@ -6,13 +6,27 @@ export const revalidate = 900
 
 export default async function VotesPage() {
   const initial = await api.votes.list({ limit: 50 })
+
+  // Compute hero stats from a larger sample
+  const sample = await api.votes.list({ limit: 200 }).catch(() => initial)
+  const adoptedCount = sample.items.filter(v => v.result === 'adopté').length
+  const adoptionRate = sample.items.length > 0
+    ? Math.round(adoptedCount / sample.items.length * 100)
+    : 0
+  const avgParticipation = sample.items.length > 0
+    ? Math.round(sample.items.reduce((s, v) => s + (v.total_voters / 577), 0) / sample.items.length * 100)
+    : 0
+
+  const heroStats = [
+    { value: initial.total.toLocaleString('fr-FR'), label: 'scrutins XVIIᵉ législature' },
+    { value: `${adoptionRate} %`, label: "taux d'adoption" },
+    { value: `${avgParticipation} %`, label: 'participation moyenne' },
+    { value: '17ᵉ', label: 'législature · depuis 2024' },
+  ]
+
   return (
-    <div className="max-w-4xl mx-auto px-4 md:px-8 py-6">
-      <h1 className="font-serif text-3xl text-navy mb-2">Votes</h1>
-      <p className="text-gray-mid text-sm mb-6">Assemblée Nationale · 17ème législature</p>
-      <Suspense fallback={<div className="text-gray-mid text-sm">Chargement...</div>}>
-        <VotesClient initial={initial} />
-      </Suspense>
-    </div>
+    <Suspense fallback={<div className="text-gray-mid text-sm p-8">Chargement...</div>}>
+      <VotesClient initial={initial} heroStats={heroStats} />
+    </Suspense>
   )
 }

--- a/frontend/src/components/DeputyAvatar.tsx
+++ b/frontend/src/components/DeputyAvatar.tsx
@@ -6,13 +6,14 @@ import { getInitials } from '@/lib/utils'
 type Props = {
   name: string
   photoUrl: string | null
-  size?: 'sm' | 'lg'
+  size?: 'sm' | 'lg' | 'xl'
   priority?: boolean
 }
 
 const sizes = {
   sm: { px: 40, className: 'w-10 h-10 text-sm' },
   lg: { px: 64, className: 'w-16 h-16 text-xl' },
+  xl: { px: 80, className: 'w-20 h-20 text-2xl' },
 }
 
 export function DeputyAvatar({ name, photoUrl, size = 'sm', priority = false }: Props) {

--- a/frontend/src/components/DeputyAvatar.tsx
+++ b/frontend/src/components/DeputyAvatar.tsx
@@ -6,28 +6,33 @@ import { getInitials } from '@/lib/utils'
 type Props = {
   name: string
   photoUrl: string | null
-  size?: 'sm' | 'lg' | 'xl'
+  size?: 'sm' | 'lg' | 'xl' | '2xl'
   priority?: boolean
 }
 
 const sizes = {
-  sm: { px: 40, className: 'w-10 h-10 text-sm' },
-  lg: { px: 64, className: 'w-16 h-16 text-xl' },
-  xl: { px: 80, className: 'w-20 h-20 text-2xl' },
+  sm:  { w: 40,  h: 40,  className: 'w-10 h-10 text-sm',  rounded: 'rounded-full' },
+  lg:  { w: 64,  h: 64,  className: 'w-16 h-16 text-xl',  rounded: 'rounded-full' },
+  xl:  { w: 80,  h: 80,  className: 'w-20 h-20 text-2xl', rounded: 'rounded-full' },
+  '2xl': { w: 210, h: 262, className: 'text-4xl',           rounded: 'rounded-[14px]' },
 }
 
 export function DeputyAvatar({ name, photoUrl, size = 'sm', priority = false }: Props) {
   const [imgError, setImgError] = useState(false)
-  const { px, className } = sizes[size]
+  const { w, h, className, rounded } = sizes[size]
+  const style = size === '2xl' ? { width: 210, height: 262, flexShrink: 0 } : undefined
 
   if (photoUrl && !imgError) {
     return (
-      <div className={`${className} rounded-full overflow-hidden flex-shrink-0 bg-navy-muted`}>
+      <div
+        className={`${className} ${rounded} overflow-hidden flex-shrink-0 bg-navy-muted`}
+        style={style}
+      >
         <Image
           src={photoUrl}
           alt={name}
-          width={px}
-          height={px}
+          width={w}
+          height={h}
           className="object-cover object-top w-full h-full"
           priority={priority}
           onError={() => setImgError(true)}
@@ -37,7 +42,10 @@ export function DeputyAvatar({ name, photoUrl, size = 'sm', priority = false }: 
   }
 
   return (
-    <div className={`${className} rounded-full bg-navy-muted flex items-center justify-center text-navy font-medium flex-shrink-0`}>
+    <div
+      className={`${className} ${rounded} bg-navy-muted flex items-center justify-center text-navy font-medium flex-shrink-0`}
+      style={style}
+    >
       {getInitials(name)}
     </div>
   )

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -1,9 +1,21 @@
+'use client'
+
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import { MonEluLogo } from './MonEluLogo'
 
 export const NAV_HEIGHT_PX = 64
 
+const navLinks = [
+  { href: '/deputes', label: 'Députés' },
+  { href: '/votes', label: 'Votes' },
+  { href: '/chat', label: 'Chat IA' },
+  { href: '/a-propos', label: 'À propos' },
+]
+
 export function Nav() {
+  const pathname = usePathname()
+
   return (
     <nav
       className="hidden md:flex items-center justify-between px-8 bg-white border-b border-gray-border sticky top-0 z-50"
@@ -13,10 +25,18 @@ export function Nav() {
         <MonEluLogo size={32} variant="light" />
       </Link>
       <div className="flex items-center gap-8 text-sm font-medium text-gray-mid">
-        <Link href="/deputes" className="hover:text-navy transition-colors">Députés</Link>
-        <Link href="/votes" className="hover:text-navy transition-colors">Votes</Link>
-        <Link href="/chat" className="hover:text-navy transition-colors">Chat IA</Link>
-        <Link href="/a-propos" className="hover:text-navy transition-colors">À propos</Link>
+        {navLinks.map(({ href, label }) => {
+          const active = pathname === href || pathname.startsWith(href + '/')
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={`transition-colors hover:text-navy ${active ? 'text-navy border-b-2 border-red-civic pb-0.5' : ''}`}
+            >
+              {label}
+            </Link>
+          )
+        })}
       </div>
       <a href="https://monelu-production.up.railway.app/docs"
         target="_blank"

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -15,9 +15,8 @@ export function Nav() {
       <div className="flex items-center gap-8 text-sm font-medium text-gray-mid">
         <Link href="/deputes" className="hover:text-navy transition-colors">Députés</Link>
         <Link href="/votes" className="hover:text-navy transition-colors">Votes</Link>
-        <Link href="/votes" className="hover:text-navy transition-colors">Explorer</Link>
         <Link href="/chat" className="hover:text-navy transition-colors">Chat IA</Link>
-        <Link href="/#methodologie" className="hover:text-navy transition-colors">Méthodologie</Link>
+        <Link href="/a-propos" className="hover:text-navy transition-colors">À propos</Link>
       </div>
       <a href="https://monelu-production.up.railway.app/docs"
         target="_blank"

--- a/frontend/src/components/PageTransition.tsx
+++ b/frontend/src/components/PageTransition.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { useEffect, useRef } from 'react'
+
+export function PageTransition({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    el.style.opacity = '0'
+    el.style.transform = 'translateY(6px)'
+    const raf = requestAnimationFrame(() => {
+      el.style.transition = 'opacity 0.3s ease, transform 0.3s ease'
+      el.style.opacity = '1'
+      el.style.transform = 'translateY(0)'
+    })
+    return () => cancelAnimationFrame(raf)
+  }, [pathname])
+
+  return <div ref={ref}>{children}</div>
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -44,6 +44,24 @@ export function groupVotesByParty(
   return map
 }
 
+export function partyHex(party: string | null): string {
+  if (!party) return '#9CA3AF'
+  const map: Record<string, string> = {
+    'Rassemblement National':                           '#003189',
+    'Ensemble pour la République':                      '#C79A2E',
+    'La France insoumise - Nouveau Front Populaire':    '#C9302A',
+    'Socialistes et apparentés':                        '#E07A2E',
+    'Droite Républicaine':                              '#0066CC',
+    'Écologiste et Social':                             '#1F8A5B',
+    'Les Démocrates':                                   '#F97316',
+    'Horizons & Indépendants':                          '#0D9488',
+    'Libertés, Indépendants, Outre-mer et Territoires': '#7C3AED',
+    'Union des droites pour la République':             '#DC2626',
+    'Gauche Démocrate et Républicaine':                 '#B45309',
+  }
+  return map[party] ?? '#6B7280'
+}
+
 export function partyColor(party: string | null): string {
   if (!party) return 'bg-gray-100 text-gray-600'
   const map: Record<string, string> = {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -62,6 +62,22 @@ export function partyHex(party: string | null): string {
   return map[party] ?? '#6B7280'
 }
 
+export function themeColors(theme: string | null): { c: string; bg: string } {
+  const map: Record<string, { c: string; bg: string }> = {
+    'Énergie & Environnement': { c: '#2A5DB0', bg: '#E8EFFE' },
+    'Économie & Budget':       { c: '#B45309', bg: '#FEF3C7' },
+    'Santé & Social':          { c: '#7C3AED', bg: '#EDE9FE' },
+    'Justice & Sécurité':      { c: '#0D7490', bg: '#E0F7FA' },
+    'Agriculture':             { c: '#1F8A5B', bg: '#ECFDF5' },
+    'Transport & Logement':    { c: '#B45309', bg: '#FFF7ED' },
+    'Institutions':            { c: '#374151', bg: '#F2F3F5' },
+    'International':           { c: '#374151', bg: '#F2F3F5' },
+    'Éducation & Culture':     { c: '#7C3AED', bg: '#EDE9FE' },
+    'Autre':                   { c: '#6B7280', bg: '#F3F4F6' },
+  }
+  return map[theme ?? ''] ?? { c: '#6B7280', bg: '#F3F4F6' }
+}
+
 export function partyColor(party: string | null): string {
   if (!party) return 'bg-gray-100 text-gray-600'
   const map: Record<string, string> = {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -59,7 +59,11 @@ export function partyHex(party: string | null): string {
     'Union des droites pour la République':             '#DC2626',
     'Gauche Démocrate et Républicaine':                 '#B45309',
   }
-  return map[party] ?? '#6B7280'
+  const color = map[party]
+  if (!color && process.env.NODE_ENV === 'development') {
+    console.warn(`partyHex: unknown party "${party}", using fallback. Add it to the map in lib/utils.ts.`)
+  }
+  return color ?? '#6B7280'
 }
 
 export function themeColors(theme: string | null): { c: string; bg: string } {

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -24,6 +24,7 @@ const config: Config = {
       fontFamily: {
         serif: ['var(--font-serif)', 'Georgia', 'serif'],
         sans: ['var(--font-sans)', 'system-ui', 'sans-serif'],
+        newsreader: ['var(--font-newsreader)', 'Georgia', 'serif'],
       },
       fontSize: {
         'display': ['3rem', { lineHeight: '1.1', fontWeight: '400' }],


### PR DESCRIPTION
## What
Major visual overhaul of the frontend: deputy profile page, deputies list, votes pages, chat UI, and nav are all redesigned with a consistent navy/cream/red design system.
A new `/a-propos` page and a `PageTransition` component are added.

## Why
The previous UI was functional but visually inconsistent - mixing Tailwind utility colors without a shared palette, and lacking polish on the deputy profile and vote detail pages.
This branch lands a cohesive redesign that matches the MonÉlu brand (navy `#1B2B50`, cream `#F7F4ED`, accent red `#E0786E`) across every page.

## Changes
- `deputes/[id]/page.tsx` - full redesign: party-colored avatar banner, stat cards, vote breakdown bar, scrollable vote history table with inline position badges
- `deputes/DeputiesClient.tsx` - streamlined search/filter bar, party color chips, card layout improvements
- `votes/[id]/VoteDetailClient.tsx` - new dedicated client component extracted from the page; shows vote result header, aggregate bar, and deputy position table
- `votes/VotesClient.tsx` - redesigned vote list with result badges and cleaner card layout
- `chat/page.tsx` - conversation persistence, dark mode support, improved message rendering and new chat button
- `a-propos/page.tsx` - new "About" page added with project context
- `components/Nav.tsx` - dynamic links, active-link highlight, `/a-propos` entry added
- `components/PageTransition.tsx` - new framer-motion fade/slide wrapper applied to route changes
- `components/DeputyAvatar.tsx` - `xl` size option added, border styling improved
- `lib/utils.ts` - `partyHex()` added, maps party names to brand hex colors
- `next.config.mjs` - minor config additions
- `tailwind.config.ts` - extended with brand color tokens

## Testing
- Existing `VotesClient` tests updated to match refactored component interface
- Manual: deputy profile, deputies list, vote detail, and chat pages verified locally

## Risks / Notes
- The `VoteDetailClient` extraction moves rendering logic from a server component to a client component - double-check hydration on slow connections
- `partyHex` uses a hard-coded mapping; new parties added mid-legislature will fall back to a neutral gray

## Breaking Changes
None - all routes and API contracts are unchanged.