### PR TITLE
fix: link landing hero dot and vote badge to the deputy's real position (MON-102)

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -46,23 +46,18 @@ async function getStats() {
     let picked: Deputy | null = null
     let pickedPosition: 'pour' | 'contre' | 'abstention' | null = null
 
+    const votingPositions = ['pour', 'contre', 'abstention'] as const
+    const isVotingPosition = (position: string): position is (typeof votingPositions)[number] =>
+      (votingPositions as readonly string[]).includes(position)
+
     if (featuredVote) {
       try {
         const voteDetail = await api.votes.get(featuredVote.vote_id)
-        const eligible = (voteDetail.positions ?? []).filter(
-          (p): p is typeof p & { position: 'pour' | 'contre' | 'abstention' } =>
-            p.position === 'pour' || p.position === 'contre' || p.position === 'abstention'
-        )
-        const withPhoto = eligible
-          .map(p => ({ pos: p, deputy: deputies?.find(d => d.deputy_id === p.deputy_id) }))
-          .find(x => x.deputy?.photo_url)
-        if (withPhoto?.deputy) {
-          picked = withPhoto.deputy
-          pickedPosition = withPhoto.pos.position
-        } else if (eligible.length) {
-          const fallback = eligible[Math.floor(eligible.length / 2)]
-          picked = await api.deputies.get(fallback.deputy_id)
-          pickedPosition = fallback.position
+        const eligible = (voteDetail.positions ?? []).filter(p => isVotingPosition(p.position))
+        if (eligible.length) {
+          const middle = eligible[Math.floor(eligible.length / 2)]
+          picked = await api.deputies.get(middle.deputy_id)
+          pickedPosition = middle.position as (typeof votingPositions)[number]
         }
       } catch { /* ignore */ }
     }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -18,6 +18,8 @@ export type DeputyInfo = {
   votesFor: number
   votesAgainst: number
   abstentions: number
+  /** This deputy's real position on the featured vote (pour/contre/abstention). */
+  votePosition: 'pour' | 'contre' | 'abstention' | null
 }
 
 async function getStats() {
@@ -36,10 +38,39 @@ async function getStats() {
       return total > bestTotal ? v : best
     }, null) ?? votes[0] ?? null
 
-    // Pick first deputy with a photo, fetch their scorecard
+    // Pick a deputy who actually voted on the featured scrutin, so the "your
+    // deputy" card reflects a real vote_positions row instead of an unrelated
+    // deputy (MON-102).
     let deputyInfo: DeputyInfo | null = null
     const deputies = deputyList?.items as Deputy[] | undefined
-    const picked = deputies?.find(d => d.photo_url) ?? deputies?.[0] ?? null
+    let picked: Deputy | null = null
+    let pickedPosition: 'pour' | 'contre' | 'abstention' | null = null
+
+    if (featuredVote) {
+      try {
+        const voteDetail = await api.votes.get(featuredVote.vote_id)
+        const eligible = (voteDetail.positions ?? []).filter(
+          (p): p is typeof p & { position: 'pour' | 'contre' | 'abstention' } =>
+            p.position === 'pour' || p.position === 'contre' || p.position === 'abstention'
+        )
+        const withPhoto = eligible
+          .map(p => ({ pos: p, deputy: deputies?.find(d => d.deputy_id === p.deputy_id) }))
+          .find(x => x.deputy?.photo_url)
+        if (withPhoto?.deputy) {
+          picked = withPhoto.deputy
+          pickedPosition = withPhoto.pos.position
+        } else if (eligible.length) {
+          const fallback = eligible[Math.floor(eligible.length / 2)]
+          picked = await api.deputies.get(fallback.deputy_id)
+          pickedPosition = fallback.position
+        }
+      } catch { /* ignore */ }
+    }
+
+    if (!picked) {
+      picked = deputies?.find(d => d.photo_url) ?? deputies?.[0] ?? null
+    }
+
     if (picked) {
       try {
         const sc: Scorecard = await api.deputies.scorecard(picked.deputy_id)
@@ -54,6 +85,7 @@ async function getStats() {
           votesFor: sc.votes_for ?? 0,
           votesAgainst: sc.votes_against ?? 0,
           abstentions: sc.abstentions ?? 0,
+          votePosition: pickedPosition,
         }
       } catch { /* ignore */ }
     }

--- a/frontend/src/components/home/AssemblyScrollExperience.tsx
+++ b/frontend/src/components/home/AssemblyScrollExperience.tsx
@@ -280,6 +280,10 @@ function CinematicExperience({ stats, leadVote, deputyInfo }: Props) {
     })
 
     const heroColor = COLORS[heroKind]
+    // Keep the connective link line's color in sync with the hero dot (MON-102).
+    const linkStops = $$('[data-linkstop]') as unknown as SVGStopElement[]
+    linkStops.forEach(stop => stop.setAttribute('stop-color', heroColor.c))
+    if (linkPath) linkPath.style.filter = `drop-shadow(0 0 6px ${heroColor.g})`
     const heroRing = document.createElement('div')
     heroRing.style.cssText = `position:absolute;left:${hero.x}px;top:${hero.y}px;width:54px;height:54px;border-radius:999px;border:2px solid ${heroColor.c};opacity:0;transform:translate(-50%,-50%) scale(0.5);will-change:opacity,transform;box-shadow:0 0 18px ${heroColor.g};`
     fxLayer.appendChild(heroRing)
@@ -662,12 +666,12 @@ function CinematicExperience({ stats, leadVote, deputyInfo }: Props) {
           <svg data-link width="100%" height="100%" style={{ position: 'absolute', inset: 0, overflow: 'visible', opacity: 0 }}>
             <defs>
               <linearGradient id="linkgrad" x1="0" y1="1" x2="1" y2="0">
-                <stop offset="0" stopColor="#F04438" stopOpacity="0.05" />
-                <stop offset="0.5" stopColor="#F04438" stopOpacity="0.95" />
-                <stop offset="1" stopColor="#F04438" stopOpacity="0.95" />
+                <stop data-linkstop offset="0" stopColor="#F04438" stopOpacity="0.05" />
+                <stop data-linkstop offset="0.5" stopColor="#F04438" stopOpacity="0.95" />
+                <stop data-linkstop offset="1" stopColor="#F04438" stopOpacity="0.95" />
               </linearGradient>
             </defs>
-            <path data-linkpath d="" fill="none" stroke="url(#linkgrad)" strokeWidth="2.4" strokeLinecap="round" style={{ filter: 'drop-shadow(0 0 6px rgba(240,68,56,0.7))' }} />
+            <path data-linkpath d="" fill="none" stroke="url(#linkgrad)" strokeWidth="2.4" strokeLinecap="round" />
           </svg>
 
           {/* corner chrome */}

--- a/frontend/src/components/home/AssemblyScrollExperience.tsx
+++ b/frontend/src/components/home/AssemblyScrollExperience.tsx
@@ -255,9 +255,20 @@ function CinematicExperience({ stats, leadVote, deputyInfo }: Props) {
     const counts = { pour: 0, contre: 0, abst: 0 }
     seats.forEach(s => { counts[s.kind]++ })
 
+    // The hero seat must reflect the deputy's real vote_positions row (MON-102) —
+    // fall back to 'contre' only when no real position is available.
+    const heroKind: 'pour' | 'contre' | 'abst' =
+      deputyInfo?.votePosition === 'pour' ? 'pour'
+        : deputyInfo?.votePosition === 'abstention' ? 'abst'
+        : 'contre'
     let hero: Seat | null = null
-    const candidates = seats.filter(s => s.kind === 'contre' && s.x > 540 && s.x < 800 && s.y > 660 && s.y < 850)
-    hero = candidates.length ? candidates[Math.floor(candidates.length / 2)] : seats[Math.floor(seats.length / 2)]
+    const candidates = seats.filter(s => s.kind === heroKind && s.x > 540 && s.x < 800 && s.y > 660 && s.y < 850)
+    const sameKind = seats.filter(s => s.kind === heroKind)
+    hero = candidates.length
+      ? candidates[Math.floor(candidates.length / 2)]
+      : sameKind.length
+        ? sameKind[Math.floor(sameKind.length / 2)]
+        : seats[Math.floor(seats.length / 2)]
 
     seats.forEach(s => {
       const el = document.createElement('div')
@@ -268,11 +279,12 @@ function CinematicExperience({ stats, leadVote, deputyInfo }: Props) {
       dotsLayer.appendChild(el)
     })
 
+    const heroColor = COLORS[heroKind]
     const heroRing = document.createElement('div')
-    heroRing.style.cssText = `position:absolute;left:${hero.x}px;top:${hero.y}px;width:54px;height:54px;border-radius:999px;border:2px solid #f4564a;opacity:0;transform:translate(-50%,-50%) scale(0.5);will-change:opacity,transform;box-shadow:0 0 18px rgba(244,86,74,0.6);`
+    heroRing.style.cssText = `position:absolute;left:${hero.x}px;top:${hero.y}px;width:54px;height:54px;border-radius:999px;border:2px solid ${heroColor.c};opacity:0;transform:translate(-50%,-50%) scale(0.5);will-change:opacity,transform;box-shadow:0 0 18px ${heroColor.g};`
     fxLayer.appendChild(heroRing)
     const heroGlow = document.createElement('div')
-    heroGlow.style.cssText = `position:absolute;left:${hero.x}px;top:${hero.y}px;width:120px;height:120px;border-radius:999px;background:radial-gradient(circle,rgba(244,86,74,0.45) 0%,rgba(244,86,74,0) 70%);opacity:0;transform:translate(-50%,-50%) scale(0.6);will-change:opacity,transform;`
+    heroGlow.style.cssText = `position:absolute;left:${hero.x}px;top:${hero.y}px;width:120px;height:120px;border-radius:999px;background:radial-gradient(circle,${heroColor.g} 0%,rgba(0,0,0,0) 70%);opacity:0;transform:translate(-50%,-50%) scale(0.6);will-change:opacity,transform;`
     fxLayer.appendChild(heroGlow)
 
     // ---- helpers ----
@@ -556,14 +568,38 @@ function CinematicExperience({ stats, leadVote, deputyInfo }: Props) {
       window.removeEventListener('resize', onResize)
       if (raf) cancelAnimationFrame(raf)
     }
-  }, [stats, leadVote])
+  }, [stats, leadVote, deputyInfo])
 
   const totalVotes = leadVote.votesFor + leadVote.votesAgainst + leadVote.abstentions
