### PR TITLE
feat: expose party alignment and dissident rate (MON-85)

### DIFF
--- a/api/routers/deputies.py
+++ b/api/routers/deputies.py
@@ -6,13 +6,16 @@ from starlette.requests import Request
 from api.db import MART_UNAVAILABLE, get_conn
 from api.limiter import limiter
 from api.schemas import (
+    DeputyAlignment,
     DeputyDetail,
+    DeputyDissidentVotesResponse,
     DeputyListResponse,
     DeputyScorecard,
     DeputyStats,
     DeputySummary,
     DeputyVoteItem,
     DeputyVotesResponse,
+    DissidentVoteItem,
 )
 
 router = APIRouter()
@@ -171,3 +174,88 @@ def get_scorecard(request: Request, deputy_id: str):
     if not row:
         raise HTTPException(status_code=404, detail="Deputy not found")
     return DeputyScorecard(**row)
+
+
+@router.get("/{deputy_id}/alignment", response_model=DeputyAlignment)
+@limiter.limit("10/minute")
+def get_alignment(request: Request, deputy_id: str):
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT
+                        deputy_id,
+                        full_name,
+                        party,
+                        total_votes,
+                        aligned_votes,
+                        dissident_votes,
+                        party_alignment_rate,
+                        dissident_rate,
+                        updated_at
+                    FROM analytics_marts.mart_party_alignment
+                    WHERE deputy_id = %s
+                    """,
+                    (deputy_id,),
+                )
+                row = cur.fetchone()
+    except psycopg2.errors.UndefinedTable:
+        raise MART_UNAVAILABLE from None
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Deputy not found")
+    return DeputyAlignment(**row)
+
+
+@router.get("/{deputy_id}/dissident-votes", response_model=DeputyDissidentVotesResponse)
+@limiter.limit("10/minute")
+def get_dissident_votes(
+    request: Request,
+    deputy_id: str,
+    limit: int = Query(10, ge=1, le=50),
+):
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM vote_positions vp
+                    JOIN deputies d ON d.deputy_id = vp.deputy_id
+                    JOIN analytics_intermediate.int_party_vote_majority m
+                        ON m.vote_id = vp.vote_id AND m.party = d.party
+                    WHERE vp.deputy_id = %s
+                      AND vp.position IN ('pour', 'contre', 'abstention')
+                      AND vp.position != m.majority_position
+                    """,
+                    (deputy_id,),
+                )
+                total = cur.fetchone()["count"]
+
+                cur.execute(
+                    """
+                    SELECT vp.vote_id, v.voted_at, v.vote_title, v.result,
+                           vp.position, m.majority_position
+                    FROM vote_positions vp
+                    JOIN deputies d ON d.deputy_id = vp.deputy_id
+                    JOIN analytics_intermediate.int_party_vote_majority m
+                        ON m.vote_id = vp.vote_id AND m.party = d.party
+                    JOIN analytics_marts.mart_vote_summary v ON v.vote_id = vp.vote_id
+                    WHERE vp.deputy_id = %s
+                      AND vp.position IN ('pour', 'contre', 'abstention')
+                      AND vp.position != m.majority_position
+                    ORDER BY v.voted_at DESC
+                    LIMIT %s
+                    """,
+                    (deputy_id, limit),
+                )
+                rows = cur.fetchall()
+    except psycopg2.errors.UndefinedTable:
+        raise MART_UNAVAILABLE from None
+
+    return DeputyDissidentVotesResponse(
+        deputy_id=deputy_id,
+        total=total,
+        items=[DissidentVoteItem(**r) for r in rows],
+    )

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -61,6 +61,37 @@ class DeputyScorecard(_Base):
     abstention_pct: float = Field(description="abstentions / present_votes, 0–1")
 
 
