### PR TITLE
fix: confidence label casing + postal-code lookup (MON-74, MON-84)

### DIFF
--- a/api/routers/search.py
+++ b/api/routers/search.py
@@ -38,7 +38,7 @@ class SearchResponse(BaseModel):
     chunks_retrieved: int
     sources: list[SourceItem]
     query_type: str = "rag"
-    confidence: str = "MEDIUM"
+    confidence: str = "medium"
     data_source: str = "RAG"
     caveat: str | None = None
 
@@ -64,7 +64,7 @@ def search(request: Request, body: SearchRequest):
             chunks_retrieved=result["chunks_retrieved"],
             sources=[SourceItem(**s) for s in result.get("sources", [])],
             query_type=result.get("query_type", "rag"),
-            confidence=result.get("confidence", "MEDIUM"),
+            confidence=result.get("confidence", "medium"),
             data_source=result.get("data_source", "RAG"),
             caveat=result.get("caveat"),
         )

--- a/frontend/__tests__/lib/postal.test.ts
+++ b/frontend/__tests__/lib/postal.test.ts
@@ -1,0 +1,49 @@
+import { resolvePostalCode } from '@/lib/postal'
+
+function mockFetch(status: number, body: unknown) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response)
+}
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('resolvePostalCode', () => {
+  it('resolves a valid postal code to its department name', async () => {
+    mockFetch(200, [{ departement: { code: '75', nom: 'Paris' } }])
+    const result = await resolvePostalCode('75001')
+    expect(result).toBe('Paris')
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('codePostal=75001')
+    )
+  })
+
+  it('returns null for non-postal-code input without calling fetch', async () => {
+    global.fetch = jest.fn()
+    const result = await resolvePostalCode('Marine Le Pen')
+    expect(result).toBeNull()
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns null when the API responds with no communes', async () => {
+    mockFetch(200, [])
+    const result = await resolvePostalCode('00000')
+    expect(result).toBeNull()
+  })
+
+  it('returns null on a non-ok HTTP response', async () => {
+    mockFetch(500, {})
+    const result = await resolvePostalCode('75001')
+    expect(result).toBeNull()
+  })
+
+  it('returns null when the fetch itself throws', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('network error'))
+    const result = await resolvePostalCode('75001')
+    expect(result).toBeNull()
+  })
+})

--- a/frontend/src/app/deputes/DeputiesClient.tsx
+++ b/frontend/src/app/deputes/DeputiesClient.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { Deputy } from '@/lib/api'
 import { getInitials, partyHex } from '@/lib/utils'
 import { DeputyAvatar } from '@/components/DeputyAvatar'
+import { resolvePostalCode } from '@/lib/postal'
 
 type DeputyList = { total: number; items: Deputy[]; limit: number; offset: number }
 type SortKey = 'nom' | 'region' | 'parti'
@@ -29,6 +30,20 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
     return () => clearTimeout(t)
   }, [search])
 
+  const [postalResult, setPostalResult] = useState<{ code: string; department: string | null } | null>(null)
+  useEffect(() => {
+    if (!/^\d{5}$/.test(debouncedSearch)) return
+    let cancelled = false
+    resolvePostalCode(debouncedSearch).then(department => {
+      if (!cancelled) setPostalResult({ code: debouncedSearch, department })
+    })
+    return () => { cancelled = true }
+  }, [debouncedSearch])
+
+  const postalMatch = postalResult?.code === debouncedSearch ? postalResult : null
+  const resolvedDepartment = postalMatch?.department ?? ''
+  const postalNotFound = postalMatch !== null && postalMatch.department === null
+
   const skipFirstSync = useRef(true)
   useEffect(() => {
     if (skipFirstSync.current) { skipFirstSync.current = false; return }
@@ -40,7 +55,7 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
   }, [debouncedSearch, router])
 
   const filtered = useMemo(() => {
-    const q = debouncedSearch.toLowerCase()
+    const q = (resolvedDepartment || debouncedSearch).toLowerCase()
     const items = q
       ? initial.items.filter(d =>
           d.full_name.toLowerCase().includes(q) ||
@@ -53,7 +68,7 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
     if (sort === 'region') return items.sort((a, b) => (a.department ?? '').localeCompare(b.department ?? '', 'fr'))
     if (sort === 'parti')  return items.sort((a, b) => (a.party ?? '').localeCompare(b.party ?? '', 'fr'))
     return items
-  }, [initial.items, debouncedSearch, sort])
+  }, [initial.items, debouncedSearch, resolvedDepartment, sort])
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))
   const safePage = Math.min(page, totalPages)