-  const voteResultLabel = leadVote.result.toLowerCase().includes('adopt') ? 'A voté pour' : 'A voté contre'
-  const voteResultIcon = leadVote.result.toLowerCase().includes('adopt') ? '✓' : '✕'
-  const voteResultColor = leadVote.result.toLowerCase().includes('adopt') ? '#1fd4a6' : '#f3b6b1'
-  const voteResultBg = leadVote.result.toLowerCase().includes('adopt') ? 'rgba(31,212,166,0.16)' : 'rgba(217,48,37,0.16)'
-  const voteResultBorder = leadVote.result.toLowerCase().includes('adopt') ? 'rgba(31,212,166,0.35)' : 'rgba(240,88,76,0.35)'
+
+  // Prefer the deputy's real vote_positions row over the bill's overall
+  // result so the badge always matches the highlighted hero seat (MON-102).
+  const votePosition = deputyInfo?.votePosition
+  const voteResultLabel =
+    votePosition === 'pour' ? 'A voté pour'
+      : votePosition === 'abstention' ? "S'est abstenu sur"
+      : votePosition === 'contre' ? 'A voté contre'
+      : leadVote.result.toLowerCase().includes('adopt') ? 'A voté pour' : 'A voté contre'
+  const voteResultIcon =
+    votePosition === 'pour' ? '✓'
+      : votePosition === 'abstention' ? '–'
+      : votePosition === 'contre' ? '✕'
+      : leadVote.result.toLowerCase().includes('adopt') ? '✓' : '✕'
+  const voteResultColor =
+    votePosition === 'pour' ? '#1fd4a6'
+      : votePosition === 'abstention' ? '#c7cfe0'
+      : votePosition === 'contre' ? '#f3b6b1'
+      : leadVote.result.toLowerCase().includes('adopt') ? '#1fd4a6' : '#f3b6b1'
+  const voteResultBg =
+    votePosition === 'pour' ? 'rgba(31,212,166,0.16)'
+      : votePosition === 'abstention' ? 'rgba(185,196,216,0.16)'
+      : votePosition === 'contre' ? 'rgba(217,48,37,0.16)'
+      : leadVote.result.toLowerCase().includes('adopt') ? 'rgba(31,212,166,0.16)' : 'rgba(217,48,37,0.16)'
+  const voteResultBorder =
+    votePosition === 'pour' ? 'rgba(31,212,166,0.35)'
+      : votePosition === 'abstention' ? 'rgba(185,196,216,0.35)'
+      : votePosition === 'contre' ? 'rgba(240,88,76,0.35)'
+      : leadVote.result.toLowerCase().includes('adopt') ? 'rgba(31,212,166,0.35)' : 'rgba(240,88,76,0.35)'
 
   return (
     <div

--- a/frontend/src/components/home/AssemblyScrollExperience.tsx
+++ b/frontend/src/components/home/AssemblyScrollExperience.tsx
@@ -269,6 +269,10 @@ function CinematicExperience({ stats, leadVote, deputyInfo }: Props) {
       : sameKind.length
         ? sameKind[Math.floor(sameKind.length / 2)]
         : seats[Math.floor(seats.length / 2)]
+    // Force the hero seat's own kind to match heroKind so its dot color never
+    // disagrees with the ring/glow, even in the rare case where no seat of
+    // heroKind exists and we fell back to an arbitrary seat above.
+    hero.kind = heroKind
 
     seats.forEach(s => {
       const el = document.createElement('div')
@@ -578,32 +582,21 @@ function CinematicExperience({ stats, leadVote, deputyInfo }: Props) {
 
   // Prefer the deputy's real vote_positions row over the bill's overall
   // result so the badge always matches the highlighted hero seat (MON-102).
-  const votePosition = deputyInfo?.votePosition
-  const voteResultLabel =
-    votePosition === 'pour' ? 'A voté pour'
-      : votePosition === 'abstention' ? "S'est abstenu sur"
-      : votePosition === 'contre' ? 'A voté contre'
-      : leadVote.result.toLowerCase().includes('adopt') ? 'A voté pour' : 'A voté contre'
-  const voteResultIcon =
-    votePosition === 'pour' ? '✓'
-      : votePosition === 'abstention' ? '–'
-      : votePosition === 'contre' ? '✕'
-      : leadVote.result.toLowerCase().includes('adopt') ? '✓' : '✕'
-  const voteResultColor =
-    votePosition === 'pour' ? '#1fd4a6'
-      : votePosition === 'abstention' ? '#c7cfe0'
-      : votePosition === 'contre' ? '#f3b6b1'
-      : leadVote.result.toLowerCase().includes('adopt') ? '#1fd4a6' : '#f3b6b1'
-  const voteResultBg =
-    votePosition === 'pour' ? 'rgba(31,212,166,0.16)'
-      : votePosition === 'abstention' ? 'rgba(185,196,216,0.16)'
-      : votePosition === 'contre' ? 'rgba(217,48,37,0.16)'
-      : leadVote.result.toLowerCase().includes('adopt') ? 'rgba(31,212,166,0.16)' : 'rgba(217,48,37,0.16)'
-  const voteResultBorder =
-    votePosition === 'pour' ? 'rgba(31,212,166,0.35)'
-      : votePosition === 'abstention' ? 'rgba(185,196,216,0.35)'
-      : votePosition === 'contre' ? 'rgba(240,88,76,0.35)'
-      : leadVote.result.toLowerCase().includes('adopt') ? 'rgba(31,212,166,0.35)' : 'rgba(240,88,76,0.35)'
+  const billAdopted = leadVote.result.toLowerCase().includes('adopt')
+  const effectivePosition: 'pour' | 'contre' | 'abstention' =
+    deputyInfo?.votePosition ?? (billAdopted ? 'pour' : 'contre')
+  const VOTE_BADGE = {
+    pour: { label: 'A voté pour', icon: '✓', color: '#1fd4a6', bg: 'rgba(31,212,166,0.16)', border: 'rgba(31,212,166,0.35)' },
+    contre: { label: 'A voté contre', icon: '✕', color: '#f3b6b1', bg: 'rgba(217,48,37,0.16)', border: 'rgba(240,88,76,0.35)' },
+    abstention: { label: "S'est abstenu sur", icon: '–', color: '#c7cfe0', bg: 'rgba(185,196,216,0.16)', border: 'rgba(185,196,216,0.35)' },
+  } as const
+  const {
+    label: voteResultLabel,
+    icon: voteResultIcon,
+    color: voteResultColor,
+    bg: voteResultBg,
+    border: voteResultBorder,
+  } = VOTE_BADGE[effectivePosition]
 
   return (
     <div


### PR DESCRIPTION
## Summary
- The homepage hemicycle animation picked an arbitrary deputy (first one with a photo) and an unrelated "most-voted" scrutin, then hardcoded the highlighted seat and its connective link line to red (`contre`) purely for camera-framing, while the card badge ("A voté pour/contre ce texte") was derived from the bill's overall adopted/rejected result. None of these three pieces of state referenced each other, so the dot color, link line, and badge text could (and often did) contradict each other.
- Now the featured deputy is picked from that scrutin's actual `vote_positions` (via `GET /votes/{id}`), and the highlighted seat color, its connective link line, and the card badge are all derived from that single real `pour`/`contre`/`abstention` value.

## Changes
- `frontend/src/app/page.tsx`: fetch the featured vote's positions and resolve a deputy who actually voted on it (the middle eligible voter, excluding `nonVotant`), carrying their real position through `DeputyInfo.votePosition`.
- `frontend/src/components/home/AssemblyScrollExperience.tsx`:
  - hero seat kind/color and the card's vote badge (label/icon/colors) derive from `deputyInfo.votePosition`, with the old bill-result-based logic kept only as a fallback when no per-deputy position is available.
  - the connective SVG link line's gradient stops and drop-shadow now follow the same hero color instead of a hardcoded red.
  - the badge label/icon/color/bg/border ternary chains were collapsed into a single `VOTE_BADGE` lookup table.
  - the hero seat's own `kind` is force-set to match `heroKind` after selection, so its dot color can never disagree with the ring/glow even in the rare case where no seat of the target kind exists in a given render.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` passes on the touched files
- [x] `next build` compiles and type-checks successfully (unrelated 429 from the prod API during `/sitemap.xml` prerender is a pre-existing infra issue, not caused by this change)
- [ ] Manually verify on the running dev server that the hero dot, connective link line, and badge colors all agree across `pour`/`contre`/`abstention` examples

Closes MON-102