### PR TITLE
feat: server-side vote search, global command palette, deputy lookup (MON-86..88)

### DIFF
--- a/api/routers/votes.py
+++ b/api/routers/votes.py
@@ -45,6 +45,10 @@ def list_votes(
     ),
     result: str = Query(None, description="Filter by result: adopté | rejeté"),
     theme: str = Query(None, description="Filter by theme category"),
+    search: str = Query(
+        None,
+        description="Full-text search over vote_title and summary_plain (French stemming)",
+    ),
 ):
     # Decode before opening a connection so a bad cursor fails fast with 422.
     cursor_key = _decode_cursor(before) if before else None
@@ -62,6 +66,15 @@ def list_votes(
                 if theme:
                     conditions.append(sql.SQL("theme = %s"))
                     params.append(theme)
+
+                if search:
+                    conditions.append(
+                        sql.SQL(
+                            "to_tsvector('french', vote_title || ' ' || coalesce(summary_plain, ''))"
+                            " @@ plainto_tsquery('french', %s)"
+                        )
+                    )
+                    params.append(search)
 
                 # total reflects the full filtered set, independent of the cursor window.
                 count_where = (

--- a/frontend/src/app/votes/VotesClient.tsx
+++ b/frontend/src/app/votes/VotesClient.tsx
@@ -62,17 +62,13 @@ export function VotesClient({ initial, heroStats }: { initial: VoteList; heroSta
   }, [result, theme, router])
 
   const { data, isLoading } = useSWR(
-    `votes:${result}:${theme}:${offset}`,
-    () => api.votes.list({ result: result || undefined, theme: theme || undefined, limit: PAGE_SIZE, offset }),
+    `votes:${result}:${theme}:${search}:${offset}`,
+    () => api.votes.list({ result: result || undefined, theme: theme || undefined, search: search || undefined, limit: PAGE_SIZE, offset }),
     { keepPreviousData: true }
   )
 
-  const rawVotes = data?.items ?? initial.items
-  const total    = data?.total  ?? initial.total
-
-  const votes = search
-    ? rawVotes.filter(v => v.vote_title.toLowerCase().includes(search.toLowerCase()))
-    : rawVotes
+  const votes = data?.items ?? (search ? [] : initial.items)
+  const total = data?.total  ?? (search ? 0 : initial.total)
 
   const totalPages = Math.ceil(total / PAGE_SIZE)
 

--- a/frontend/src/app/votes/[id]/VoteDetailClient.tsx
+++ b/frontend/src/app/votes/[id]/VoteDetailClient.tsx
@@ -1,7 +1,17 @@
 'use client'
-import { useState, useRef, useCallback } from 'react'
+import { useState, useRef, useCallback, useMemo, useEffect } from 'react'
 import Link from 'next/link'
 import { ShareButton } from '@/components/ShareButton'
+import { getInitials, partyHex } from '@/lib/utils'
+import { resolvePostalCode } from '@/lib/postal'
+
+interface DeputyLookupEntry {
+  deputy_id: string
+  full_name: string
+  party: string | null
+  department: string | null
+  position: string | null
+}
 
 interface GroupRow {
   name: string
@@ -50,6 +60,14 @@ interface Props {
   dissidents: Dissident[]
   related: RelatedVote[]
   apiUrl: string
+  deputyLookup: DeputyLookupEntry[]
+}
+
+const POSITION_LABELS: Record<string, string> = {
+  pour: 'Pour',
+  contre: 'Contre',
+  abstention: 'Abstention',
+  nonVotant: 'Non votant',
 }
 
 function shortDate(dateStr: string): string {
@@ -61,11 +79,40 @@ export function VoteDetailClient(props: Props) {
     voteId, voteTitle, result, votedAt, summary, theme,
     votesFor, votesAgainst, abstentions, totalVoters,
     pourPct, contrePct, abstPct,
-    groups, dissidents, related, apiUrl,
+    groups, dissidents, related, apiUrl, deputyLookup,
   } = props
 
   const [showBar, setShowBar] = useState(false)
   const obsRef = useRef<IntersectionObserver | null>(null)
+
+  // ── "Comment a voté votre député ?" lookup ──
+  const [lookupQuery, setLookupQuery] = useState('')
+  const [selected, setSelected] = useState<DeputyLookupEntry | null>(null)
+  const [postalResult, setPostalResult] = useState<{ code: string; department: string | null } | null>(null)
+
+  useEffect(() => {
+    const q = lookupQuery.trim()
+    if (!/^\d{5}$/.test(q)) return
+    let cancelled = false
+    resolvePostalCode(q).then(department => {
+      if (!cancelled) setPostalResult({ code: q, department })
+    })
+    return () => { cancelled = true }
+  }, [lookupQuery])
+
+  const postalMatch = postalResult?.code === lookupQuery.trim() ? postalResult : null
+  const resolvedDept = postalMatch?.department ?? null
+
+  const suggestions = useMemo(() => {
+    if (resolvedDept) {
+      return deputyLookup.filter(d => d.department === resolvedDept).slice(0, 6)
+    }
+    const q = lookupQuery.trim().toLowerCase()
+    if (!q || q.length < 2) return []
+    return deputyLookup
+      .filter(d => d.full_name.toLowerCase().includes(q))
+      .slice(0, 6)
+  }, [lookupQuery, deputyLookup, resolvedDept])
 
   const heroRef = useCallback((el: HTMLDivElement | null) => {
     if (obsRef.current) { obsRef.current.disconnect(); obsRef.current = null }
@@ -233,6 +280,72 @@ export function VoteDetailClient(props: Props) {
 
           {/* Main column */}
           <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 52 }}>
+
+            {/* Comment a voté votre député ? */}
+            <section>
+              <div style={{ font: '700 12px/1 var(--font-sans)', letterSpacing: '0.18em', textTransform: 'uppercase', color: '#C9302A' }}>Votre député</div>
+              <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: '#1B2B50', margin: '12px 0 4px', letterSpacing: '-0.01em' }}>Comment a voté votre député&nbsp;?</h2>
+              <p style={{ fontSize: 15, color: '#6B7280', margin: '0 0 18px', maxWidth: 560 }}>Tapez un nom ou un code postal pour retrouver sa position sur ce scrutin.</p>
+
+              <div style={{ position: 'relative', maxWidth: 440 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10, background: '#fff', border: '1px solid #E4E6EA', borderRadius: 10, padding: '0 16px', height: 48 }}>
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#9CA3AF" strokeWidth="2" strokeLinecap="round"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.2-3.2"/></svg>
+                  <input
+                    type="text"
+                    value={lookupQuery}
+                    onChange={e => { setLookupQuery(e.target.value); setSelected(null) }}
+                    placeholder="Nom du député ou code postal…"
+                    style={{ flex: 1, border: 'none', outline: 'none', fontSize: 14.5, color: '#1B2B50', background: 'transparent' }}
+                  />
+                </div>
+
+                {suggestions.length > 0 && !selected && (
+                  <div style={{ position: 'absolute', top: '100%', left: 0, right: 0, marginTop: 6, background: '#fff', border: '1px solid #E4E6EA', borderRadius: 10, boxShadow: '0 8px 24px rgba(0,0,0,0.1)', zIndex: 10, overflow: 'hidden' }}>
+                    {suggestions.map(d => (
+                      <button
+                        key={d.deputy_id}
+                        onClick={() => { setSelected(d); setLookupQuery(d.full_name) }}
+                        style={{ display: 'flex', width: '100%', alignItems: 'center', gap: 10, padding: '10px 16px', background: 'none', border: 'none', borderBottom: '1px solid #F0F1F3', cursor: 'pointer', textAlign: 'left' }}
+                      >
+                        <span style={{ width: 28, height: 28, flexShrink: 0, borderRadius: 999, display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 700, fontSize: 11, color: '#fff', background: partyHex(d.party) }}>
+                          {getInitials(d.full_name)}
+                        </span>
+                        <span style={{ fontSize: 13.5, color: '#1B2B50', fontWeight: 500 }}>{d.full_name}</span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+
+                {lookupQuery.trim().length >= 2 && suggestions.length === 0 && !selected && !/^\d{1,4}$/.test(lookupQuery.trim()) && (
+                  <div style={{ marginTop: 8, fontSize: 13, color: '#9CA3AF' }}>Aucun député trouvé pour « {lookupQuery} ».</div>
+                )}
+              </div>
+
+              {selected && (
+                <Link href={`/deputes/${selected.deputy_id}`} style={{ display: 'flex', alignItems: 'center', gap: 16, marginTop: 16, maxWidth: 440, background: '#fff', border: '1px solid #E4E6EA', borderRadius: 12, padding: '16px 20px', boxShadow: '0 1px 3px rgba(0,0,0,0.05)', textDecoration: 'none' }}>
+                  <span style={{ width: 44, height: 44, flexShrink: 0, borderRadius: 999, display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 700, fontSize: 14, color: '#fff', background: partyHex(selected.party) }}>
+                    {getInitials(selected.full_name)}
+                  </span>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontWeight: 600, fontSize: 15, color: '#1B2B50' }}>{selected.full_name}</div>
+                    <div style={{ fontSize: 13, color: '#9CA3AF', marginTop: 2 }}>{selected.party ?? 'Parti inconnu'}</div>
+                  </div>
+                  {selected.position ? (
+                    <span style={{
+                      fontSize: 13, fontWeight: 700, padding: '6px 14px', borderRadius: 999,
+                      color: selected.position === 'pour' ? '#1F8A5B' : selected.position === 'contre' ? '#C9302A' : '#6B7280',
+                      background: selected.position === 'pour' ? '#EAF5EF' : selected.position === 'contre' ? '#FBE9E7' : '#F0F1F3',
+                    }}>
+                      {POSITION_LABELS[selected.position] ?? selected.position}
+                    </span>
+                  ) : (
+                    <span style={{ fontSize: 13, fontWeight: 700, padding: '6px 14px', borderRadius: 999, color: '#9CA3AF', background: '#F2F3F5' }}>
+                      Absent · non enregistré
+                    </span>
+                  )}
+                </Link>
+              )}
+            </section>
 
             {/* Ventilation par groupe */}
             {groups.length > 0 && (

--- a/frontend/src/app/votes/[id]/page.tsx
+++ b/frontend/src/app/votes/[id]/page.tsx
@@ -67,14 +67,15 @@ export default async function VoteDetailPage({ params }: { params: Promise<{ id:
     }
     for (const pos of vote.positions) {
       if (pos.position === 'nonVotant') continue
-      const majority = majorityByParty[pos.party]
+      const party = pos.party_short || 'Non inscrit'
+      const majority = majorityByParty[party]
       if (majority && pos.position !== majority && dissidents.length < 4) {
         dissidents.push({
           deputy_id: pos.deputy_id,
           full_name: pos.full_name,
           initials: getInitials(pos.full_name),
-          party: pos.party,
-          avatarColor: partyHex(pos.party),
+          party,
+          avatarColor: partyHex(party),
           vote: pos.position,
           note: 'Dissident · contre son groupe',
         })
@@ -96,6 +97,24 @@ export default async function VoteDetailPage({ params }: { params: Promise<{ id:
 
   const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? 'https://monelu-production.up.railway.app'
 
+  // Full deputy roster (paginated — /deputies caps limit at 200) so "how did my
+  // deputy vote?" can surface an explicit "absent / non enregistré" state for
+  // deputies with no recorded position on this vote, not just an empty result.
+  const rosterPages = await Promise.all(
+    [0, 200, 400].map(offset => api.deputies.list({ limit: 200, offset }).catch(() => ({ items: [] })))
+  )
+  const positionByDeputy = new Map(vote.positions?.map(p => [p.deputy_id, p]) ?? [])
+  const deputyLookup = rosterPages.flatMap(page => page.items).map(d => {
+    const pos = positionByDeputy.get(d.deputy_id)
+    return {
+      deputy_id: d.deputy_id,
+      full_name: d.full_name,
+      party: pos?.party_short ?? d.party,
+      department: d.department,
+      position: pos?.position ?? null,
+    }
+  })
+
   return (
     <Suspense fallback={<div style={{ padding: '48px 32px', color: '#9CA3AF', fontSize: 14 }}>Chargement…</div>}>
       <VoteDetailClient
@@ -116,6 +135,7 @@ export default async function VoteDetailPage({ params }: { params: Promise<{ id:
         dissidents={dissidents}
         related={related}
         apiUrl={apiUrl}
+        deputyLookup={deputyLookup}
       />
     </Suspense>
   )

--- a/frontend/src/app/votes/[id]/page.tsx
+++ b/frontend/src/app/votes/[id]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { Suspense } from 'react'
 import { api } from '@/lib/api'
-import { getInitials, groupVotesByParty, partyHex } from '@/lib/utils'
+import { getInitials, groupVotesByParty, partyHex, partyShort } from '@/lib/utils'
 import { VoteDetailClient } from './VoteDetailClient'
 
 export const dynamicParams = true
@@ -100,6 +100,11 @@ export default async function VoteDetailPage({ params }: { params: Promise<{ id:
   // Full deputy roster (paginated — /deputies caps limit at 200) so "how did my
   // deputy vote?" can surface an explicit "absent / non enregistré" state for
   // deputies with no recorded position on this vote, not just an empty result.
+  // These 3 URLs are identical across every vote page, so Next's fetch data
+  // cache dedupes them to 3 real network calls per revalidate window rather
+  // than 3 × (number of statically generated vote pages) — relevant if this
+  // ever hits the API's 30 req/min limiter; failures degrade to an empty
+  // roster (via .catch) rather than failing the build.
   const rosterPages = await Promise.all(
     [0, 200, 400].map(offset => api.deputies.list({ limit: 200, offset }).catch(() => ({ items: [] })))
   )
@@ -109,7 +114,11 @@ export default async function VoteDetailPage({ params }: { params: Promise<{ id:
     return {
       deputy_id: d.deputy_id,
       full_name: d.full_name,
-      party: pos?.party_short ?? d.party,
+      // Always a short code, whether it comes from the recorded position or is
+      // derived from the deputy's full party name — keeps the lookup card and
+      // suggestion list visually consistent regardless of whether the deputy
+      // voted on this scrutin.
+      party: pos?.party_short ?? partyShort(d.party),
       department: d.department,
       position: pos?.position ?? null,
     }

--- a/frontend/src/components/GlobalSearch.tsx
+++ b/frontend/src/components/GlobalSearch.tsx
@@ -1,0 +1,204 @@
+'use client'
+import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
+import { useRouter } from 'next/navigation'
+import { api, type Deputy, type Vote } from '@/lib/api'
+import { getInitials, partyHex } from '@/lib/utils'
+
+type ResultRow =
+  | { type: 'deputy'; key: string; id: string; label: string; sub: string | null }
+  | { type: 'vote'; key: string; id: string; label: string; adopted: boolean }
+  | { type: 'ai'; key: string; query: string }
+
+// Simple heuristic: French interrogatives at the start, or a trailing "?".
+const INTERROGATIVES = ['qui', 'quel', 'quelle', 'quels', 'quelles', 'comment', 'pourquoi', 'quand', 'où', 'combien']
+
+function looksLikeQuestion(q: string): boolean {
+  const trimmed = q.trim()
+  if (trimmed.endsWith('?')) return true
+  const first = trimmed.toLowerCase().split(/\s+/)[0]?.replace(/[’']/g, "'").split("'")[0]
+  return INTERROGATIVES.includes(first ?? '')
+}
+
+type Results = { query: string; deputies: Deputy[]; votes: Vote[] }
+
+const EMPTY_RESULTS: Results = { query: '', deputies: [], votes: [] }
+
+export function GlobalSearch() {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [debounced, setDebounced] = useState('')
+  const [results, setResults] = useState<Results>(EMPTY_RESULTS)
+  const [activeIndex, setActiveIndex] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  function closeSearch() {
+    setOpen(false)
+    setQuery('')
+    setResults(EMPTY_RESULTS)
+    setActiveIndex(0)
+  }
+
+  // Cmd/Ctrl-K opens from anywhere; Escape closes.
+  useEffect(() => {
+    function onKeyDown(e: globalThis.KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        setOpen(o => !o)
+      } else if (e.key === 'Escape') {
+        closeSearch()
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+    const t = setTimeout(() => inputRef.current?.focus(), 10)
+    return () => clearTimeout(t)
+  }, [open])
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(query), 200)
+    return () => clearTimeout(t)
+  }, [query])
+
+  useEffect(() => {
+    const q = debounced.trim()
+    if (q.length < 2) return
+    let cancelled = false
+    Promise.all([
+      api.deputies.list({ search: q, limit: 5 }).catch(() => ({ items: [] as Deputy[] })),
+      api.votes.list({ search: q, limit: 5 }).catch(() => ({ items: [] as Vote[] })),
+    ]).then(([d, v]) => {
+      if (!cancelled) { setResults({ query: q, deputies: d.items, votes: v.items }); setActiveIndex(0) }
+    })
+    return () => { cancelled = true }
+  }, [debounced])
+
+  // Only show results for the query they were fetched for — avoids a flash of
+  // stale rows from the previous search while the new one is in flight.
+  const resultsMatch = results.query === debounced.trim()
+  const deputies = resultsMatch ? results.deputies : []
+  const votes = resultsMatch ? results.votes : []
+
+  const isQuestion = query.trim().length > 2 && looksLikeQuestion(query)
+
+  const rows: ResultRow[] = [
+    ...deputies.map(d => ({ type: 'deputy' as const, key: `d-${d.deputy_id}`, id: d.deputy_id, label: d.full_name, sub: d.party })),
+    ...votes.map(v => ({ type: 'vote' as const, key: `v-${v.vote_id}`, id: v.vote_id, label: v.vote_title, adopted: v.result === 'adopté' })),
+    ...(isQuestion ? [{ type: 'ai' as const, key: 'ai', query: query.trim() }] : []),
+  ]
+
+  function go(row: ResultRow) {
+    closeSearch()
+    if (row.type === 'deputy') router.push(`/deputes/${row.id}`)
+    else if (row.type === 'vote') router.push(`/votes/${row.id}`)
+    else router.push(`/chat?q=${encodeURIComponent(row.query)}`)
+  }
+
+  function onQueryChange(value: string) {
+    setQuery(value)
+    setActiveIndex(0)
+  }
+
+  function onInputKeyDown(e: KeyboardEvent) {
+    if (e.key === 'ArrowDown') { e.preventDefault(); setActiveIndex(i => Math.min(i + 1, rows.length - 1)) }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setActiveIndex(i => Math.max(i - 1, 0)) }
+    else if (e.key === 'Enter') { e.preventDefault(); const row = rows[activeIndex]; if (row) go(row) }
+  }
+
+  let lastGroup: string | null = null
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        aria-label="Rechercher (Cmd+K)"
+        style={{ display: 'flex', alignItems: 'center', gap: 8, border: '1px solid #E4E6EA', borderRadius: 8, padding: '6px 12px', background: '#fff', color: '#6B7280', fontSize: 13, cursor: 'pointer' }}
+      >
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><circle cx="11" cy="11" r="7" /><path d="m20 20-3.2-3.2" /></svg>
+        <span className="hidden lg:inline">Rechercher</span>
+        <span className="hidden lg:inline font-mono" style={{ fontSize: 11, color: '#9CA3AF', border: '1px solid #E4E6EA', borderRadius: 4, padding: '1px 5px' }}>⌘K</span>
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Recherche globale"
+          onClick={closeSearch}
+          style={{ position: 'fixed', inset: 0, background: 'rgba(17,24,39,0.5)', zIndex: 100, display: 'flex', justifyContent: 'center', paddingTop: '12vh' }}
+        >
+          <div onClick={e => e.stopPropagation()} style={{ width: '100%', maxWidth: 560, maxHeight: '70vh', background: '#fff', borderRadius: 14, boxShadow: '0 24px 64px rgba(0,0,0,0.25)', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '14px 20px', borderBottom: '1px solid #E4E6EA', flexShrink: 0 }}>
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#9CA3AF" strokeWidth="2" strokeLinecap="round"><circle cx="11" cy="11" r="7" /><path d="m20 20-3.2-3.2" /></svg>
+              <input
+                ref={inputRef}
+                value={query}
+                onChange={e => onQueryChange(e.target.value)}
+                onKeyDown={onInputKeyDown}
+                placeholder="Un député, un vote, ou une question…"
+                aria-label="Rechercher un député, un vote, ou poser une question"
+                style={{ flex: 1, border: 'none', outline: 'none', fontSize: 16, color: '#1B2B50' }}
+              />
+              <button onClick={closeSearch} aria-label="Fermer la recherche" style={{ border: 'none', background: 'none', color: '#9CA3AF', cursor: 'pointer', fontSize: 12.5 }}>Échap</button>
+            </div>
+
+            <div role="listbox" style={{ overflowY: 'auto', padding: '8px 0' }}>
+              {rows.length === 0 && (
+                <div style={{ padding: '24px 20px', textAlign: 'center', color: '#9CA3AF', fontSize: 13.5 }}>
+                  {query.trim().length < 2 ? 'Tapez au moins 2 caractères…' : `Aucun résultat pour « ${query.trim()} ».`}
+                </div>
+              )}
+
+              {rows.map((row, i) => {
+                const groupLabel = row.type === 'deputy' ? 'Députés' : row.type === 'vote' ? 'Votes' : 'Assistant IA'
+                const showGroup = groupLabel !== lastGroup
+                lastGroup = groupLabel
+                return (
+                  <div key={row.key}>
+                    {showGroup && (
+                      <div style={{ padding: '8px 20px 4px', font: '700 11px/1 var(--font-sans)', letterSpacing: '0.1em', textTransform: 'uppercase', color: '#9CA3AF' }}>
+                        {groupLabel}
+                      </div>
+                    )}
+                    <div
+                      role="option"
+                      aria-selected={activeIndex === i}
+                      onMouseEnter={() => setActiveIndex(i)}
+                      onClick={() => go(row)}
+                      style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 20px', cursor: 'pointer', background: activeIndex === i ? '#F7F4ED' : 'transparent' }}
+                    >
+                      {row.type === 'deputy' && (
+                        <>
+                          <span style={{ width: 26, height: 26, borderRadius: 999, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 700, fontSize: 10, color: '#fff', background: partyHex(row.sub) }}>
+                            {getInitials(row.label)}
+                          </span>
+                          <span style={{ fontWeight: 500, color: '#1B2B50' }}>{row.label}</span>
+                        </>
+                      )}
+                      {row.type === 'vote' && (
+                        <>
+                          <span style={{ fontWeight: 500, color: '#1B2B50', flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{row.label}</span>
+                          <span style={{ fontSize: 12, fontWeight: 600, flexShrink: 0, color: row.adopted ? '#1F8A5B' : '#C9302A' }}>{row.adopted ? 'Adopté' : 'Rejeté'}</span>
+                        </>
+                      )}
+                      {row.type === 'ai' && (
+                        <>
+                          <span style={{ fontSize: 15 }}>💬</span>
+                          <span style={{ fontWeight: 500, color: '#1B2B50' }}>Poser « {row.query} » à l&apos;IA →</span>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { MonEluLogo } from './MonEluLogo'
+import { GlobalSearch } from './GlobalSearch'
 
 export const NAV_HEIGHT_PX = 64
 
@@ -38,11 +39,14 @@ export function Nav() {
           )
         })}
       </div>
-      <a href="https://monelu-production.up.railway.app/docs"
-        target="_blank"
-        className="text-sm border border-navy text-navy px-4 py-1.5 rounded hover:bg-navy hover:text-white transition-colors">
-        Explorer l&apos;API →
-      </a>
+      <div className="flex items-center gap-4">
+        <GlobalSearch />
+        <a href="https://monelu-production.up.railway.app/docs"
+          target="_blank"
+          className="text-sm border border-navy text-navy px-4 py-1.5 rounded hover:bg-navy hover:text-white transition-colors">
+          Explorer l&apos;API →
+        </a>
+      </div>
     </nav>
   )
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -43,7 +43,7 @@ export type VoteDetail = Vote & {
   positions?: Array<{
     deputy_id: string
     full_name: string
-    party: string
+    party_short: string | null
     position: string
   }>
 }
@@ -154,10 +154,11 @@ export const api = {
       apiFetch<DissidentVotesResponse>(`/deputies/${id}/dissident-votes/?limit=${limit}`, { revalidate: 86400 }),
   },
   votes: {
-    list: (params?: { result?: string; theme?: string; limit?: number; offset?: number; before?: string }) => {
+    list: (params?: { result?: string; theme?: string; search?: string; limit?: number; offset?: number; before?: string }) => {
       const q = new URLSearchParams()
       if (params?.result) q.set('result', params.result)
       if (params?.theme)  q.set('theme',  params.theme)
+      if (params?.search) q.set('search', params.search)
       if (params?.limit) q.set('limit', String(params.limit))
       if (params?.offset) q.set('offset', String(params.offset))
       if (params?.before) q.set('before', params.before)

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -33,11 +33,11 @@ export function partyShort(party: string | null): string {
 
 
 export function groupVotesByParty(
-  positions: Array<{ party: string; position: string }>
+  positions: Array<{ party_short: string | null; position: string }>
 ): Record<string, Record<string, number>> {
   const map: Record<string, Record<string, number>> = {}
   for (const p of positions) {
-    const party = p.party || 'Non inscrit'
+    const party = p.party_short || 'Non inscrit'
     if (!map[party]) map[party] = { pour: 0, contre: 0, abstention: 0, nonVotant: 0 }
     map[party][p.position] = (map[party][p.position] || 0) + 1
   }

--- a/transform/models/marts/mart_vote_summary.sql
+++ b/transform/models/marts/mart_vote_summary.sql
@@ -1,3 +1,9 @@
+{{
+  config(
+    post_hook="create index if not exists idx_mart_vote_summary_fts on {{ this }} using gin (to_tsvector('french', vote_title || ' ' || coalesce(summary_plain, '')))"
+  )
+}}
+
 with votes as (
     select * from {{ ref('stg_votes') }}
 ),


### PR DESCRIPTION
## Summary

Three product-readiness issues from the June audit ("Product Readiness 2026-07" project), delivered in dependency order: the vote search API first, then the global search that depends on it, plus the independent deputy-lookup widget.

### MON-87 — Server-side vote search endpoint
- `GET /votes` gains `?search=`, matched against `to_tsvector('french', vote_title || ' ' || coalesce(summary_plain, ''))  @@ plainto_tsquery('french', %s)`, composable with the existing `result`/`theme` filters and keyset pagination.
- Backing GIN index (`idx_mart_vote_summary_fts`) is created via a **dbt `post_hook`** on `mart_vote_summary` rather than a plain SQL migration — the mart is a `table`-materialized model rebuilt on every `dbt run` (`deploy.yml`, on merge to `master`), so an index applied outside dbt would be dropped on the next rebuild.
- Frontend `/votes` page now searches server-side (debounced via the existing search box) instead of filtering only the currently-loaded page of 50 rows.

### MON-88 — Global search ("one box for everything")
- New `GlobalSearch` component: Cmd/Ctrl-K overlay + a search trigger in the desktop nav.
- Queries deputies and votes in parallel (via the new search endpoint) and offers a "Poser « … » à l'IA →" row that hands off to `/chat?q=…` when the query looks like a question (starts with a French interrogative or ends in "?").
- Results grouped by type, arrow-key navigable, Enter to open, Escape to close.

### MON-86 — "How did my deputy vote?" on vote pages
- New section on `/votes/[id]`: name or postal-code search over the full deputy roster (fetched once, paginated 3×200 since `/deputies` caps `limit` at 200) cross-referenced against this vote's recorded positions.
- Deputies with no recorded position on the vote get an explicit "Absent · non enregistré" state rather than dropping out of results silently.

### Found along the way
`VoteDetail.positions` was typed as `{ party: string }` on the frontend, but the API actually returns `party_short` (no alias in the pydantic schema). `groupVotesByParty` and the dissidents list were silently keying on `undefined` for every position, defaulting every deputy into "Non inscrit". Fixed the type and the two call sites since MON-86 touches this exact data path — flagging here rather than treating it as an unrelated fix.

## Testing
- `ruff check .` / `ruff format --check .` — clean, repo-wide.
- `pytest tests/unit/ -q` — 16 passed.
- `pytest tests/ -q` — 75 passed, 27 pre-existing integration errors (no local Postgres — expected per the skill's documented baseline).
- `npx tsc --noEmit` — clean.
- `npx eslint` on all touched files — clean (including the newer `react-hooks/set-state-in-effect` rule, which required restructuring the postal-code and debounce effects to match the existing `DeputiesClient` pattern).
- `npx jest` — 40 passed, 6 suites.
- dbt: no local `profiles.yml` to run `dbt compile`/`dbt run` against; the post-hook syntax is standard dbt and will be exercised by CI/deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)