### PR TITLE
Phase 4: LLM function-calling intent router (second routing stage)

### DIFF
--- a/rag/chain/llm_router.py
+++ b/rag/chain/llm_router.py
@@ -1,0 +1,143 @@
+"""
+rag/chain/llm_router.py
+
+Second-stage intent classification for questions the regex router
+(sql_router.py) doesn't match. A small, fast Groq model picks one of
+the *existing* whitelisted intents via function calling — the SQL
+itself stays hard-coded and parameterized in sql_router.SQL_QUERIES,
+so the zero-hallucination guarantee of the SQL path is preserved: the
+LLM only ever selects which pre-written query to run, never writes SQL.
+
+Any failure — API error, timeout, unknown intent, "rag" verdict —
+returns None and the caller falls back to standard RAG retrieval.
+"""
+
+import json
+import logging
+import os
+
+from dotenv import load_dotenv
+from groq import Groq
+
+from rag.chain.sql_router import (
+    SQL_QUERIES,
+    _has_notable_deputy,
+    execute_intent,
+)
+
+load_dotenv()
+
+log = logging.getLogger(__name__)
+
+# Fast/cheap model — this is a classification call, not generation.
+CLASSIFIER_MODEL = "llama-3.1-8b-instant"
+_CLASSIFIER_TIMEOUT = 5.0
+
+_groq_client = Groq(api_key=os.getenv("GROQ_API_KEY"), timeout=_CLASSIFIER_TIMEOUT)
+
+# Human descriptions keep the tool schema self-documenting for the model.
+INTENT_DESCRIPTIONS = {
+    "deputy_total_count": "how many deputies are tracked (total / en exercice)",
+    "deputy_count_by_party": "deputy count per parliamentary group / which group is largest",
+    "deputy_by_department": "which deputies represent a département or circonscription",
+    "deputy_top_presence": "ranking of deputies with the BEST presence/attendance rate",
+    "deputy_bottom_presence": "ranking of deputies with the WORST presence/attendance rate",
+    "deputy_top_abstention": "ranking of deputies with the most abstentions",
+    "deputy_most_contre": "ranking of deputies who voted AGAINST most often",
+    "deputy_most_pour": "ranking of deputies who voted FOR most often",
+    "deputy_dissidents": "deputies who vote differently from their own group's majority",
+    "party_abstention_rate": "abstention rate per parliamentary group",
+    "party_presence_rate": "presence rate per group, incl. comparisons between groups",
+    "party_position_totals": "per-group pour/contre/abstention totals, 'votes more for or against'",
+    "party_alignment": "voting discipline/cohesion per group",
+    "vote_total_count": "total number of votes analysed",
+    "vote_result_count": "how many votes were adopted vs rejected overall",
+    "vote_latest": "the most recent vote(s) in the chamber, no result filter",
+    "vote_first": "the earliest recorded vote",
+    "vote_top_participation": "votes with the highest turnout / most votants",
+    "vote_closest": "the closest/tightest votes (smallest pour/contre margin)",
+    "votes_by_period": "vote counts for a specific month/year or this week/month",
+}
+
+_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "route_question",
+        "description": (
+            "Classify a French question about the Assemblée Nationale into one "
+            "of the predefined aggregate intents, or 'rag' if it is about a "
+            "specific deputy, a specific vote/law, opinions, or anything not "
+            "listed."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "intent": {
+                    "type": "string",
+                    "enum": [*INTENT_DESCRIPTIONS.keys(), "rag"],
+                    "description": "\n".join(f"- {k}: {v}" for k, v in INTENT_DESCRIPTIONS.items()),
+                },
+            },
+            "required": ["intent"],
+        },
+    },
+}
+
+_SYSTEM = (
+    "You classify French civic questions about the Assemblée Nationale. "
+    "Pick the single best intent, or 'rag' when the question is about a "
+    "specific deputy's record, a specific law or vote's content, requires "
+    "text understanding, or matches no intent. When a question filters "
+    "recent votes by result (adopté/rejeté), answer 'rag'. Always call "
+    "the tool."
+)
+
+
+def classify_intent(question: str) -> str | None:
+    """Return a whitelisted intent name, or None (→ RAG)."""
+    try:
+        response = _groq_client.chat.completions.create(
+            model=CLASSIFIER_MODEL,
+            messages=[
+                {"role": "system", "content": _SYSTEM},
+                {"role": "user", "content": question},
+            ],
+            tools=[_TOOL],
+            tool_choice={"type": "function", "function": {"name": "route_question"}},
+            temperature=0.0,
+            max_tokens=64,
+        )
+        calls = response.choices[0].message.tool_calls
+        if not calls:
+            return None
+        intent = json.loads(calls[0].function.arguments).get("intent")
+    except Exception as exc:
+        log.warning("LLM router classification failed: %s", exc)
+        return None
+
+    # Whitelist enforcement — anything the model invents falls to RAG.
+    if intent not in SQL_QUERIES:
+        return None
+    return intent
+
+
+def llm_route(question: str) -> dict | None:
+    """
+    LLM-classified routing for questions the regex router missed.
+    Same output contract as sql_router.route(); None → RAG fallback.
+    """
+    # Deputy-specific questions belong to RAG (notable-deputy pin) —
+    # cheaper to check here than to rely on the classifier.
+    if _has_notable_deputy(question):
+        return None
+
+    intent = classify_intent(question)
+    if not intent:
+        return None
+
+    log.debug("LLM router intent=%s — bypassing RAG", intent)
+    result = execute_intent(intent, question)
+    if result is not None:
+        result["data_source"] = "SQL"
+        result["router"] = "llm"
+    return result

