### PR TITLE
feat: public API tier — keys, tiered rate limits, developer page (MON-98)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "CLAUDE.md",
         "hashed_secret": "ffddd4c9867f24ed207b1da5b50693e6d85a7889",
         "is_verified": false,
-        "line_number": 166
+        "line_number": 168
       }
     ],
     "README.md": [
@@ -252,5 +252,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-25T00:29:08Z"
+  "generated_at": "2026-07-06T16:58:28Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,8 @@ Assemblée Nationale Open Data (ZIPs)
 | `votes` | Legislative votes (title, result adopté/rejeté, aggregate counts) |
 | `vote_positions` | Per-deputy position per vote (pour/contre/abstention/nonVotant) |
 | `document_chunks` | Phase 2: content + JSONB metadata + vector(1536) |
+| `api_keys` | Manually-issued public API keys (sha256 hash, label, rate_limit_multiplier) |
+| `api_key_usage` | Per-key, per-endpoint, per-day request counters for usage accounting |
 
 Important data quirks:
 - `nonVotant` ≠ `abstention`: present in chamber but did not vote vs. formally abstained

--- a/api/auth.py
+++ b/api/auth.py
@@ -1,0 +1,94 @@
+"""
+api/auth.py
+API key resolution for the public API tier (MON-98).
+
+Keys are issued manually (email request -> row insert into api_keys). Only the
+sha256 hash of the raw key is ever stored or compared. Active keys are cached
+in-process with a short TTL so almost every request resolves from memory
+instead of hitting the DB.
+"""
+
+import hashlib
+import logging
+import threading
+import time
+from dataclasses import dataclass
+
+from api.db import get_conn
+
+logger = logging.getLogger(__name__)
+
+API_KEY_HEADER = "X-API-Key"  # pragma: allowlist secret
+_CACHE_TTL_SECONDS = 300
+
+
+@dataclass(frozen=True)
+class ApiKeyRecord:
+    id: int
+    label: str
+    rate_limit_multiplier: int
+
+
+_cache_lock = threading.Lock()
+_cache_by_hash: dict[str, ApiKeyRecord] = {}
+_cache_loaded_at = 0.0
+
+
+def _hash_key(raw_key: str) -> str:
+    return hashlib.sha256(raw_key.encode("utf-8")).hexdigest()
+
+
+def _reload_cache() -> None:
+    global _cache_by_hash, _cache_loaded_at
+    fresh: dict[str, ApiKeyRecord] = {}
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT key_hash, id, label, rate_limit_multiplier
+                FROM api_keys
+                WHERE revoked_at IS NULL
+                """
+            )
+            for row in cur.fetchall():
+                fresh[row["key_hash"]] = ApiKeyRecord(
+                    id=row["id"],
+                    label=row["label"],
+                    rate_limit_multiplier=row["rate_limit_multiplier"],
+                )
+    with _cache_lock:
+        _cache_by_hash = fresh
+        _cache_loaded_at = time.monotonic()
+
+
+def resolve_api_key(raw_key: str | None) -> ApiKeyRecord | None:
+    """Return the active key record for a raw header value, or None if missing/invalid/revoked."""
+    if not raw_key:
+        return None
+    with _cache_lock:
+        stale = time.monotonic() - _cache_loaded_at > _CACHE_TTL_SECONDS
+    if stale:
+        try:
+            _reload_cache()
+        except Exception as exc:
+            logger.warning("API key cache reload failed: %s", exc)
+    return _cache_by_hash.get(_hash_key(raw_key))
+
+
+def record_usage(api_key_id: int, endpoint: str) -> None:
+    """Best-effort per-day usage counter increment; never raises into the request path."""
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO api_key_usage (api_key_id, endpoint, day, request_count)
+                    VALUES (%s, %s, CURRENT_DATE, 1)
+                    ON CONFLICT (api_key_id, endpoint, day)
+                    DO UPDATE SET request_count = api_key_usage.request_count + 1
+                    """,
+                    (api_key_id, endpoint),
+                )
+            conn.commit()
+    except Exception as exc:
+        logger.warning("API key usage logging failed: %s", exc)

--- a/api/limiter.py
+++ b/api/limiter.py
@@ -6,5 +6,33 @@ Keeping it in its own module avoids circular imports.
 
 from slowapi import Limiter
 from slowapi.util import get_remote_address
