### PR TITLE
feat: sitemap.xml, robots.txt, and freshness badge (MON-94, MON-80)

### DIFF
--- a/frontend/__tests__/components/FreshnessBadge.test.tsx
+++ b/frontend/__tests__/components/FreshnessBadge.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+
+import { FreshnessBadge } from '@/components/FreshnessBadge'
+import { api } from '@/lib/api'
+
+jest.mock('@/lib/api', () => ({
+  api: { health: jest.fn() },
+}))
+
+afterEach(() => jest.clearAllMocks())
+
+describe('FreshnessBadge', () => {
+  it('renders a fresh state for a recent ingestion date', async () => {
+    ;(api.health as jest.Mock).mockResolvedValue({ last_ingestion: new Date().toISOString() })
+    render(await FreshnessBadge())
+    expect(screen.getByText(/Données à jour au/)).toBeInTheDocument()
+  })
+
+  it('renders a stale state when ingestion is older than 4 days', async () => {
+    const old = new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString()
+    ;(api.health as jest.Mock).mockResolvedValue({ last_ingestion: old })
+    const { container } = render(await FreshnessBadge())
+    expect(container.querySelector('.bg-amber-50')).toBeInTheDocument()
+  })
+
+  it('renders nothing when the health check fails', async () => {
+    ;(api.health as jest.Mock).mockRejectedValue(new Error('API error: 503'))
+    const result = await FreshnessBadge()
+    expect(result).toBeNull()
+  })
+
+  it('renders nothing when last_ingestion is missing', async () => {
+    ;(api.health as jest.Mock).mockResolvedValue({})
+    const result = await FreshnessBadge()
+    expect(result).toBeNull()
+  })
+})

--- a/frontend/src/app/api/revalidate/route.ts
+++ b/frontend/src/app/api/revalidate/route.ts
@@ -25,6 +25,7 @@ export async function POST(req: NextRequest) {
   revalidatePath('/deputes')
   revalidatePath('/deputes/[id]', 'page')
   revalidatePath('/votes/[id]', 'page')
+  revalidatePath('/sitemap.xml')
 
   return Response.json({ revalidated: true, at: new Date().toISOString() })
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -6,6 +6,7 @@ import './globals.css'
 import { Nav } from '@/components/Nav'
 import { BottomNav } from '@/components/BottomNav'
 import { PageTransition } from '@/components/PageTransition'
+import { FreshnessBadge } from '@/components/FreshnessBadge'
 
 const serif = DM_Serif_Display({
   subsets: ['latin'],
@@ -62,6 +63,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="fr" className={`${serif.variable} ${sans.variable} ${newsreader.variable}`}>
       <body className="bg-gray-off min-h-screen">
         <Nav />
+        <FreshnessBadge />
         <main className="pb-20 md:pb-0"><PageTransition>{children}</PageTransition></main>
         <BottomNav />
         <Analytics />

--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -1,0 +1,8 @@
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: '*', allow: '/' },
+    sitemap: 'https://mon-elu.vercel.app/sitemap.xml',
+  }
+}

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,0 +1,64 @@
+import type { MetadataRoute } from 'next'
+import { api } from '@/lib/api'
+
+const SITE_URL = 'https://mon-elu.vercel.app'
+
+export const revalidate = 3600
+
+async function deputyUrls(): Promise<MetadataRoute.Sitemap> {
+  const urls: MetadataRoute.Sitemap = []
+  const limit = 200
+  let offset = 0
+  let total = Infinity
+
+  while (offset < total) {
+    const page = await api.deputies.list({ limit, offset })
+    total = page.total
+    for (const d of page.items) {
+      urls.push({
+        url: `${SITE_URL}/deputes/${d.deputy_id}`,
+        lastModified: new Date(d.mandate_end ?? d.mandate_start ?? Date.now()),
+        changeFrequency: 'daily',
+        priority: 0.7,
+      })
+    }
+    offset += limit
+    if (page.items.length === 0) break
+  }
+  return urls
+}
+
+async function voteUrls(): Promise<MetadataRoute.Sitemap> {
+  const urls: MetadataRoute.Sitemap = []
+  let cursor: string | undefined
+  const limit = 200
+
+  do {
+    const page = await api.votes.list({ limit, before: cursor })
+    for (const v of page.items) {
+      urls.push({
+        url: `${SITE_URL}/votes/${v.vote_id}`,
+        lastModified: new Date(v.voted_at),
+        changeFrequency: 'monthly',
+        priority: 0.6,
+      })
+    }
+    cursor = page.next_cursor ?? undefined
+  } while (cursor)
+
+  return urls
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const staticUrls: MetadataRoute.Sitemap = [
+    { url: SITE_URL, changeFrequency: 'daily', priority: 1.0 },
+    { url: `${SITE_URL}/deputes`, changeFrequency: 'daily', priority: 0.9 },
+    { url: `${SITE_URL}/votes`, changeFrequency: 'daily', priority: 0.9 },
+    { url: `${SITE_URL}/chat`, changeFrequency: 'monthly', priority: 0.5 },
+    { url: `${SITE_URL}/a-propos`, changeFrequency: 'monthly', priority: 0.4 },
+  ]
+
+  const [deputies, votes] = await Promise.all([deputyUrls(), voteUrls()])
+
+  return [...staticUrls, ...deputies, ...votes]
+}

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,50 +1,60 @@
 import type { MetadataRoute } from 'next'