@@ -196,7 +211,11 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
 
           {filtered.length === 0 ? (
             <div style={{ padding: '64px 0', textAlign: 'center' }}>
-              <p style={{ color: '#6B7280', fontSize: 15, marginBottom: 12 }}>Aucun résultat pour cette recherche</p>
+              <p style={{ color: '#6B7280', fontSize: 15, marginBottom: 12 }}>
+                {postalNotFound
+                  ? 'Code postal introuvable. Essayez un nom, une circonscription ou un département.'
+                  : 'Aucun résultat pour cette recherche'}
+              </p>
               <button
                 onClick={clearSearch}
                 style={{ fontSize: 14, color: NAVY, textDecoration: 'underline', background: 'none', border: 'none', cursor: 'pointer' }}

--- a/frontend/src/lib/postal.ts
+++ b/frontend/src/lib/postal.ts
@@ -1,4 +1,18 @@
-// TODO: wire to a postal-code → department lookup (e.g. geo.api.gouv.fr /communes?codePostal=)
-export async function resolvePostalCode(_input: string): Promise<string | null> {
-  return null
+// Resolves a French postal code to its department name via geo.api.gouv.fr,
+// matching the full-name format stored in deputies.department (see
+// scripts/update_party.py DEPT_NAMES). Non-postal-code input (names,
+// department names) is left for the caller to search on directly.
+export async function resolvePostalCode(input: string): Promise<string | null> {
+  if (!/^\d{5}$/.test(input)) return null
+
+  try {
+    const res = await fetch(
+      `https://geo.api.gouv.fr/communes?codePostal=${input}&fields=departement&format=json`
+    )
+    if (!res.ok) return null
+    const communes = await res.json()
+    return communes[0]?.departement?.nom ?? null
+  } catch {
+    return null
+  }
 }

--- a/rag/chain/rag_chain.py
+++ b/rag/chain/rag_chain.py
@@ -30,7 +30,7 @@ def extract_confidence(answer: str) -> tuple[str, str]:
         level = match.group(1).upper()
         clean = _CONFIDENCE_PATTERN.sub("", answer).strip()
         return clean, level
-    return answer, "MEDIUM"
+    return answer, "medium"
 
 
 def compute_confidence(chunks: list[dict]) -> str:
@@ -39,15 +39,15 @@ def compute_confidence(chunks: list[dict]) -> str:
     Based on top chunk similarity and number of supporting chunks.
     """
     if not chunks:
-        return "FAIBLE"
+        return "low"
     top_sim = chunks[0].get("similarity", 0)
     strong_chunks = sum(1 for c in chunks if c.get("similarity", 0) >= 0.5)
 
     if top_sim >= 0.65 and strong_chunks >= 2:
-        return "ÉLEVÉ"
+        return "high"
     if top_sim >= 0.5:
-        return "MOYEN"
-    return "FAIBLE"
+        return "medium"
+    return "low"
 
 
 def ask(

--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -393,7 +393,7 @@ def route(question: str) -> dict | None:
         "chunks_retrieved": 0,
         "sources": [],
         "query_type": intent,
-        "confidence": "HIGH",
+        "confidence": "high",
         "data_source": "SQL",
         "caveat": "Données calculées directement depuis la base de données. Aucune génération IA.",
     }

--- a/tests/unit/test_confidence.py
+++ b/tests/unit/test_confidence.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from api.routers.search import SearchResponse
+from rag.chain.rag_chain import compute_confidence
+
+VALID_CONFIDENCE_VALUES = {"high", "medium", "low"}
+
+
+def test_compute_confidence_high():
+    chunks = [{"similarity": 0.7}, {"similarity": 0.6}]
+    assert compute_confidence(chunks) == "high"
+
+
+def test_compute_confidence_medium():
+    chunks = [{"similarity": 0.55}]
+    assert compute_confidence(chunks) == "medium"
+
+
+def test_compute_confidence_low_on_weak_similarity():
+    chunks = [{"similarity": 0.2}]
+    assert compute_confidence(chunks) == "low"
+
+
+def test_compute_confidence_low_on_no_chunks():
+    assert compute_confidence([]) == "low"
+
+
+def test_compute_confidence_returns_only_documented_values():
+    cases = [
+        [],
+        [{"similarity": 0.2}],
+        [{"similarity": 0.55}],
+        [{"similarity": 0.7}, {"similarity": 0.6}],
+    ]
+    for chunks in cases:
+        assert compute_confidence(chunks) in VALID_CONFIDENCE_VALUES
+
+
+def test_search_response_default_confidence_is_lowercase():
+    response = SearchResponse(answer="a", question="q", chunks_retrieved=0, sources=[])
+    assert response.confidence in VALID_CONFIDENCE_VALUES


### PR DESCRIPTION
## Summary

- **MON-74** — every RAG chat answer showed a raw `ÉLEVÉ` badge instead of `Haute confiance`. Root cause: three backend producers of the `confidence` field disagreed on casing/language (`rag_chain.py` emitted French uppercase `ÉLEVÉ`/`MOYEN`/`FAIBLE`, `sql_router.py` emitted English uppercase `HIGH`, `api/routers/search.py` defaulted to `MEDIUM`), while the frontend's `Bubbles.tsx` `confidenceLabel`/`confidenceColor` maps only recognize lowercase English keys (`high`/`medium`/`low`) — a contract already asserted by the existing `frontend/__tests__/lib/api.test.ts`. Normalized all three producers to lowercase English; no frontend change needed.
- **MON-84** — the hero search promised "find your deputy by postal code" but `frontend/src/lib/postal.ts:resolvePostalCode` was a stub that always returned `null`, so a postal code silently fell through as a raw search string that never matches `full_name`/`department`/`party`. Implemented the lookup via the public `geo.api.gouv.fr` API (the TODO comment's own suggestion), resolving a 5-digit postal code to the department's full French name — the exact format already stored in `deputies.department` (see `scripts/update_party.py` `DEPT_NAMES`). Non-postal-code input is left untouched via a `^\d{5}$` guard, so existing name/department search behavior is unaffected. Per the ticket's acceptance criteria, also wired the same lookup into the `/deputes` page's own search box (`DeputiesClient.tsx`), not just the home hero, and added a postal-specific empty state ("Code postal introuvable…") instead of the generic no-results message.

## Testing
- `python -m pytest tests/unit/ -q` — 10 passed
- `ruff check .` / `ruff format --check .` — clean, repo-wide
- `npm test` (frontend) — 5 suites, 36 passed, including new `postal.test.ts` (valid code, non-code input, empty API result, non-ok response, thrown fetch error)
- `npx tsc --noEmit` and `npx eslint .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)