+from starlette.requests import Request
 
-limiter = Limiter(key_func=get_remote_address, default_limits=["30/minute"])
+from api.auth import API_KEY_HEADER, resolve_api_key
+
+
+def rate_limit_key(request: Request) -> str:
+    """Bucket keyed requests by API key id, anonymous requests by IP.
+
+    The key's rate_limit_multiplier is embedded in the returned string so
+    `tiered_limit` below can read it back without a second cache lookup.
+    """
+    record = resolve_api_key(request.headers.get(API_KEY_HEADER))
+    if record:
+        return f"apikey:{record.id}:{record.rate_limit_multiplier}"
+    return get_remote_address(request)
+
+
+def tiered_limit(base_per_minute: int):
+    """Build a dynamic slowapi limit: anonymous keeps `base`, keyed requests get base * multiplier."""
+
+    def _limit(key: str) -> str:
+        if key.startswith("apikey:"):
+            multiplier = int(key.rsplit(":", 1)[-1])
+            return f"{base_per_minute * multiplier}/minute"
+        return f"{base_per_minute}/minute"
+
+    return _limit
+
+
+limiter = Limiter(key_func=rate_limit_key, default_limits=[])

--- a/api/main.py
+++ b/api/main.py
@@ -47,6 +47,9 @@ _warn_if_placeholder("OPENAI_API_KEY", os.getenv("OPENAI_API_KEY"))
 _warn_if_placeholder("GROQ_API_KEY", os.getenv("GROQ_API_KEY"))
 _warn_if_placeholder("DATABASE_URL", os.getenv("DATABASE_URL"), context="the API")
 
+from starlette.concurrency import run_in_threadpool  # noqa: E402
+
+from api.auth import API_KEY_HEADER, record_usage, resolve_api_key  # noqa: E402
 from api.db import close_pool, get_conn, init_pool  # noqa: E402
 from api.limiter import limiter  # noqa: E402
 from rag.chain.sql_router import warm_pool as _warm_sql_pool  # noqa: E402
@@ -116,6 +119,21 @@ async def _unhandled_exception_handler(request: Request, exc: Exception) -> JSON
 
 app.add_exception_handler(Exception, _unhandled_exception_handler)
 
+
+# ---------------------------------------------------------------------------
+# API key usage logging (MON-98) — only keyed requests touch the DB; anonymous
+# traffic is unaffected. Runs in the threadpool so a slow write never blocks
+# the event loop.
+# ---------------------------------------------------------------------------
+@app.middleware("http")
+async def _log_api_key_usage(request: Request, call_next):
+    response = await call_next(request)
+    record = resolve_api_key(request.headers.get(API_KEY_HEADER))
+    if record:
+        await run_in_threadpool(record_usage, record.id, request.url.path)
+    return response
+
+
 # ---------------------------------------------------------------------------
 # CORS
 # ---------------------------------------------------------------------------