+class DeputyAlignment(_Base):
+    """Party alignment / dissident rate for a single deputy (mart_party_alignment)."""
+
+    deputy_id: str
+    full_name: str
+    party: Optional[str] = None
+    total_votes: int = Field(description="Votes counted toward alignment (pour/contre/abstention)")
+    aligned_votes: int
+    dissident_votes: int
+    party_alignment_rate: float = Field(description="aligned_votes / total_votes, 0-1")
+    dissident_rate: float = Field(description="dissident_votes / total_votes, 0-1")
+    updated_at: Optional[datetime] = None
+
+
+class DissidentVoteItem(_Base):
+    """A single vote where the deputy diverged from their party's majority position."""
+
+    vote_id: str
+    voted_at: Optional[datetime] = None
+    vote_title: str
+    result: Optional[str] = None
+    position: str
+    majority_position: str
+
+
+class DeputyDissidentVotesResponse(_Base):
+    deputy_id: str
+    total: int
+    items: list[DissidentVoteItem]
+
+
 class DeputyStats(_Base):
     avg_presence_rate: Optional[float] = Field(
         None,

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -2,10 +2,11 @@ import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { api } from '@/lib/api'
-import type { DeputyVoteItem } from '@/lib/api'
+import type { DeputyVoteItem, DissidentVoteItem } from '@/lib/api'
 import { partyHex, formatDate } from '@/lib/utils'
 import { DeputyAvatar } from '@/components/DeputyAvatar'
 import { ShareButton } from '@/components/ShareButton'
+import { InfoTooltip } from '@/components/InfoTooltip'
 
 export const dynamicParams = true
 export const revalidate = 86400
@@ -40,13 +41,17 @@ const POS = {
 
 export default async function DeputyPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
-  const [deputy, scorecard, deputyStats, recentVotes] = await Promise.all([
+  const [deputy, scorecard, deputyStats, recentVotes, alignment, dissidentVotes] = await Promise.all([
     api.deputies.get(id).catch(() => null),
     api.deputies.scorecard(id).catch(() => null),
     api.deputies.stats().catch(() => null),
     api.deputies.votes(id, 10).catch(() => null),
+    api.deputies.alignment(id).catch(() => null),
+    api.deputies.dissidentVotes(id, 10).catch(() => null),
   ])
   if (!deputy) notFound()
+
+  const alignmentPct = alignment ? Math.round(alignment.party_alignment_rate * 100) : null
 
   const presencePct    = scorecard ? Math.round((scorecard.presence_rate ?? 0) * 100) : null
   const avgPresencePct = deputyStats ? Math.round((deputyStats.avg_presence_rate ?? 0) * 100) : null
@@ -258,6 +263,74 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                   </div>
                 )}
               </div>
+            </section>
+          )}
+
+          {/* Party alignment / dissident rate */}
+          {alignment && alignmentPct !== null && (
+            <section>
+              <div style={{ fontWeight: 700, fontSize: 12, letterSpacing: '0.18em', textTransform: 'uppercase', color: RED }}>
+                Alignement avec son groupe
+              </div>
+              <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: NAVY, margin: '12px 0 22px', letterSpacing: '-0.01em' }}>
+                Vote-t-il·elle avec son groupe politique ?
+              </h2>
+              <div style={{ background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12, overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.05)', padding: '26px 30px' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
+                  <span style={{ fontSize: 14, color: '#6B7280', fontWeight: 500, display: 'flex', alignItems: 'center', gap: 8 }}>
+                    Vote avec son groupe
+                    <InfoTooltip text="Alignement calculé en comparant, vote par vote, la position du député à la position majoritaire de son groupe parlementaire actuel. Les votes non-votants sont exclus. Limite : l'historique est comparé au groupe actuel du député, même s'il en a changé en cours de mandat." />
+                  </span>
+                  <span className="font-mono" style={{ fontWeight: 700, fontSize: 18, color: NAVY }}>{alignmentPct}%</span>
+                </div>
+                <div style={{ position: 'relative', height: 9, background: '#EEF0F2', borderRadius: 999, overflow: 'hidden' }}>
+                  <div style={{ height: '100%', background: NAVY, borderRadius: 999, width: `${alignmentPct}%`, transition: 'width 0.4s' }} />
+                </div>
+                <p style={{ fontSize: 13, color: '#6B7280', marginTop: 16 }}>
+                  <span style={{ fontWeight: 700, color: NAVY }}>{alignment.dissident_votes}</span> vote{alignment.dissident_votes !== 1 ? 's' : ''} dissident{alignment.dissident_votes !== 1 ? 's' : ''} sur {alignment.total_votes} vote{alignment.total_votes !== 1 ? 's' : ''} comptabilisé{alignment.total_votes !== 1 ? 's' : ''}
+                </p>
+              </div>
+
+              {dissidentVotes && dissidentVotes.items.length > 0 && (
+                <div style={{ marginTop: 22 }}>
+                  <div style={{ fontSize: 13, fontWeight: 600, color: NAVY, marginBottom: 12 }}>
+                    Votes dissidents récents
+                  </div>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                    {dissidentVotes.items.map((v: DissidentVoteItem) => (
+                      <Link
+                        key={v.vote_id}
+                        href={`/votes/${v.vote_id}`}
+                        style={{
+                          display: 'block', background: '#fff', border: `1px solid ${LINE}`, borderRadius: 10,
+                          padding: '14px 18px', textDecoration: 'none',
+                        }}
+                      >
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap', marginBottom: 6 }}>
+                          {v.voted_at && (
+                            <span className="font-mono" style={{ fontSize: 12, color: '#9CA3AF' }}>
+                              {formatDate(v.voted_at)}
+                            </span>
+                          )}
+                          <span style={{
+                            fontSize: 12, fontWeight: 700, padding: '3px 10px', borderRadius: 999,
+                            color: POS[v.position as keyof typeof POS]?.color ?? NAVY,
+                            background: POS[v.position as keyof typeof POS]?.bg ?? LINE,
+                          }}>
+                            A voté {POS[v.position as keyof typeof POS]?.label ?? v.position}
+                          </span>
+                          <span style={{ fontSize: 12, color: '#9CA3AF' }}>
+                            groupe : {POS[v.majority_position as keyof typeof POS]?.label ?? v.majority_position}
+                          </span>
+                        </div>
+                        <div style={{ fontSize: 15.5, color: NAVY, lineHeight: 1.35 }}>
+                          {v.vote_title}
+                        </div>
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              )}
             </section>
           )}
 

--- a/frontend/src/components/InfoTooltip.tsx
+++ b/frontend/src/components/InfoTooltip.tsx
@@ -1,0 +1,54 @@
+'use client'
+import { useState } from 'react'
+
+type Props = {
+  text: string
+  ariaLabel?: string
+}
+
+const NAVY = '#1B2B50'
+
+export function InfoTooltip({ text, ariaLabel = 'Plus d’informations' }: Props) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <span style={{ position: 'relative', display: 'inline-flex' }}>
+      <button
+        type="button"
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        onClick={e => { e.preventDefault(); setOpen(o => !o) }}
+        aria-label={ariaLabel}
+        aria-expanded={open}
+        style={{
+          display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+          width: 16, height: 16, borderRadius: 999, border: `1px solid #C7CDD8`,
+          background: '#fff', color: '#6B7280', fontSize: 11, fontWeight: 700,
+          cursor: 'pointer', padding: 0, lineHeight: 1,
+        }}
+      >
+        i
+      </button>
+      {open && (
+        <span
+          role="tooltip"
+          style={{
+            position: 'absolute', bottom: '140%', left: '50%', transform: 'translateX(-50%)',
+            width: 260, padding: '10px 12px', borderRadius: 8, background: NAVY, color: '#fff',
+            fontSize: 12.5, lineHeight: 1.5, boxShadow: '0 6px 18px rgba(0,0,0,0.18)',
+            zIndex: 10,
+          }}
+        >
+          {text}
+          <span style={{
+            position: 'absolute', top: '100%', left: '50%', transform: 'translateX(-50%)',
+            width: 0, height: 0, borderLeft: '6px solid transparent', borderRight: '6px solid transparent',
+            borderTop: `6px solid ${NAVY}`,
+          }} />
+        </span>
+      )}
+    </span>
+  )
+}

