### PR TITLE
Phase 2: RAG data quality — canonical party labels + active-mandate counts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ Assemblée Nationale Open Data (ZIPs)
 - `chain/prompts.py`: TTL-cached system prompt (data horizon refreshed hourly) via `build_system_prompt()`. Call per request — do not cache the return value.
 - `chain/rag_chain.py`: `ask()` — retrieve → format → Groq `llama-3.3-70b-versatile` (temperature=0.2)
 - `experiments/mlflow_eval.py`: 11 golden Q&A pairs split into router suite (live SQL ground truth) and retrieval suite (keyword scoring).
-- 3,741 chunks in production: 3,149 vote + 577 deputy + 12 party + 1 global_stats + 2 notable_deputy · avg 87 tokens · $0.0065 to embed
+- ~5,900 chunks in production (2026-07): 5,105 vote + 645 deputy + 12 party + 1 global_stats + 102 notable_deputy + 20 law_summary · party and global chunks count active mandates only
 
 **`archive/infra-aws/`** — Archived AWS Terraform IaC (not live)
 - Modeled an Airflow+Spark architecture never built, with no compute for the actual FastAPI app — archived rather than fixed (MON-46). See Phase 5 and decision 1 in the decisions log.

--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -160,7 +160,10 @@ SQL_QUERIES = {
         LIMIT 20
     """,
     "deputy_total_count": """
-        SELECT COUNT(*) as total FROM deputies
+        SELECT
+            COUNT(*) FILTER (WHERE mandate_end IS NULL) as active,
+            COUNT(*) as total
+        FROM deputies
     """,
     "vote_total_count": """
         SELECT
@@ -172,9 +175,12 @@ SQL_QUERIES = {
         FROM votes
     """,
     "deputy_count_by_party": """
+        -- Active mandates only: group sizes must reflect the current
+        -- Assemblée, not everyone who ever sat during the legislature.
         SELECT party, COUNT(*) as count
         FROM deputies
         WHERE party IS NOT NULL
+          AND mandate_end IS NULL
         GROUP BY party
         ORDER BY count DESC
     """,
@@ -271,14 +277,19 @@ FORMATTERS = {
         if rows
         else "Aucun député trouvé pour ce département."
     ),
-    "deputy_total_count": lambda rows: f"MonÉlu suit {rows[0]['total']} députés au total.",
+    "deputy_total_count": lambda rows: (
+        f"MonÉlu suit {rows[0]['active']} députés en exercice "
+        f"({rows[0]['total']} au total sur la 17e législature, "
+        f"en comptant les mandats terminés)."
+    ),
     "vote_total_count": lambda rows: (
         f"MonÉlu a analysé {rows[0]['total']} votes au total "
         f"(du {rows[0]['from_date']} au {rows[0]['to_date']}). "
         f"{rows[0]['adopted']} adoptés, {rows[0]['rejected']} rejetés."
     ),
     "deputy_count_by_party": lambda rows: (
-        f"Répartition des {sum(r['count'] for r in rows)} députés par groupe parlementaire :\n"
+        f"Répartition des {sum(r['count'] for r in rows)} députés en exercice "
+        f"par groupe parlementaire :\n"
         + "\n".join(f"- {r['party']} : {r['count']} députés" for r in rows)
     ),
     "party_abstention_rate": lambda rows: (

--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -146,9 +146,12 @@ PATTERNS = [
 
 SQL_QUERIES = {
     "deputy_by_department": """
+        -- Active mandates only — same "en exercice" policy as the
+        -- deputy count intents
         SELECT full_name, party, department
         FROM deputies
         WHERE department = %(dept)s
+          AND mandate_end IS NULL
         ORDER BY full_name
     """,
     "deputy_by_department_all": """

--- a/rag/pipeline/chunker.py
+++ b/rag/pipeline/chunker.py
@@ -219,6 +219,8 @@ def chunk_party_summaries() -> list[dict]:
                 -- windowed — see docs/decisions.md), averaged per deputy so
                 -- high-vote deputies don't dominate the party mean
                 WITH deputy_presence AS (
+                    -- Active mandates only: group sizes and presence
+                    -- averages describe the current Assemblée
                     SELECT d.deputy_id, d.party,
                            LEAST(
                                COUNT(vp.position_id)::numeric / NULLIF((
@@ -231,6 +233,7 @@ def chunk_party_summaries() -> list[dict]:
                     FROM deputies d
                     LEFT JOIN vote_positions vp ON d.deputy_id = vp.deputy_id
                     WHERE d.party IS NOT NULL
+                      AND d.mandate_end IS NULL
                     GROUP BY d.deputy_id
                 ),
                 party_positions AS (
@@ -300,6 +303,7 @@ def chunk_global_stats() -> list[dict]:
             cur.execute(
                 """
                 SELECT
+                  (SELECT COUNT(*) FROM deputies WHERE mandate_end IS NULL)   AS active_deputies,
                   (SELECT COUNT(*) FROM deputies)                             AS total_deputies,
                   (SELECT COUNT(*) FROM votes)                                AS total_votes,
                   (SELECT COUNT(*) FROM vote_positions)                       AS total_positions,
@@ -345,6 +349,7 @@ def chunk_global_stats() -> list[dict]:
     finally:
         conn.close()
 
+    active_dep = int(stats["active_deputies"] or 0)
     total_dep = int(stats["total_deputies"] or 0)
     total_votes = int(stats["total_votes"] or 0)
     total_pos = int(stats["total_positions"] or 0)
@@ -369,7 +374,8 @@ def chunk_global_stats() -> list[dict]:
         )
 
     content = (
-        f"MonÉlu suit {total_dep} députés de l'Assemblée Nationale française.\n"
+        f"MonÉlu suit {active_dep} députés en exercice à l'Assemblée Nationale française "
+        f"({total_dep} au total sur la 17e législature, mandats terminés compris).\n"
         f"Au total, {total_votes:,} votes ont été analysés.\n"
         f"{total_pos:,} positions individuelles de vote sont enregistrées.\n"
         f"Parmi les votes : {adopted:,} ont été adoptés et {rejected:,} ont été rejetés.\n"

--- a/scripts/backfill_party_labels.py
+++ b/scripts/backfill_party_labels.py
@@ -1,0 +1,147 @@
+"""
+scripts/backfill_party_labels.py
+
+Normalizes deputies.party to the canonical 17th-legislature parliamentary
+group labels.
+
+Why this exists: the daily pipeline resolves party labels from AMO10,
+which only lists *active* deputies. Deputies who leave mid-legislature
+keep whatever label they had at departure — a mix of PARPOL spellings
+("Rassemblement national", "Parti socialiste"), pre-2024 group names
+("Ensemble ! (majorité présidentielle)"), and in some cases outright
+wrong PARPOL data (Jérôme Nury labeled "Régions et peuples solidaires"
+although he sat with Droite Républicaine). This fragments every
+party-level aggregate: the same group appears under several labels.
+
+Two normalization layers:
+  1. LABEL_MAP    — variant label → canonical GP label, applied only when
+                    the correspondence is one-to-one for every deputy
+                    carrying the variant.
+  2. OVERRIDES    — deputy_id → label, for individually verified deputies
+                    whose stored label cannot be mapped safely in bulk.
+
+NULL parties are left NULL — unknown is better than guessed.
+
+Dry-run by default; pass --apply to write. After applying, rebuild the
+RAG index (`make rag-index`) so party/deputy chunks pick up the labels.
+
+Usage:
+    python -m scripts.backfill_party_labels            # report only
+    python -m scripts.backfill_party_labels --apply    # update deputies.party
+"""
+
+import argparse
+import os
+
+import psycopg2
+from dotenv import load_dotenv
+from psycopg2.extras import execute_batch
+
+load_dotenv()
+
+# Canonical 17th-legislature parliamentary groups + Non inscrit.
+# Keep in sync with the dbt accepted_values test on stg_deputies.party.
+CANONICAL_LABELS = {
+    "Rassemblement National",
+    "Ensemble pour la République",
+    "La France insoumise - Nouveau Front Populaire",
+    "Socialistes et apparentés",
+    "Droite Républicaine",
+    "Écologiste et Social",
+    "Les Démocrates",
+    "Horizons & Indépendants",
+    "Libertés, Indépendants, Outre-mer et Territoires",
+    "Union des droites pour la République",
+    "Gauche Démocrate et Républicaine",
+    "Non inscrit",
+}
+
+# Variant → canonical. Only mappings that hold for every deputy carrying
+# the variant label (verified against the deputies concerned, 2026-07).
+LABEL_MAP = {
+    # case variant of the same group
+    "Rassemblement national": "Rassemblement National",
+    # PARPOL spelling of the group
+    "La France Insoumise": "La France insoumise - Nouveau Front Populaire",
+    # PS deputies → their L17 group
+    "Parti socialiste": "Socialistes et apparentés",
+    # Horizons deputies → their L17 group
+    "Horizons": "Horizons & Indépendants",
+    # LR deputies → their L17 group (LR group renamed Droite Républicaine)
+    "Les Républicains": "Droite Républicaine",
+}
+
+# Individually verified deputies whose stored label is wrong or ambiguous.
+# Each entry cites why. deputy_id → canonical label.
+OVERRIDES = {
+    # "Ensemble ! (majorité présidentielle)" holders — all sat with EPR
+    # except Philippe Bolo (MoDem, groupe Les Démocrates).
+    "PA795144": "Ensemble pour la République",  # Antoine Armand
+    "PA719736": "Ensemble pour la République",  # Camille Galliard-Minier
+    "PA2960": "Ensemble pour la République",  # Éric Woerth
+    "PA335758": "Ensemble pour la République",  # Franck Riester
+    "PA677483": "Ensemble pour la République",  # Stéphane Mazars
+    "PA793940": "Ensemble pour la République",  # Thomas Cazenave
+    "PA720162": "Les Démocrates",  # Philippe Bolo — MoDem
+    # Alliance centriste (PARPOL) — Olivier Falorni sat with Les Démocrates
+    "PA605694": "Les Démocrates",
+    # Régions et peuples solidaires (wrong PARPOL) — Jérôme Nury is LR,
+    # sat with Droite Républicaine
+    "PA720644": "Droite Républicaine",
+}
+
+
+def compute_changes(rows: list[tuple]) -> tuple[list[tuple], list[tuple]]:
+    """Split deputies into (changes, unmapped-non-canonical)."""
+    changes = []
+    unmapped = []
+    for deputy_id, full_name, current in rows:
+        if current is None:
+            continue
+        target = OVERRIDES.get(deputy_id) or LABEL_MAP.get(current)
+        if target and target != current:
+            changes.append((deputy_id, full_name, current, target))
+        elif target is None and current not in CANONICAL_LABELS:
+            unmapped.append((deputy_id, full_name, current))
+    return changes, unmapped
+
+
+def backfill(apply: bool) -> None:
+    conn = psycopg2.connect(os.environ["DATABASE_URL"])
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT deputy_id, full_name, party FROM deputies ORDER BY full_name")
+            rows = cur.fetchall()
+
+        changes, unmapped = compute_changes(rows)
+
+        print(f"Deputies in DB       : {len(rows)}")
+        print(f"Label changes        : {len(changes)}")
+        print(f"Unmapped non-canonical labels remaining: {len(unmapped)}\n")
+        for _, full_name, old, new in changes:
+            print(f"  {full_name:<32} {old:<42} → {new}")
+        for deputy_id, full_name, label in unmapped:
+            print(f"  UNMAPPED {deputy_id} {full_name}: {label!r}")
+
+        if apply and changes:
+            with conn.cursor() as cur:
+                execute_batch(
+                    cur,
+                    "UPDATE deputies SET party = %s WHERE deputy_id = %s",
+                    [(new, deputy_id) for deputy_id, _, _, new in changes],
+                    page_size=200,
+                )
+            conn.commit()
+            print(f"\nCommitted {len(changes)} updates.")
+            print("Rebuild the RAG index so chunks pick up the labels: make rag-index")
+        elif not apply:
+            print("\nDry run — re-run with --apply to write.")
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Normalize deputies.party to canonical labels.")
+    parser.add_argument("--apply", action="store_true", help="write updates (default: dry run)")
+    args = parser.parse_args()
+    backfill(apply=args.apply)

--- a/scripts/backfill_party_labels.py
+++ b/scripts/backfill_party_labels.py
@@ -98,10 +98,15 @@ def compute_changes(rows: list[tuple]) -> tuple[list[tuple], list[tuple]]:
     for deputy_id, full_name, current in rows:
         if current is None:
             continue
+        if current in CANONICAL_LABELS:
+            # Already canonical — never touch it, even if an OVERRIDE
+            # exists: the deputy may have legitimately changed groups
+            # since the override was written.
+            continue
         target = OVERRIDES.get(deputy_id) or LABEL_MAP.get(current)
         if target and target != current:
             changes.append((deputy_id, full_name, current, target))
-        elif target is None and current not in CANONICAL_LABELS:
+        elif target is None:
             unmapped.append((deputy_id, full_name, current))
     return changes, unmapped
 

--- a/scripts/ingest_deputies.py
+++ b/scripts/ingest_deputies.py
@@ -167,7 +167,11 @@ ON CONFLICT (deputy_id) DO UPDATE SET
     full_name       = EXCLUDED.full_name,
     first_name      = EXCLUDED.first_name,
     last_name       = EXCLUDED.last_name,
-    party           = EXCLUDED.party,
+    -- AMO10 has no inline party; this script always inserts NULL and
+    -- update_party.py fills it afterwards. COALESCE keeps the previous
+    -- label instead of wiping it, so a run where update_party fails (or
+    -- a deputy leaves between the two steps) can't NULL out the party.
+    party           = COALESCE(EXCLUDED.party, deputies.party),
     party_short     = EXCLUDED.party_short,
     circonscription = EXCLUDED.circonscription,
     department      = EXCLUDED.department,

--- a/scripts/ingest_organes.py
+++ b/scripts/ingest_organes.py
@@ -68,7 +68,12 @@ def build_gp_map(zf: zipfile.ZipFile) -> dict[str, str]:
 def build_deputy_party_map(zf: zipfile.ZipFile, gp_map: dict[str, str]) -> dict[str, str]:
     """
     Returns {deputy_id: party_name} by scanning each acteur's mandats.
-    Priority: GP mandat > PARPOL mandat > None.
+    Priority: active GP mandat > most recent ended GP mandat > active PARPOL.
+
+    Ended GP mandats must not be skipped: deputies who left mid-legislature
+    otherwise fall back to their PARPOL label ("Rassemblement national",
+    "Renaissance", "Parti socialiste", …), which fragments the party
+    dimension with spellings that never match the GP group labels.
     """
     deputy_map: dict[str, str] = {}
     acteur_files = [
@@ -92,23 +97,26 @@ def build_deputy_party_map(zf: zipfile.ZipFile, gp_map: dict[str, str]) -> dict[
         if isinstance(mandats_raw, dict):
             mandats_raw = [mandats_raw]
 
-        gp_party = None
+        active_gp = None
+        ended_gps: list[tuple[str, str]] = []  # (date_fin, party)
         parpol_party = None
 
         for mandat in mandats_raw:
             type_organe = mandat.get("typeOrgane")
             date_fin = mandat.get("dateFin")
-            if date_fin:  # skip ended mandats
-                continue
             organe_ref = mandat.get("organes", {}).get("organeRef")
-            if not organe_ref:
+            if not organe_ref or organe_ref not in gp_map:
                 continue
-            if type_organe == "GP" and organe_ref in gp_map:
-                gp_party = gp_map[organe_ref]
-            elif type_organe == "PARPOL" and organe_ref in gp_map and not gp_party:
+            if type_organe == "GP":
+                if date_fin:
+                    ended_gps.append((date_fin, gp_map[organe_ref]))
+                else:
+                    active_gp = gp_map[organe_ref]
+            elif type_organe == "PARPOL" and not date_fin:
                 parpol_party = gp_map[organe_ref]
 
-        party = gp_party or parpol_party
+        latest_ended_gp = max(ended_gps)[1] if ended_gps else None
+        party = active_gp or latest_ended_gp or parpol_party
         if party:
             deputy_map[deputy_id] = party
 

--- a/scripts/ingest_organes.py
+++ b/scripts/ingest_organes.py
@@ -115,7 +115,7 @@ def build_deputy_party_map(zf: zipfile.ZipFile, gp_map: dict[str, str]) -> dict[
             elif type_organe == "PARPOL" and not date_fin:
                 parpol_party = gp_map[organe_ref]
 
-        latest_ended_gp = max(ended_gps)[1] if ended_gps else None
+        latest_ended_gp = max(ended_gps, key=lambda t: t[0])[1] if ended_gps else None
         party = active_gp or latest_ended_gp or parpol_party
         if party:
             deputy_map[deputy_id] = party

--- a/scripts/update_party.py
+++ b/scripts/update_party.py
@@ -128,6 +128,19 @@ DEPT_NAMES = {
 
 
 def update_parties(conn, deputy_map: dict[str, str]) -> None:
+    from scripts.backfill_party_labels import CANONICAL_LABELS
+
+    # Never write a non-canonical label: the PARPOL fallback in
+    # build_deputy_party_map can produce party spellings ("Renaissance",
+    # "Parti socialiste") that fragment the party dimension and fail the
+    # dbt accepted_values gate the next day. Warn and keep the old value.
+    skipped = {
+        deputy_id: party for deputy_id, party in deputy_map.items() if party not in CANONICAL_LABELS
+    }
+    for deputy_id, party in skipped.items():
+        print(f"  WARNING: skipping non-canonical label {party!r} for {deputy_id}")
+    deputy_map = {k: v for k, v in deputy_map.items() if k not in skipped}
+
     print(f"\nUpdating party for {len(deputy_map)} deputies …")
     rows = [(party, deputy_id) for deputy_id, party in deputy_map.items()]
     with conn.cursor() as cur:

--- a/tests/unit/test_party_labels.py
+++ b/tests/unit/test_party_labels.py
@@ -1,0 +1,112 @@
+"""
+Table-driven tests for the party-label normalization logic that encodes
+the 2026-07 fragmentation incident's lessons:
+  - scripts/backfill_party_labels.py::compute_changes
+  - scripts/ingest_organes.py::build_deputy_party_map priority order
+"""
+
+import io
+import json
+import zipfile
+
+from scripts.backfill_party_labels import CANONICAL_LABELS, LABEL_MAP, compute_changes
+from scripts.ingest_organes import build_deputy_party_map
+
+# ---------------------------------------------------------------------------
+# compute_changes
+# ---------------------------------------------------------------------------
+
+
+def test_variant_label_is_mapped():
+    changes, unmapped = compute_changes([("PA1", "Alice", "Rassemblement national")])
+    assert changes == [("PA1", "Alice", "Rassemblement national", "Rassemblement National")]
+    assert unmapped == []
+
+
+def test_canonical_label_is_never_touched_even_with_override():
+    # PA605694 (Falorni) has an OVERRIDE, but a canonical current label wins
+    changes, unmapped = compute_changes([("PA605694", "Olivier Falorni", "Les Démocrates")])
+    assert changes == []
+    assert unmapped == []
+
+
+def test_override_beats_label_map():
+    # PA720162 (Bolo) carried "Ensemble !" but sat with Les Démocrates
+    changes, _ = compute_changes(
+        [("PA720162", "Philippe Bolo", "Ensemble ! (majorité présidentielle)")]
+    )
+    assert changes == [
+        (
+            "PA720162",
+            "Philippe Bolo",
+            "Ensemble ! (majorité présidentielle)",
+            "Les Démocrates",
+        )
+    ]
+
+
+def test_null_party_is_left_alone():
+    changes, unmapped = compute_changes([("PA9", "Untel", None)])
+    assert changes == []
+    assert unmapped == []
+
+
+def test_unknown_label_is_reported_not_guessed():
+    changes, unmapped = compute_changes([("PA9", "Untel", "Parti Inconnu")])
+    assert changes == []
+    assert unmapped == [("PA9", "Untel", "Parti Inconnu")]
+
+
+def test_label_map_targets_are_canonical():
+    assert set(LABEL_MAP.values()) <= CANONICAL_LABELS
+
+
+# ---------------------------------------------------------------------------
+# build_deputy_party_map priority: active GP > latest ended GP > PARPOL
+# ---------------------------------------------------------------------------
+
+
+def _make_amo10_zip(mandats: list[dict]) -> zipfile.ZipFile:
+    acteur = {"acteur": {"uid": {"#text": "PA1"}, "mandats": {"mandat": mandats}}}
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("json/acteur/PA1.json", json.dumps(acteur))
+    return zipfile.ZipFile(buf)
+
+
+GP_MAP = {"ORG_GP1": "Groupe A", "ORG_GP2": "Groupe B", "ORG_PP": "Parti P"}
+
+
+def _mandat(type_organe: str, organe_ref: str, date_fin: str | None) -> dict:
+    return {
+        "typeOrgane": type_organe,
+        "dateFin": date_fin,
+        "organes": {"organeRef": organe_ref},
+    }
+
+
+def test_active_gp_wins_over_everything():
+    zf = _make_amo10_zip(
+        [
+            _mandat("GP", "ORG_GP1", None),
+            _mandat("GP", "ORG_GP2", "2025-01-01"),
+            _mandat("PARPOL", "ORG_PP", None),
+        ]
+    )
+    assert build_deputy_party_map(zf, GP_MAP) == {"PA1": "Groupe A"}
+
+
+def test_latest_ended_gp_beats_active_parpol():
+    zf = _make_amo10_zip(
+        [
+            _mandat("GP", "ORG_GP1", "2024-12-01"),
+            _mandat("GP", "ORG_GP2", "2025-06-01"),
+            _mandat("PARPOL", "ORG_PP", None),
+        ]
+    )
+    assert build_deputy_party_map(zf, GP_MAP) == {"PA1": "Groupe B"}
+
+
+def test_parpol_is_last_resort():
+    zf = _make_amo10_zip([_mandat("PARPOL", "ORG_PP", None)])
+    assert build_deputy_party_map(zf, GP_MAP) == {"PA1": "Parti P"}

--- a/transform/models/staging/schema.yml
+++ b/transform/models/staging/schema.yml
@@ -10,6 +10,30 @@ models:
         tests: [not_null]
       - name: is_active
         tests: [not_null]
+      - name: party
+        description: >
+          Canonical 17th-legislature parliamentary group label. Keep this
+          list in sync with CANONICAL_LABELS in scripts/backfill_party_labels.py.
+          NULL is allowed (deputies whose group was never resolved); any
+          other label means the ingestion pipeline is fragmenting the
+          party dimension again.
+        tests:
+          - accepted_values:
+              values:
+                - 'Rassemblement National'
+                - 'Ensemble pour la République'
+                - 'La France insoumise - Nouveau Front Populaire'
+                - 'Socialistes et apparentés'
+                - 'Droite Républicaine'
+                - 'Écologiste et Social'
+                - 'Les Démocrates'
+                - 'Horizons & Indépendants'
+                - 'Libertés, Indépendants, Outre-mer et Territoires'
+                - 'Union des droites pour la République'
+                - 'Gauche Démocrate et Républicaine'
+                - 'Non inscrit'
+              config:
+                where: "party is not null"
 
   - name: stg_votes
     description: "Cleaned and typed vote records"


### PR DESCRIPTION
## Context

Phase 2 of the RAG remediation (follows #165). The diagnostic battery showed every party-level answer polluted by label fragmentation: 22 distinct `deputies.party` values for 11 real parliamentary groups ("Rassemblement National" ×122 **and** "Rassemblement national" ×5, stale "Les Républicains"/"Parti socialiste"/"Ensemble ! (majorité présidentielle)" labels, 44 NULLs), and "Combien de députés suivis ?" answered 648 by mixing active deputies, ended mandates, and (pre-#165) test fixtures.

Root cause: `ingest_deputies.py` NULLs `party` on every daily upsert, and `update_party.py` restores it **only for deputies still listed in AMO10 (actives)**. Deputies who leave mid-legislature keep whatever label they had at departure, forever.

## Changes

- **`scripts/backfill_party_labels.py`** (new): normalizes `deputies.party` to the canonical L17 group labels. A safe 1:1 variant map (5 labels) plus per-deputy overrides for 9 individually verified cases — including Philippe Bolo (MoDem → Les Démocrates, not EPR like the other "Ensemble !" holders) and Jérôme Nury (whose "Régions et peuples solidaires" PARPOL label was simply wrong; he sat with Droite Républicaine). Dry-run by default. Applied to prod: 24 updates, 0 non-canonical labels remain. NULLs stay NULL — unknown beats guessed.
- **`scripts/ingest_deputies.py`**: upsert uses `COALESCE(EXCLUDED.party, deputies.party)` so the daily wipe-then-restore dance can no longer strand deputies at NULL.
- **`scripts/ingest_organes.py`**: `build_deputy_party_map` prefers the most recent *ended* GP mandat over PARPOL labels, so future departures keep their group label instead of regressing to party spellings.
- **`transform/models/staging/schema.yml`**: `accepted_values` test on `stg_deputies.party` (11 groups + Non inscrit, `where party is not null`) — CI now blocks any relapse into fragmentation.
- **`rag/chain/sql_router.py` + `rag/pipeline/chunker.py`**: deputy counts distinguish "en exercice" (577 — the exact seat count) from the legislature total (645); party group sizes and presence averages computed over active mandates only.

Note: the AN AMO50 dataset was evaluated as a backfill source and rejected — it's a stale July-2024 snapshot where every deputy's group is "Non inscrit" (groups weren't formed yet).

## Verification

- Prod after apply + `make rag-index`: party labels 22 → 12, party chunks 20 → 12.
- "Combien de députés sont suivis ?" → "577 députés en exercice (645 au total sur la 17e législature)".
- "Quel parti a le plus de députés ?" → clean 12-group canonical list, no duplicates.
- `ruff` clean; 30 unit tests pass; dbt schema change is test-only (no model SQL touched).
- Full retest log: `notes/dispatch/rag_remediation_phase2_2026-07-04.md` (local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaSxrbyge58arGqm7a9nbL