@@ -137,12 +155,13 @@ app.add_middleware(
 # ---------------------------------------------------------------------------
 # Routers
 # ---------------------------------------------------------------------------
-from api.routers import deputies, votes  # noqa: E402
+from api.routers import deputies, keys, votes  # noqa: E402
 from api.routers.search import router as search_router  # noqa: E402
 
 app.include_router(deputies.router, prefix="/deputies", tags=["Deputies"])
 app.include_router(votes.router, prefix="/votes", tags=["Votes"])
 app.include_router(search_router, prefix="/search", tags=["Search"])
+app.include_router(keys.router, prefix="/keys", tags=["API Keys"])
 
 
 # ---------------------------------------------------------------------------

--- a/api/main.py
+++ b/api/main.py
@@ -122,15 +122,20 @@ app.add_exception_handler(Exception, _unhandled_exception_handler)
 
 # ---------------------------------------------------------------------------
 # API key usage logging (MON-98) — only keyed requests touch the DB; anonymous
-# traffic is unaffected. Runs in the threadpool so a slow write never blocks
-# the event loop.
+# traffic is unaffected. Both the key lookup (which can hit the DB on a cache
+# miss) and the usage write run in the threadpool so neither ever blocks the
+# event loop.
 # ---------------------------------------------------------------------------
 @app.middleware("http")
 async def _log_api_key_usage(request: Request, call_next):
     response = await call_next(request)
-    record = resolve_api_key(request.headers.get(API_KEY_HEADER))
+    record = await run_in_threadpool(resolve_api_key, request.headers.get(API_KEY_HEADER))
     if record:
-        await run_in_threadpool(record_usage, record.id, request.url.path)
+        # Route template ("/deputies/{deputy_id}") once routing has resolved, so usage
+        # aggregates per endpoint rather than fragmenting per resource id.
+        route = request.scope.get("route")
+        endpoint = route.path if route is not None else request.url.path
+        await run_in_threadpool(record_usage, record.id, endpoint)
     return response
 
 

--- a/api/routers/deputies.py
+++ b/api/routers/deputies.py
@@ -4,7 +4,7 @@ from psycopg2 import sql
 from starlette.requests import Request
 
 from api.db import MART_UNAVAILABLE, get_conn
-from api.limiter import limiter
+from api.limiter import limiter, tiered_limit
 from api.schemas import (
     DeputyAlignment,
     DeputyDetail,
@@ -22,7 +22,7 @@ router = APIRouter()
 
 
 @router.get("/", response_model=DeputyListResponse)
-@limiter.limit("30/minute")
+@limiter.limit(tiered_limit(30))
 def list_deputies(
     request: Request,
     limit: int = Query(50, ge=1, le=200),
@@ -76,7 +76,7 @@ def list_deputies(
 
 
 @router.get("/stats", response_model=DeputyStats)
-@limiter.limit("30/minute")
+@limiter.limit(tiered_limit(30))
 def get_deputy_stats(request: Request):
     try:
         with get_conn() as conn:
@@ -93,7 +93,7 @@ def get_deputy_stats(request: Request):
 
 
 @router.get("/{deputy_id}", response_model=DeputyDetail)
-@limiter.limit("30/minute")
+@limiter.limit(tiered_limit(30))
 def get_deputy(request: Request, deputy_id: str):
     with get_conn() as conn:
         with conn.cursor() as cur:
@@ -106,7 +106,7 @@ def get_deputy(request: Request, deputy_id: str):
 
 
 @router.get("/{deputy_id}/votes", response_model=DeputyVotesResponse)
-@limiter.limit("30/minute")
+@limiter.limit(tiered_limit(30))
 def get_deputy_votes(
     request: Request,
     deputy_id: str,
@@ -144,7 +144,7 @@ def get_deputy_votes(
 
 
 @router.get("/{deputy_id}/scorecard", response_model=DeputyScorecard)
-@limiter.limit("10/minute")
+@limiter.limit(tiered_limit(10))
 def get_scorecard(request: Request, deputy_id: str):
     try:
         with get_conn() as conn:
@@ -177,7 +177,7 @@ def get_scorecard(request: Request, deputy_id: str):
 
 
 @router.get("/{deputy_id}/alignment", response_model=DeputyAlignment)
-@limiter.limit("10/minute")
+@limiter.limit(tiered_limit(10))
 def get_alignment(request: Request, deputy_id: str):
     try:
         with get_conn() as conn:
@@ -209,7 +209,7 @@ def get_alignment(request: Request, deputy_id: str):
 
 
 @router.get("/{deputy_id}/dissident-votes", response_model=DeputyDissidentVotesResponse)
-@limiter.limit("10/minute")
+@limiter.limit(tiered_limit(10))
 def get_dissident_votes(
     request: Request,
     deputy_id: str,

--- a/api/routers/keys.py
+++ b/api/routers/keys.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter, HTTPException, Request
+
+from api.auth import API_KEY_HEADER, resolve_api_key
+from api.db import get_conn
+from api.limiter import limiter, tiered_limit
+from api.schemas import ApiKeyUsageDay, ApiKeyUsageResponse
+
+router = APIRouter()
+
+
+@router.get("/usage", response_model=ApiKeyUsageResponse)
+@limiter.limit(tiered_limit(10))
+def get_key_usage(request: Request):
+    """Usage for the calling key over the last 30 days, grouped by endpoint and day."""
+    record = resolve_api_key(request.headers.get(API_KEY_HEADER))
+    if not record:
+        raise HTTPException(status_code=401, detail=f"Missing or invalid {API_KEY_HEADER} header")
+
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT endpoint, day, request_count
+                FROM api_key_usage
+                WHERE api_key_id = %s AND day >= CURRENT_DATE - INTERVAL '30 days'
+                ORDER BY day DESC, endpoint
+                """,
+                (record.id,),
+            )
+            rows = cur.fetchall()
+
+    return ApiKeyUsageResponse(
+        label=record.label,
+        rate_limit_multiplier=record.rate_limit_multiplier,
+        items=[ApiKeyUsageDay(**r) for r in rows],
+    )

--- a/api/routers/search.py
+++ b/api/routers/search.py
@@ -5,7 +5,7 @@ import groq
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from api.limiter import limiter
+from api.limiter import limiter, tiered_limit
 from rag.chain.rag_chain import ask
 
 logger = logging.getLogger(__name__)
@@ -48,7 +48,7 @@ class SearchResponse(BaseModel):
     response_model=SearchResponse,
     summary="Posez une question sur les votes et les députés",
 )
-@limiter.limit("10/minute")
+@limiter.limit(tiered_limit(10))
 def search(request: Request, body: SearchRequest):
     # Plain `def` on purpose: ask() does blocking psycopg2 + Groq I/O, so FastAPI
     # must run it in the threadpool, not on the event loop.

--- a/api/routers/votes.py
+++ b/api/routers/votes.py
@@ -9,7 +9,7 @@ from psycopg2 import sql
 from starlette.requests import Request
 
 from api.db import MART_UNAVAILABLE, get_conn
-from api.limiter import limiter
+from api.limiter import limiter, tiered_limit
 from api.schemas import VoteDetail, VoteListResponse, VotePosition, VoteSummary
 
 router = APIRouter()
@@ -32,7 +32,7 @@ def _decode_cursor(token: str) -> tuple[datetime, str]:
 
 
 @router.get("/", response_model=VoteListResponse)
-@limiter.limit("30/minute")
+@limiter.limit(tiered_limit(30))
 def list_votes(
     request: Request,
     limit: int = Query(50, ge=1, le=200),
@@ -133,7 +133,7 @@ def list_votes(
 
 
 @router.get("/latest", response_model=list[VoteSummary])
-@limiter.limit("30/minute")
+@limiter.limit(tiered_limit(30))
 def latest_votes(request: Request):
     try:
         with get_conn() as conn:
@@ -155,7 +155,7 @@ def latest_votes(request: Request):
 
 
 @router.get("/{vote_id}", response_model=VoteDetail)
-@limiter.limit("30/minute")
+@limiter.limit(tiered_limit(30))
 def get_vote(request: Request, vote_id: str):
     try:
         with get_conn() as conn:

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -169,3 +169,20 @@ class VoteListResponse(_Base):
         description="Opaque keyset cursor — pass as ?before= to fetch the next page; "
         "null when there are no more rows.",
     )
+
+
+# ---------------------------------------------------------------------------
+# API keys (MON-98)
+# ---------------------------------------------------------------------------
+
+
+class ApiKeyUsageDay(_Base):
+    endpoint: str
+    day: date
+    request_count: int
+
+
+class ApiKeyUsageResponse(_Base):
+    label: str
+    rate_limit_multiplier: int
+    items: list[ApiKeyUsageDay]

--- a/data/migrations/004_api_keys.sql
+++ b/data/migrations/004_api_keys.sql
@@ -1,0 +1,29 @@
+-- MonÉlu — public API tier: keys and usage accounting (MON-98)
+-- Idempotent: CREATE TABLE IF NOT EXISTS — safe to re-run.
+
+-- Keys are issued manually (email request -> row insert); no self-serve signup.
+-- Only the sha256 hash of the raw key is stored, never the raw value.
+CREATE TABLE IF NOT EXISTS api_keys (
+    id SERIAL PRIMARY KEY,
+    key_hash TEXT NOT NULL UNIQUE,
+    label TEXT NOT NULL,
+    contact_email TEXT,
+    -- Anonymous requests share the per-route base limit (e.g. 30/min, 10/min
+    -- on expensive endpoints). A keyed request's effective limit is
+    -- base * rate_limit_multiplier, so relative route protection is preserved.
+    rate_limit_multiplier INTEGER NOT NULL DEFAULT 4,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    revoked_at TIMESTAMPTZ
+);
+
+-- Per-key, per-endpoint, per-day request counters for usage accounting.
+CREATE TABLE IF NOT EXISTS api_key_usage (
+    id SERIAL PRIMARY KEY,
+    api_key_id INTEGER NOT NULL REFERENCES api_keys(id),
+    endpoint TEXT NOT NULL,
+    day DATE NOT NULL,
+    request_count INTEGER NOT NULL DEFAULT 0,
+    UNIQUE (api_key_id, endpoint, day)
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_key_usage_key_day ON api_key_usage (api_key_id, day);

--- a/frontend/src/app/developpeurs/page.tsx
+++ b/frontend/src/app/developpeurs/page.tsx
@@ -1,0 +1,89 @@
+import type { Metadata } from 'next'
+import { LegalPageLayout, LegalSection } from '@/components/LegalPageLayout'
+
+const API_BASE = 'https://monelu-production.up.railway.app'
+
+export const metadata: Metadata = {
+  title: 'Développeurs - MonÉlu',
+  description: "Documentation de l'API MonÉlu : endpoints, limites de débit, clés d'accès et licence des données.",
+}
+
+const textStyle = { fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }
+const codeBlockStyle = {
+  background: '#F7F4ED',
+  border: '1px solid #ECE7DC',
+  borderRadius: '8px',
+  padding: '14px 18px',
+  fontSize: '14px',
+  color: '#1B2B50',
+  fontFamily: 'monospace',
+  overflowX: 'auto' as const,
+}
+
+export default function DeveloppeursPage() {
+  return (
+    <LegalPageLayout eyebrow="API" title="Construire avec MonÉlu">
+      <LegalSection title="L'API">
+        <p style={{ ...textStyle, marginBottom: '10px' }}>
+          MonÉlu expose l&apos;intégralité des votes et des fiches de députés via une API REST publique.
+          La documentation interactive (OpenAPI/Swagger) liste tous les endpoints, leurs paramètres et
+          leurs schémas de réponse :
+        </p>
+        <p style={textStyle}>
+          <a href={`${API_BASE}/docs`} target="_blank" rel="noopener noreferrer" style={{ color: '#1B2B50', fontWeight: 600 }}>
+            {API_BASE}/docs
+          </a>
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Limites de débit">
+        <p style={{ ...textStyle, marginBottom: '10px' }}>
+          Toute requête anonyme partage un même quota par adresse IP :
+        </p>
+        <ul style={{ fontSize: '15px', lineHeight: 1.85, color: '#4B5563', margin: '0 0 10px', paddingLeft: '20px' }}>
+          <li><strong>30 requêtes / minute</strong> sur la plupart des endpoints (listes, fiches, votes).</li>
+          <li><strong>10 requêtes / minute</strong> sur les endpoints coûteux (scorecards, alignement, recherche sémantique).</li>
+        </ul>
+        <p style={textStyle}>
+          Une clé d&apos;API donne un quota individuel plus élevé sur ces mêmes limites (multiple de la limite
+          anonyme selon la clé) - utile si vous scrapez le jeu de données complet ou intégrez MonÉlu dans un
+          produit. Le comportement anonyme reste inchangé.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Obtenir une clé">
+        <p style={{ ...textStyle, marginBottom: '10px' }}>
+          Les clés sont émises manuellement pour l&apos;instant - pas d&apos;inscription en libre-service.
+          Écrivez à{' '}
+          <a href="mailto:walidelkhoukh99@gmail.com" style={{ color: '#1B2B50' }}>walidelkhoukh99@gmail.com</a>{' '}
+          en précisant votre usage prévu (recherche, rédaction, produit) et le volume de requêtes attendu.
+        </p>
+        <p style={{ ...textStyle, marginBottom: '10px' }}>
+          Une fois la clé reçue, passez-la dans l&apos;en-tête <code>X-API-Key</code> de chaque requête :
+        </p>
+        <div style={codeBlockStyle}>
+          curl -H &quot;X-API-Key: votre_cle&quot; {API_BASE}/deputes/
+        </div>
+      </LegalSection>
+
+      <LegalSection title="Suivre votre usage">
+        <p style={{ ...textStyle, marginBottom: '10px' }}>
+          Chaque clé peut consulter son propre historique de requêtes des 30 derniers jours, par endpoint et
+          par jour :
+        </p>
+        <div style={codeBlockStyle}>
+          curl -H &quot;X-API-Key: votre_cle&quot; {API_BASE}/keys/usage
+        </div>
+      </LegalSection>
+
+      <LegalSection title="Licence des données">
+        <p style={textStyle}>
+          Les données servies par l&apos;API sont publiées sous la Licence Ouverte / Open Licence 2.0
+          (&laquo;&nbsp;Etalab 2.0&nbsp;&raquo;) - réutilisation libre, y compris commerciale, sous réserve
+          d&apos;attribution. Détails complets sur la page{' '}
+          <a href="/licence-donnees" style={{ color: '#1B2B50' }}>Licence des données</a>.
+        </p>
+      </LegalSection>
+    </LegalPageLayout>
+  )
+}

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -66,6 +66,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${SITE_URL}/votes`, changeFrequency: 'daily', priority: 0.9 },
     { url: `${SITE_URL}/chat`, changeFrequency: 'monthly', priority: 0.5 },
     { url: `${SITE_URL}/a-propos`, changeFrequency: 'monthly', priority: 0.4 },
+    { url: `${SITE_URL}/developpeurs`, changeFrequency: 'monthly', priority: 0.4 },
   ]
 
   const [deputies, votes] = await Promise.all([deputyUrls(), voteUrls()])

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -48,7 +48,7 @@ export function Footer() {
       <div style={{ display: 'flex', gap: '28px', fontSize: '13.5px', flexWrap: 'wrap' }}>
         <Link href="/deputes" style={{ color: '#6B7280', textDecoration: 'none' }}>Députés</Link>
         <Link href="/votes" style={{ color: '#6B7280', textDecoration: 'none' }}>Votes</Link>
-        <a href="https://monelu-production.up.railway.app/docs" target="_blank" rel="noopener noreferrer" style={{ color: '#6B7280', textDecoration: 'none' }}>API</a>
+        <Link href="/developpeurs" style={{ color: '#6B7280', textDecoration: 'none' }}>Développeurs</Link>
         <a href="https://github.com/Walid-peach" target="_blank" rel="noopener noreferrer" style={{ color: '#6B7280', textDecoration: 'none' }}>GitHub</a>
         {legalLinks.map((l) => (
           <Link key={l.href} href={l.href} style={{ color: '#6B7280', textDecoration: 'none' }}>{l.label}</Link>

--- a/tests/unit/test_api_keys.py
+++ b/tests/unit/test_api_keys.py
@@ -90,3 +90,41 @@ def test_get_key_usage_returns_usage_for_valid_key(client, mock_cursor):
     assert data["label"] == "Test NGO"
     assert data["rate_limit_multiplier"] == 4
     assert data["items"][0]["request_count"] == 12
+
+
+def test_end_to_end_keyed_request_gets_higher_effective_limit():
+    """Drives a real @limiter.limit(tiered_limit(...)) route end to end: anonymous is
+    capped at the base limit, a keyed request with a multiplier gets base * multiplier —
+    proving the decorator, key_func, and tiered_limit actually compose correctly, not
+    just in isolation."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient as FastAPITestClient
+    from slowapi import _rate_limit_exceeded_handler
+    from slowapi.errors import RateLimitExceeded
+    from slowapi.middleware import SlowAPIMiddleware
+    from starlette.requests import Request as StarletteRequest
+
+    from api.limiter import limiter, tiered_limit
+
+    test_app = FastAPI()
+    test_app.state.limiter = limiter
+    test_app.add_middleware(SlowAPIMiddleware)
+    test_app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    @test_app.get("/_test_tiered_limit_endpoint")
+    @limiter.limit(tiered_limit(1))
+    def _tiered_endpoint(request: StarletteRequest):
+        return {"ok": True}
+
+    with FastAPITestClient(test_app) as tc:
+        # Anonymous: 1 request/minute — the second in the same window is rejected.
+        assert tc.get("/_test_tiered_limit_endpoint").status_code == 200
+        assert tc.get("/_test_tiered_limit_endpoint").status_code == 429
+
+        # Keyed with a 3x multiplier: 3 requests succeed before the 4th trips the limit.
+        record = auth.ApiKeyRecord(id=99, label="E2E", rate_limit_multiplier=3)
+        headers = {"X-API-Key": "whatever"}
+        with patch("api.limiter.resolve_api_key", return_value=record):
+            for _ in range(3):
+                assert tc.get("/_test_tiered_limit_endpoint", headers=headers).status_code == 200
+            assert tc.get("/_test_tiered_limit_endpoint", headers=headers).status_code == 429

--- a/tests/unit/test_api_keys.py
+++ b/tests/unit/test_api_keys.py
@@ -1,0 +1,92 @@
+"""Unit tests for the API key tier (MON-98): resolution, tiered limits, usage endpoint."""
+
+from unittest.mock import MagicMock, patch
+
+import api.auth as auth
+from api.limiter import rate_limit_key, tiered_limit
+
+
+def _reset_cache():
+    auth._cache_by_hash = {}
+    auth._cache_loaded_at = 0.0
+
+
+def test_resolve_api_key_missing_header_returns_none():
+    assert auth.resolve_api_key(None) is None
+    assert auth.resolve_api_key("") is None
+
+
+def test_resolve_api_key_hits_cache_without_reload():
+    _reset_cache()
+    record = auth.ApiKeyRecord(id=1, label="Test", rate_limit_multiplier=4)
+    auth._cache_by_hash[auth._hash_key("secret")] = record
+    import time
+
+    auth._cache_loaded_at = time.monotonic()
+
+    with patch.object(auth, "_reload_cache") as reload_mock:
+        result = auth.resolve_api_key("secret")
+    reload_mock.assert_not_called()
+    assert result == record
+    _reset_cache()
+
+
+def test_resolve_api_key_unknown_key_returns_none():
+    _reset_cache()
+    import time
+
+    auth._cache_loaded_at = time.monotonic()
+    with patch.object(auth, "_reload_cache"):
+        assert auth.resolve_api_key("not-a-real-key") is None
+    _reset_cache()
+
+
+def test_record_usage_swallows_db_errors():
+    with patch.object(auth, "get_conn", side_effect=RuntimeError("db down")):
+        auth.record_usage(1, "/deputies/")  # must not raise
+
+
+def test_rate_limit_key_anonymous_falls_back_to_ip():
+    request = MagicMock()
+    request.headers.get.return_value = None
+    with patch.object(auth, "resolve_api_key", return_value=None):
+        key = rate_limit_key(request)
+    assert "apikey:" not in key
+
+
+def test_rate_limit_key_keyed_embeds_id_and_multiplier():
+    request = MagicMock()
+    request.headers.get.return_value = "raw-key"
+    record = auth.ApiKeyRecord(id=7, label="Partner", rate_limit_multiplier=10)
+    with patch("api.limiter.resolve_api_key", return_value=record):
+        key = rate_limit_key(request)
+    assert key == "apikey:7:10"
+
+
+def test_tiered_limit_anonymous_uses_base():
+    limit_fn = tiered_limit(30)
+    assert limit_fn("203.0.113.5") == "30/minute"
+
+
+def test_tiered_limit_keyed_scales_by_multiplier():
+    limit_fn = tiered_limit(30)
+    assert limit_fn("apikey:7:4") == "120/minute"
+
+
+def test_get_key_usage_requires_header(client):
+    resp = client.get("/keys/usage")
+    assert resp.status_code == 401
+
+
+def test_get_key_usage_returns_usage_for_valid_key(client, mock_cursor):
+    record = auth.ApiKeyRecord(id=1, label="Test NGO", rate_limit_multiplier=4)
+    mock_cursor.fetchall.return_value = [
+        {"endpoint": "/deputies/", "day": "2026-07-01", "request_count": 12},
+    ]
+    with patch("api.routers.keys.resolve_api_key", return_value=record):
+        resp = client.get("/keys/usage", headers={"X-API-Key": "whatever"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["label"] == "Test NGO"
+    assert data["rate_limit_multiplier"] == 4
+    assert data["items"][0]["request_count"] == 12


### PR DESCRIPTION
## What
Turns the MonÉlu API into a first-class product surface: manually-issued API
keys with per-key rate-limit tiers, a `/developpeurs` page documenting
endpoints and terms, and per-key usage visibility.

## Why
Researchers, NGOs, and newsrooms are the plausible first paying customers,
and the API already exists — this is packaging, not building. Keys also
protect the free tier: today one aggressive scraper and 577-page builds
share the same anonymous IP bucket as real users (MON-98).

## Changes
- `data/migrations/004_api_keys.sql`: new `api_keys` (sha256 key hash, label,
  contact email, `rate_limit_multiplier`, revocation) and `api_key_usage`
  (per key/endpoint/day request counters) tables. Idempotent
  `CREATE TABLE IF NOT EXISTS`, consistent with the existing migration style.
- `api/auth.py`: resolves the `X-API-Key` header against a 5-minute
  in-process cache of active keys (sha256-hashed comparison only — raw keys
  are never stored), and a best-effort `record_usage()` upsert.
- `api/limiter.py`: `rate_limit_key()` buckets keyed requests by key id
  (embedding the key's multiplier in the bucket string) and falls back to
  the existing IP-based key for anonymous traffic. `tiered_limit(base)`
  builds a dynamic slowapi limit — anonymous keeps `base`/minute, keyed
  requests get `base * multiplier`/minute. Anonymous behavior is unchanged.
- `api/routers/{deputies,votes,search}.py`: swapped static
  `@limiter.limit("30/minute")` / `"10/minute"` decorators for
  `tiered_limit(30)` / `tiered_limit(10)`, preserving the existing per-route
  baselines.
- `api/routers/keys.py` (new): `GET /keys/usage` — a keyed request's own
  30-day usage by endpoint/day. 401 without a valid key.
- `api/main.py`: lightweight usage-logging middleware — runs
  `record_usage()` in the threadpool only when a valid key is present, so
  anonymous requests never touch this path.
- `api/schemas.py`: `ApiKeyUsageDay` / `ApiKeyUsageResponse`.
- `frontend/src/app/developpeurs/page.tsx` (new): endpoints (links the
  existing `/docs` OpenAPI page), rate limits, how to request a key, the
  usage endpoint, and a link to the existing Etalab licence page. Reuses
  `LegalPageLayout`/`LegalSection` for visual consistency with the other
  legal/info pages.
- `Footer.tsx` / `sitemap.ts`: link to `/developpeurs` instead of the raw
  `/docs` URL; added to the sitemap.
- `CLAUDE.md`: documented the two new tables in the Database section.

## Testing
- `tests/unit/test_api_keys.py` (new): key resolution (cache hit/miss,
  reload skip, DB-error swallowing in `record_usage`), `rate_limit_key`
  anonymous vs. keyed bucketing, `tiered_limit` scaling, and `/keys/usage`
  (401 without a key, 200 with usage rows).
- `python -m pytest tests/unit/ -q` — 86 passed.
- `python -m pytest tests/ -q` — 146 passed; the 27 `tests/integration/`
  errors are pre-existing local-Postgres connection failures (Docker not
  running locally), unrelated to this change.
- `ruff check .` / `ruff format --check .` — clean.
- Frontend: `tsc --noEmit` and `eslint` on the touched files — clean.
- Not tested: end-to-end against a live Supabase instance with a real
  issued key (no key exists yet — issuance is a manual DB insert, first key
  to be created after this merges).

## Risks / Notes
- **Schema migration**: `data/migrations/004_api_keys.sql` adds two new
  tables via idempotent `CREATE TABLE IF NOT EXISTS` — no destructive DDL,
  applied automatically by `migrate.py` on the next Railway deploy, same as
  every prior migration in this repo.
- Key issuance stays fully manual for this PR (email → `INSERT INTO
  api_keys`), matching the issue's "no self-serve signup" scope. A short
  `INSERT` snippet for issuing a key isn't included in code — happy to add
  a `scripts/` helper if that's wanted before the first real key is cut.
- `record_usage()` is best-effort (swallows and logs DB errors) so a usage
  write failure never breaks the request path.

## Breaking Changes
None. Anonymous rate limits and response shapes are unchanged.