--- a/rag/chain/llm_router.py
+++ b/rag/chain/llm_router.py
@@ -20,9 +20,11 @@ from dotenv import load_dotenv
 from groq import Groq
 
 from rag.chain.sql_router import (
+    _RESULT_WORDS,
     SQL_QUERIES,
     _has_notable_deputy,
     execute_intent,
+    normalize_text,
 )
 
 load_dotenv()
@@ -135,7 +137,15 @@ def llm_route(question: str) -> dict | None:
     if not intent:
         return None
 
-    log.debug("LLM router intent=%s — bypassing RAG", intent)
+    # Hard guard, mirroring detect_intent(): result-filtered recency
+    # questions ("les votes rejetés les plus récents") belong to the
+    # recency-sorted retriever — vote_latest/vote_first SQL has no
+    # result filter and would answer wrong. The system prompt asks the
+    # classifier to say "rag" here, but that instruction is soft.
+    if intent in ("vote_latest", "vote_first") and _RESULT_WORDS.search(normalize_text(question)):
+        return None
+
+    log.info("LLM router intent=%s — bypassing RAG", intent)
     result = execute_intent(intent, question)
     if result is not None:
         result["data_source"] = "SQL"

--- a/rag/chain/rag_chain.py
+++ b/rag/chain/rag_chain.py
@@ -13,6 +13,7 @@ from groq import Groq
 
 load_dotenv()
 
+from rag.chain.llm_router import llm_route  # noqa: E402
 from rag.chain.prompts import RAG_TEMPLATE, build_system_prompt  # noqa: E402
 from rag.chain.retriever import retrieve  # noqa: E402
 from rag.chain.sql_router import route as sql_route  # noqa: E402
@@ -55,10 +56,17 @@ def ask(
     deputy_id: str = None,
     chunk_type: str = None,
 ) -> dict:
-    # A1 — try SQL router first
+    # A1 — regex SQL router first (fast path, no LLM call)
     sql_result = sql_route(question)
     if sql_result is not None:
         return sql_result
+
+    # A2 — LLM intent classification over the same whitelisted SQL,
+    # for phrasings the regex patterns miss. Falls through to RAG on
+    # any failure or a "rag" verdict.
+    llm_result = llm_route(question)
+    if llm_result is not None:
+        return llm_result
 
     # B1 hybrid retrieval available in rag/chain/hybrid_retriever.py
     # Reverted to cosine-only: after SQL routing fixes, hybrid scored 0.644

--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -737,17 +737,16 @@ def run_sql_query(intent: str, params: dict | None = None) -> list[dict]:
         pool.putconn(conn, close=broken)
 
 
-def route(question: str) -> dict | None:
+def execute_intent(intent: str, question: str) -> dict | None:
     """
-    Main entry point.
-    Returns a structured answer dict if the question is an
-    aggregation query, or None if RAG should handle it.
+    Run a known intent's whitelisted SQL and format the answer.
+    Shared by the regex path (route) and the LLM classifier path
+    (rag/chain/llm_router.py). Returns None when required parameters
+    can't be resolved or the query yields nothing — callers fall back
+    to RAG.
     """
-    intent = detect_intent(question)
-    if not intent:
+    if intent not in SQL_QUERIES:
         return None
-
-    log.debug("SQL router intent=%s — bypassing RAG", intent)
 
     # Department queries need the detected code as a parameter.
     # If no department name is detected, fall back to RAG — a vague
@@ -759,24 +758,20 @@ def route(question: str) -> dict | None:
             return None
         circo = detect_circonscription(question)
         rows = run_sql_query("deputy_by_department", {"dept": dept_name, "circo": circo})
-        formatter_key = "deputy_by_department"
     elif intent == "votes_by_period":
         period = extract_period(question)
         if not period:
             return None
         rows = run_sql_query("votes_by_period", period)
