### PR TITLE
fix: use plain dash in deputy and vote page metadata titles

### DIFF
--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -21,13 +21,13 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
   const deputy = await api.deputies.get(id).catch(() => null)
   if (!deputy) return {}
   const description = `Bilan de mandat, votes et présence de ${deputy.full_name}${
-    deputy.party ? ` (${deputy.party})` : deputy.department ? ` — ${deputy.department}` : ''
+    deputy.party ? ` (${deputy.party})` : deputy.department ? ` - ${deputy.department}` : ''
   }.`
   return {
-    title: `${deputy.full_name} — MonÉlu`,
+    title: `${deputy.full_name} - MonÉlu`,
     description,
-    openGraph: { title: `${deputy.full_name} — MonÉlu`, description },
-    twitter:   { card: 'summary_large_image', title: `${deputy.full_name} — MonÉlu`, description },
+    openGraph: { title: `${deputy.full_name} - MonÉlu`, description },
+    twitter:   { card: 'summary_large_image', title: `${deputy.full_name} - MonÉlu`, description },
   }
 }
 

--- a/frontend/src/app/votes/[id]/page.tsx
+++ b/frontend/src/app/votes/[id]/page.tsx
@@ -16,10 +16,10 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
   const shortTitle = vote.vote_title.length > 80 ? vote.vote_title.slice(0, 80) + '…' : vote.vote_title
   const description = `${result} · ${vote.votes_for} pour · ${vote.votes_against} contre · ${vote.abstentions} abstentions.`
   return {
-    title: `${result} — ${shortTitle} — MonÉlu`,
+    title: `${result} - ${shortTitle} - MonÉlu`,
     description,
-    openGraph: { title: `${result} — ${shortTitle} — MonÉlu`, description, url: `https://mon-elu.vercel.app/votes/${id}` },
-    twitter: { card: 'summary_large_image', title: `${result} — ${shortTitle} — MonÉlu`, description },
+    openGraph: { title: `${result} - ${shortTitle} - MonÉlu`, description, url: `https://mon-elu.vercel.app/votes/${id}` },
+    twitter: { card: 'summary_large_image', title: `${result} - ${shortTitle} - MonÉlu`, description },
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #155 review. Replaces em dashes with plain dashes in the `generateMetadata` title / openGraph / twitter strings on the deputy and vote detail pages, per the project no-em-dash convention.

## Scope
- `deputes/[id]/page.tsx` - metadata title (×3) and the description's department separator.
- `votes/[id]/page.tsx` - metadata title (×3).
- Deliberately untouched: visible French prose (about page, site title), and empty-value placeholders like `presencePct ?? '—'` where the em dash is an intentional typographic glyph.

## Testing
- `tsc` clean for both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)