### PR TITLE
Phase 3: SQL router intents — rankings, temporal, and comparison questions

### DIFF
--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -139,7 +139,14 @@ PATTERNS = [
     (r"député.*(meilleur|plus (haut|élevé)|top).*présence", "deputy_top_presence"),
     (r"(meilleur|plus (haut|élevé)).*présence.*député", "deputy_top_presence"),
     (r"(top|classement).*député.*présence", "deputy_top_presence"),
-    (r"député.*(abstiennent|abstient|abstention)", "deputy_top_abstention"),
+    # superlative required, and "le moins" excluded: "combien de députés du
+    # RN se sont abstenus sur X" or "quel député s'abstient le moins" must
+    # NOT get the top-abstentions ranking
+    (
+        r"député.*(abstiennent|abstient|abstention).*(le plus|plus souvent|davantage)"
+        r"|député.*(le plus|plus souvent) d.abstentions?",
+        "deputy_top_abstention",
+    ),
     (r"député.*(voté|vote|votent).*contre.*(le plus|plus souvent)", "deputy_most_contre"),
     (r"(qui|quel député).*(le plus|plus souvent).*(voté |vote )?contre", "deputy_most_contre"),
     (r"député.*(voté|vote|votent).*pour.*(le plus|plus souvent)", "deputy_most_pour"),
@@ -689,6 +696,9 @@ def _has_notable_deputy(question: str) -> bool:
     return False
 
 
+_RESULT_WORDS = re.compile(r"adopté|rejeté|rejet\b|adoption")
+
+
 def detect_intent(question: str) -> str | None:
     """Return intent key if question matches an aggregation pattern."""
     q = normalize_text(question)
@@ -696,6 +706,11 @@ def detect_intent(question: str) -> str | None:
         if re.search(pattern, q):
             # Don't let global-aggregate patterns swallow deputy-specific questions
             if intent in _DEPUTY_NAME_INTENTS and _has_notable_deputy(question):
+                return None
+            # "les votes rejetés les plus récents" is a result-filtered
+            # recency question — retriever.py handles those (recency-sorted
+            # retrieval); the unfiltered latest-votes SQL would be wrong
+            if intent in ("vote_latest", "vote_first") and _RESULT_WORDS.search(q):
                 return None
             return intent
     return None

--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -110,6 +110,20 @@ def detect_department(question: str) -> str | None:
     return None
 
 
+def detect_circonscription(question: str) -> str | None:
+    """'1ère circonscription des Yvelines' → '1' (bare number, matching the DB)."""
+    m = re.search(
+        r"\b(\d{1,2})\s*(?:ère|ere|e|ème|eme)?\s*circonscription", normalize_text(question)
+    )
+    return m.group(1) if m else None
+
+
+# Pattern order matters: the first match wins.
+#   - deputy-level rankings must precede the party-level rate patterns
+#     ("quels députés s'abstiennent le plus" would otherwise route to
+#     party_abstention_rate)
+#   - period questions must precede vote_latest ("la semaine dernière"
+#     contains "dernière")
 PATTERNS = [
     # deputies by department — must come before generic deputy_count patterns
     (
@@ -119,6 +133,18 @@ PATTERNS = [
         "deputy_by_department",
     ),
     (r"combien.*député.*département|député.*quel département", "deputy_by_department"),
+    # deputy rankings — before any party-level rate pattern
+    (r"député.*(pire|plus (bas|faible)|moins bon).*présence", "deputy_bottom_presence"),
+    (r"(pire|plus (bas|faible)).*présence.*député", "deputy_bottom_presence"),
+    (r"député.*(meilleur|plus (haut|élevé)|top).*présence", "deputy_top_presence"),
+    (r"(meilleur|plus (haut|élevé)).*présence.*député", "deputy_top_presence"),
+    (r"(top|classement).*député.*présence", "deputy_top_presence"),
+    (r"député.*(abstiennent|abstient|abstention)", "deputy_top_abstention"),
+    (r"député.*(voté|vote|votent).*contre.*(le plus|plus souvent)", "deputy_most_contre"),
+    (r"(qui|quel député).*(le plus|plus souvent).*(voté |vote )?contre", "deputy_most_contre"),
+    (r"député.*(voté|vote|votent).*pour.*(le plus|plus souvent)", "deputy_most_pour"),
+    (r"(dissiden|votent différemment|vote différemment)", "deputy_dissidents"),
+    (r"(qui|députés?).*(contre|différemment de) (son|leur) (groupe|parti)", "deputy_dissidents"),
     # total deputy count
     (r"combien.*député.*(total|suivis|enregistrés|au total|en tout)", "deputy_total_count"),
     # party / group counts
@@ -128,15 +154,35 @@ PATTERNS = [
     # abstention rate
     (r"(quel groupe|quel parti).*(abstien|abstention|plus d.abstention)", "party_abstention_rate"),
     (r"(qui|quel).*(abstient|abstentions).*(plus|davantage|le plus)", "party_abstention_rate"),
-    # presence rate
+    # presence rate — also answers "différence de présence entre X et Y":
+    # the full per-group table contains both terms of any comparison
+    (r"différence.*présence|présence.*différence", "party_presence_rate"),
+    (r"compar.*présence.*(groupe|parti)", "party_presence_rate"),
     (r"(quel groupe|quel parti).*(présence|particip|vote le plus)", "party_presence_rate"),
     (r"taux de présence.*(groupe|parti|moyen|chaque)", "party_presence_rate"),
+    # votes in a time period — before vote_latest ("semaine dernière")
+    (
+        r"(combien|quels).*votes?.*(janvier|février|mars|avril|mai|juin|juillet"
+        r"|août|septembre|octobre|novembre|décembre)",
+        "votes_by_period",
+    ),
+    (r"(combien|quels).*votes?.*(cette semaine|ce mois|semaine dernière)", "votes_by_period"),
+    # latest / first vote
+    (r"(dernier|derniers) (vote|scrutin)|votes? les? plus récents?", "vote_latest"),
+    (r"premier (vote|scrutin)|vote le plus ancien", "vote_first"),
+    # participation / closest
+    (r"votes?.*(plus de|le plus|top).*(participation|votants)", "vote_top_participation"),
+    (r"(participation|votants).*(le plus|la plus|maximum)", "vote_top_participation"),
+    (r"votes?.*(serré|serrés)", "vote_closest"),
     # vote totals
     (r"combien.*votes?.*(total|au total|en tout|depuis|enregistrés)", "vote_total_count"),
     (r"(nombre|volume|total).*votes?", "vote_total_count"),
     # vote result counts (adopté/rejeté)
     (r"combien de votes.*(adopté|rejeté)", "vote_result_count"),
     (r"combien.*(adopté|rejeté)", "vote_result_count"),
+    # party position totals ("le RN vote-t-il plus souvent pour ou contre ?")
+    (r"(vote|votent).*(pour ou contre|contre ou pour)", "party_position_totals"),
+    (r"(groupe|parti).*(plus souvent|majoritairement).*(pour|contre)", "party_position_totals"),
     # party alignment / discipline
     (r"discipline.*(vote|voting)|taux de discipline", "party_alignment"),
     (r"(vote|votent).*(toujours|souvent|jamais).*(ensemble|même sens)", "party_alignment"),
@@ -144,14 +190,131 @@ PATTERNS = [
     (r"qui vote.*(toujours|souvent|jamais).*(avec|contre).*(parti|groupe)", "party_alignment"),
 ]
 
+# Rankings exclude deputies with too few votes in their mandate window:
+# a deputy present for 3 votes and attending all 3 is not "the most
+# present deputy" in any meaningful sense.
+_MIN_WINDOW_VOTES = 100
+
+# Canonical per-deputy presence over the mandate window (see
+# docs/decisions.md); shared by both presence-ranking intents.
+_DEPUTY_PRESENCE_RANKING = f"""
+    SELECT d.full_name, d.party,
+           ROUND(LEAST(
+               COUNT(vp.position_id)::numeric / NULLIF(wv.window_votes, 0), 1
+           ) * 100, 1) AS presence_pct
+    FROM deputies d
+    LEFT JOIN vote_positions vp ON d.deputy_id = vp.deputy_id
+    CROSS JOIN LATERAL (
+        SELECT COUNT(*) AS window_votes FROM votes v
+        WHERE (d.mandate_start IS NULL OR v.voted_at >= d.mandate_start)
+          AND (d.mandate_end IS NULL OR v.voted_at <= d.mandate_end)
+    ) wv
+    WHERE d.mandate_end IS NULL
+    GROUP BY d.deputy_id, wv.window_votes
+    HAVING wv.window_votes >= {_MIN_WINDOW_VOTES}
+    ORDER BY presence_pct {{direction}}, d.full_name
+    LIMIT %(n)s
+"""
+
 SQL_QUERIES = {
+    "deputy_top_presence": _DEPUTY_PRESENCE_RANKING.format(direction="DESC"),
+    "deputy_bottom_presence": _DEPUTY_PRESENCE_RANKING.format(direction="ASC"),
+    "deputy_top_abstention": """
+        SELECT d.full_name, d.party, COUNT(*) AS n
+        FROM vote_positions vp
+        JOIN deputies d ON d.deputy_id = vp.deputy_id
+        WHERE vp.position = 'abstention'
+        GROUP BY d.deputy_id
+        ORDER BY n DESC
+        LIMIT %(n)s
+    """,
+    "deputy_most_contre": """
+        SELECT d.full_name, d.party, COUNT(*) AS n
+        FROM vote_positions vp
+        JOIN deputies d ON d.deputy_id = vp.deputy_id
+        WHERE vp.position = 'contre'
+        GROUP BY d.deputy_id
+        ORDER BY n DESC
+        LIMIT %(n)s
+    """,
+    "deputy_most_pour": """
+        SELECT d.full_name, d.party, COUNT(*) AS n
+        FROM vote_positions vp
+        JOIN deputies d ON d.deputy_id = vp.deputy_id
+        WHERE vp.position = 'pour'
+        GROUP BY d.deputy_id
+        ORDER BY n DESC
+        LIMIT %(n)s
+    """,
+    "deputy_dissidents": f"""
+        SELECT full_name, party, total_votes, dissident_votes,
+               ROUND(dissident_rate * 100, 1) AS dissident_pct
+        FROM analytics_marts.mart_party_alignment
+        WHERE total_votes >= {_MIN_WINDOW_VOTES}
+        ORDER BY dissident_rate DESC
+        LIMIT %(n)s
+    """,
+    "vote_latest": """
+        SELECT vote_title, voted_at::date AS d, result,
+               votes_for, votes_against, abstentions, total_voters
+        FROM votes
+        ORDER BY voted_at DESC
+        LIMIT %(n)s
+    """,
+    "vote_first": """
+        SELECT vote_title, voted_at::date AS d, result,
+               votes_for, votes_against, abstentions, total_voters
+        FROM votes
+        ORDER BY voted_at ASC
+        LIMIT 1
+    """,
+    "vote_top_participation": """
+        SELECT vote_title, voted_at::date AS d, result, total_voters
+        FROM votes
+        ORDER BY total_voters DESC NULLS LAST
+        LIMIT %(n)s
+    """,
+    "vote_closest": f"""
+        -- floor on total_voters: 1-1 amendment votes in a near-empty
+        -- hemicycle are ties but not "les votes les plus serrés"
+        SELECT vote_title, voted_at::date AS d, result,
+               votes_for, votes_against, total_voters,
+               ABS(votes_for - votes_against) AS margin
+        FROM votes
+        WHERE total_voters >= {_MIN_WINDOW_VOTES}
+        ORDER BY margin ASC, total_voters DESC
+        LIMIT %(n)s
+    """,
+    "votes_by_period": """
+        SELECT
+            COUNT(*) AS total,
+            COUNT(*) FILTER (WHERE result = 'adopté') AS adopted,
+            COUNT(*) FILTER (WHERE result = 'rejeté') AS rejected,
+            %(label)s AS period_label
+        FROM votes
+        WHERE voted_at >= %(start)s AND voted_at < %(end)s
+    """,
+    "party_position_totals": """
+        SELECT d.party,
+               COUNT(*) FILTER (WHERE vp.position = 'pour')       AS pour,
+               COUNT(*) FILTER (WHERE vp.position = 'contre')     AS contre,
+               COUNT(*) FILTER (WHERE vp.position = 'abstention') AS abstention
+        FROM vote_positions vp
+        JOIN deputies d ON d.deputy_id = vp.deputy_id
+        WHERE d.party IS NOT NULL
+        GROUP BY d.party
+        ORDER BY (COUNT(*) FILTER (WHERE vp.position = 'pour')
+                + COUNT(*) FILTER (WHERE vp.position = 'contre')) DESC
+    """,
     "deputy_by_department": """
         -- Active mandates only — same "en exercice" policy as the
-        -- deputy count intents
-        SELECT full_name, party, department
+        -- deputy count intents. circo narrows to one circonscription
+        -- when the question names one.
+        SELECT full_name, party, department, circonscription
         FROM deputies
         WHERE department = %(dept)s
           AND mandate_end IS NULL
+          AND (%(circo)s IS NULL OR circonscription = %(circo)s)
         ORDER BY full_name
     """,
     "deputy_by_department_all": """
@@ -270,7 +433,110 @@ SQL_QUERIES = {
     """,
 }
 
+
+def _fmt_vote_line(r: dict) -> str:
+    return (
+        f"- {r['vote_title']} ({r['d']}) : {r['result']} — "
+        f"{r.get('votes_for', '?')} pour, {r.get('votes_against', '?')} contre, "
+        f"{r['total_voters']} votants"
+    )
+
+
 FORMATTERS = {
+    "deputy_top_presence": lambda rows: (
+        "Députés en exercice avec le meilleur taux de présence "
+        f"(au moins {_MIN_WINDOW_VOTES} votes sur leur mandat) :\n"
+        + "\n".join(
+            f"- {r['full_name']} ({r['party'] or 'groupe non renseigné'}) : {r['presence_pct']}%"
+            for r in rows
+        )
+    ),
+    "deputy_bottom_presence": lambda rows: (
+        "Députés en exercice avec le plus faible taux de présence "
+        f"(au moins {_MIN_WINDOW_VOTES} votes sur leur mandat) :\n"
+        + "\n".join(
+            f"- {r['full_name']} ({r['party'] or 'groupe non renseigné'}) : {r['presence_pct']}%"
+            for r in rows
+        )
+    ),
+    "deputy_top_abstention": lambda rows: (
+        "Députés avec le plus d'abstentions :\n"
+        + "\n".join(
+            f"- {r['full_name']} ({r['party'] or 'groupe non renseigné'}) : {r['n']} abstentions"
+            for r in rows
+        )
+    ),
+    "deputy_most_contre": lambda rows: (
+        "Députés ayant le plus souvent voté contre :\n"
+        + "\n".join(
+            f"- {r['full_name']} ({r['party'] or 'groupe non renseigné'}) : {r['n']} votes contre"
+            for r in rows
+        )
+    ),
+    "deputy_most_pour": lambda rows: (
+        "Députés ayant le plus souvent voté pour :\n"
+        + "\n".join(
+            f"- {r['full_name']} ({r['party'] or 'groupe non renseigné'}) : {r['n']} votes pour"
+            for r in rows
+        )
+    ),
+    "deputy_dissidents": lambda rows: (
+        "Députés votant le plus souvent différemment de la majorité de leur "
+        f"groupe (au moins {_MIN_WINDOW_VOTES} votes) :\n"
+        + "\n".join(
+            f"- {r['full_name']} ({r['party'] or 'groupe non renseigné'}) : "
+            f"{r['dissident_pct']}% de votes dissidents "
+            f"({r['dissident_votes']} sur {r['total_votes']})"
+            for r in rows
+        )
+    ),
+    "vote_latest": lambda rows: (
+        f"Le dernier vote enregistré date du {rows[0]['d']} : "
+        f"{rows[0]['vote_title']} — {rows[0]['result']} "
+        f"({rows[0]['votes_for']} pour, {rows[0]['votes_against']} contre, "
+        f"{rows[0]['abstentions']} abstentions sur {rows[0]['total_voters']} votants)."
+        + (
+            "\n\nVotes précédents :\n" + "\n".join(_fmt_vote_line(r) for r in rows[1:])
+            if len(rows) > 1
+            else ""
+        )
+    ),
+    "vote_first": lambda rows: (
+        f"Le premier vote enregistré date du {rows[0]['d']} : "
+        f"{rows[0]['vote_title']} — {rows[0]['result']} "
+        f"({rows[0]['votes_for']} pour, {rows[0]['votes_against']} contre, "
+        f"{rows[0]['abstentions']} abstentions sur {rows[0]['total_voters']} votants)."
+    ),
+    "vote_top_participation": lambda rows: (
+        "Votes avec la plus forte participation :\n"
+        + "\n".join(
+            f"- {r['vote_title']} ({r['d']}) : {r['total_voters']} votants — {r['result']}"
+            for r in rows
+        )
+    ),
+    "vote_closest": lambda rows: (
+        f"Votes les plus serrés (au moins {_MIN_WINDOW_VOTES} votants) :\n"
+        + "\n".join(
+            f"- {r['vote_title']} ({r['d']}) : {r['votes_for']} pour / "
+            f"{r['votes_against']} contre (écart {r['margin']}) — {r['result']}"
+            for r in rows
+        )
+    ),
+    "votes_by_period": lambda rows: (
+        f"{rows[0]['total']} vote(s) enregistré(s) {rows[0]['period_label']} : "
+        f"{rows[0]['adopted']} adopté(s), {rows[0]['rejected']} rejeté(s)."
+        if rows[0]["total"]
+        else f"Aucun vote enregistré {rows[0]['period_label']}."
+    ),
+    "party_position_totals": lambda rows: (
+        "Positions de vote par groupe parlementaire :\n"
+        + "\n".join(
+            f"- {r['party']} : {r['pour']:,} pour, {r['contre']:,} contre, "
+            f"{r['abstention']:,} abstentions — "
+            f"vote majoritairement {'pour' if r['pour'] >= r['contre'] else 'contre'}"
+            for r in rows
+        )
+    ),
     "deputy_by_department": lambda rows: (
         (
             f"{len(rows)} député(s) dans les {CODE_TO_DEPT_NAME.get(rows[0]['department'], rows[0]['department'])} "
@@ -324,7 +590,94 @@ FORMATTERS = {
 }
 
 
-_DEPUTY_NAME_INTENTS = {"vote_total_count", "vote_result_count"}
+# Intents that must yield to RAG when a specific deputy is named
+# ("le dernier vote de Marine Le Pen" is about her record, not the
+# chamber's latest vote)
+_DEPUTY_NAME_INTENTS = {
+    "vote_total_count",
+    "vote_result_count",
+    "vote_latest",
+    "vote_first",
+    "votes_by_period",
+}
+
+# Intents whose SQL takes a LIMIT %(n)s
+_TOP_N_INTENTS = {
+    "deputy_top_presence",
+    "deputy_bottom_presence",
+    "deputy_top_abstention",
+    "deputy_most_contre",
+    "deputy_most_pour",
+    "deputy_dissidents",
+    "vote_latest",
+    "vote_top_participation",
+    "vote_closest",
+}
+
+_DEFAULT_TOP_N = 5
+_MAX_TOP_N = 20
+
+_MONTHS = {
+    "janvier": 1,
+    "février": 2,
+    "mars": 3,
+    "avril": 4,
+    "mai": 5,
+    "juin": 6,
+    "juillet": 7,
+    "août": 8,
+    "septembre": 9,
+    "octobre": 10,
+    "novembre": 11,
+    "décembre": 12,
+}
+
+
+def extract_top_n(question: str) -> int:
+    """'les 5 députés', 'top 3' → 5, 3; default 5, capped at 20."""
+    m = re.search(r"\b(?:les|top)\s+(\d{1,2})\b", normalize_text(question))
+    if not m:
+        return _DEFAULT_TOP_N
+    return max(1, min(int(m.group(1)), _MAX_TOP_N))
+
+
+def extract_period(question: str) -> dict | None:
+    """
+    Resolve a month/year or relative-week/month mention to
+    {"start": date, "end": date, "label": str}. Returns None if the
+    question has no resolvable period (caller falls back to RAG).
+    """
+    import datetime as _dt
+
+    q = normalize_text(question)
+    today = _dt.date.today()
+
+    m = re.search(
+        r"\b(janvier|février|mars|avril|mai|juin|juillet|août"
+        r"|septembre|octobre|novembre|décembre)\b(?:\s+(\d{4}))?",
+        q,
+    )
+    if m:
+        month = _MONTHS[m.group(1)]
+        year = int(m.group(2)) if m.group(2) else today.year
+        start = _dt.date(year, month, 1)
+        end = _dt.date(year + 1, 1, 1) if month == 12 else _dt.date(year, month + 1, 1)
+        return {"start": start, "end": end, "label": f"en {m.group(1)} {year}"}
+
+    if "cette semaine" in q:
+        start = today - _dt.timedelta(days=today.weekday())
+        return {"start": start, "end": today + _dt.timedelta(days=1), "label": "cette semaine"}
+    if "semaine dernière" in q:
+        start = today - _dt.timedelta(days=today.weekday() + 7)
+        return {
+            "start": start,
+            "end": start + _dt.timedelta(days=7),
+            "label": "la semaine dernière",
+        }
+    if "ce mois" in q:
+        start = today.replace(day=1)
+        return {"start": start, "end": today + _dt.timedelta(days=1), "label": "ce mois-ci"}
+    return None
 
 
 def _has_notable_deputy(question: str) -> bool:
@@ -389,8 +742,18 @@ def route(question: str) -> dict | None:
         dept_name = detect_department(question)
         if not dept_name:
             return None
-        rows = run_sql_query("deputy_by_department", {"dept": dept_name})
+        circo = detect_circonscription(question)
+        rows = run_sql_query("deputy_by_department", {"dept": dept_name, "circo": circo})
         formatter_key = "deputy_by_department"
+    elif intent == "votes_by_period":
+        period = extract_period(question)
+        if not period:
+            return None
+        rows = run_sql_query("votes_by_period", period)
+        formatter_key = "votes_by_period"
+    elif intent in _TOP_N_INTENTS:
+        rows = run_sql_query(intent, {"n": extract_top_n(question)})
+        formatter_key = intent
     else:
         rows = run_sql_query(intent)
         formatter_key = intent

--- a/tests/unit/test_sql_router_intents.py
+++ b/tests/unit/test_sql_router_intents.py
@@ -91,6 +91,19 @@ def test_recency_result_question_stays_rag():
     assert detect_intent("Quels votes ont été rejetés récemment ?") is None
 
 
+def test_result_filtered_latest_stays_rag():
+    assert detect_intent("Quels sont les votes rejetés les plus récents ?") is None
+
+
+def test_abstention_without_superlative_stays_rag():
+    q = "Combien de députés du RN se sont abstenus sur le PLFSS ?"
+    assert detect_intent(q) != "deputy_top_abstention"
+
+
+def test_abstention_le_moins_not_top_ranking():
+    assert detect_intent("Quel député s'abstient le moins ?") != "deputy_top_abstention"
+
+
 # ---------------------------------------------------------------------------
 # extract_top_n
 # ---------------------------------------------------------------------------
@@ -152,3 +165,72 @@ def test_circonscription_absent():
     from rag.chain.sql_router import detect_circonscription
 
     assert detect_circonscription("Qui sont les députés des Yvelines ?") is None
+
+
+# ---------------------------------------------------------------------------
+# FORMATTERS smoke test — every formatter must render its SQL's row shape
+# ---------------------------------------------------------------------------
+
+_SAMPLE_ROWS = {
+    "deputy_top_presence": [{"full_name": "A", "party": "P", "presence_pct": 99.0}],
+    "deputy_bottom_presence": [{"full_name": "A", "party": None, "presence_pct": 1.0}],
+    "deputy_top_abstention": [{"full_name": "A", "party": "P", "n": 10}],
+    "deputy_most_contre": [{"full_name": "A", "party": "P", "n": 10}],
+    "deputy_most_pour": [{"full_name": "A", "party": "P", "n": 10}],
+    "deputy_dissidents": [
+        {
+            "full_name": "A",
+            "party": "P",
+            "total_votes": 100,
+            "dissident_votes": 20,
+            "dissident_pct": 20.0,
+        }
+    ],
+    "vote_latest": [
+        {
+            "vote_title": "T",
+            "d": "2026-07-02",
+            "result": "adopté",
+            "votes_for": 1,
+            "votes_against": 2,
+            "abstentions": 0,
+            "total_voters": 3,
+        }
+    ]
+    * 2,
+    "vote_first": [
+        {
+            "vote_title": "T",
+            "d": "2025-07-01",
+            "result": "adopté",
+            "votes_for": 1,
+            "votes_against": 2,
+            "abstentions": 0,
+            "total_voters": 3,
+        }
+    ],
+    "vote_top_participation": [
+        {"vote_title": "T", "d": "2026-01-01", "result": "adopté", "total_voters": 500}
+    ],
+    "vote_closest": [
+        {
+            "vote_title": "T",
+            "d": "2026-01-01",
+            "result": "rejeté",
+            "votes_for": 77,
+            "votes_against": 77,
+            "total_voters": 154,
+            "margin": 0,
+        }
+    ],
+    "votes_by_period": [{"total": 10, "adopted": 4, "rejected": 6, "period_label": "en juin 2026"}],
+    "party_position_totals": [{"party": "P", "pour": 10, "contre": 5, "abstention": 1}],
+}
+
+
+def test_every_new_formatter_renders_its_row_shape():
+    from rag.chain.sql_router import FORMATTERS
+
+    for intent, rows in _SAMPLE_ROWS.items():
+        out = FORMATTERS[intent](rows)
+        assert isinstance(out, str) and out, intent

--- a/tests/unit/test_sql_router_intents.py
+++ b/tests/unit/test_sql_router_intents.py
@@ -1,0 +1,154 @@
+"""
+Routing tests for the Phase 3 SQL router intents (rankings, temporal,
+comparisons). Pure regex/extraction logic — no DB.
+
+These encode the diagnostic battery's failures: every question below was
+previously either answered wrong by RAG (extrapolating from 5 retrieved
+chunks) or refused, although the answer is deterministic SQL.
+"""
+
+import datetime
+
+from rag.chain.sql_router import detect_intent, extract_period, extract_top_n
+
+# ---------------------------------------------------------------------------
+# detect_intent — battery questions route to the right intent
+# ---------------------------------------------------------------------------
+
+
+def test_top_presence():
+    q = "Quels sont les 5 députés avec le meilleur taux de présence ?"
+    assert detect_intent(q) == "deputy_top_presence"
+
+
+def test_bottom_presence():
+    q = "Quels sont les 5 députés avec le pire taux de présence ?"
+    assert detect_intent(q) == "deputy_bottom_presence"
+
+
+def test_deputy_abstention_ranking_not_party_rate():
+    q = "Quels sont les 3 députés qui s'abstiennent le plus ?"
+    assert detect_intent(q) == "deputy_top_abstention"
+
+
+def test_party_abstention_still_routes_to_party_rate():
+    q = "Quel groupe s'abstient le plus ?"
+    assert detect_intent(q) == "party_abstention_rate"
+
+
+def test_most_contre():
+    q = "Quel député a voté contre le plus souvent ?"
+    assert detect_intent(q) == "deputy_most_contre"
+
+
+def test_dissidents():
+    q = "Quels députés du même parti votent différemment de leur groupe ?"
+    assert detect_intent(q) == "deputy_dissidents"
+
+
+def test_vote_latest():
+    assert detect_intent("Quel est le dernier vote à l'Assemblée ?") == "vote_latest"
+
+
+def test_vote_latest_yields_to_named_deputy():
+    assert detect_intent("Quel est le dernier vote de Marine Le Pen ?") is None
+
+
+def test_vote_first():
+    assert detect_intent("Quel est le premier vote enregistré ?") == "vote_first"
+
+
+def test_top_participation():
+    q = "Quels sont les 5 votes avec le plus de participation ?"
+    assert detect_intent(q) == "vote_top_participation"
+
+
+def test_closest_vote():
+    assert detect_intent("Quel est le vote le plus serré ?") == "vote_closest"
+
+
+def test_votes_by_month():
+    assert detect_intent("Combien de votes ont eu lieu en juin 2026 ?") == "votes_by_period"
+
+
+def test_votes_this_week_not_latest():
+    # "cette semaine" must win over any recency wording
+    assert detect_intent("Quels votes ont été adoptés cette semaine ?") == "votes_by_period"
+
+
+def test_party_position_totals():
+    q = "Le RN vote-t-il plus souvent pour ou contre ?"
+    assert detect_intent(q) == "party_position_totals"
+
+
+def test_presence_comparison_routes_to_party_presence():
+    q = "Quelle est la différence de présence entre le RN et LFI ?"
+    assert detect_intent(q) == "party_presence_rate"
+
+
+def test_recency_result_question_stays_rag():
+    # recency+result questions are RAG's job (recency-sorted retrieval)
+    assert detect_intent("Quels votes ont été rejetés récemment ?") is None
+
+
+# ---------------------------------------------------------------------------
+# extract_top_n
+# ---------------------------------------------------------------------------
+
+
+def test_top_n_from_les():
+    assert extract_top_n("Quels sont les 3 députés qui s'abstiennent le plus ?") == 3
+
+
+def test_top_n_default():
+    assert extract_top_n("Quel député a voté contre le plus souvent ?") == 5
+
+
+def test_top_n_capped():
+    assert extract_top_n("les 99 députés les plus présents") == 20
+    assert extract_top_n("top 15 des votes") == 15
+
+
+# ---------------------------------------------------------------------------
+# extract_period
+# ---------------------------------------------------------------------------
+
+
+def test_month_with_year():
+    p = extract_period("Combien de votes ont eu lieu en juin 2026 ?")
+    assert p["start"] == datetime.date(2026, 6, 1)
+    assert p["end"] == datetime.date(2026, 7, 1)
+
+
+def test_december_rolls_year():
+    p = extract_period("Combien de votes en décembre 2025 ?")
+    assert p["end"] == datetime.date(2026, 1, 1)
+
+
+def test_this_week():
+    p = extract_period("Quels votes ont été adoptés cette semaine ?")
+    assert p["start"].weekday() == 0  # Monday
+    assert p["label"] == "cette semaine"
+
+
+def test_no_period_returns_none():
+    assert extract_period("Combien de votes au total ?") is None
+
+
+# ---------------------------------------------------------------------------
+# detect_circonscription
+# ---------------------------------------------------------------------------
+
+
+def test_circonscription_detected():
+    from rag.chain.sql_router import detect_circonscription
+
+    q = "Qui est le député de la 1ère circonscription des Yvelines ?"
+    assert detect_circonscription(q) == "1"
+    assert detect_circonscription("le député de la 12e circonscription du Nord") == "12"
+
+
+def test_circonscription_absent():
+    from rag.chain.sql_router import detect_circonscription
+
+    assert detect_circonscription("Qui sont les députés des Yvelines ?") is None


### PR DESCRIPTION
## Context

Phase 3 of the RAG remediation (follows #165, #166). The 29-question diagnostic battery scored **0/14** on ranking, temporal, and comparison questions: "top 5 deputies by presence" was refused with a false "no data" claim, "latest vote" was wrong by a month, "most contre votes" named the wrong deputy, and group comparisons extrapolated from whichever 5 chunks retrieval happened to return. These questions are deterministic SQL — there is no `ORDER BY presence_rate` in embedding space — so they belong in `sql_router.py` (the zero-LLM, zero-hallucination path), which previously covered only 8 intents.

## Changes

All in `rag/chain/sql_router.py` + tests:

- **Deputy rankings**: `deputy_top_presence` / `deputy_bottom_presence` (canonical mandate-window presence, active mandates only, ≥100-vote floor so a 3-vote mandate can't rank first), `deputy_top_abstention`, `deputy_most_contre` / `deputy_most_pour`, `deputy_dissidents` (reads `mart_party_alignment`).
- **Temporal**: `vote_latest` / `vote_first`, `votes_by_period` with French month/year parsing plus "cette semaine" / "ce mois" / "semaine dernière"; falls back to RAG when no period resolves.
- **Vote rankings**: `vote_top_participation`, `vote_closest` (≥100-votant floor — 1-1 ties in an empty hemicycle are not "les votes les plus serrés").
- **Comparisons**: `party_position_totals` ("le RN vote-t-il plus souvent pour ou contre ?"); "différence de présence entre X et Y" routes to the existing `party_presence_rate` table.
- **Granularity fix**: `deputy_by_department` handles "1ère circonscription des Yvelines" via `detect_circonscription()` — previously dumped all 14 department deputies.
- **Routing safety**: pattern-order constraints documented (deputy rankings before party rates, periods before "dernier"); notable-deputy guard extended so "le dernier vote de Marine Le Pen" still reaches RAG; `extract_top_n()` honors "les 3 députés…" with default 5, cap 20.

## Verification

Re-ran the 14 previously-failed battery questions against prod; all now route to SQL and match direct DB queries exactly:

- Latest vote: 02/07/2026 (RAG previously said 02/06/2026)
- Most contre: Anthony Brosse 2,842 (RAG previously said Rousset 1,620)
- Top abstentions: Oberti 388 / Hamelet 358 / Salmon 317 — exact
- June 2026: 695 votes (162 adoptés, 533 rejetés) — exact
- RN totals: 105,196 pour vs 85,459 contre — exact
- 1ère circo Yvelines: exactly Charles Rodwell

23 new unit tests (routing, top-N, period parsing, circo detection); 60 unit tests pass; ruff clean. Full retest log: `notes/dispatch/rag_remediation_phase3_2026-07-04.md` (local).

Known limit: regex routing doesn't scale to phrasing variants — that ceiling is Phase 4 (LLM function-calling intent classification over the same whitelisted SQL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaSxrbyge58arGqm7a9nbL