### PR TITLE
perf: materialize int_party_vote_majority as a table

### DIFF
--- a/transform/models/intermediate/int_party_vote_majority.sql
+++ b/transform/models/intermediate/int_party_vote_majority.sql
@@ -1,3 +1,10 @@
+{{
+    config(
+        materialized='table',
+        indexes=[{'columns': ['vote_id', 'party'], 'unique': true}]
+    )
+}}
+
 with position_counts as (
     select
         d.party,

--- a/transform/models/intermediate/schema.yml
+++ b/transform/models/intermediate/schema.yml
@@ -8,6 +8,11 @@ models:
       excluded by design. Parties that cast exclusively nonvotant on a given
       vote produce no row, and those deputies are excluded from
       mart_party_alignment totals for that vote.
+
+      Materialized as a table (overriding the intermediate-layer view
+      default) because the API queries it directly for GET
+      /{deputy_id}/dissident-votes — as a view it recomputed a full join of
+      vote_positions x deputies on every request (MON-118).
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns: [party, vote_id]


### PR DESCRIPTION
## What
Materializes `int_party_vote_majority` as a dbt table (with a supporting unique index on `(vote_id, party)`) instead of the intermediate-layer default view.

## Why
`GET /{deputy_id}/dissident-votes` (`api/routers/deputies.py`) queries `analytics_intermediate.int_party_vote_majority` directly, twice per request (a `COUNT(*)` and a paginated `SELECT`). As a view, every one of those queries re-executed a full join of `vote_positions` x `deputies` (~715k rows) and re-aggregated majority positions for the entire chamber, even though the result is identical for all 577 deputies. This made the deputy detail page slow to load on the frontend.

Closes MON-118 (https://linear.app/monelu/issue/MON-118/deputy-detail-page-is-slow-to-load-dissident-votes-query-recomputes-a)

## Changes
- `transform/models/intermediate/int_party_vote_majority.sql`: added a `config()` block overriding materialization to `table` and adding a unique index on `(vote_id, party)` (matching the existing `dbt_utils.unique_combination_of_columns` test on those columns), since the API now reads this table directly in a hot path.
- `transform/models/intermediate/schema.yml`: documented why this one intermediate model deviates from the view-by-default convention.

## Testing
- Not run locally: no DB creds available in this environment, and the local dbt/Python 3.14 toolchain has an unrelated pre-existing incompatibility that blocks even `dbt parse`.
- CI's `ci.yml` runs `dbt compile` + `dbt test` against a live Postgres on every PR, validating the model builds and the existing tests on `int_party_vote_majority` still pass.
- Manual validation not performed — recommend a before/after page-load timing check on `/deputes/[id]` after merge.

## Risks / Notes
- The next `dbt run` on merge will rebuild this model as a table for the first time — a one-time build cost, no ongoing risk.
- `mart_party_alignment` reads from this model via `ref()`; materializing it as a table only speeds up that mart's build, no output change.
- Frontend streaming/Suspense improvements noted in MON-118 are a secondary follow-up, out of scope here.

## Breaking Changes
None. Same columns, same semantics — only the storage/materialization strategy changes.