-        formatter_key = "votes_by_period"
     elif intent in _TOP_N_INTENTS:
         rows = run_sql_query(intent, {"n": extract_top_n(question)})
-        formatter_key = intent
     else:
         rows = run_sql_query(intent)
-        formatter_key = intent
 
     if not rows:
         return None
 
-    formatter = FORMATTERS.get(formatter_key)
+    formatter = FORMATTERS.get(intent)
     answer_text = formatter(rows) if formatter else str(rows)
 
     return {
@@ -789,3 +784,17 @@ def route(question: str) -> dict | None:
         "data_source": "SQL",
         "caveat": "Données calculées directement depuis la base de données. Aucune génération IA.",
     }
+
+
+def route(question: str) -> dict | None:
+    """
+    Main entry point.
+    Returns a structured answer dict if the question is an
+    aggregation query, or None if RAG should handle it.
+    """
+    intent = detect_intent(question)
+    if not intent:
+        return None
+
+    log.debug("SQL router intent=%s — bypassing RAG", intent)
+    return execute_intent(intent, question)

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -32,6 +32,7 @@ def _fake_groq_response(text: str) -> MagicMock:
 def test_ask_returns_required_keys():
     with (
         patch("rag.chain.rag_chain.sql_route", return_value=None),
+        patch("rag.chain.rag_chain.llm_route", return_value=None),
         patch("rag.chain.rag_chain.retrieve", return_value=_FAKE_CHUNKS),
         patch("rag.chain.rag_chain._groq_client") as mock_groq,
     ):
@@ -49,12 +50,37 @@ def test_ask_returns_required_keys():
 def test_ask_propagates_groq_timeout():
     timeout_exc = groq.APITimeoutError(request=httpx.Request("POST", "https://api.groq.com"))
     with (
+        patch("rag.chain.rag_chain.sql_route", return_value=None),
+        patch("rag.chain.rag_chain.llm_route", return_value=None),
         patch("rag.chain.rag_chain.retrieve", return_value=_FAKE_CHUNKS),
         patch("rag.chain.rag_chain._groq_client") as mock_groq,
     ):
         mock_groq.chat.completions.create.side_effect = timeout_exc
         with pytest.raises(groq.APITimeoutError):
             ask("Question quelconque ?")
