### PR TITLE
fix: unify typography system across all pages (MON-72)

### DIFF
--- a/frontend/src/app/a-propos/page.tsx
+++ b/frontend/src/app/a-propos/page.tsx
@@ -144,7 +144,7 @@ export default function AProposPage() {
         <div style={{ maxWidth: '1180px', margin: '0 auto', display: 'grid', gridTemplateColumns: '1fr 400px', gap: '80px', alignItems: 'center' }}>
           <div>
             <div className="text-red-civic font-semibold text-xs tracking-[0.18em] uppercase mb-5">Notre mission</div>
-            <h1 className="font-newsreader" style={{ fontWeight: 600, fontSize: '52px', lineHeight: 1.06, letterSpacing: '-0.02em', color: '#1B2B50', margin: '0 0 22px', maxWidth: '600px' }}>
+            <h1 className="font-newsreader text-headline" style={{ fontWeight: 600, lineHeight: 1.06, letterSpacing: '-0.02em', color: '#1B2B50', margin: '0 0 22px', maxWidth: '600px' }}>
               La démocratie mérite<br />des données <em>en clair</em>.
             </h1>
             <p style={{ fontSize: '18px', lineHeight: 1.65, color: '#4B5563', maxWidth: '500px', margin: '0 0 32px' }}>
@@ -173,10 +173,10 @@ export default function AProposPage() {
             {heroStats.map((s) => (
               <div key={s.label} style={{ padding: '16px 0', borderBottom: '1px solid #F0F1F3', display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: '16px' }}>
                 <span style={{ fontSize: '14px', color: '#6B7280', lineHeight: 1.35 }}>{s.label}</span>
-                <span className="font-newsreader" style={{ fontWeight: 600, fontSize: '28px', color: '#1B2B50', letterSpacing: '-0.02em', whiteSpace: 'nowrap' }}>{s.value}</span>
+                <span className="font-newsreader text-[28px]" style={{ fontWeight: 600, color: '#1B2B50', letterSpacing: '-0.02em', whiteSpace: 'nowrap' }}>{s.value}</span>
               </div>
             ))}
-            <div style={{ paddingTop: '16px', fontFamily: 'monospace', fontSize: '11.5px', color: '#9CA3AF' }}>
+            <div className="font-mono" style={{ paddingTop: '16px', fontSize: '11.5px', color: '#9CA3AF' }}>
               Mise à jour continue · flux officiel AN
             </div>
           </div>
@@ -191,7 +191,7 @@ export default function AProposPage() {
             <div style={{ width: '40px', height: '3px', background: '#1B2B50', borderRadius: '2px' }} />
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: '28px' }}>
-            <p className="font-newsreader" style={{ fontWeight: 500, fontSize: '26px', lineHeight: 1.5, color: '#1B2B50', margin: 0 }}>
+            <p className="font-newsreader text-[26px]" style={{ fontWeight: 500, lineHeight: 1.5, color: '#1B2B50', margin: 0 }}>
               &laquo;&nbsp;Les données parlementaires existent — elles sont publiques, officielles, riches. Mais elles sont éparpillées, peu structurées, et inaccessibles au plus grand nombre.&nbsp;&raquo;
             </p>
             <p style={{ fontSize: '16px', lineHeight: 1.7, color: '#4B5563', margin: 0 }}>
@@ -209,7 +209,7 @@ export default function AProposPage() {
         <div style={{ maxWidth: '1180px', margin: '0 auto' }}>
           <div style={{ marginBottom: '48px' }}>
             <div className="text-red-civic font-semibold text-xs tracking-[0.18em] uppercase mb-3">Nos engagements</div>
-            <h2 className="font-newsreader" style={{ fontWeight: 600, fontSize: '38px', color: '#1B2B50', margin: 0, letterSpacing: '-0.015em' }}>Ce qui nous guide</h2>
+            <h2 className="font-newsreader text-section" style={{ fontWeight: 600, color: '#1B2B50', margin: 0, letterSpacing: '-0.015em' }}>Ce qui nous guide</h2>
           </div>
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: '24px' }}>
             {valeurs.map((v) => (
@@ -231,7 +231,7 @@ export default function AProposPage() {
           <div style={{ marginBottom: '52px', display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between' }}>
             <div>
               <div style={{ fontWeight: 700, fontSize: '12px', letterSpacing: '0.18em', textTransform: 'uppercase', color: '#E0786E', marginBottom: '14px' }}>Architecture</div>
-              <h2 className="font-newsreader" style={{ fontWeight: 600, fontSize: '38px', color: '#fff', margin: 0, letterSpacing: '-0.015em' }}>
+              <h2 className="font-newsreader text-section" style={{ fontWeight: 600, color: '#fff', margin: 0, letterSpacing: '-0.015em' }}>
                 Une infrastructure de production,<br />pas un prototype.
               </h2>
             </div>
@@ -244,12 +244,12 @@ export default function AProposPage() {
           <div style={{ display: 'flex', alignItems: 'stretch', marginBottom: '48px', background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)', borderRadius: '14px', overflow: 'hidden' }}>
             {pipeline.map((pl, i) => (
               <div key={pl.step} style={{ flex: 1, padding: '28px 22px', borderRight: i < pipeline.length - 1 ? '1px solid rgba(255,255,255,0.07)' : 'none' }}>
-                <div style={{ fontWeight: 700, fontSize: '10px', letterSpacing: '0.2em', textTransform: 'uppercase', color: '#E0786E', marginBottom: '14px', fontFamily: 'monospace' }}>{pl.step}</div>
+                <div className="font-mono" style={{ fontWeight: 700, fontSize: '10px', letterSpacing: '0.2em', textTransform: 'uppercase', color: '#E0786E', marginBottom: '14px' }}>{pl.step}</div>
                 <div style={{ fontWeight: 700, fontSize: '16px', color: '#fff', marginBottom: '8px' }}>{pl.title}</div>
                 <div style={{ fontSize: '13px', lineHeight: 1.6, color: '#9CA3AF' }}>{pl.desc}</div>
                 <div style={{ marginTop: '16px', display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
                   {pl.tags.map((tag) => (
-                    <span key={tag} style={{ fontFamily: 'monospace', fontSize: '11px', padding: '3px 9px', borderRadius: '4px', background: 'rgba(255,255,255,0.07)', color: '#9CA3AF', border: '1px solid rgba(255,255,255,0.08)' }}>{tag}</span>
+                    <span key={tag} className="font-mono" style={{ fontSize: '11px', padding: '3px 9px', borderRadius: '4px', background: 'rgba(255,255,255,0.07)', color: '#9CA3AF', border: '1px solid rgba(255,255,255,0.08)' }}>{tag}</span>
                   ))}
                 </div>
               </div>
@@ -260,7 +260,7 @@ export default function AProposPage() {
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: '16px' }}>
             {techCards.map((tc) => (
               <div key={tc.name} style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.08)', borderRadius: '10px', padding: '20px 18px' }}>
-                <div style={{ fontFamily: 'monospace', fontSize: '11px', letterSpacing: '0.12em', textTransform: 'uppercase', color: '#E0786E', marginBottom: '10px' }}>{tc.cat}</div>
+                <div className="font-mono" style={{ fontSize: '11px', letterSpacing: '0.12em', textTransform: 'uppercase', color: '#E0786E', marginBottom: '10px' }}>{tc.cat}</div>
                 <div style={{ fontSize: '14px', fontWeight: 600, color: '#fff', marginBottom: '6px' }}>{tc.name}</div>
                 <div style={{ fontSize: '13px', color: '#6B7280', lineHeight: 1.5 }}>{tc.desc}</div>
               </div>
@@ -274,7 +274,7 @@ export default function AProposPage() {
         <div style={{ maxWidth: '1180px', margin: '0 auto', display: 'grid', gridTemplateColumns: '1fr 420px', gap: '72px', alignItems: 'start' }}>
           <div>
             <div className="text-red-civic font-semibold text-xs tracking-[0.18em] uppercase mb-3">Transparence des données</div>
-            <h2 className="font-newsreader" style={{ fontWeight: 600, fontSize: '38px', color: '#1B2B50', margin: '0 0 22px', letterSpacing: '-0.015em' }}>D&apos;où viennent les données&nbsp;?</h2>
+            <h2 className="font-newsreader text-section" style={{ fontWeight: 600, color: '#1B2B50', margin: '0 0 22px', letterSpacing: '-0.015em' }}>D&apos;où viennent les données&nbsp;?</h2>
             <p style={{ fontSize: '16px', lineHeight: 1.7, color: '#4B5563', margin: '0 0 36px' }}>
               Toutes les informations affichées sur MonÉlu proviennent de sources publiques officielles. Nous ne produisons pas de données — nous les structurons, les enrichissons et les rendons accessibles. Chaque entrée est horodatée et traçable.
             </p>
@@ -288,7 +288,7 @@ export default function AProposPage() {
                     <div style={{ fontWeight: 600, fontSize: '15px', color: '#1B2B50' }}>{src.name}</div>
                     <div style={{ fontSize: '13px', color: '#9CA3AF', marginTop: '3px' }}>{src.desc}</div>
                   </div>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontFamily: 'monospace', fontSize: '11px', color: '#1F8A5B', background: '#EAF5EF', padding: '5px 11px', borderRadius: '999px', whiteSpace: 'nowrap' }}>
+                  <div className="font-mono" style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '11px', color: '#1F8A5B', background: '#EAF5EF', padding: '5px 11px', borderRadius: '999px', whiteSpace: 'nowrap' }}>
                     <span style={{ width: '6px', height: '6px', borderRadius: '999px', background: '#1F8A5B', flexShrink: 0, display: 'inline-block' }} />
                     {src.status}
                   </div>
@@ -304,7 +304,7 @@ export default function AProposPage() {
               {freshness.map((fr) => (
                 <div key={fr.label} style={{ padding: '14px 0', borderBottom: '1px solid #F0F1F3', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '12px' }}>
                   <span style={{ fontSize: '13.5px', color: '#374151' }}>{fr.label}</span>
-                  <span style={{ fontFamily: 'monospace', fontSize: '12px', color: '#6B7280' }}>{fr.cadence}</span>
+                  <span className="font-mono" style={{ fontSize: '12px', color: '#6B7280' }}>{fr.cadence}</span>
                 </div>
               ))}
               <div style={{ paddingTop: '18px', fontSize: '12.5px', lineHeight: 1.6, color: '#9CA3AF' }}>
@@ -325,7 +325,7 @@ export default function AProposPage() {
         <div style={{ maxWidth: '1180px', margin: '0 auto', display: 'grid', gridTemplateColumns: '1fr 540px', gap: '80px', alignItems: 'center' }}>
           <div>
             <div className="text-red-civic font-semibold text-xs tracking-[0.18em] uppercase mb-3">Pour les développeurs</div>
-            <h2 className="font-newsreader" style={{ fontWeight: 600, fontSize: '38px', color: '#1B2B50', margin: '0 0 20px', letterSpacing: '-0.015em' }}>
+            <h2 className="font-newsreader text-section" style={{ fontWeight: 600, color: '#1B2B50', margin: '0 0 20px', letterSpacing: '-0.015em' }}>
               Une API REST pensée pour être utilisée.
             </h2>
             <p style={{ fontSize: '16px', lineHeight: 1.7, color: '#4B5563', margin: '0 0 32px' }}>
@@ -357,9 +357,9 @@ export default function AProposPage() {
               <span style={{ width: '11px', height: '11px', borderRadius: '999px', background: '#FF5F57', display: 'inline-block' }} />
               <span style={{ width: '11px', height: '11px', borderRadius: '999px', background: '#FEBC2E', display: 'inline-block' }} />
               <span style={{ width: '11px', height: '11px', borderRadius: '999px', background: '#28C840', display: 'inline-block' }} />
-              <span style={{ fontFamily: 'monospace', fontSize: '12px', color: '#4B5563', marginLeft: '8px' }}>Terminal</span>
+              <span className="font-mono" style={{ fontSize: '12px', color: '#4B5563', marginLeft: '8px' }}>Terminal</span>
             </div>
-            <div style={{ padding: '24px 24px 28px', fontFamily: 'monospace', fontSize: '13.5px', lineHeight: 2, color: '#E4E6EA', overflowX: 'auto' }}>
+            <div className="font-mono" style={{ padding: '24px 24px 28px', fontSize: '13.5px', lineHeight: 2, color: '#E4E6EA', overflowX: 'auto' }}>
               <div><span style={{ color: '#9CA3AF' }}># Votes d&apos;un député</span></div>
               <div style={{ marginTop: '8px' }}>
                 <span style={{ color: '#E0786E' }}>GET</span>
@@ -442,7 +442,7 @@ export default function AProposPage() {
               </div>
             </div>
             <div style={{ flexShrink: 0, background: '#fff', border: '1px solid #E4E6EA', borderRadius: '10px', padding: '16px 20px', minWidth: '200px' }}>
-              <div style={{ fontWeight: 700, fontSize: '10px', letterSpacing: '0.14em', textTransform: 'uppercase', color: '#9CA3AF', marginBottom: '12px', fontFamily: 'monospace' }}>Temps de réponse</div>
+              <div className="font-mono" style={{ fontWeight: 700, fontSize: '10px', letterSpacing: '0.14em', textTransform: 'uppercase', color: '#9CA3AF', marginBottom: '12px' }}>Temps de réponse</div>
               <div style={{ fontSize: '14px', color: '#374151', lineHeight: 1.6 }}>
                 Bugs &amp; questions techniques<br />
                 <span style={{ fontWeight: 600, color: '#1B2B50' }}>sous 48 h</span>
@@ -461,7 +461,7 @@ export default function AProposPage() {
       <div style={{ padding: '80px 56px', background: '#1B2B50' }}>
         <div style={{ maxWidth: '1180px', margin: '0 auto', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '48px', flexWrap: 'wrap' }}>
           <div>
-            <h2 className="font-newsreader" style={{ fontWeight: 600, fontSize: '42px', color: '#fff', margin: '0 0 14px', letterSpacing: '-0.015em' }}>
+            <h2 className="font-newsreader text-section-lg" style={{ fontWeight: 600, color: '#fff', margin: '0 0 14px', letterSpacing: '-0.015em' }}>
               Prêt à explorer les données&nbsp;?
             </h2>
             <p style={{ fontSize: '16px', color: '#9CA3AF', margin: 0, lineHeight: 1.6 }}>

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -1,4 +1,7 @@
 'use client'
+// Typography exception: this page uses inline styles throughout because all colors and
+// sizes are computed dynamically from JS dark/light mode state (dk, txt1, txt2, bg0, …).
+// Converting to Tailwind classes would require a full theme rewrite.
 import { useState, useRef, useEffect, useCallback, Suspense } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { api } from '@/lib/api'

--- a/frontend/src/app/deputes/DeputiesClient.tsx
+++ b/frontend/src/app/deputes/DeputiesClient.tsx
@@ -92,8 +92,8 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
           }}>
             Annuaire des députés
           </div>
-          <h1 className="font-serif" style={{
-            fontWeight: 600, fontSize: 'clamp(32px,4vw,48px)', lineHeight: 1.05,
+          <h1 className="font-newsreader text-[clamp(32px,4vw,48px)]" style={{
+            fontWeight: 600, lineHeight: 1.05,
             letterSpacing: '-0.015em', color: NAVY, margin: 0, maxWidth: 760,
           }}>
             Les {initial.total} députés de l&apos;Assemblée nationale,{' '}
@@ -179,7 +179,7 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
 
           {/* Count row */}
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 4px 14px' }}>
-            <span style={{ fontFamily: 'monospace', fontSize: 13, color: '#6B7280' }}>
+            <span className="font-mono" style={{ fontSize: 13, color: '#6B7280' }}>
               {filtered.length} député{filtered.length !== 1 ? 's' : ''}
             </span>
             {debouncedSearch && (

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -114,8 +114,8 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
               <div style={{ fontWeight: 700, fontSize: 12, letterSpacing: '0.18em', textTransform: 'uppercase', color: RED }}>
                 Député·e · XVII<sup>e</sup> législature
               </div>
-              <h1 className="font-serif" style={{
-                fontWeight: 600, fontSize: 'clamp(36px,4.5vw,58px)', lineHeight: 1.0,
+              <h1 className="font-newsreader text-[clamp(36px,4.5vw,58px)]" style={{
+                fontWeight: 600, lineHeight: 1.0,
                 letterSpacing: '-0.02em', color: NAVY, margin: '14px 0 0',
               }}>
                 {deputy.full_name}
@@ -173,7 +173,7 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
             <div style={{ display: 'grid', gridTemplateColumns: `repeat(${stats.length},1fr)`, marginTop: 38, borderTop: `1px solid #ECE7DC` }}>
               {stats.map((s, i) => (
                 <div key={i} style={{ padding: '22px 14px 18px', borderRight: i < stats.length - 1 ? `1px solid #ECE7DC` : undefined }}>
-                  <div className="font-serif" style={{ fontWeight: 600, fontSize: 34, color: NAVY, letterSpacing: '-0.01em', lineHeight: 1 }}>
+                  <div className="font-newsreader text-[34px]" style={{ fontWeight: 600, color: NAVY, letterSpacing: '-0.01em', lineHeight: 1 }}>
                     {s.value}
                   </div>
                   <div style={{ fontSize: 12.5, color: '#6B7280', marginTop: 4, lineHeight: 1.35 }}>
@@ -196,7 +196,7 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
               <div style={{ fontWeight: 700, fontSize: 12, letterSpacing: '0.18em', textTransform: 'uppercase', color: RED }}>
                 Bilan de mandat
               </div>
-              <h2 className="font-serif" style={{ fontWeight: 600, fontSize: 30, color: NAVY, margin: '12px 0 22px', letterSpacing: '-0.01em' }}>
+              <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: NAVY, margin: '12px 0 22px', letterSpacing: '-0.01em' }}>
                 Répartition des votes
               </h2>
               <div style={{ background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12, overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.05)', padding: '26px 30px' }}>
@@ -216,7 +216,7 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                   ].map(({ color, label, pct }) => (
                     <span key={label} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                       <span style={{ width: 10, height: 10, borderRadius: 999, background: color, flexShrink: 0 }} />
-                      {label} <span style={{ fontFamily: 'monospace', color: '#6B7280' }}>{pct}%</span>
+                      {label} <span className="font-mono" style={{ color: '#6B7280' }}>{pct}%</span>
                     </span>
                   ))}
                 </div>
@@ -232,7 +232,7 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                             {presencePct >= avgPresencePct ? '↑' : '↓'} moy. {avgPresencePct}%
                           </span>
                         )}
-                        <span style={{ fontFamily: 'monospace', fontWeight: 700, fontSize: 18, color: NAVY }}>{presencePct}%</span>
+                        <span className="font-mono" style={{ fontWeight: 700, fontSize: 18, color: NAVY }}>{presencePct}%</span>
                       </div>
                     </div>
                     <div style={{ position: 'relative', height: 9, background: '#EEF0F2', borderRadius: 999, overflow: 'hidden' }}>
@@ -260,7 +260,7 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
               <div style={{ fontWeight: 700, fontSize: 12, letterSpacing: '0.18em', textTransform: 'uppercase', color: RED }}>
                 Votes marquants
               </div>
-              <h2 className="font-serif" style={{ fontWeight: 600, fontSize: 30, color: NAVY, margin: '12px 0 22px', letterSpacing: '-0.01em' }}>
+              <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: NAVY, margin: '12px 0 22px', letterSpacing: '-0.01em' }}>
                 Les votes récents de la législature
               </h2>
               <div style={{ position: 'relative', paddingLeft: 32 }}>
@@ -283,7 +283,7 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
 
                         <div style={{ display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap' }}>
                           {v.voted_at && (
-                            <span style={{ fontFamily: 'monospace', fontSize: 12.5, color: '#9CA3AF', letterSpacing: '0.02em' }}>
+                            <span className="font-mono" style={{ fontSize: 12.5, color: '#9CA3AF', letterSpacing: '0.02em' }}>
                               {formatDate(v.voted_at)}
                             </span>
                           )}
@@ -302,7 +302,7 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                         </div>
 
                         <Link href={`/votes/${v.vote_id}`} style={{ textDecoration: 'none' }}>
-                          <div className="font-serif" style={{ fontSize: 21, color: NAVY, marginTop: 8, lineHeight: 1.3, cursor: 'pointer' }}>
+                          <div className="font-newsreader text-[21px]" style={{ color: NAVY, marginTop: 8, lineHeight: 1.3, cursor: 'pointer' }}>
                             {v.vote_title}
                           </div>
                         </Link>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -14,7 +14,7 @@
 
 @layer base {
   body { @apply font-sans bg-white text-navy; }
-  h1, h2, h3 { @apply font-serif; }
+  h1, h2, h3 { @apply font-newsreader; }
 }
 
 @layer utilities {

--- a/frontend/src/app/votes/VotesClient.tsx
+++ b/frontend/src/app/votes/VotesClient.tsx
@@ -100,7 +100,7 @@ export function VotesClient({ initial, heroStats }: { initial: VoteList; heroSta
             Scrutins publics
           </div>
 
-          <h1 className="font-newsreader" style={{ fontWeight: 600, fontSize: 48, lineHeight: 1.05, letterSpacing: '-0.015em', color: '#1B2B50', margin: '16px 0 0', maxWidth: 760 }}>
+          <h1 className="font-newsreader text-display" style={{ fontWeight: 600, lineHeight: 1.05, letterSpacing: '-0.015em', color: '#1B2B50', margin: '16px 0 0', maxWidth: 760 }}>
             Les votes de l&apos;Assemblée nationale, <span style={{ color: '#C9302A' }}>en clair</span>.
           </h1>
 
@@ -112,7 +112,7 @@ export function VotesClient({ initial, heroStats }: { initial: VoteList; heroSta
           <div style={{ display: 'flex', gap: 0, marginTop: 32, border: '1px solid #ECE7DC', borderRadius: 12, background: '#fff', overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.05)', maxWidth: 700 }}>
             {heroStats.map((hs, i) => (
               <div key={i} style={{ flex: 1, padding: '18px 22px', borderRight: i < heroStats.length - 1 ? '1px solid #ECE7DC' : 'none' }}>
-                <div className="font-newsreader" style={{ fontWeight: 600, fontSize: 30, color: '#1B2B50', letterSpacing: '-0.01em' }}>{hs.value}</div>
+                <div className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: '#1B2B50', letterSpacing: '-0.01em' }}>{hs.value}</div>
                 <div style={{ fontSize: 12, color: '#9CA3AF', marginTop: 4, lineHeight: 1.35 }}>{hs.label}</div>
               </div>
             ))}
@@ -168,7 +168,7 @@ export function VotesClient({ initial, heroStats }: { initial: VoteList; heroSta
         <div style={{ maxWidth: 1180, margin: '0 auto' }}>
 
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 4px 14px' }}>
-            <span style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 13, color: '#6B7280' }}>
+            <span className="font-mono" style={{ fontSize: 13, color: '#6B7280' }}>
               {total.toLocaleString('fr-FR')} scrutins
               {result && ` · ${result.charAt(0).toUpperCase() + result.slice(1)}s`}
               {theme && ` · ${theme}`}
@@ -205,7 +205,7 @@ export function VotesClient({ initial, heroStats }: { initial: VoteList; heroSta
                     onMouseLeave={e => (e.currentTarget.style.background = '#fff')}>
 
                     {/* Date */}
-                    <div suppressHydrationWarning style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 12, color: '#9CA3AF', lineHeight: 1.4 }}>
+                    <div suppressHydrationWarning className="font-mono" style={{ fontSize: 12, color: '#9CA3AF', lineHeight: 1.4 }}>
                       {shortDate(vote.voted_at)}
                     </div>
 
@@ -237,7 +237,7 @@ export function VotesClient({ initial, heroStats }: { initial: VoteList; heroSta
                         <span style={{ fontSize: 12, fontWeight: 700, letterSpacing: '0.05em', padding: '3px 10px', borderRadius: 999, background: adopted ? '#EAF5EF' : '#FBE9E7', color: adopted ? '#1F8A5B' : '#C9302A' }}>
                           {adopted ? 'Adopté' : 'Rejeté'}
                         </span>
-                        <span style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 11.5, color: '#6B7280' }}>
+                        <span className="font-mono" style={{ fontSize: 11.5, color: '#6B7280' }}>
                           {vote.votes_for} pour · {vote.votes_against} contre
                         </span>
                       </div>

--- a/frontend/src/app/votes/[id]/VoteDetailClient.tsx
+++ b/frontend/src/app/votes/[id]/VoteDetailClient.tsx
@@ -104,7 +104,7 @@ export function VoteDetailClient(props: Props) {
             <span style={{ display: 'inline-flex', alignItems: 'center', fontSize: 12, fontWeight: 700, padding: '5px 14px', borderRadius: 999, background: adopted ? '#EAF5EF' : '#FBE9E7', color: adopted ? '#1F8A5B' : '#C9302A', flexShrink: 0 }}>
               {adopted ? 'Adopté' : 'Rejeté'}
             </span>
-            <span style={{ fontFamily: 'monospace', fontSize: 12.5, color: '#6B7280', flexShrink: 0 }}>
+            <span className="font-mono" style={{ fontSize: 12.5, color: '#6B7280', flexShrink: 0 }}>
               {votesFor} pour · {votesAgainst} contre
             </span>
           </div>
@@ -133,11 +133,11 @@ export function VoteDetailClient(props: Props) {
                 <span style={{ font: '700 11.5px/1 var(--font-sans)', letterSpacing: '0.16em', textTransform: 'uppercase', color: '#9CA3AF' }}>
                   Scrutin public · n°{voteId}
                 </span>
-                <span style={{ fontFamily: 'monospace', fontSize: 11.5, color: '#9CA3AF' }}>·</span>
-                <span suppressHydrationWarning style={{ fontFamily: 'monospace', fontSize: 12, color: '#9CA3AF' }}>{shortDate(votedAt)}</span>
+                <span className="font-mono" style={{ fontSize: 11.5, color: '#9CA3AF' }}>·</span>
+                <span suppressHydrationWarning className="font-mono" style={{ fontSize: 12, color: '#9CA3AF' }}>{shortDate(votedAt)}</span>
               </div>
 
-              <h1 className="font-newsreader" style={{ fontWeight: 600, fontSize: 44, lineHeight: 1.05, letterSpacing: '-0.015em', color: '#1B2B50', margin: 0, maxWidth: 620 }}>
+              <h1 className="font-newsreader text-title" style={{ fontWeight: 600, lineHeight: 1.05, letterSpacing: '-0.015em', color: '#1B2B50', margin: 0, maxWidth: 620 }}>
                 {voteTitle}
               </h1>
 
@@ -171,15 +171,15 @@ export function VoteDetailClient(props: Props) {
               {/* Big numbers */}
               <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 0, textAlign: 'center', marginBottom: 22 }}>
                 <div style={{ borderRight: '1px solid #F0F1F3', padding: '0 12px' }}>
-                  <div className="font-newsreader" style={{ fontSize: 42, fontWeight: 600, color: '#1F8A5B', letterSpacing: '-0.02em' }}>{votesFor.toLocaleString('fr-FR')}</div>
+                  <div className="font-newsreader text-section-lg" style={{ fontWeight: 600, color: '#1F8A5B', letterSpacing: '-0.02em' }}>{votesFor.toLocaleString('fr-FR')}</div>
                   <div style={{ fontSize: 12, fontWeight: 600, color: '#1F8A5B', marginTop: 3, letterSpacing: '0.04em' }}>POUR</div>
                 </div>
                 <div style={{ borderRight: '1px solid #F0F1F3', padding: '0 12px' }}>
-                  <div className="font-newsreader" style={{ fontSize: 42, fontWeight: 600, color: '#C9302A', letterSpacing: '-0.02em' }}>{votesAgainst.toLocaleString('fr-FR')}</div>
+                  <div className="font-newsreader text-section-lg" style={{ fontWeight: 600, color: '#C9302A', letterSpacing: '-0.02em' }}>{votesAgainst.toLocaleString('fr-FR')}</div>
                   <div style={{ fontSize: 12, fontWeight: 600, color: '#C9302A', marginTop: 3, letterSpacing: '0.04em' }}>CONTRE</div>
                 </div>
                 <div style={{ padding: '0 12px' }}>
-                  <div className="font-newsreader" style={{ fontSize: 42, fontWeight: 600, color: '#9CA3AF', letterSpacing: '-0.02em' }}>{abstentions.toLocaleString('fr-FR')}</div>
+                  <div className="font-newsreader text-section-lg" style={{ fontWeight: 600, color: '#9CA3AF', letterSpacing: '-0.02em' }}>{abstentions.toLocaleString('fr-FR')}</div>
                   <div style={{ fontSize: 12, fontWeight: 600, color: '#9CA3AF', marginTop: 3, letterSpacing: '0.04em' }}>ABST.</div>
                 </div>
               </div>
@@ -190,7 +190,7 @@ export function VoteDetailClient(props: Props) {
                 <div style={{ width: `${contrePct}%`, background: '#D9685E' }} />
                 <div style={{ flex: 1, background: '#E4E6EA' }} />
               </div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', fontFamily: 'monospace', fontSize: 11, color: '#9CA3AF', marginBottom: 22 }}>
+              <div className="font-mono" style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11, color: '#9CA3AF', marginBottom: 22 }}>
                 <span>{pourPct}%</span><span>{contrePct}%</span><span>{abstPct}%</span>
               </div>
 
@@ -231,7 +231,7 @@ export function VoteDetailClient(props: Props) {
             {groups.length > 0 && (
               <section>
                 <div style={{ font: '700 12px/1 var(--font-sans)', letterSpacing: '0.18em', textTransform: 'uppercase', color: '#C9302A' }}>Ventilation par groupe</div>
-                <h2 className="font-newsreader" style={{ fontWeight: 600, fontSize: 30, color: '#1B2B50', margin: '12px 0 4px', letterSpacing: '-0.01em' }}>Comment chaque groupe a voté</h2>
+                <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: '#1B2B50', margin: '12px 0 4px', letterSpacing: '-0.01em' }}>Comment chaque groupe a voté</h2>
                 <p style={{ fontSize: 15, color: '#6B7280', margin: '0 0 22px', maxWidth: 560 }}>Position majoritaire exprimée par les membres de chaque groupe parlementaire.</p>
 
                 <div style={{ background: '#fff', border: '1px solid #E4E6EA', borderRadius: 12, overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
@@ -254,9 +254,9 @@ export function VoteDetailClient(props: Props) {
                           </div>
                           <span style={{ fontSize: 12, fontWeight: 700, padding: '4px 11px', borderRadius: 999, color: posColor, background: posBg, flexShrink: 0 }}>{g.position}</span>
                         </div>
-                        <div style={{ fontFamily: 'monospace', fontSize: 13, color: '#1F8A5B', textAlign: 'right', fontWeight: 600 }}>{g.pour}</div>
-                        <div style={{ fontFamily: 'monospace', fontSize: 13, color: '#C9302A', textAlign: 'right', fontWeight: 600 }}>{g.contre}</div>
-                        <div style={{ fontFamily: 'monospace', fontSize: 13, color: '#9CA3AF', textAlign: 'right' }}>{g.abst}</div>
+                        <div className="font-mono" style={{ fontSize: 13, color: '#1F8A5B', textAlign: 'right', fontWeight: 600 }}>{g.pour}</div>
+                        <div className="font-mono" style={{ fontSize: 13, color: '#C9302A', textAlign: 'right', fontWeight: 600 }}>{g.contre}</div>
+                        <div className="font-mono" style={{ fontSize: 13, color: '#9CA3AF', textAlign: 'right' }}>{g.abst}</div>
                       </div>
                     )
                   })}
@@ -268,7 +268,7 @@ export function VoteDetailClient(props: Props) {
             {dissidents.length > 0 && (
               <section>
                 <div style={{ font: '700 12px/1 var(--font-sans)', letterSpacing: '0.18em', textTransform: 'uppercase', color: '#C9302A' }}>Votes notables</div>
-                <h2 className="font-newsreader" style={{ fontWeight: 600, fontSize: 30, color: '#1B2B50', margin: '12px 0 22px', letterSpacing: '-0.01em' }}>Dissidences &amp; surprises</h2>
+                <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: '#1B2B50', margin: '12px 0 22px', letterSpacing: '-0.01em' }}>Dissidences &amp; surprises</h2>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
                   {dissidents.map((d) => {
                     const voteColor = d.vote === 'pour' ? '#1F8A5B' : d.vote === 'contre' ? '#C9302A' : '#6B7280'
@@ -312,7 +312,7 @@ export function VoteDetailClient(props: Props) {
                           {r.vote_title}
                         </div>
                         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 7 }}>
-                          <span suppressHydrationWarning style={{ fontFamily: 'monospace', fontSize: 11, color: '#9CA3AF' }}>
+                          <span suppressHydrationWarning className="font-mono" style={{ fontSize: 11, color: '#9CA3AF' }}>
                             {new Date(r.voted_at).toLocaleDateString('fr-FR', { day: 'numeric', month: 'short', year: 'numeric' })}
                           </span>
                           <span style={{ fontSize: 11.5, fontWeight: 600, padding: '3px 9px', borderRadius: 999, color: rAdopted ? '#1F8A5B' : '#C9302A', background: rAdopted ? '#EAF5EF' : '#FBE9E7' }}>

--- a/frontend/src/components/home/AssemblyScrollExperience.tsx
+++ b/frontend/src/components/home/AssemblyScrollExperience.tsx
@@ -1,5 +1,6 @@
 'use client'
-
+// Typography exception: this cinematic scroll component uses inline styles throughout
+// because all colors, opacities, and sizes are computed dynamically by the animation engine.
 import { useEffect, useRef, useState } from 'react'
 import { useReducedMotion } from 'framer-motion'
 import Image from 'next/image'

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -37,7 +37,7 @@ const config: Config = {
       fontSize: {
         // Heading scale — use these on h1/h2/h3 instead of inline fontSize
         'headline':    ['3.25rem', { lineHeight: '1.06' }], // 52px — hero h1
-        'display':     ['3rem',    { lineHeight: '1.1'  }], // 48px — list page h1
+        'display':     ['3rem',    { lineHeight: '1.1', fontWeight: '400' }], // 48px — list page h1
         'title':       ['2.75rem', { lineHeight: '1.05' }], // 44px — detail page h1
         'section-lg':  ['2.625rem',{ lineHeight: '1.1'  }], // 42px — major section h2, stat numbers
         'section':     ['2.375rem',{ lineHeight: '1.1'  }], // 38px — section h2

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,5 +1,12 @@
 import type { Config } from 'tailwindcss'
 
+/**
+ * Font role contract:
+ *   font-serif      (DM Serif Display)  — landing page hero only
+ *   font-newsreader (Newsreader)        — editorial headings (h1/h2/h3) on all data pages
+ *   font-sans       (DM Sans)           — body copy, UI labels, navigation
+ *   font-mono       (system monospace)  — numbers, dates, metadata, code blocks
+ */
 const config: Config = {
   content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
   theme: {
@@ -25,10 +32,17 @@ const config: Config = {
         serif: ['var(--font-serif)', 'Georgia', 'serif'],
         sans: ['var(--font-sans)', 'system-ui', 'sans-serif'],
         newsreader: ['var(--font-newsreader)', 'Georgia', 'serif'],
+        mono: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
       },
       fontSize: {
-        'display': ['3rem', { lineHeight: '1.1', fontWeight: '400' }],
-        'display-sm': ['2rem', { lineHeight: '1.15', fontWeight: '400' }],
+        // Heading scale — use these on h1/h2/h3 instead of inline fontSize
+        'headline':    ['3.25rem', { lineHeight: '1.06' }], // 52px — hero h1
+        'display':     ['3rem',    { lineHeight: '1.1'  }], // 48px — list page h1
+        'title':       ['2.75rem', { lineHeight: '1.05' }], // 44px — detail page h1
+        'section-lg':  ['2.625rem',{ lineHeight: '1.1'  }], // 42px — major section h2, stat numbers
+        'section':     ['2.375rem',{ lineHeight: '1.1'  }], // 38px — section h2
+        'section-sm':  ['1.875rem',{ lineHeight: '1.1'  }], // 30px — sub-section h2
+        'display-sm':  ['2rem',    { lineHeight: '1.15' }], // 32px (legacy alias)
       },
     },
   },


### PR DESCRIPTION
## Summary

Fixes MON-72 — establishes a clear typographic role for each font family and removes ad-hoc inline `fontSize`/`fontFamily` values from heading elements.

### Finding → Fix

**MON-72 — font-mono missing, raw `fontFamily: 'monospace'` scattered across 5 files**
- Added `mono: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace']` to `tailwind.config.ts`
- Replaced every `fontFamily: 'monospace'` inline style with `className="font-mono"` in: `DeputiesClient.tsx`, `deputes/[id]/page.tsx`, `VotesClient.tsx`, `VoteDetailClient.tsx`, `a-propos/page.tsx`

**MON-72 — no named heading size scale, all heading `fontSize` values hard-coded inline**
- Added named entries to `tailwind.config.ts`: `text-headline` (52px), `text-display` (48px, existing), `text-title` (44px), `text-section-lg` (42px), `text-section` (38px), `text-section-sm` (30px)
- Replaced inline `fontSize` on every h1/h2/h3 across all data pages with named or arbitrary Tailwind classes

**MON-72 — `deputes/[id]/page.tsx` uses `font-serif` on headings, inconsistent with all other pages**
- Changed `className="font-serif"` → `className="font-newsreader"` on h1, h2, and editorial div elements

**MON-72 — globals.css base rule declared `font-serif` for h1/h2/h3, contradicting actual page usage**
- Changed base rule to `font-newsreader` to align with what all data pages intentionally do; `font-serif` (DM Serif Display) remains available for the landing hero via explicit class

**Font role documentation**
- Added JSDoc comment block in `tailwind.config.ts` codifying each font family's role
- Added exception comments to `chat/page.tsx` and `AssemblyScrollExperience.tsx` — both use inline styles throughout because colors/sizes are computed dynamically from JS state

## Pre-existing build failures (not introduced by this PR)

Both `npm run build` failures were already present on `master` before this branch:
- ESLint not installed (`npm install --save-dev eslint` needed)
- `jest.setup.ts:5` — `Cannot use namespace 'jest' as a value` TypeScript error

## Testing

- [ ] `npm run build` — same pre-existing errors as on `master`, no new failures
- [ ] Visual check: `/deputes`, `/deputes/[id]`, `/votes`, `/votes/[id]`, `/a-propos` — consistent `font-newsreader` headings throughout
- [ ] `/chat` — unaffected (exception documented)
- [ ] Landing page — `AssemblyScrollExperience` unaffected (exception documented)
- [ ] No raw `fontFamily: 'monospace'` remains in any page or data-page component

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qgd2TLnJf7Ufu9Btzy1yxw