### PR TITLE
feat: add share buttons to deputy and vote pages (MON-67, MON-68)

### DIFF
--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -5,6 +5,7 @@ import { api } from '@/lib/api'
 import type { DeputyVoteItem } from '@/lib/api'
 import { partyHex, formatDate } from '@/lib/utils'
 import { DeputyAvatar } from '@/components/DeputyAvatar'
+import { ShareButton } from '@/components/ShareButton'
 
 export const dynamicParams = true
 export const revalidate = 86400
@@ -164,6 +165,12 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                 >
                   Votes récents
                 </a>
+                <ShareButton
+                  url={`/deputes/${id}`}
+                  title={`${deputy.full_name} — MonÉlu`}
+                  text={`Bilan de mandat et votes de ${deputy.full_name}`}
+                  ariaLabel="Partager ce député"
+                />
               </div>
             </div>
           </div>

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -167,7 +167,7 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                 </a>
                 <ShareButton
                   url={`/deputes/${id}`}
-                  title={`${deputy.full_name} — MonÉlu`}
+                  title={`${deputy.full_name} - MonÉlu`}
                   text={`Bilan de mandat et votes de ${deputy.full_name}`}
                   ariaLabel="Partager ce député"
                 />

--- a/frontend/src/app/votes/[id]/VoteDetailClient.tsx
+++ b/frontend/src/app/votes/[id]/VoteDetailClient.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useState, useRef, useCallback } from 'react'
 import Link from 'next/link'
+import { ShareButton } from '@/components/ShareButton'
 
 interface GroupRow {
   name: string
@@ -214,6 +215,12 @@ export function VoteDetailClient(props: Props) {
                   style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', border: '1px solid #E4E6EA', color: '#4B5563', padding: '11px 16px', borderRadius: 8, fontWeight: 600, fontSize: 14, cursor: 'pointer', textDecoration: 'none' }}>
                   <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/></svg>
                 </a>
+                <ShareButton
+                  url={`/votes/${voteId}`}
+                  title={`${adopted ? 'Adopté' : 'Rejeté'} — ${voteTitle}`}
+                  text="Suivez ce scrutin sur MonÉlu"
+                  ariaLabel="Partager ce vote"
+                />
               </div>
             </div>
           </div>

--- a/frontend/src/app/votes/[id]/VoteDetailClient.tsx
+++ b/frontend/src/app/votes/[id]/VoteDetailClient.tsx
@@ -217,7 +217,7 @@ export function VoteDetailClient(props: Props) {
                 </a>
                 <ShareButton
                   url={`/votes/${voteId}`}
-                  title={`${adopted ? 'Adopté' : 'Rejeté'} — ${voteTitle}`}
+                  title={`${adopted ? 'Adopté' : 'Rejeté'} - ${voteTitle}`}
                   text="Suivez ce scrutin sur MonÉlu"
                   ariaLabel="Partager ce vote"
                 />

--- a/frontend/src/components/ShareButton.tsx
+++ b/frontend/src/components/ShareButton.tsx
@@ -20,8 +20,10 @@ export function ShareButton({ url, title, text, ariaLabel }: ShareButtonProps) {
       try {
         await navigator.share({ url: fullUrl, title, text })
         return
-      } catch {
-        // user cancelled or API not available — fall through to clipboard
+      } catch (err) {
+        // User cancelled the share sheet: respect that, don't copy instead.
+        if (err instanceof Error && err.name === 'AbortError') return
+        // API genuinely unavailable - fall through to clipboard.
       }
     }
     try {


### PR DESCRIPTION
## Summary

Adds a share affordance to the two public detail pages, reusing the existing (previously unused) `ShareButton` component - native Web Share API with a clipboard-copy fallback and a "Copié !" confirmation.

### MON-67 - Share option on Vote pages
- `ShareButton` added to the result-card Actions row in `VoteDetailClient.tsx`.
- Shares `/votes/[id]` with a title of `Adopté|Rejeté — <vote title>`.
- OG/twitter meta already present via `generateMetadata` in `votes/[id]/page.tsx` - no change needed.

### MON-68 - Share option on Deputy pages
- `ShareButton` added to the profile CTA row in `deputes/[id]/page.tsx`.
- Shares `/deputes/[id]` with title `<full name> — MonÉlu` and an explicit deputy `ariaLabel` (the component default was vote-specific).
- OG/twitter meta already present via `generateMetadata` - no change needed.

## Testing
- `next build` compiles successfully. (Local `tsc`/eslint surface only pre-existing test-file noise from missing `@types/jest`/`eslint` dev deps, which CI installs.)
- Manual: clicking share copies the canonical absolute URL; native share sheet used where available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)