### PR TITLE
feat: add since filter and summary_plain to deputy votes endpoint (MON-90 backend)

### DIFF
--- a/api/routers/deputies.py
+++ b/api/routers/deputies.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+from typing import Optional
+
 import psycopg2.errors
 from fastapi import APIRouter, HTTPException, Query
 from psycopg2 import sql
@@ -111,6 +114,11 @@ def get_deputy_votes(
     request: Request,
     deputy_id: str,
     limit: int = Query(10, ge=1, le=50),
+    since: Optional[datetime] = Query(
+        None,
+        description="Only return votes after this timestamp (ISO 8601) — used to "
+        "surface what changed since a visitor's last visit.",
+    ),
 ):
     try:
         with get_conn() as conn:
@@ -121,16 +129,19 @@ def get_deputy_votes(
                 )
                 total = cur.fetchone()["count"]
 
+                since_clause = "AND v.voted_at > %s" if since else ""
+                params = (deputy_id, since, limit) if since else (deputy_id, limit)
                 cur.execute(
-                    """
-                    SELECT vp.vote_id, v.voted_at, v.vote_title, v.result, vp.position
+                    f"""
+                    SELECT vp.vote_id, v.voted_at, v.vote_title, v.result, vp.position,
+                           v.summary_plain
                     FROM vote_positions vp
                     JOIN analytics_marts.mart_vote_summary v ON v.vote_id = vp.vote_id
-                    WHERE vp.deputy_id = %s
+                    WHERE vp.deputy_id = %s {since_clause}
                     ORDER BY v.voted_at DESC
                     LIMIT %s
                     """,
-                    (deputy_id, limit),
+                    params,
                 )
                 rows = cur.fetchall()
     except psycopg2.errors.UndefinedTable:

--- a/api/routers/deputies.py
+++ b/api/routers/deputies.py
@@ -129,19 +129,22 @@ def get_deputy_votes(
                 )
                 total = cur.fetchone()["count"]
 
-                since_clause = "AND v.voted_at > %s" if since else ""
-                params = (deputy_id, since, limit) if since else (deputy_id, limit)
+                conditions = [sql.SQL("vp.deputy_id = %s")]
+                params: list = [deputy_id]
+                if since:
+                    conditions.append(sql.SQL("v.voted_at > %s"))
+                    params.append(since)
+                where = sql.SQL(" WHERE ") + sql.SQL(" AND ").join(conditions)
+
                 cur.execute(
-                    f"""
-                    SELECT vp.vote_id, v.voted_at, v.vote_title, v.result, vp.position,
-                           v.summary_plain
-                    FROM vote_positions vp
-                    JOIN analytics_marts.mart_vote_summary v ON v.vote_id = vp.vote_id
-                    WHERE vp.deputy_id = %s {since_clause}
-                    ORDER BY v.voted_at DESC
-                    LIMIT %s
-                    """,
-                    params,
+                    sql.SQL("""
+                        SELECT vp.vote_id, v.voted_at, v.vote_title, v.result, vp.position,
+                               v.summary_plain
+                        FROM vote_positions vp
+                        JOIN analytics_marts.mart_vote_summary v ON v.vote_id = vp.vote_id
+                        {} ORDER BY v.voted_at DESC LIMIT %s
+                    """).format(where),
+                    params + [limit],
                 )
                 rows = cur.fetchall()
     except psycopg2.errors.UndefinedTable:

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -105,6 +105,7 @@ class DeputyVoteItem(_Base):
     vote_title: str
     result: Optional[str] = None
     position: str
+    summary_plain: Optional[str] = None
 
 
 class DeputyVotesResponse(_Base):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -209,6 +209,45 @@ def test_get_dissident_votes_empty(client, mock_cursor):
     assert data["items"] == []
 
 
+def test_get_deputy_votes_includes_summary_plain(client, mock_cursor):
+    mock_cursor.fetchone.return_value = {"count": 1}
+    mock_cursor.fetchall.return_value = [
+        {
+            "vote_id": "VTANR5L17V1",
+            "voted_at": "2024-07-16T15:00:00",
+            "vote_title": "Vote sur le projet de loi de finances",
+            "result": "adopté",
+            "position": "pour",
+            "summary_plain": "Ce texte prévoit...",
+        }
+    ]
+    resp = client.get("/deputies/PA1/votes")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["items"][0]["summary_plain"] == "Ce texte prévoit..."
+
+
+def test_get_deputy_votes_since_filter(client, mock_cursor):
+    mock_cursor.fetchone.return_value = {"count": 5}
+    mock_cursor.fetchall.return_value = [
+        {
+            "vote_id": "VTANR5L17V2",
+            "voted_at": "2026-07-05T15:00:00",
+            "vote_title": "Vote récent",
+            "result": "adopté",
+            "position": "contre",
+            "summary_plain": None,
+        }
+    ]
+    resp = client.get("/deputies/PA1/votes?since=2026-07-01T00:00:00")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 5
+    assert len(data["items"]) == 1
+    executed_sql = mock_cursor.execute.call_args_list[-1].args[0]
+    assert "v.voted_at > %s" in executed_sql
+
+
 # ---------------------------------------------------------------------------
 # Votes
 # ---------------------------------------------------------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -239,13 +239,27 @@ def test_get_deputy_votes_since_filter(client, mock_cursor):
             "summary_plain": None,
         }
     ]
-    resp = client.get("/deputies/PA1/votes?since=2026-07-01T00:00:00")
+    resp = client.get("/deputies/PA1/votes?since=2026-07-01T00:00:00&limit=5")
+    assert resp.status_code == 200
+    data = resp.json()
+    # total reflects the unfiltered count (pre-existing pagination semantics on
+    # this endpoint); only items are narrowed by since.
+    assert data["total"] == 5
+    assert len(data["items"]) == 1
+    # The SELECT (last execute call) must carry deputy_id, the decoded since
+    # timestamp, and the limit — in that order.
+    select_params = mock_cursor.execute.call_args_list[-1].args[1]
+    assert select_params == ["PA1", datetime(2026, 7, 1, 0, 0, 0), 5]
+
+
+def test_get_deputy_votes_since_in_the_future_returns_no_items(client, mock_cursor):
+    mock_cursor.fetchone.return_value = {"count": 5}
+    mock_cursor.fetchall.return_value = []
+    resp = client.get("/deputies/PA1/votes?since=2099-01-01T00:00:00")
     assert resp.status_code == 200
     data = resp.json()
     assert data["total"] == 5
-    assert len(data["items"]) == 1
-    executed_sql = mock_cursor.execute.call_args_list[-1].args[0]
-    assert "v.voted_at > %s" in executed_sql
+    assert data["items"] == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds an optional `since` query param to `/deputies/{id}/votes` to fetch only votes cast after a given timestamp - the primitive MON-90's "Mon député" dashboard needs for its "what changed since your last visit" section.
- Fixes `summary_plain` being silently dropped from this endpoint: the frontend type (`DeputyVoteItem` in `frontend/src/lib/api.ts`) and the deputy profile page already expected it, but the backend schema and SQL query never selected it, so it was always `undefined` in production.

Part of MON-90 ("Mon député" personalized dashboard). This is PR1 of 2 (backend first); the frontend dashboard follows in a second PR once this merges.

## Test plan
- [x] `pytest tests/test_api.py -k deputy_votes` - new tests for `since` filter and `summary_plain`
- [x] Full unit test suite (`pytest`) - 149 passed (integration tests fail locally due to no Postgres running, pre-existing/unrelated)
- [x] `ruff check` / `ruff format --check` clean