-import { api } from '@/lib/api'
+import { api, type Deputy, type Vote } from '@/lib/api'
 
 const SITE_URL = 'https://mon-elu.vercel.app'
+const PAGE_SIZE = 200
+const OFFSET_CAP = 2000 // api.votes.list() rejects offset beyond this — see api/routers/votes.py
 
 export const revalidate = 3600
 
-async function deputyUrls(): Promise<MetadataRoute.Sitemap> {
-  const urls: MetadataRoute.Sitemap = []
-  const limit = 200
-  let offset = 0
-  let total = Infinity
-
-  while (offset < total) {
-    const page = await api.deputies.list({ limit, offset })
-    total = page.total
-    for (const d of page.items) {
-      urls.push({
-        url: `${SITE_URL}/deputes/${d.deputy_id}`,
-        lastModified: new Date(d.mandate_end ?? d.mandate_start ?? Date.now()),
-        changeFrequency: 'daily',
-        priority: 0.7,
-      })
-    }
-    offset += limit
-    if (page.items.length === 0) break
+function toDeputyUrl(d: Deputy): MetadataRoute.Sitemap[number] {
+  return {
+    url: `${SITE_URL}/deputes/${d.deputy_id}`,
+    lastModified: new Date(d.mandate_end ?? d.mandate_start ?? Date.now()),
+    changeFrequency: 'daily',
+    priority: 0.7,
   }
-  return urls
+}
+
+function toVoteUrl(v: Vote): MetadataRoute.Sitemap[number] {
+  return {
+    url: `${SITE_URL}/votes/${v.vote_id}`,
+    lastModified: new Date(v.voted_at ?? Date.now()),
+    changeFrequency: 'monthly',
+    priority: 0.6,
+  }
+}
+
+async function deputyUrls(): Promise<MetadataRoute.Sitemap> {
+  const first = await api.deputies.list({ limit: PAGE_SIZE, offset: 0 })
+  const offsets: number[] = []
+  for (let offset = PAGE_SIZE; offset < first.total; offset += PAGE_SIZE) offsets.push(offset)
+
+  const rest = await Promise.all(
+    offsets.map(offset => api.deputies.list({ limit: PAGE_SIZE, offset }))
+  )
+
+  return [first, ...rest].flatMap(page => page.items.map(toDeputyUrl))
 }
 
 async function voteUrls(): Promise<MetadataRoute.Sitemap> {
-  const urls: MetadataRoute.Sitemap = []
-  let cursor: string | undefined
-  const limit = 200
+  // First 2000 votes: offset-based pages fetched in parallel (offset is capped
+  // server-side at OFFSET_CAP). Anything beyond that walks the keyset `before`
+  // cursor sequentially, since deep pagination has no parallel-safe offset.
+  const offsets: number[] = []
+  for (let offset = 0; offset < OFFSET_CAP; offset += PAGE_SIZE) offsets.push(offset)
 
-  do {
-    const page = await api.votes.list({ limit, before: cursor })
-    for (const v of page.items) {
-      urls.push({
-        url: `${SITE_URL}/votes/${v.vote_id}`,
-        lastModified: new Date(v.voted_at),
-        changeFrequency: 'monthly',
-        priority: 0.6,
-      })
-    }
+  const offsetPages = await Promise.all(
+    offsets.map(offset => api.votes.list({ limit: PAGE_SIZE, offset }))
+  )
+  const urls = offsetPages.flatMap(page => page.items.map(toVoteUrl))
+
+  let cursor = offsetPages.at(-1)?.next_cursor ?? undefined
+  while (cursor) {
+    const page = await api.votes.list({ limit: PAGE_SIZE, before: cursor })
+    urls.push(...page.items.map(toVoteUrl))
     cursor = page.next_cursor ?? undefined
-  } while (cursor)
+  }
 
   return urls
 }

--- a/frontend/src/components/FreshnessBadge.tsx
+++ b/frontend/src/components/FreshnessBadge.tsx
@@ -1,0 +1,48 @@
+import { api } from '@/lib/api'
+
+const STALE_AFTER_MS = 4 * 24 * 60 * 60 * 1000 // matches dbt's warn_after: 4 days
+
+function describeFreshness(lastIngestion: string): { stale: boolean; formatted: string } | null {
+  const date = new Date(lastIngestion)
+  if (Number.isNaN(date.getTime())) return null
+
+  return {
+    stale: Date.now() - date.getTime() > STALE_AFTER_MS,
+    formatted: new Intl.DateTimeFormat('fr-FR', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    }).format(date),
+  }
+}
+
+export async function FreshnessBadge() {
+  let lastIngestion: string | null = null
+  try {
+    const health = await api.health()
+    lastIngestion = typeof health.last_ingestion === 'string' ? health.last_ingestion : null
+  } catch {
+    return null
+  }
+
+  if (!lastIngestion) return null
+
+  const freshness = describeFreshness(lastIngestion)
+  if (!freshness) return null
+  const { stale, formatted } = freshness
+
+  return (
+    <div
+      className={`flex items-center justify-center gap-2 py-1.5 text-xs font-medium border-b ${
+        stale
+          ? 'bg-amber-50 text-amber-700 border-amber-200'
+          : 'bg-gray-off text-gray-mid border-gray-border'
+      }`}
+    >
+      <span
+        className={`inline-block w-1.5 h-1.5 rounded-full ${stale ? 'bg-amber-500' : 'bg-emerald-500'}`}
+      />
+      Données à jour au {formatted}
+    </div>
+  )
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -123,13 +123,14 @@ export const api = {
       apiFetch<DeputyVotesResponse>(`/deputies/${id}/votes/?limit=${limit}`, { revalidate: 86400 }),
   },
   votes: {
-    list: (params?: { result?: string; theme?: string; limit?: number; offset?: number }) => {
+    list: (params?: { result?: string; theme?: string; limit?: number; offset?: number; before?: string }) => {
       const q = new URLSearchParams()
       if (params?.result) q.set('result', params.result)
       if (params?.theme)  q.set('theme',  params.theme)
       if (params?.limit) q.set('limit', String(params.limit))
       if (params?.offset) q.set('offset', String(params.offset))
-      return apiFetch<{ total: number; items: Vote[]; limit: number; offset: number }>(
+      if (params?.before) q.set('before', params.before)
+      return apiFetch<{ total: number; items: Vote[]; limit: number; offset: number; next_cursor: string | null }>(
         `/votes/?${q}`,
         { revalidate: 900 }
       )


### PR DESCRIPTION
## Summary

- **MON-94** — Add `app/sitemap.ts` and `app/robots.ts`. The sitemap pages through `api.deputies.list()` (offset) and `api.votes.list()` (keyset `before` cursor, since offset is capped at 2000 server-side and there are 5,000+ votes) to list all deputy and vote pages with `lastModified`, plus the static routes. `robots.ts` allows all and points to the sitemap. Both are wired into the existing `POST /api/revalidate` webhook (already called daily by `ingest_prod.yml` after ingestion) so the sitemap refreshes on the same signal as the rest of the site.
- **MON-80** — Add `FreshnessBadge`, an async server component that reads `/health`'s `last_ingestion`, formats it in French, and renders it under the nav on every page via `layout.tsx`. Shows an amber warning state once the data is older than 4 days — matching dbt's own `warn_after` staleness threshold in `transform/models/staging/sources.yml`. Fails soft (renders nothing) if the health check errors, rather than crashing the layout.

## Testing

- `npm test` — all 5 suites / 39 tests pass, including 4 new tests for `FreshnessBadge` (fresh, stale, health-check-failure, missing-field cases).
- `npm run lint` — clean (had to hoist the staleness `Date.now()` call out of the component body into a plain helper to satisfy the `react-hooks/purity` rule).
- `npm run build` — succeeds; `/sitemap.xml` and `/robots.txt` generate against the live production API.
- Verified against a production build locally: `/robots.txt` returns the expected rules + sitemap reference, `/sitemap.xml` returns **5,712 URLs** (matches the ~5,600 estimate in the issue), and the freshness badge renders "Données à jour au 1 juillet 2026" on `/` and `/votes`.

## Follow-up (not part of this PR)

MON-94's acceptance criteria also calls for submitting the sitemap to Google Search Console and recording an indexation baseline — that's a manual, one-time action for whoever owns the GSC property, done after this merges and deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)