--- a/frontend/src/components/InfoTooltip.tsx
+++ b/frontend/src/components/InfoTooltip.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState } from 'react'
+import { useState, useId } from 'react'
 
 type Props = {
   text: string
@@ -10,6 +10,7 @@ const NAVY = '#1B2B50'
 
 export function InfoTooltip({ text, ariaLabel = 'Plus d’informations' }: Props) {
   const [open, setOpen] = useState(false)
+  const tooltipId = useId()
 
   return (
     <span style={{ position: 'relative', display: 'inline-flex' }}>
@@ -22,6 +23,7 @@ export function InfoTooltip({ text, ariaLabel = 'Plus d’informations' }: Props
         onClick={e => { e.preventDefault(); setOpen(o => !o) }}
         aria-label={ariaLabel}
         aria-expanded={open}
+        aria-describedby={open ? tooltipId : undefined}
         style={{
           display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
           width: 16, height: 16, borderRadius: 999, border: `1px solid #C7CDD8`,
@@ -34,6 +36,7 @@ export function InfoTooltip({ text, ariaLabel = 'Plus d’informations' }: Props
       {open && (
         <span
           role="tooltip"
+          id={tooltipId}
           style={{
             position: 'absolute', bottom: '140%', left: '50%', transform: 'translateX(-50%)',
             width: 260, padding: '10px 12px', borderRadius: 8, background: NAVY, color: '#fff',

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -52,6 +52,33 @@ export type DeputyStats = {
   avg_presence_rate: number
 }
 
+export type Alignment = {
+  deputy_id: string
+  full_name: string
+  party: string | null
+  total_votes: number
+  aligned_votes: number
+  dissident_votes: number
+  party_alignment_rate: number
+  dissident_rate: number
+  updated_at: string | null
+}
+
+export type DissidentVoteItem = {
+  vote_id: string
+  voted_at: string | null
+  vote_title: string
+  result: string | null
+  position: string
+  majority_position: string
+}
+
+export type DissidentVotesResponse = {
+  deputy_id: string
+  total: number
+  items: DissidentVoteItem[]
+}
+
 export type DeputyVoteItem = {
   vote_id: string
   voted_at: string | null
@@ -121,6 +148,10 @@ export const api = {
     stats: () => apiFetch<DeputyStats>('/deputies/stats/', { revalidate: 3600 }),
     votes: (id: string, limit = 10) =>
       apiFetch<DeputyVotesResponse>(`/deputies/${id}/votes/?limit=${limit}`, { revalidate: 86400 }),
+    alignment: (id: string) =>
+      apiFetch<Alignment>(`/deputies/${id}/alignment/`, { revalidate: 86400 }),
+    dissidentVotes: (id: string, limit = 10) =>
+      apiFetch<DissidentVotesResponse>(`/deputies/${id}/dissident-votes/?limit=${limit}`, { revalidate: 86400 }),
   },
   votes: {
     list: (params?: { result?: string; theme?: string; limit?: number; offset?: number }) => {

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -52,6 +52,28 @@ CREATE TABLE IF NOT EXISTS analytics_marts.mart_vote_summary (
     summary_plain TEXT,
     theme         TEXT
 );
+
+CREATE TABLE IF NOT EXISTS analytics_marts.mart_party_alignment (
+    deputy_id             TEXT PRIMARY KEY,
+    full_name             TEXT,
+    party                 TEXT,
+    department            TEXT,
+    total_votes           INTEGER,
+    aligned_votes         INTEGER,
+    dissident_votes       INTEGER,
+    party_alignment_rate  NUMERIC,
+    dissident_rate        NUMERIC,
+    updated_at            TIMESTAMPTZ
+);
+
+CREATE SCHEMA IF NOT EXISTS analytics_intermediate;
+
+CREATE TABLE IF NOT EXISTS analytics_intermediate.int_party_vote_majority (
+    party             TEXT,
+    vote_id           TEXT,
+    majority_position TEXT,
+    PRIMARY KEY (party, vote_id)
+);
 """
 
 # Fixture data ---------------------------------------------------------------
@@ -93,6 +115,24 @@ DEPUTY_C = {
     "party_short": "RE",
     "circonscription": "3ème circonscription de Paris",
     "department": "Paris",
+    "mandate_start": "2024-07-07",
+    "mandate_end": None,
+    "photo_url": None,
+}
+
+# Same party as PA001 — splits the first 5 votes 'pour'/'contre' so the party
+# majority ties and resolves to 'contre' (tie-break is alphabetical), making
+# PA001 a dissident on those 5 votes. Gives alignment/dissident-votes tests a
+# deterministic non-trivial scenario.
+DEPUTY_D = {
+    "deputy_id": "PA004",
+    "full_name": "Denis Lefebvre",
+    "first_name": "Denis",
+    "last_name": "Lefebvre",
+    "party": "Rassemblement National",
+    "party_short": "RN",
+    "circonscription": "4ème circonscription du Var",
+    "department": "Var",
     "mandate_start": "2024-07-07",
     "mandate_end": None,
     "photo_url": None,
@@ -180,14 +220,16 @@ def db_conn():
 
     # Seed base fixtures used by most tests
     with conn.cursor() as cur:
-        for deputy in (DEPUTY_A, DEPUTY_B, DEPUTY_C):
+        for deputy in (DEPUTY_A, DEPUTY_B, DEPUTY_C, DEPUTY_D):
             cur.execute(_DEPUTY_UPSERT, deputy)
 
         votes = [_make_vote(i, "adopté" if i % 3 != 0 else "rejeté") for i in range(1, 26)]
         for v in votes:
             cur.execute(_VOTE_UPSERT, v)
 
-        # Seed positions: PA001 voted pour on every vote, PA002 voted contre
+        # Seed positions: PA001 voted pour on every vote, PA002 voted contre.
+        # PA004 (same party as PA001) votes contre on the first 5 votes and
+        # pour on the rest — see DEPUTY_D comment for why.
         for v in votes:
             cur.execute(
                 _POSITION_UPSERT,
@@ -196,6 +238,15 @@ def db_conn():
             cur.execute(
                 _POSITION_UPSERT,
                 {"vote_id": v["vote_id"], "deputy_id": "PA002", "position": "contre"},
+            )
+        for i, v in enumerate(votes, start=1):
+            cur.execute(
+                _POSITION_UPSERT,
+                {
+                    "vote_id": v["vote_id"],
+                    "deputy_id": "PA004",
+                    "position": "contre" if i <= 5 else "pour",
+                },
             )
 
         # Seed mart_vote_summary mirror for pagination / scorecard tests
@@ -225,6 +276,45 @@ def db_conn():
             """
         )
 
+        # Seed int_party_vote_majority: RN ties 1-1 on the first 5 votes
+        # (PA001 pour, PA004 contre) — resolves to 'contre' alphabetically,
+        # making PA001 dissident there. RN is unanimous 'pour' on the rest.
+        for i, v in enumerate(votes, start=1):
+            majority = "contre" if i <= 5 else "pour"
+            cur.execute(
+                """
+                INSERT INTO analytics_intermediate.int_party_vote_majority
+                    (party, vote_id, majority_position)
+                VALUES ('Rassemblement National', %(vote_id)s, %(majority)s)
+                ON CONFLICT (party, vote_id) DO UPDATE SET majority_position = EXCLUDED.majority_position
+                """,
+                {"vote_id": v["vote_id"], "majority": majority},
+            )
+            cur.execute(
+                """
+                INSERT INTO analytics_intermediate.int_party_vote_majority
+                    (party, vote_id, majority_position)
+                VALUES ('La France Insoumise', %(vote_id)s, 'contre')
+                ON CONFLICT (party, vote_id) DO UPDATE SET majority_position = EXCLUDED.majority_position
+                """,
+                {"vote_id": v["vote_id"]},
+            )
+
+        # Seed mart_party_alignment for alignment/dissident-votes tests:
+        # PA001 is dissident on the first 5 votes (pour vs. tie-broken majority
+        # contre), aligned on the remaining 20.
+        cur.execute(
+            """
+            INSERT INTO analytics_marts.mart_party_alignment
+                (deputy_id, full_name, party, department, total_votes,
+                 aligned_votes, dissident_votes, party_alignment_rate,
+                 dissident_rate, updated_at)
+            VALUES ('PA001', 'Alice Martin', 'Rassemblement National', 'Var',
+                    25, 20, 5, 0.8, 0.2, NOW())
+            ON CONFLICT (deputy_id) DO NOTHING
+            """
+        )
+
     yield conn
 
     # Teardown — truncate all data so the schema can be reused by other test runs.
@@ -233,6 +323,8 @@ def db_conn():
     with conn.cursor() as cur:
         cur.execute("TRUNCATE analytics_marts.mart_vote_summary CASCADE")
         cur.execute("TRUNCATE analytics_marts.mart_deputy_scorecard CASCADE")
+        cur.execute("TRUNCATE analytics_marts.mart_party_alignment CASCADE")
+        cur.execute("TRUNCATE analytics_intermediate.int_party_vote_majority CASCADE")
         cur.execute("TRUNCATE vote_positions CASCADE")
         cur.execute("TRUNCATE votes CASCADE")
         cur.execute("TRUNCATE deputies CASCADE")

--- a/tests/integration/test_alignment.py
+++ b/tests/integration/test_alignment.py
@@ -1,0 +1,107 @@
+"""
+Integration tests for the party alignment / dissident-votes SQL used by
+api/routers/deputies.py.
+
+Fixtures (see conftest.py): PA001 (Rassemblement National) is dissident on
+the first 5 seeded votes and aligned on the remaining 20, via a tied RN
+majority that resolves to 'contre' by the alphabetical tie-break used in
+transform/models/intermediate/int_party_vote_majority.sql.
+"""
+
+import pytest
+
+_ALIGNMENT_SQL = """
+SELECT
+    deputy_id,
+    full_name,
+    party,
+    total_votes,
+    aligned_votes,
+    dissident_votes,
+    party_alignment_rate,
+    dissident_rate,
+    updated_at
+FROM analytics_marts.mart_party_alignment
+WHERE deputy_id = %s
+"""
+
+_DISSIDENT_VOTES_SQL = """
+SELECT vp.vote_id, v.voted_at, v.vote_title, v.result,
+       vp.position, m.majority_position
+FROM vote_positions vp
+JOIN deputies d ON d.deputy_id = vp.deputy_id
+JOIN analytics_intermediate.int_party_vote_majority m
+    ON m.vote_id = vp.vote_id AND m.party = d.party
+JOIN analytics_marts.mart_vote_summary v ON v.vote_id = vp.vote_id
+WHERE vp.deputy_id = %s
+  AND vp.position IN ('pour', 'contre', 'abstention')
+  AND vp.position != m.majority_position
+ORDER BY v.voted_at DESC
+LIMIT %s
+"""
+
+_DISSIDENT_VOTES_COUNT_SQL = """
+SELECT COUNT(*)
+FROM vote_positions vp
+JOIN deputies d ON d.deputy_id = vp.deputy_id
+JOIN analytics_intermediate.int_party_vote_majority m
+    ON m.vote_id = vp.vote_id AND m.party = d.party
+WHERE vp.deputy_id = %s
+  AND vp.position IN ('pour', 'contre', 'abstention')
+  AND vp.position != m.majority_position
+"""
+
+
+@pytest.mark.integration
+def test_alignment_row_returned(db_conn):
+    with db_conn.cursor() as cur:
+        cur.execute(_ALIGNMENT_SQL, ("PA001",))
+        row = cur.fetchone()
+
+    assert row is not None
+    assert row["deputy_id"] == "PA001"
+    assert row["total_votes"] == 25
+    assert row["aligned_votes"] == 20
+    assert row["dissident_votes"] == 5
+    assert float(row["party_alignment_rate"]) == 0.8
+    assert float(row["dissident_rate"]) == 0.2
+
+
+@pytest.mark.integration
+def test_alignment_unknown_deputy_returns_no_rows(db_conn):
+    with db_conn.cursor() as cur:
+        cur.execute(_ALIGNMENT_SQL, ("PA_DOES_NOT_EXIST",))
+        row = cur.fetchone()
+
+    assert row is None
+
+
+@pytest.mark.integration
+def test_dissident_votes_count_matches_mart(db_conn):
+    """Vote-level dissident count must agree with the mart's aggregate."""
+    with db_conn.cursor() as cur:
+        cur.execute(_DISSIDENT_VOTES_COUNT_SQL, ("PA001",))
+        count_row = cur.fetchone()
+
+    assert count_row["count"] == 5
+
+
+@pytest.mark.integration
+def test_dissident_votes_items(db_conn):
+    with db_conn.cursor() as cur:
+        cur.execute(_DISSIDENT_VOTES_SQL, ("PA001", 10))
+        rows = cur.fetchall()
+
+    assert len(rows) == 5
+    for row in rows:
+        assert row["position"] == "pour"
+        assert row["majority_position"] == "contre"
+
+
+@pytest.mark.integration
+def test_dissident_votes_respects_limit(db_conn):
+    with db_conn.cursor() as cur:
+        cur.execute(_DISSIDENT_VOTES_SQL, ("PA001", 2))
+        rows = cur.fetchall()
+
+    assert len(rows) == 2

--- a/tests/integration/test_chunker.py
+++ b/tests/integration/test_chunker.py
@@ -37,7 +37,7 @@ def test_chunk_votes_filtered_by_ids(db_conn):
 @pytest.mark.integration
 def test_chunk_deputies_returns_seeded_deputies(db_conn):
     chunks = chunk_deputies()
-    assert len(chunks) == 3
+    assert len(chunks) == 4
     deputy_ids = {c["metadata"]["deputy_id"] for c in chunks}
     assert "PA001" in deputy_ids
     assert "PA002" in deputy_ids

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -154,6 +154,61 @@ def test_get_scorecard_not_found(client, mock_cursor):
     assert resp.status_code == 404
 
 
+def test_get_alignment(client, mock_cursor):
+    mock_cursor.fetchone.return_value = {
+        "deputy_id": "PA1",
+        "full_name": "Jean Martin",
+        "party": "Rassemblement National",
+        "total_votes": 25,
+        "aligned_votes": 20,
+        "dissident_votes": 5,
+        "party_alignment_rate": 0.8,
+        "dissident_rate": 0.2,
+        "updated_at": None,
+    }
+    resp = client.get("/deputies/PA1/alignment")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["party_alignment_rate"] == 0.8
+    assert data["dissident_votes"] == 5
+
+
+def test_get_alignment_not_found(client, mock_cursor):
+    mock_cursor.fetchone.return_value = None
+    resp = client.get("/deputies/NONEXISTENT/alignment")
+    assert resp.status_code == 404
+
+
+def test_get_dissident_votes(client, mock_cursor):
+    mock_cursor.fetchone.return_value = {"count": 1}
+    mock_cursor.fetchall.return_value = [
+        {
+            "vote_id": "VTANR5L17V1",
+            "voted_at": "2024-07-16T15:00:00",
+            "vote_title": "Vote sur le projet de loi de finances",
+            "result": "adopté",
+            "position": "pour",
+            "majority_position": "contre",
+        }
+    ]
+    resp = client.get("/deputies/PA1/dissident-votes")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["items"][0]["position"] == "pour"
+    assert data["items"][0]["majority_position"] == "contre"
+
+
+def test_get_dissident_votes_empty(client, mock_cursor):
+    mock_cursor.fetchone.return_value = {"count": 0}
+    mock_cursor.fetchall.return_value = []
+    resp = client.get("/deputies/PA1/dissident-votes")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 0
+    assert data["items"] == []
+
+
 # ---------------------------------------------------------------------------
 # Votes
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Exposes party alignment / dissident rate — data already computed daily by
`mart_party_alignment` (dbt, tested in CI) — via two new API endpoints and a
new deputy-profile section.

## Why

`transform/models/marts/mart_party_alignment.sql` computes `party_alignment_rate`,
`dissident_rate`, `aligned_votes`, and `dissident_votes` per deputy, but nothing
surfaced it. "Does my deputy vote with their party or break ranks?" is the
platform's highest-leverage differentiator vs. the AN's own site (MON-85,
priority High) — the compute existed, only exposure was missing.

## Changes

- **API** (`api/routers/deputies.py`, `api/schemas.py`):
  - `GET /deputies/{id}/alignment` — reads `analytics_marts.mart_party_alignment`
    directly, mirrors the existing `/scorecard` endpoint's pattern
    (`UndefinedTable → 503`, no row → 404).
  - `GET /deputies/{id}/dissident-votes?limit=` — paginated list of votes
    where the deputy diverged from their party's majority position, joining
    `vote_positions` → `analytics_intermediate.int_party_vote_majority` →
    `analytics_marts.mart_vote_summary`. Reuses the intermediate model's
    majority-position logic rather than duplicating it.
- **Frontend**:
  - `frontend/src/components/InfoTooltip.tsx` (new) — small, local hover/focus
    tooltip. Deliberately narrow in scope; MON-81 (still Backlog) will own the
    general reusable tooltip/popover system with `/a-propos` anchors.
  - `frontend/src/app/deputes/[id]/page.tsx` — new "Alignement avec son
    groupe" section: alignment-rate gauge, dissident vote count, a methodology
    tooltip (states the current-party limitation per the mart's `schema.yml`
    doc), and a "Votes dissidents récents" list linking each vote to
    `/votes/[id]`. Renders conditionally so a missing mart degrades gracefully,
    matching the existing `scorecard`/`recentVotes` behavior.
  - `frontend/src/lib/api.ts` — `Alignment`/`DissidentVoteItem`/
    `DissidentVotesResponse` types and `api.deputies.alignment()` /
    `api.deputies.dissidentVotes()`.
- **Tests**:
  - `tests/test_api.py` — unit tests for both endpoints (found / not-found /
    empty), mocked cursor, mirrors the existing `/scorecard` test pattern.
  - `tests/integration/conftest.py` — stubs `analytics_marts.mart_party_alignment`
    and `analytics_intermediate.int_party_vote_majority` (dbt doesn't run in
    this test tier), adds a fourth seeded deputy (PA004, same party as PA001)
    to create a deterministic tied-majority/dissident scenario.
  - `tests/integration/test_alignment.py` (new) — integration tests running
    the real alignment + dissident-votes SQL against seeded fixtures on a
    live Postgres instance.
  - `tests/integration/test_chunker.py` — updated a hardcoded deputy count
    (3 → 4) that the new PA004 fixture affected.

## Testing

- `pytest tests/ -q` — 96 passed (69 unit/mocked + 27 integration), including
  5 new alignment integration tests and 4 new unit tests.
- `ruff check .` / `ruff format --check .` — clean, repo-wide.
- Frontend: `tsc --noEmit`, `next lint`, `next build` — all clean.
- Manual end-to-end: ran the API against a real local Postgres (wiped and
  rebuilt the Docker volume first — it had drifted from the current
  migrations, unrelated pre-existing rot), seeded a happy-path deputy/vote,
  hit both endpoints live via curl, then loaded `/deputes/PA_SMOKE` in a
  browser (screenshot verified: 80% gauge, dissident count, dissident vote
  card linking to `/votes/[id]`).

## Risks / Notes

- The mart's known limitation (alignment computed against the deputy's
  *current* party, not their party at vote time) is stated in the tooltip
  copy per the acceptance criteria, not resolved — tracked separately in the
  mart's `schema.yml` doc.
- `InfoTooltip` is intentionally minimal/local; MON-81 will likely
  generalize or replace it with a shared component + `/a-propos` anchors.
- No dbt, `railway.json`, or deploy-config changes — read-only additions
  against existing marts/views.

## Breaking Changes

None.