+
+
+def test_ask_stage_ordering():
+    """sql_route wins over llm_route; llm_route wins over retrieval."""
+    sql_answer = {"answer": "sql", "data_source": "SQL"}
+    llm_answer = {"answer": "llm", "data_source": "SQL", "router": "llm"}
+
+    with (
+        patch("rag.chain.rag_chain.sql_route", return_value=sql_answer),
+        patch("rag.chain.rag_chain.llm_route", return_value=llm_answer) as m_llm,
+        patch("rag.chain.rag_chain.retrieve") as m_retrieve,
+    ):
+        assert ask("q")["answer"] == "sql"
+        m_llm.assert_not_called()
+        m_retrieve.assert_not_called()
+
+    with (
+        patch("rag.chain.rag_chain.sql_route", return_value=None),
+        patch("rag.chain.rag_chain.llm_route", return_value=llm_answer),
+        patch("rag.chain.rag_chain.retrieve") as m_retrieve,
+    ):
+        assert ask("q")["answer"] == "llm"
+        m_retrieve.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_llm_router.py
+++ b/tests/unit/test_llm_router.py
@@ -1,0 +1,79 @@
+"""
+Unit tests for the LLM intent classifier (rag/chain/llm_router.py).
+Groq is mocked throughout — these test the safety envelope, not the model:
+whitelist enforcement, failure fallback, and the notable-deputy yield.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from rag.chain.llm_router import classify_intent, llm_route
+
+
+def _groq_response(intent: str | None) -> MagicMock:
+    resp = MagicMock()
+    if intent is None:
+        resp.choices[0].message.tool_calls = None
+    else:
+        call = MagicMock()
+        call.function.arguments = json.dumps({"intent": intent})
+        resp.choices[0].message.tool_calls = [call]
+    return resp
+
+
+def test_valid_intent_passes_whitelist():
+    with patch("rag.chain.llm_router._groq_client") as mock_groq:
+        mock_groq.chat.completions.create.return_value = _groq_response("vote_latest")
+        assert classify_intent("Quel scrutin a eu lieu en dernier ?") == "vote_latest"
+
+
+def test_rag_verdict_returns_none():
+    with patch("rag.chain.llm_router._groq_client") as mock_groq:
+        mock_groq.chat.completions.create.return_value = _groq_response("rag")
+        assert classify_intent("Que dit la loi sur la justice ?") is None
+
+
+def test_invented_intent_rejected_by_whitelist():
+    with patch("rag.chain.llm_router._groq_client") as mock_groq:
+        mock_groq.chat.completions.create.return_value = _groq_response("drop_table_votes")
+        assert classify_intent("n'importe quoi") is None
+
+
+def test_api_failure_returns_none():
+    with patch("rag.chain.llm_router._groq_client") as mock_groq:
+        mock_groq.chat.completions.create.side_effect = TimeoutError("groq down")
+        assert classify_intent("Quel scrutin a eu lieu en dernier ?") is None
+
+
+def test_no_tool_call_returns_none():
+    with patch("rag.chain.llm_router._groq_client") as mock_groq:
+        mock_groq.chat.completions.create.return_value = _groq_response(None)
+        assert classify_intent("question") is None
+
+
+def test_llm_route_yields_to_notable_deputy():
+    # Must return None (→ RAG) without even calling Groq
+    with patch("rag.chain.llm_router._groq_client") as mock_groq:
+        result = llm_route("Quel est le dernier vote de Marine Le Pen ?")
+        assert result is None
+        mock_groq.chat.completions.create.assert_not_called()
+
+
+def test_llm_route_tags_result_with_router_field():
+    fake_answer = {
+        "answer": "x",
+        "question": "q",
+        "chunks_retrieved": 0,
+        "sources": [],
+        "query_type": "vote_latest",
+        "confidence": "high",
+        "data_source": "SQL",
+        "caveat": "c",
+    }
+    with (
+        patch("rag.chain.llm_router.classify_intent", return_value="vote_latest"),
+        patch("rag.chain.llm_router.execute_intent", return_value=dict(fake_answer)),
+    ):
+        result = llm_route("Quel scrutin a eu lieu en dernier ?")
+        assert result["router"] == "llm"
+        assert result["data_source"] == "SQL"

--- a/tests/unit/test_llm_router.py
+++ b/tests/unit/test_llm_router.py
@@ -59,6 +59,13 @@ def test_llm_route_yields_to_notable_deputy():
         mock_groq.chat.completions.create.assert_not_called()
 
 
+def test_llm_route_hard_guards_result_filtered_latest():
+    # Even if the classifier (wrongly) picks vote_latest for a
+    # result-filtered recency question, the hard guard yields to RAG.
+    with patch("rag.chain.llm_router.classify_intent", return_value="vote_latest"):
+        assert llm_route("Quels sont les votes rejetés les plus récents ?") is None
+
+
 def test_llm_route_tags_result_with_router_field():
     fake_answer = {
         "answer": "x",


### PR DESCRIPTION
## Context

Phase 4 of the RAG remediation (follows #165, #166, #167). Phase 3's regex router answers ranking/temporal questions deterministically, but only for phrasings its ~45 patterns anticipate. "Donne-moi le classement des députés les plus assidus", "Qui sont les députés les plus absents ?", "Nombre de scrutins en mai 2026 ?" all missed the patterns and fell through to RAG, which refuses or extrapolates. Maintaining a regex per phrasing variant doesn't scale.

## Changes

Two-stage routing in `rag_chain.ask()`:

1. **Regex router** — unchanged fast path, zero LLM calls.
2. **LLM classifier** (`rag/chain/llm_router.py`, new) — fires only when regex misses. Groq `llama-3.1-8b-instant` (temperature 0, forced tool call, 5s timeout) picks one of the *existing* whitelisted intents or "rag". **The SQL stays hard-coded and parameterized in `sql_router.SQL_QUERIES`** — the LLM only selects which pre-written query runs, never writes SQL, so the zero-hallucination property of the SQL path is preserved.

Safety envelope:
- Whitelist enforcement: an invented intent name → RAG.
- API error / timeout / missing tool call → RAG.
- Notable-deputy questions yield to RAG before Groq is called.
- Result-filtered recency questions instructed to classify as "rag" (recency-sorted retrieval handles those).
- `execute_intent()` extracted from `route()` so both stages share identical param extraction, ranking floors, and formatting.
- LLM-routed answers carry `"router": "llm"` for observability.

## Verification

Live against prod — all five regex-missed phrasings now route to the correct intent with exact answers ("assidus" → top presence; "absents" → bottom presence; "scrutin...votants" → 574-votant PLFSS; "mai 2026" → 923 votes, verified; "en dernier" → 02/07/2026). Control questions stay in RAG: Attal PLFSS (notable yield, no Groq call), law-content question ("rag" verdict), "rejetés récemment" (recency retrieval).

7 new unit tests with mocked Groq (whitelist rejection, failure fallback, notable yield, router tagging); 75 unit tests pass; ruff clean. Full retest log: `notes/dispatch/rag_remediation_phase4_2026-07-04.md` (local).

Cost/latency: one extra fast Groq call only on regex misses; free tier, answer time still dominated by the generation call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaSxrbyge58arGqm7a9nbL