### PR TITLE
Phase 5: anti-extrapolation guardrails + extended MLflow eval

### DIFF
--- a/rag/chain/hybrid_retriever.py
+++ b/rag/chain/hybrid_retriever.py
@@ -18,7 +18,7 @@ from pgvector.psycopg2 import register_vector
 from rank_bm25 import BM25Okapi
 
 from rag.chain.retriever import detect_recency_intent
-from rag.constants import EMBEDDING_MODEL, IVFFLAT_PROBES
+from rag.constants import EMBEDDING_MODEL
 from rag.db_utils import connect_with_retry
 
 load_dotenv()
@@ -53,7 +53,8 @@ def _get_candidates(
         with conn.cursor(cursor_factory=psycopg2.extensions.cursor) as plain_cur:
             register_vector(plain_cur)
         with conn.cursor() as cur:
-            cur.execute("SET LOCAL ivfflat.probes = %s", (IVFFLAT_PROBES,))
+            # exact cosine scan — the IVFFlat index was dropped in
+            # migration 003, no probes GUC to set
             cur.execute(
                 """
                 SELECT content, metadata,

--- a/rag/chain/llm_router.py
+++ b/rag/chain/llm_router.py
@@ -123,6 +123,25 @@ def classify_intent(question: str) -> str | None:
     return intent
 
 
+def _mentions_notable_deputy(question: str) -> bool:
+    """
+    True if the question names a notable deputy. Checks both the static
+    keyword map (rag/constants.py) and the DB-backed notable map used by
+    the retriever pin — the static map does not cover every indexed
+    notable (e.g. Braun-Pivet), and a missed name here sends a
+    deputy-specific question to a ranking intent.
+    """
+    if _has_notable_deputy(question):
+        return True
+    try:
+        from rag.chain.retriever import detect_notable_deputy, get_notable_deputy_ids
+
+        return detect_notable_deputy(question, get_notable_deputy_ids()) is not None
+    except Exception as exc:  # DB unavailable — fail open to RAG-safe side
+        log.warning("notable-deputy DB lookup failed in llm_router: %s", exc)
+        return True
+
+
 def llm_route(question: str) -> dict | None:
     """
     LLM-classified routing for questions the regex router missed.
@@ -130,7 +149,7 @@ def llm_route(question: str) -> dict | None:
     """
     # Deputy-specific questions belong to RAG (notable-deputy pin) —
     # cheaper to check here than to rely on the classifier.
-    if _has_notable_deputy(question):
+    if _mentions_notable_deputy(question):
         return None
 
     intent = classify_intent(question)

--- a/rag/chain/prompts.py
+++ b/rag/chain/prompts.py
@@ -54,7 +54,15 @@ Règles absolues :
 6. Cite toujours les chiffres exacts quand ils sont disponibles.
 7. Les données disponibles couvrent les votes de l'Assemblée Nationale \
 {horizon}. Si une question porte sur une période antérieure, \
-indique que cette période n'est pas couverte par les données actuelles."""
+indique que cette période n'est pas couverte par les données actuelles.
+8. Les sources fournies sont des EXTRAITS, pas la base complète. \
+Ne calcule JAMAIS de classement, de maximum, de minimum, de total \
+global ou de comparaison entre groupes à partir des seuls extraits \
+fournis : les députés ou votes mentionnés ne sont pas un échantillon \
+représentatif. Si la question demande un classement ou un agrégat \
+global que les sources ne donnent pas déjà sous forme calculée, \
+réponds : "Je ne peux pas établir ce classement à partir des extraits \
+fournis." """
 
 
 SUMMARY_PROMPT = (
@@ -88,4 +96,8 @@ Question : {question}
 Instructions :
 - Réponds en te basant UNIQUEMENT sur les sources ci-dessus
 - Si plusieurs sources sont pertinentes, synthétise-les
-- Si une source contredit une autre, signale-le"""
+- Si une source contredit une autre, signale-le
+- Les sources sont des extraits : ne calcule AUCUN classement, total \
+global ou comparaison entre groupes à partir des députés ou votes \
+mentionnés. Si la réponse exige un tel calcul et qu'aucune source ne \
+le donne déjà, dis que tu ne peux pas l'établir à partir des extraits."""

--- a/rag/experiments/mlflow_eval.py
+++ b/rag/experiments/mlflow_eval.py
@@ -144,6 +144,20 @@ def _router_golden(counts: dict) -> list[dict]:
             "label": "router — llm classifier (assidus)",
             "expect_sql": True,
         },
+        {
+            # deterministic since Phase 3 (deputy_top_abstention intent)
+            "question": "Quels députés ont le plus d'abstentions ?",
+            "keywords": ["abstention"],
+            "label": "router — députés abstentions",
+            "expect_sql": True,
+        },
+        {
+            # deterministic since Phase 3 (deputy_by_department active-only)
+            "question": "Qui sont les députés des Yvelines ?",
+            "keywords": ["Yvelines"],
+            "label": "router — députés Yvelines",
+            "expect_sql": True,
+        },
     ]
 
 
@@ -173,20 +187,6 @@ RETRIEVAL_GOLDEN = [
         "keywords": ["rejeté", "vote"],
         "label": "retrieval — votes récents rejetés",
         "expect_sql": False,
-    },
-    {
-        # deterministic since Phase 3 (deputy_top_abstention intent)
-        "question": "Quels députés ont le plus d'abstentions ?",
-        "keywords": ["abstention"],
-        "label": "router — députés abstentions",
-        "expect_sql": True,
-    },
-    {
-        # deterministic since Phase 3 (deputy_by_department active-only)
-        "question": "Qui sont les députés des Yvelines ?",
-        "keywords": ["Yvelines"],
-        "label": "router — députés Yvelines",
-        "expect_sql": True,
     },
 ]
 

--- a/rag/experiments/mlflow_eval.py
+++ b/rag/experiments/mlflow_eval.py
@@ -28,23 +28,36 @@ def _get_live_counts() -> dict:
     try:
         with psycopg2.connect(url) as conn:
             with conn.cursor() as cur:
-                cur.execute("SELECT COUNT(*) FROM deputies")
-                total_deputies = cur.fetchone()[0]
+                cur.execute("SELECT COUNT(*) FROM deputies WHERE mandate_end IS NULL")
+                active_deputies = cur.fetchone()[0]
                 cur.execute("SELECT COUNT(*) FROM votes")
                 total_votes = cur.fetchone()[0]
                 cur.execute(
-                    "SELECT party, COUNT(*) AS n FROM deputies WHERE party IS NOT NULL "
+                    "SELECT party, COUNT(*) AS n FROM deputies "
+                    "WHERE party IS NOT NULL AND mandate_end IS NULL "
                     "GROUP BY party ORDER BY n DESC LIMIT 1"
                 )
                 row = cur.fetchone()
                 top_party, top_party_count = (
                     (row[0], row[1]) if row else ("Rassemblement National", 0)
                 )
+                cur.execute("SELECT MAX(voted_at)::date FROM votes")
+                latest_vote_date = str(cur.fetchone()[0])
+                cur.execute(
+                    "SELECT d.full_name FROM vote_positions vp "
+                    "JOIN deputies d ON d.deputy_id = vp.deputy_id "
+                    "WHERE vp.position = 'abstention' "
+                    "GROUP BY d.deputy_id ORDER BY COUNT(*) DESC LIMIT 1"
+                )
+                row = cur.fetchone()
+                top_abstention_deputy = row[0] if row else "?"
         return {
-            "total_deputies": str(total_deputies),
+            "total_deputies": str(active_deputies),
             "total_votes": str(total_votes),
             "top_party": top_party,
             "top_party_count": str(top_party_count),
+            "latest_vote_date": latest_vote_date,
+            "top_abstention_deputy": top_abstention_deputy,
         }
     except Exception as exc:
         print(f"[eval] live counts failed, using placeholders: {exc}")
@@ -53,6 +66,8 @@ def _get_live_counts() -> dict:
             "total_votes": "vote",
             "top_party": "Rassemblement National",
             "top_party_count": "122",
+            "latest_vote_date": "2026",
+            "top_abstention_deputy": "député",
         }
 
 
@@ -96,6 +111,39 @@ def _router_golden(counts: dict) -> list[dict]:
             "label": "router — discipline RN",
             "expect_sql": True,
         },
+        # Phase 3/4 intents — ground truth from live DB at eval time
+        {
+            "question": "Quel est le dernier vote à l'Assemblée ?",
+            "keywords": [counts["latest_vote_date"]],
+            "label": "router — dernier vote",
+            "expect_sql": True,
+        },
+        {
+            "question": "Quels sont les 3 députés qui s'abstiennent le plus ?",
+            "keywords": [counts["top_abstention_deputy"]],
+            "label": "router — top abstentions députés",
+            "expect_sql": True,
+        },
+        {
+            "question": "Quels sont les 5 députés avec le meilleur taux de présence ?",
+            "keywords": ["présence", "%"],
+            "label": "router — top présence députés",
+            "expect_sql": True,
+        },
+        {
+            "question": "Quels sont les 5 votes avec le plus de participation ?",
+            "keywords": ["votants"],
+            "label": "router — top participation",
+            "expect_sql": True,
+        },
+        {
+            # phrasing outside the regex patterns — exercises the LLM
+            # classifier stage (Phase 4)
+            "question": "Donne-moi le classement des députés les plus assidus",
+            "keywords": ["présence", "%"],
+            "label": "router — llm classifier (assidus)",
+            "expect_sql": True,
+        },
     ]
 
 
@@ -127,16 +175,18 @@ RETRIEVAL_GOLDEN = [
         "expect_sql": False,
     },
     {
+        # deterministic since Phase 3 (deputy_top_abstention intent)
         "question": "Quels députés ont le plus d'abstentions ?",
         "keywords": ["abstention"],
-        "label": "retrieval — députés abstentions",
-        "expect_sql": False,
+        "label": "router — députés abstentions",
+        "expect_sql": True,
     },
     {
+        # deterministic since Phase 3 (deputy_by_department active-only)
         "question": "Qui sont les députés des Yvelines ?",
         "keywords": ["Yvelines"],
-        "label": "retrieval — députés Yvelines",
-        "expect_sql": False,
+        "label": "router — députés Yvelines",
+        "expect_sql": True,
     },
 ]
 
@@ -156,10 +206,15 @@ def run_config(label: str, k: int, use_sql_router: bool, retriever_type: str = "
 
     # Monkey-patch the imported names inside rag_chain so ask() sees the changes
     original_sql_route = _rag_chain.sql_route
+    original_llm_route = _rag_chain.llm_route
     original_retrieve = _rag_chain.retrieve
 
     if not use_sql_router:
+        # Disable both routing stages so the config isolates retrieval
+        # quality — otherwise the Phase 4 LLM classifier would still
+        # answer the router-suite questions via SQL.
         _rag_chain.sql_route = lambda q: None
+        _rag_chain.llm_route = lambda q: None
 
     # Swap retriever based on type, and enforce k override if needed
     if retriever_type == "hybrid":
@@ -235,6 +290,7 @@ def run_config(label: str, k: int, use_sql_router: bool, retriever_type: str = "
 
     finally:
         _rag_chain.sql_route = original_sql_route
+        _rag_chain.llm_route = original_llm_route
         _rag_chain.retrieve = original_retrieve
 
     return {

--- a/tests/unit/test_llm_router.py
+++ b/tests/unit/test_llm_router.py
@@ -62,8 +62,31 @@ def test_llm_route_yields_to_notable_deputy():
 def test_llm_route_hard_guards_result_filtered_latest():
     # Even if the classifier (wrongly) picks vote_latest for a
     # result-filtered recency question, the hard guard yields to RAG.
-    with patch("rag.chain.llm_router.classify_intent", return_value="vote_latest"):
+    with (
+        patch("rag.chain.llm_router._mentions_notable_deputy", return_value=False),
+        patch("rag.chain.llm_router.classify_intent", return_value="vote_latest"),
+    ):
         assert llm_route("Quels sont les votes rejetés les plus récents ?") is None
+
+
+def test_llm_route_yields_to_db_backed_notable():
+    # Braun-Pivet is not in the static keyword map but is in the
+    # DB-backed notable map — llm_route must still yield to RAG.
+    with (
+        patch(
+            "rag.chain.retriever.get_notable_deputy_ids", return_value={"PA1": "Yaël Braun-Pivet"}
+        ),
+        patch("rag.chain.llm_router._groq_client") as mock_groq,
+    ):
+        assert llm_route("Quel est le taux de présence de Yaël Braun-Pivet ?") is None
+        mock_groq.chat.completions.create.assert_not_called()
+
+
+def test_llm_route_fails_open_to_rag_when_db_lookup_breaks():
+    with patch(
+        "rag.chain.retriever.get_notable_deputy_ids", side_effect=ConnectionError("db down")
+    ):
+        assert llm_route("Une question quelconque sans nom de député ?") is None
 
 
 def test_llm_route_tags_result_with_router_field():
@@ -78,6 +101,7 @@ def test_llm_route_tags_result_with_router_field():
         "caveat": "c",
     }
     with (
+        patch("rag.chain.llm_router._mentions_notable_deputy", return_value=False),
         patch("rag.chain.llm_router.classify_intent", return_value="vote_latest"),
         patch("rag.chain.llm_router.execute_intent", return_value=dict(fake_answer)),
     ):

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -1,0 +1,23 @@
+"""
+Locks in the anti-extrapolation guardrail (Phase 5): a prompt refactor
+must not silently drop the rule that forbids computing rankings or
+group comparisons from retrieved extracts.
+"""
+
+from unittest.mock import patch
+
+from rag.chain.prompts import RAG_TEMPLATE
+
+
+def test_system_prompt_contains_anti_extrapolation_rule():
+    with patch("rag.chain.prompts.get_data_horizon", return_value="du X au Y"):
+        from rag.chain.prompts import build_system_prompt
+
+        prompt = build_system_prompt()
+    assert "EXTRAITS" in prompt
+    assert "classement" in prompt
+
+
+def test_rag_template_contains_anti_extrapolation_rule():
+    assert "extraits" in RAG_TEMPLATE
+    assert "AUCUN classement" in RAG_TEMPLATE


### PR DESCRIPTION
## Context

Final phase of the RAG remediation (follows #165-#168). Phases 3-4 route deterministic questions to SQL, but when a ranking/comparison question still reaches RAG (phrasing both router stages miss), the LLM extrapolated from whichever 5 chunks retrieval returned — the battery's F2 case computed an "RN vs LFI presence difference" from 3 sampled deputies. And the MLflow eval didn't cover any of the new routing behavior, so regressions were invisible.

## Changes

- **Anti-extrapolation guardrail** (`rag/chain/prompts.py`): system-prompt rule 8 + a mirrored `RAG_TEMPLATE` instruction — retrieved sources are extracts, never compute rankings/max/min/global totals/group comparisons from them; refuse explicitly. Verified live with routers bypassed: the top-5-presence question now refuses, and the RN-vs-LFI comparison presents the sourced individual figures then explicitly declines the group comparison.
- **MLflow eval extension** (`rag/experiments/mlflow_eval.py`): 5 new router-suite cases covering the Phase 3 intents (latest vote asserted against live `MAX(voted_at)`, top abstentions against the live top deputy, top présence, top participation) and the Phase 4 classifier ("députés les plus assidus" — phrasing outside the regex patterns). `_get_live_counts()` uses active-mandate counts (Phase 2 semantics). The "no router" config now disables **both** routing stages so it actually isolates retrieval quality.
- **Regression caught by the new eval, fixed here**: "Quel est le taux de présence de Yaël Braun-Pivet ?" routed to a SQL ranking intent because `llm_route`'s notable-deputy yield only consulted the static keyword map, which lacks Braun-Pivet. `_mentions_notable_deputy()` now also checks the retriever's DB-backed notable map and fails open to RAG if that lookup breaks. Two stale eval expectations updated (Yvelines, top abstentions — legitimately SQL since Phase 3).
- **Pre-existing `make rag-eval` crash fixed**: `hybrid_retriever.py` still imported `IVFFLAT_PROBES`, deleted from constants when the IVFFlat index was dropped (migration 003).

## Verification

- Guardrail: live checks with both routers bypassed (see above).
- Eval: the shipped config's **router suite scored 11/11 at 1.00** (including all new intents and the LLM-classifier case) before the run hit the Groq free-tier daily token cap mid-retrieval-suite — today's diagnostic battery consumed the quota. Full 3-config rerun (`make rag-eval`) pending quota reset (~1h); no code path is untested by the unit suite in the meantime.
- 79 unit tests pass (4 new for the DB-backed notable yield and fail-open behavior); ruff clean.
- Full log: `notes/dispatch/rag_remediation_phase5_2026-07-04.md` (local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaSxrbyge58arGqm7a9nbL