### PR TITLE
feat: add /mon-depute personalized dashboard (MON-90 frontend)

### DIFF
--- a/api/routers/deputies.py
+++ b/api/routers/deputies.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+from typing import Optional
+
 import psycopg2.errors
 from fastapi import APIRouter, HTTPException, Query
 from psycopg2 import sql
@@ -111,6 +114,11 @@ def get_deputy_votes(
     request: Request,
     deputy_id: str,
     limit: int = Query(10, ge=1, le=50),
+    since: Optional[datetime] = Query(
+        None,
+        description="Only return votes after this timestamp (ISO 8601) — used to "
+        "surface what changed since a visitor's last visit.",
+    ),
 ):
     try:
         with get_conn() as conn:
@@ -121,16 +129,19 @@ def get_deputy_votes(
                 )
                 total = cur.fetchone()["count"]
 
+                since_clause = "AND v.voted_at > %s" if since else ""
+                params = (deputy_id, since, limit) if since else (deputy_id, limit)
                 cur.execute(
-                    """
-                    SELECT vp.vote_id, v.voted_at, v.vote_title, v.result, vp.position
+                    f"""
+                    SELECT vp.vote_id, v.voted_at, v.vote_title, v.result, vp.position,
+                           v.summary_plain
                     FROM vote_positions vp
                     JOIN analytics_marts.mart_vote_summary v ON v.vote_id = vp.vote_id
-                    WHERE vp.deputy_id = %s
+                    WHERE vp.deputy_id = %s {since_clause}
                     ORDER BY v.voted_at DESC
                     LIMIT %s
                     """,
-                    (deputy_id, limit),
+                    params,
                 )
                 rows = cur.fetchall()
     except psycopg2.errors.UndefinedTable:

--- a/api/routers/deputies.py
+++ b/api/routers/deputies.py
@@ -129,19 +129,22 @@ def get_deputy_votes(
                 )
                 total = cur.fetchone()["count"]
 
-                since_clause = "AND v.voted_at > %s" if since else ""
-                params = (deputy_id, since, limit) if since else (deputy_id, limit)
+                conditions = [sql.SQL("vp.deputy_id = %s")]
+                params: list = [deputy_id]
+                if since:
+                    conditions.append(sql.SQL("v.voted_at > %s"))
+                    params.append(since)
+                where = sql.SQL(" WHERE ") + sql.SQL(" AND ").join(conditions)
+
                 cur.execute(
-                    f"""
-                    SELECT vp.vote_id, v.voted_at, v.vote_title, v.result, vp.position,
-                           v.summary_plain
-                    FROM vote_positions vp
-                    JOIN analytics_marts.mart_vote_summary v ON v.vote_id = vp.vote_id
-                    WHERE vp.deputy_id = %s {since_clause}
-                    ORDER BY v.voted_at DESC
-                    LIMIT %s
-                    """,
-                    params,
+                    sql.SQL("""
+                        SELECT vp.vote_id, v.voted_at, v.vote_title, v.result, vp.position,
+                               v.summary_plain
+                        FROM vote_positions vp
+                        JOIN analytics_marts.mart_vote_summary v ON v.vote_id = vp.vote_id
+                        {} ORDER BY v.voted_at DESC LIMIT %s
+                    """).format(where),
+                    params + [limit],
                 )
                 rows = cur.fetchall()
     except psycopg2.errors.UndefinedTable:

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -105,6 +105,7 @@ class DeputyVoteItem(_Base):
     vote_title: str
     result: Optional[str] = None
     position: str
+    summary_plain: Optional[str] = None
 
 
 class DeputyVotesResponse(_Base):

--- a/frontend/__tests__/lib/api.test.ts
+++ b/frontend/__tests__/lib/api.test.ts
@@ -49,6 +49,23 @@ describe('api.search', () => {
   })
 })
 
+describe('api.deputies.votes', () => {
+  it('omits since from the query string when not provided', async () => {
+    mockFetch(200, { deputy_id: 'PA1', total: 0, items: [] })
+    await api.deputies.votes('PA1', 10)
+    const url = (global.fetch as jest.Mock).mock.calls[0][0] as string
+    expect(url).toContain('limit=10')
+    expect(url).not.toContain('since=')
+  })
+
+  it('includes since in the query string when provided', async () => {
+    mockFetch(200, { deputy_id: 'PA1', total: 0, items: [] })
+    await api.deputies.votes('PA1', 50, '2026-07-01T00:00:00.000Z')
+    const url = (global.fetch as jest.Mock).mock.calls[0][0] as string
+    expect(url).toContain('since=2026-07-01T00%3A00%3A00.000Z')
+  })
+})
+
 describe('apiFetch (via api.health)', () => {
   it('throws on a non-ok response', async () => {
     mockFetch(503, { detail: 'Service Unavailable' })

--- a/frontend/__tests__/lib/mon-depute.test.ts
+++ b/frontend/__tests__/lib/mon-depute.test.ts
@@ -1,0 +1,56 @@
+import {
+  getFollowedDeputyId,
+  setFollowedDeputyId,
+  clearFollowedDeputyId,
+  getLastSeenAt,
+  setLastSeenAt,
+} from '@/lib/mon-depute'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('followed deputy persistence', () => {
+  it('returns null when no deputy is followed', () => {
+    expect(getFollowedDeputyId()).toBeNull()
+  })
+
+  it('persists and retrieves the followed deputy id', () => {
+    setFollowedDeputyId('PA1')
+    expect(getFollowedDeputyId()).toBe('PA1')
+  })
+
+  it('clears the followed deputy id', () => {
+    setFollowedDeputyId('PA1')
+    clearFollowedDeputyId()
+    expect(getFollowedDeputyId()).toBeNull()
+  })
+
+  it('does not throw when localStorage is unavailable', () => {
+    const original = window.localStorage
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: () => { throw new Error('blocked') },
+        setItem: () => { throw new Error('blocked') },
+        removeItem: () => { throw new Error('blocked') },
+      },
+      configurable: true,
+    })
+    expect(() => setFollowedDeputyId('PA1')).not.toThrow()
+    expect(getFollowedDeputyId()).toBeNull()
+    Object.defineProperty(window, 'localStorage', { value: original, configurable: true })
+  })
+})
+
+describe('per-deputy last-seen timestamp', () => {
+  it('returns null when never set', () => {
+    expect(getLastSeenAt('PA1')).toBeNull()
+  })
+
+  it('persists and retrieves per deputy independently', () => {
+    setLastSeenAt('PA1', '2026-07-01T00:00:00.000Z')
+    setLastSeenAt('PA2', '2026-07-02T00:00:00.000Z')
+    expect(getLastSeenAt('PA1')).toBe('2026-07-01T00:00:00.000Z')
+    expect(getLastSeenAt('PA2')).toBe('2026-07-02T00:00:00.000Z')
+  })
+})

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -2,11 +2,14 @@ import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { api } from '@/lib/api'
-import type { DeputyVoteItem, DissidentVoteItem } from '@/lib/api'
+import type { DissidentVoteItem } from '@/lib/api'
 import { partyHex, formatDate } from '@/lib/utils'
+import { positionStyle } from '@/lib/vote-position'
 import { DeputyAvatar } from '@/components/DeputyAvatar'
 import { ShareButton } from '@/components/ShareButton'
 import { InfoTooltip } from '@/components/InfoTooltip'
+import { FollowDeputyButton } from '@/components/FollowDeputyButton'
+import { VoteTimelineItem } from '@/components/VoteTimelineItem'
 
 export const dynamicParams = true
 export const revalidate = 86400
@@ -30,13 +33,6 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
     openGraph: { title: `${deputy.full_name} - MonÉlu`, description },
     twitter:   { card: 'summary_large_image', title: `${deputy.full_name} - MonÉlu`, description },
   }
-}
-
-const POS = {
-  pour:       { label: 'Pour',       color: '#1F8A5B', bg: '#EAF5EF' },
-  contre:     { label: 'Contre',     color: RED,        bg: '#FBE9E7' },
-  abstention: { label: 'Abstention', color: '#6B7280',  bg: '#F0F1F3' },
-  nonVotant:  { label: 'Non votant', color: '#9CA3AF',  bg: '#F5F6F7' },
 }
 
 export default async function DeputyPage({ params }: { params: Promise<{ id: string }> }) {
@@ -176,6 +172,7 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                   text={`Bilan de mandat et votes de ${deputy.full_name}`}
                   ariaLabel="Partager ce député"
                 />
+                <FollowDeputyButton deputyId={id} />
               </div>
             </div>
           </div>
@@ -314,13 +311,13 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                           )}
                           <span style={{
                             fontSize: 12, fontWeight: 700, padding: '3px 10px', borderRadius: 999,
-                            color: POS[v.position as keyof typeof POS]?.color ?? NAVY,
-                            background: POS[v.position as keyof typeof POS]?.bg ?? LINE,
+                            color: positionStyle(v.position).color,
+                            background: positionStyle(v.position).bg,
                           }}>
-                            A voté {POS[v.position as keyof typeof POS]?.label ?? v.position}
+                            A voté {positionStyle(v.position).label}
                           </span>
                           <span style={{ fontSize: 12, color: '#9CA3AF' }}>
-                            groupe : {POS[v.majority_position as keyof typeof POS]?.label ?? v.majority_position}
+                            groupe : {positionStyle(v.majority_position).label}
                           </span>
                         </div>
                         <div style={{ fontSize: 15.5, color: NAVY, lineHeight: 1.35 }}>
@@ -348,53 +345,9 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                 <div style={{ position: 'absolute', left: 6, top: 8, bottom: 8, width: 2, background: '#E7E2D6', borderRadius: 2 }} />
 
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 28 }}>
-                  {recentVotes.items.map((v: DeputyVoteItem) => {
-                    const pos = POS[v.position as keyof typeof POS] ?? POS.nonVotant
-                    return (
-                      <div key={v.vote_id} style={{ position: 'relative' }}>
-                        {/* Dot */}
-                        <span style={{
-                          position: 'absolute', left: -32, top: 5,
-                          width: 13, height: 13, borderRadius: 999,
-                          background: pos.color,
-                          border: `3px solid ${CREAM}`,
-                          boxShadow: `0 0 0 1px ${pos.color}`,
-                        }} />
-
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap' }}>
-                          {v.voted_at && (
-                            <span className="font-mono" style={{ fontSize: 12.5, color: '#9CA3AF', letterSpacing: '0.02em' }}>
-                              {formatDate(v.voted_at)}
-                            </span>
-                          )}
-                          <span style={{
-                            fontSize: 12.5, fontWeight: 700, letterSpacing: '0.04em',
-                            padding: '4px 12px', borderRadius: 999,
-                            color: pos.color, background: pos.bg,
-                          }}>
-                            {pos.label}
-                          </span>
-                          {v.result && (
-                            <span style={{ fontSize: 12, color: '#9CA3AF' }}>
-                              Scrutin : {v.result}
-                            </span>
-                          )}
-                        </div>
-
-                        <Link href={`/votes/${v.vote_id}`} style={{ textDecoration: 'none' }}>
-                          <div className="font-newsreader text-[21px]" style={{ color: NAVY, marginTop: 8, lineHeight: 1.3, cursor: 'pointer' }}>
-                            {v.vote_title}
-                          </div>
-                        </Link>
-
-                        {v.summary_plain && (
-                          <div style={{ fontSize: 14.5, color: '#4B5563', lineHeight: 1.55, marginTop: 5, maxWidth: 680, fontStyle: 'italic' }}>
-                            {v.summary_plain}
-                          </div>
-                        )}
-                      </div>
-                    )
-                  })}
+                  {recentVotes.items.map(v => (
+                    <VoteTimelineItem key={v.vote_id} vote={v} dotBorderColor={CREAM} />
+                  ))}
                 </div>
               </div>
 

--- a/frontend/src/app/mon-depute/page.tsx
+++ b/frontend/src/app/mon-depute/page.tsx
@@ -1,0 +1,255 @@
+'use client'
+import { useState, useEffect } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { api } from '@/lib/api'
+import type { Deputy, Scorecard, Alignment, DeputyVoteItem } from '@/lib/api'
+import { partyHex } from '@/lib/utils'
+import {
+  getFollowedDeputyId,
+  clearFollowedDeputyId,
+  getLastSeenAt,
+  setLastSeenAt,
+} from '@/lib/mon-depute'
+import { DeputyAvatar } from '@/components/DeputyAvatar'
+import { InfoTooltip } from '@/components/InfoTooltip'
+import { VoteTimelineItem } from '@/components/VoteTimelineItem'
+
+const NAVY   = '#1B2B50'
+const CREAM  = '#F7F4ED'
+const LINE   = '#E4E6EA'
+const ACCENT = '#E0786E'
+const RED    = '#C9302A'
+
+type DashboardData = {
+  deputy: Deputy
+  scorecard: Scorecard | null
+  alignment: Alignment | null
+  recentVotes: DeputyVoteItem[]
+  newSinceLastVisit: DeputyVoteItem[]
+  hadPriorVisit: boolean
+}
+
+export default function MonDeputePage() {
+  const router = useRouter()
+  const [deputyId, setDeputyId] = useState<string | null>(() => getFollowedDeputyId())
+  const [data, setData] = useState<DashboardData | null>(null)
+  const [loading, setLoading] = useState(() => getFollowedDeputyId() !== null)
+  const [notFound, setNotFound] = useState(false)
+
+  useEffect(() => {
+    if (!deputyId) return
+    let cancelled = false
+    const lastSeenAt = getLastSeenAt(deputyId)
+    Promise.all([
+      api.deputies.get(deputyId).catch(() => null),
+      api.deputies.scorecard(deputyId).catch(() => null),
+      api.deputies.alignment(deputyId).catch(() => null),
+      api.deputies.votes(deputyId, 10).catch(() => null),
+      lastSeenAt ? api.deputies.votes(deputyId, 50, lastSeenAt).catch(() => null) : Promise.resolve(null),
+    ]).then(([deputy, scorecard, alignment, recent, since]) => {
+      if (cancelled) return
+      if (!deputy) {
+        setNotFound(true)
+        setLoading(false)
+        return
+      }
+      setData({
+        deputy,
+        scorecard,
+        alignment,
+        recentVotes: recent?.items ?? [],
+        newSinceLastVisit: since?.items ?? [],
+        hadPriorVisit: lastSeenAt !== null,
+      })
+      setLastSeenAt(deputyId, new Date().toISOString())
+      setLoading(false)
+    })
+    return () => { cancelled = true }
+  }, [deputyId])
+
+  function unfollow() {
+    clearFollowedDeputyId()
+    setDeputyId(null)
+    setData(null)
+  }
+
+  function change() {
+    clearFollowedDeputyId()
+    router.push('/deputes')
+  }
+
+  if (loading) {
+    return <div style={{ background: CREAM, minHeight: '100vh' }} />
+  }
+
+  if (!deputyId || notFound) {
+    return (
+      <div style={{ background: CREAM, minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '56px 24px' }}>
+        <div style={{ maxWidth: 480, textAlign: 'center' }}>
+          <div style={{ fontWeight: 700, fontSize: 12, letterSpacing: '0.18em', textTransform: 'uppercase', color: RED, marginBottom: 16 }}>
+            Mon député
+          </div>
+          <h1 className="font-newsreader text-[clamp(28px,4vw,40px)]" style={{ fontWeight: 600, color: NAVY, margin: 0, letterSpacing: '-0.015em' }}>
+            Choisissez votre député
+          </h1>
+          <p style={{ margin: '16px 0 28px', fontSize: 16, lineHeight: 1.6, color: '#4B5563' }}>
+            Suivez un député depuis sa fiche profil pour retrouver ici son bilan de vote,
+            son alignement avec son groupe, et ce qui a changé depuis votre dernière visite.
+          </p>
+          <Link
+            href="/deputes"
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 8,
+              background: ACCENT, color: '#fff', padding: '12px 26px',
+              borderRadius: 9, fontWeight: 600, fontSize: 15, textDecoration: 'none',
+              boxShadow: '0 2px 8px rgba(224,120,110,0.35)',
+            }}
+          >
+            Trouver mon député
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  const { deputy, scorecard, alignment, recentVotes, newSinceLastVisit, hadPriorVisit } = data!
+  const hex = partyHex(deputy.party)
+  const alignmentPct = alignment ? Math.round(alignment.party_alignment_rate * 100) : null
+  const presencePct = scorecard ? Math.round((scorecard.presence_rate ?? 0) * 100) : null
+  const showDiff = hadPriorVisit && newSinceLastVisit.length > 0
+
+  return (
+    <div style={{ background: CREAM, minHeight: '100vh' }}>
+      <div style={{
+        padding: '38px 56px 44px',
+        background: `linear-gradient(180deg,#ffffff 0%,${CREAM} 100%)`,
+        borderBottom: '1px solid #ECE7DC',
+      }}>
+        <div style={{ maxWidth: 900, margin: '0 auto' }}>
+          <div style={{ fontWeight: 700, fontSize: 12, letterSpacing: '0.18em', textTransform: 'uppercase', color: RED, marginBottom: 16 }}>
+            Mon député
+          </div>
+
+          <div style={{ display: 'flex', gap: 24, alignItems: 'center', flexWrap: 'wrap' }}>
+            <DeputyAvatar name={deputy.full_name} photoUrl={deputy.photo_url} size="lg" />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <h1 className="font-newsreader text-[clamp(26px,3.5vw,38px)]" style={{ fontWeight: 600, color: NAVY, margin: 0, letterSpacing: '-0.015em' }}>
+                {deputy.full_name}
+              </h1>
+              <div style={{ display: 'flex', gap: 10, alignItems: 'center', marginTop: 8, flexWrap: 'wrap' }}>
+                {deputy.department && (
+                  <span style={{ fontSize: 14, color: '#6B7280' }}>{deputy.department}</span>
+                )}
+                {deputy.party && (
+                  <span style={{
+                    display: 'inline-flex', alignItems: 'center', gap: 7,
+                    padding: '5px 12px', borderRadius: 999,
+                    background: `${hex}14`, border: `1px solid ${hex}40`,
+                    color: hex, fontWeight: 600, fontSize: 13,
+                  }}>
+                    <span style={{ width: 8, height: 8, borderRadius: 999, background: hex }} />
+                    {deputy.party}
+                  </span>
+                )}
+              </div>
+            </div>
+            <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+              <Link
+                href={`/deputes/${deputy.deputy_id}`}
+                style={{
+                  fontSize: 13.5, color: NAVY, background: '#fff', border: `1px solid ${LINE}`,
+                  padding: '9px 16px', borderRadius: 8, fontWeight: 600, textDecoration: 'none',
+                }}
+              >
+                Voir la fiche complète
+              </Link>
+              <button
+                onClick={change}
+                style={{ fontSize: 13.5, color: NAVY, background: 'none', border: 'none', cursor: 'pointer', textDecoration: 'underline', padding: '9px 4px' }}
+              >
+                Changer de député
+              </button>
+              <button
+                onClick={unfollow}
+                style={{ fontSize: 13.5, color: RED, background: 'none', border: 'none', cursor: 'pointer', textDecoration: 'underline', padding: '9px 4px' }}
+              >
+                Ne plus suivre
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div style={{ padding: '44px 56px 80px' }}>
+        <div style={{ maxWidth: 900, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 44 }}>
+
+          {/* What changed since last visit */}
+          {showDiff && (
+            <section>
+              <div style={{ fontWeight: 700, fontSize: 12, letterSpacing: '0.18em', textTransform: 'uppercase', color: RED }}>
+                Depuis votre dernière visite
+              </div>
+              <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: NAVY, margin: '12px 0 22px', letterSpacing: '-0.01em' }}>
+                {newSinceLastVisit.length} nouveau{newSinceLastVisit.length !== 1 ? 'x' : ''} vote{newSinceLastVisit.length !== 1 ? 's' : ''}
+              </h2>
+              <div style={{ position: 'relative', paddingLeft: 32 }}>
+                <div style={{ position: 'absolute', left: 6, top: 8, bottom: 8, width: 2, background: '#E7E2D6', borderRadius: 2 }} />
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 28 }}>
+                  {newSinceLastVisit.map(v => (
+                    <VoteTimelineItem key={v.vote_id} vote={v} dotBorderColor={CREAM} />
+                  ))}
+                </div>
+              </div>
+            </section>
+          )}
+
+          {/* Stats */}
+          <section style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20 }}>
+            {presencePct !== null && (
+              <div style={{ background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12, padding: '22px 24px' }}>
+                <div style={{ fontSize: 13, color: '#6B7280', fontWeight: 500, marginBottom: 10 }}>Taux de présence</div>
+                <div className="font-mono" style={{ fontWeight: 700, fontSize: 28, color: NAVY }}>{presencePct}%</div>
+                <div style={{ position: 'relative', height: 8, background: '#EEF0F2', borderRadius: 999, overflow: 'hidden', marginTop: 12 }}>
+                  <div style={{ height: '100%', background: NAVY, borderRadius: 999, width: `${presencePct}%` }} />
+                </div>
+              </div>
+            )}
+            {alignmentPct !== null && alignment && (
+              <div style={{ background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12, padding: '22px 24px' }}>
+                <div style={{ fontSize: 13, color: '#6B7280', fontWeight: 500, marginBottom: 10, display: 'flex', alignItems: 'center', gap: 6 }}>
+                  Alignement avec son groupe
+                  <InfoTooltip text="Alignement calculé en comparant, vote par vote, la position du député à la position majoritaire de son groupe parlementaire actuel." />
+                </div>
+                <div className="font-mono" style={{ fontWeight: 700, fontSize: 28, color: NAVY }}>{alignmentPct}%</div>
+                <div style={{ position: 'relative', height: 8, background: '#EEF0F2', borderRadius: 999, overflow: 'hidden', marginTop: 12 }}>
+                  <div style={{ height: '100%', background: NAVY, borderRadius: 999, width: `${alignmentPct}%` }} />
+                </div>
+              </div>
+            )}
+          </section>
+
+          {/* Recent votes */}
+          {recentVotes.length > 0 && (
+            <section>
+              <div style={{ fontWeight: 700, fontSize: 12, letterSpacing: '0.18em', textTransform: 'uppercase', color: RED }}>
+                Votes récents
+              </div>
+              <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: NAVY, margin: '12px 0 22px', letterSpacing: '-0.01em' }}>
+                Le bilan de vote de {deputy.full_name}
+              </h2>
+              <div style={{ position: 'relative', paddingLeft: 32 }}>
+                <div style={{ position: 'absolute', left: 6, top: 8, bottom: 8, width: 2, background: '#E7E2D6', borderRadius: 2 }} />
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 28 }}>
+                  {recentVotes.map(v => (
+                    <VoteTimelineItem key={v.vote_id} vote={v} dotBorderColor={CREAM} />
+                  ))}
+                </div>
+              </div>
+            </section>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/mon-depute/page.tsx
+++ b/frontend/src/app/mon-depute/page.tsx
@@ -32,10 +32,21 @@ type DashboardData = {
 
 export default function MonDeputePage() {
   const router = useRouter()
-  const [deputyId, setDeputyId] = useState<string | null>(() => getFollowedDeputyId())
+  // Both start at their server-safe defaults (localStorage doesn't exist server-side);
+  // the mount effect below corrects deputyId asynchronously via a microtask so React
+  // treats it as a post-hydration update rather than a synchronous one, avoiding a
+  // hydration mismatch between the server render and the client's first paint.
+  const [deputyId, setDeputyId] = useState<string | null>(null)
+  const [checkedStorage, setCheckedStorage] = useState(false)
   const [data, setData] = useState<DashboardData | null>(null)
-  const [loading, setLoading] = useState(() => getFollowedDeputyId() !== null)
   const [notFound, setNotFound] = useState(false)
+
+  useEffect(() => {
+    Promise.resolve().then(() => {
+      setDeputyId(getFollowedDeputyId())
+      setCheckedStorage(true)
+    })
+  }, [])
 
   useEffect(() => {
     if (!deputyId) return
@@ -50,8 +61,10 @@ export default function MonDeputePage() {
     ]).then(([deputy, scorecard, alignment, recent, since]) => {
       if (cancelled) return
       if (!deputy) {
+        // Stale followed-deputy id (e.g. the deputy record disappeared) — clear it
+        // so the visitor lands on the picker instead of a permanent dead end.
+        clearFollowedDeputyId()
         setNotFound(true)
-        setLoading(false)
         return
       }
       setData({
@@ -63,10 +76,11 @@ export default function MonDeputePage() {
         hadPriorVisit: lastSeenAt !== null,
       })
       setLastSeenAt(deputyId, new Date().toISOString())
-      setLoading(false)
     })
     return () => { cancelled = true }
   }, [deputyId])
+
+  const loading = !checkedStorage || (deputyId !== null && !data && !notFound)
 
   function unfollow() {
     clearFollowedDeputyId()

--- a/frontend/src/components/FollowDeputyButton.tsx
+++ b/frontend/src/components/FollowDeputyButton.tsx
@@ -1,0 +1,42 @@
+'use client'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { getFollowedDeputyId, setFollowedDeputyId, clearFollowedDeputyId } from '@/lib/mon-depute'
+
+const NAVY = '#1B2B50'
+const LINE = '#E4E6EA'
+
+export function FollowDeputyButton({ deputyId }: { deputyId: string }) {
+  const router = useRouter()
+  const [following, setFollowing] = useState(() => getFollowedDeputyId() === deputyId)
+
+  function toggle() {
+    if (following) {
+      clearFollowedDeputyId()
+      setFollowing(false)
+    } else {
+      setFollowedDeputyId(deputyId)
+      setFollowing(true)
+      router.push('/mon-depute')
+    }
+  }
+
+  return (
+    <button
+      onClick={toggle}
+      style={{
+        display: 'inline-flex', alignItems: 'center', gap: 8,
+        background: following ? NAVY : '#fff',
+        border: `1px solid ${following ? NAVY : LINE}`,
+        color: following ? '#fff' : NAVY,
+        padding: '12px 22px', borderRadius: 9, fontWeight: 600,
+        fontSize: 15, cursor: 'pointer',
+      }}
+    >
+      <svg width="14" height="14" viewBox="0 0 24 24" fill={following ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M12 21s-7-5.6-7-11a7 7 0 0 1 14 0c0 5.4-7 11-7 11Z" />
+      </svg>
+      {following ? 'Député suivi' : 'Suivre ce député'}
+    </button>
+  )
+}

--- a/frontend/src/components/FollowDeputyButton.tsx
+++ b/frontend/src/components/FollowDeputyButton.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { getFollowedDeputyId, setFollowedDeputyId, clearFollowedDeputyId } from '@/lib/mon-depute'
 
@@ -8,7 +8,14 @@ const LINE = '#E4E6EA'
 
 export function FollowDeputyButton({ deputyId }: { deputyId: string }) {
   const router = useRouter()
-  const [following, setFollowing] = useState(() => getFollowedDeputyId() === deputyId)
+  // Starts false to match the server render (localStorage is unavailable server-side);
+  // the effect corrects it after mount via a microtask so React treats it as an
+  // async update rather than a synchronous one, avoiding a hydration mismatch.
+  const [following, setFollowing] = useState(false)
+
+  useEffect(() => {
+    Promise.resolve().then(() => setFollowing(getFollowedDeputyId() === deputyId))
+  }, [deputyId])
 
   function toggle() {
     if (following) {

--- a/frontend/src/components/FollowedDeputyChip.tsx
+++ b/frontend/src/components/FollowedDeputyChip.tsx
@@ -1,0 +1,33 @@
+'use client'
+import { useState, useEffect } from 'react'
+import Link from 'next/link'
+import { api } from '@/lib/api'
+import { getFollowedDeputyId } from '@/lib/mon-depute'
+
+export function FollowedDeputyChip() {
+  const [name, setName] = useState<string | null>(null)
+
+  useEffect(() => {
+    const id = getFollowedDeputyId()
+    if (!id) return
+    let cancelled = false
+    api.deputies.get(id).then(d => {
+      if (!cancelled) setName(d.full_name)
+    }).catch(() => {})
+    return () => { cancelled = true }
+  }, [])
+
+  if (!name) return null
+
+  return (
+    <Link
+      href="/mon-depute"
+      className="flex items-center gap-1.5 text-xs font-medium text-navy bg-navy-muted px-3 py-1.5 rounded-full hover:opacity-80 transition-opacity"
+    >
+      <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M12 21s-7-5.6-7-11a7 7 0 0 1 14 0c0 5.4-7 11-7 11Z" />
+      </svg>
+      {name}
+    </Link>
+  )
+}

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { MonEluLogo } from './MonEluLogo'
 import { GlobalSearch } from './GlobalSearch'
+import { FollowedDeputyChip } from './FollowedDeputyChip'
 
 export const NAV_HEIGHT_PX = 64
 
@@ -40,6 +41,7 @@ export function Nav() {
         })}
       </div>
       <div className="flex items-center gap-4">
+        <FollowedDeputyChip />
         <GlobalSearch />
         <a href="https://monelu-production.up.railway.app/docs"
           target="_blank"

--- a/frontend/src/components/VoteTimelineItem.tsx
+++ b/frontend/src/components/VoteTimelineItem.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link'
+import type { DeputyVoteItem } from '@/lib/api'
+import { formatDate } from '@/lib/utils'
+import { positionStyle } from '@/lib/vote-position'
+
+const NAVY = '#1B2B50'
+
+type Props = {
+  vote: DeputyVoteItem
+  dotBorderColor: string
+}
+
+export function VoteTimelineItem({ vote: v, dotBorderColor }: Props) {
+  const pos = positionStyle(v.position)
+  return (
+    <div style={{ position: 'relative' }}>
+      {/* Dot */}
+      <span style={{
+        position: 'absolute', left: -32, top: 5,
+        width: 13, height: 13, borderRadius: 999,
+        background: pos.color,
+        border: `3px solid ${dotBorderColor}`,
+        boxShadow: `0 0 0 1px ${pos.color}`,
+      }} />
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap' }}>
+        {v.voted_at && (
+          <span className="font-mono" style={{ fontSize: 12.5, color: '#9CA3AF', letterSpacing: '0.02em' }}>
+            {formatDate(v.voted_at)}
+          </span>
+        )}
+        <span style={{
+          fontSize: 12.5, fontWeight: 700, letterSpacing: '0.04em',
+          padding: '4px 12px', borderRadius: 999,
+          color: pos.color, background: pos.bg,
+        }}>
+          {pos.label}
+        </span>
+        {v.result && (
+          <span style={{ fontSize: 12, color: '#9CA3AF' }}>
+            Scrutin : {v.result}
+          </span>
+        )}
+      </div>
+
+      <Link href={`/votes/${v.vote_id}`} style={{ textDecoration: 'none' }}>
+        <div className="font-newsreader text-[21px]" style={{ color: NAVY, marginTop: 8, lineHeight: 1.3, cursor: 'pointer' }}>
+          {v.vote_title}
+        </div>
+      </Link>
+
+      {v.summary_plain && (
+        <div style={{ fontSize: 14.5, color: '#4B5563', lineHeight: 1.55, marginTop: 5, maxWidth: 680, fontStyle: 'italic' }}>
+          {v.summary_plain}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -85,7 +85,7 @@ export type DeputyVoteItem = {
   vote_title: string
   result: string | null
   position: string
-  summary_plain?: string | null
+  summary_plain: string | null
 }
 
 export type DeputyVotesResponse = {
@@ -146,8 +146,11 @@ export const api = {
     get: (id: string) => apiFetch<Deputy>(`/deputies/${id}/`, { revalidate: 86400 }),
     scorecard: (id: string) => apiFetch<Scorecard>(`/deputies/${id}/scorecard/`, { revalidate: 86400 }),
     stats: () => apiFetch<DeputyStats>('/deputies/stats/', { revalidate: 3600 }),
-    votes: (id: string, limit = 10) =>
-      apiFetch<DeputyVotesResponse>(`/deputies/${id}/votes/?limit=${limit}`, { revalidate: 86400 }),
+    votes: (id: string, limit = 10, since?: string) => {
+      const q = new URLSearchParams({ limit: String(limit) })
+      if (since) q.set('since', since)
+      return apiFetch<DeputyVotesResponse>(`/deputies/${id}/votes/?${q}`, { revalidate: since ? 0 : 86400 })
+    },
     alignment: (id: string) =>
       apiFetch<Alignment>(`/deputies/${id}/alignment/`, { revalidate: 86400 }),
     dissidentVotes: (id: string, limit = 10) =>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -149,7 +149,7 @@ export const api = {
     votes: (id: string, limit = 10, since?: string) => {
       const q = new URLSearchParams({ limit: String(limit) })
       if (since) q.set('since', since)
-      return apiFetch<DeputyVotesResponse>(`/deputies/${id}/votes/?${q}`, { revalidate: since ? 0 : 86400 })
+      return apiFetch<DeputyVotesResponse>(`/deputies/${id}/votes/?${q}`, { revalidate: 86400 })
     },
     alignment: (id: string) =>
       apiFetch<Alignment>(`/deputies/${id}/alignment/`, { revalidate: 86400 }),

--- a/frontend/src/lib/mon-depute.ts
+++ b/frontend/src/lib/mon-depute.ts
@@ -1,0 +1,41 @@
+// Persists the visitor's chosen deputy across sessions - no accounts, same
+// localStorage-only pattern as the chat conversation history (see
+// app/chat/page.tsx). lastSeenAt is per-deputy so switching deputies doesn't
+// carry over a stale "since last visit" cutoff.
+
+const DEPUTY_KEY = 'monelu-followed-deputy'
+const LAST_SEEN_PREFIX = 'monelu-last-seen-'
+
+export function getFollowedDeputyId(): string | null {
+  try {
+    return localStorage.getItem(DEPUTY_KEY)
+  } catch {
+    return null
+  }
+}
+
+export function setFollowedDeputyId(deputyId: string): void {
+  try {
+    localStorage.setItem(DEPUTY_KEY, deputyId)
+  } catch {}
+}
+
+export function clearFollowedDeputyId(): void {
+  try {
+    localStorage.removeItem(DEPUTY_KEY)
+  } catch {}
+}
+
+export function getLastSeenAt(deputyId: string): string | null {
+  try {
+    return localStorage.getItem(LAST_SEEN_PREFIX + deputyId)
+  } catch {
+    return null
+  }
+}
+
+export function setLastSeenAt(deputyId: string, iso: string): void {
+  try {
+    localStorage.setItem(LAST_SEEN_PREFIX + deputyId, iso)
+  } catch {}
+}

--- a/frontend/src/lib/vote-position.ts
+++ b/frontend/src/lib/vote-position.ts
@@ -1,0 +1,14 @@
+const RED = '#C9302A'
+
+export const POS = {
+  pour:       { label: 'Pour',       color: '#1F8A5B', bg: '#EAF5EF' },
+  contre:     { label: 'Contre',     color: RED,        bg: '#FBE9E7' },
+  abstention: { label: 'Abstention', color: '#6B7280',  bg: '#F0F1F3' },
+  nonVotant:  { label: 'Non votant', color: '#9CA3AF',  bg: '#F5F6F7' },
+} as const
+
+export type VotePositionKey = keyof typeof POS
+
+export function positionStyle(position: string) {
+  return POS[position as VotePositionKey] ?? POS.nonVotant
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -209,6 +209,45 @@ def test_get_dissident_votes_empty(client, mock_cursor):
     assert data["items"] == []
 
 
+def test_get_deputy_votes_includes_summary_plain(client, mock_cursor):
+    mock_cursor.fetchone.return_value = {"count": 1}
+    mock_cursor.fetchall.return_value = [
+        {
+            "vote_id": "VTANR5L17V1",
+            "voted_at": "2024-07-16T15:00:00",
+            "vote_title": "Vote sur le projet de loi de finances",
+            "result": "adopté",
+            "position": "pour",
+            "summary_plain": "Ce texte prévoit...",
+        }
+    ]
+    resp = client.get("/deputies/PA1/votes")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["items"][0]["summary_plain"] == "Ce texte prévoit..."
+
+
+def test_get_deputy_votes_since_filter(client, mock_cursor):
+    mock_cursor.fetchone.return_value = {"count": 5}
+    mock_cursor.fetchall.return_value = [
+        {
+            "vote_id": "VTANR5L17V2",
+            "voted_at": "2026-07-05T15:00:00",
+            "vote_title": "Vote récent",
+            "result": "adopté",
+            "position": "contre",
+            "summary_plain": None,
+        }
+    ]
+    resp = client.get("/deputies/PA1/votes?since=2026-07-01T00:00:00")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 5
+    assert len(data["items"]) == 1
+    executed_sql = mock_cursor.execute.call_args_list[-1].args[0]
+    assert "v.voted_at > %s" in executed_sql
+
+
 # ---------------------------------------------------------------------------
 # Votes
 # ---------------------------------------------------------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -239,13 +239,27 @@ def test_get_deputy_votes_since_filter(client, mock_cursor):
             "summary_plain": None,
         }
     ]
-    resp = client.get("/deputies/PA1/votes?since=2026-07-01T00:00:00")
+    resp = client.get("/deputies/PA1/votes?since=2026-07-01T00:00:00&limit=5")
+    assert resp.status_code == 200
+    data = resp.json()
+    # total reflects the unfiltered count (pre-existing pagination semantics on
+    # this endpoint); only items are narrowed by since.
+    assert data["total"] == 5
+    assert len(data["items"]) == 1
+    # The SELECT (last execute call) must carry deputy_id, the decoded since
+    # timestamp, and the limit — in that order.
+    select_params = mock_cursor.execute.call_args_list[-1].args[1]
+    assert select_params == ["PA1", datetime(2026, 7, 1, 0, 0, 0), 5]
+
+
+def test_get_deputy_votes_since_in_the_future_returns_no_items(client, mock_cursor):
+    mock_cursor.fetchone.return_value = {"count": 5}
+    mock_cursor.fetchall.return_value = []
+    resp = client.get("/deputies/PA1/votes?since=2099-01-01T00:00:00")
     assert resp.status_code == 200
     data = resp.json()
     assert data["total"] == 5
-    assert len(data["items"]) == 1
-    executed_sql = mock_cursor.execute.call_args_list[-1].args[0]
-    assert "v.voted_at > %s" in executed_sql
+    assert data["items"] == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Implements the "Mon député" personalized dashboard (MON-90): a visitor follows a deputy once (from their profile page) and gets a persistent `/mon-depute` page with recent votes, presence, party alignment, and a "since your last visit" diff - all via localStorage, no accounts (same pattern as the chat conversation history).
- Entry points: "Suivre ce député" CTA on the deputy profile page, and a pinned chip in the top nav linking back to `/mon-depute`.
- Extracts `VoteTimelineItem` and the vote-position style map out of the deputy profile page so both pages render vote items identically instead of duplicating ~40 lines of JSX.

Stacked on #172 (backend `since` filter). This PR's diff will shrink to just the frontend changes once #172 merges.

## New files
- `frontend/src/lib/mon-depute.ts` - followed-deputy + per-deputy last-seen persistence
- `frontend/src/components/FollowDeputyButton.tsx`, `FollowedDeputyChip.tsx` - entry points
- `frontend/src/lib/vote-position.ts`, `frontend/src/components/VoteTimelineItem.tsx` - shared vote rendering
- `frontend/src/app/mon-depute/page.tsx` - the dashboard

## Test plan
- [x] `npx jest` - 48 tests passed (added coverage for the persistence lib and the `since` param passthrough in the api client)
- [x] `npx tsc --noEmit` and `npx eslint` clean on all touched/new files
- [x] `npx next build` succeeds (aside from a pre-existing, unrelated `/sitemap.xml` prerender failure caused by live-API rate limiting during the build, not introduced by this change)
- [ ] Manual: follow a deputy from their profile, confirm the nav chip and `/mon-depute` render correctly, reload to confirm persistence, and verify the "since last visit" section on a second visit