### PR TITLE
feat: sort dropdown on /deputes + unbiased hemicycle dots (MON-73, MON-71)

### DIFF
--- a/frontend/src/app/deputes/DeputiesClient.tsx
+++ b/frontend/src/app/deputes/DeputiesClient.tsx
@@ -150,25 +150,27 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
             </button>
           </div>
 
-          {/* Sort pills */}
+          {/* Sort dropdown */}
           <div style={{ display: 'flex', gap: 9, marginTop: 18, alignItems: 'center' }}>
-            <span style={{ fontSize: 13.5, color: '#9CA3AF', marginRight: 4 }}>Trier par</span>
-            {([['nom', 'Nom'], ['region', 'Région'], ['parti', 'Groupe']] as const).map(([val, label]) => (
-              <button
-                key={val}
-                onClick={() => { setSort(val); setPage(1) }}
-                aria-pressed={sort === val}
-                style={{
-                  background: sort === val ? NAVY : '#fff',
-                  color: sort === val ? '#fff' : '#4B5563',
-                  border: '1px solid ' + (sort === val ? NAVY : LINE),
-                  padding: '8px 18px', borderRadius: 999, fontSize: 13.5,
-                  fontWeight: sort === val ? 600 : 400, cursor: 'pointer',
-                }}
-              >
-                {label}
-              </button>
-            ))}
+            <label htmlFor="deputy-sort" style={{ fontSize: 13.5, color: '#9CA3AF', marginRight: 4 }}>Trier par</label>
+            <select
+              id="deputy-sort"
+              value={sort}
+              onChange={e => { setSort(e.target.value as SortKey); setPage(1) }}
+              style={{
+                background: '#fff', color: '#1B2B50',
+                border: '1px solid ' + LINE, borderRadius: 999,
+                padding: '8px 34px 8px 16px', fontSize: 13.5, fontWeight: 600,
+                cursor: 'pointer', appearance: 'none',
+                backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236B7280' stroke-width='2.4' stroke-linecap='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E")`,
+                backgroundRepeat: 'no-repeat',
+                backgroundPosition: 'right 14px center',
+              }}
+            >
+              <option value="nom">Nom</option>
+              <option value="region">Région</option>
+              <option value="parti">Groupe</option>
+            </select>
           </div>
         </div>
       </div>

--- a/frontend/src/components/home/AssemblyScrollExperience.tsx
+++ b/frontend/src/components/home/AssemblyScrollExperience.tsx
@@ -212,6 +212,17 @@ function CinematicExperience({ stats, leadVote, deputyInfo }: Props) {
     const pPour = REAL_TOTAL > 0 ? REAL_POUR / REAL_TOTAL : 0.52
     const pAbst = REAL_TOTAL > 0 ? REAL_ABST / REAL_TOTAL : 0.08
 
+    // Deterministic PRNG (mulberry32) so the seat layout is stable per render
+    // and never re-randomizes on re-render or per frame (MON-71).
+    let _seed = 0x9e3779b9 >>> 0
+    const rand = () => {
+      _seed = (_seed + 0x6d2b79f5) >>> 0
+      let t = _seed
+      t = Math.imul(t ^ (t >>> 15), t | 1)
+      t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+    }
+
     for (let a = 0; a < arcs; a++) {
       const r = rMin + (rMax - rMin) * (a / (arcs - 1))
       const arcLen = (aMax - aMin) * r
@@ -224,14 +235,14 @@ function CinematicExperience({ stats, leadVote, deputyInfo }: Props) {
         if (y < 548 || y > 980 || x < 70 || x > 1602) continue
         const aisleHalf = 70 + Math.max(0, y - 560) * 0.16
         if (Math.abs(x - CX) < aisleHalf && y > 560) continue
-        const side = t
+        // No left/right bias: kind is drawn from the global proportions so
+        // pour/contre/abst spread evenly across both wings of the hemicycle.
         let kind: 'pour' | 'contre' | 'abst'
-        const rnd = Math.random()
-        const pG = Math.min(0.85, Math.max(0.10, pPour + (side - 0.5) * 0.3))
-        if (rnd < pG) kind = 'pour'
-        else if (rnd < pG + pAbst) kind = 'abst'
+        const rnd = rand()
+        if (rnd < pPour) kind = 'pour'
+        else if (rnd < pPour + pAbst) kind = 'abst'
         else kind = 'contre'
-        seats.push({ x, y, kind, arc: a, order: Math.random(), _el: null!, _col: null! })
+        seats.push({ x, y, kind, arc: a, order: rand(), _el: null!, _col: null! })
       }
     }
     seats.sort((p, q) => (p.arc - q.arc) || (p.order - q.order))


### PR DESCRIPTION
## Summary

Two landing/list UX fixes.

### MON-73 - Sort control as a dropdown
The "Trier par" control on `/deputes` was three pill buttons (Nom / Région / Groupe), which wastes toolbar width and does not scale. Replaced with a single native `<select>` (custom chevron, navy text). `SortKey` and the `localeCompare(..., 'fr')` sort logic are unchanged - only the control UI changed. Native `<select>` keeps keyboard/screen-reader accessibility for free.

### MON-71 - Hemicycle dots across both sides
The seat-kind assignment biased `pour` toward the right and `contre` toward the left (`pG = pPour + (side - 0.5) * 0.3`), clustering the red dots on one wing. Removed the side term so `pour`/`contre`/`abst` are drawn from the global vote proportions and spread evenly across the full arc. Replaced the per-seat `Math.random()` calls with a deterministic mulberry32 PRNG so the layout is stable per render and never re-randomizes (the field is built once in an effect; the seed makes re-renders identical).

## Testing
- `tsc` clean for both source files. Existing `DeputiesClient` test exercises search only (no sort assertions) - unaffected.
- Manual: dropdown reorders the list; hemicycle shows red/green/grey on both halves with no clustering and a stable layout across reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)