### PR TITLE
fix: resolve all E501 line-length violations and enforce the rule (MON-79)

### DIFF
--- a/api/limiter.py
+++ b/api/limiter.py
@@ -24,7 +24,10 @@ def rate_limit_key(request: Request) -> str:
 
 
 def tiered_limit(base_per_minute: int):
-    """Build a dynamic slowapi limit: anonymous keeps `base`, keyed requests get base * multiplier."""
+    """Build a dynamic slowapi limit.
+
+    Anonymous requests keep `base`; keyed requests get base * multiplier.
+    """
 
     def _limit(key: str) -> str:
         if key.startswith("apikey:"):

--- a/api/routers/search.py
+++ b/api/routers/search.py
@@ -71,7 +71,10 @@ def search(request: Request, body: SearchRequest):
     except groq.APITimeoutError as e:
         raise HTTPException(
             status_code=504,
-            detail="Le service de recherche est temporairement indisponible. Réessayez dans quelques secondes.",
+            detail=(
+                "Le service de recherche est temporairement indisponible. "
+                "Réessayez dans quelques secondes."
+            ),
         ) from e
     except Exception:
         logger.exception("RAG pipeline error for question %r", body.question)

--- a/api/routers/votes.py
+++ b/api/routers/votes.py
@@ -70,7 +70,8 @@ def list_votes(
                 if search:
                     conditions.append(
                         sql.SQL(
-                            "to_tsvector('french', vote_title || ' ' || coalesce(summary_plain, ''))"
+                            "to_tsvector('french', vote_title || ' ' "
+                            "|| coalesce(summary_plain, ''))"
                             " @@ plainto_tsquery('french', %s)"
                         )
                     )

--- a/quality/expectations/votes_suite.py
+++ b/quality/expectations/votes_suite.py
@@ -16,7 +16,8 @@ def get_votes_suite() -> gx.ExpectationSuite:
     suite.add_expectation(gx.expectations.ExpectColumnToExist(column="dateScrutin"))
     suite.add_expectation(gx.expectations.ExpectColumnToExist(column="sort"))
     suite.add_expectation(gx.expectations.ExpectColumnValuesToNotBeNull(column="dateScrutin"))
-    # "sort" in raw Bronze data is a dict {"code": "adopté", ...} — values check applies to parsed data only
+    # "sort" in raw Bronze data is a dict {"code": "adopté", ...} — values
+    # check applies to parsed data only
     return suite
 
 

--- a/rag/chain/prompts.py
+++ b/rag/chain/prompts.py
@@ -72,7 +72,8 @@ SUMMARY_PROMPT = (
     'Réponds UNIQUEMENT avec un objet JSON valide: {"summary": "...", "theme": "..."}\n\n'
     "Theme doit être EXACTEMENT l'un de :\n"
     "Économie & Budget | Santé & Social | Justice & Sécurité | Énergie & Environnement | "
-    "Éducation & Culture | Agriculture | Transport & Logement | Institutions | International | Autre"
+    "Éducation & Culture | Agriculture | Transport & Logement | Institutions | "
+    "International | Autre"
 )
 
 SUMMARY_PROMPT_PROCEDURAL = (
@@ -85,7 +86,8 @@ SUMMARY_PROMPT_PROCEDURAL = (
     'Réponds UNIQUEMENT avec un objet JSON valide: {"summary": "...", "theme": "..."}\n\n'
     "Theme doit être EXACTEMENT l'un de :\n"
     "Économie & Budget | Santé & Social | Justice & Sécurité | Énergie & Environnement | "
-    "Éducation & Culture | Agriculture | Transport & Logement | Institutions | International | Autre"
+    "Éducation & Culture | Agriculture | Transport & Logement | Institutions | "
+    "International | Autre"
 )
 
 RAG_TEMPLATE = """Sources disponibles :

--- a/rag/chain/rag_chain.py
+++ b/rag/chain/rag_chain.py
@@ -114,7 +114,6 @@ if __name__ == "__main__":
         result = ask(q)
         print(f"\nQ: {q}")
         print(f"A: {result['answer']}")
-        print(
-            f"Sources: {result['chunks_retrieved']} chunks, top similarity: {result['sources'][0]['similarity']:.3f}"
-        )
+        top_similarity = result["sources"][0]["similarity"]
+        print(f"Sources: {result['chunks_retrieved']} chunks, top similarity: {top_similarity:.3f}")
         print("---")

--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -546,7 +546,8 @@ FORMATTERS = {
     ),
     "deputy_by_department": lambda rows: (
         (
-            f"{len(rows)} député(s) dans les {CODE_TO_DEPT_NAME.get(rows[0]['department'], rows[0]['department'])} "
+            f"{len(rows)} député(s) dans les "
+            f"{CODE_TO_DEPT_NAME.get(rows[0]['department'], rows[0]['department'])} "
             f"(département {rows[0]['department']}) :\n"
             + "\n".join(f"- {r['full_name']} ({r['party'] or 'parti non renseigné'})" for r in rows)
         )
@@ -717,7 +718,10 @@ def detect_intent(question: str) -> str | None:
 
 
 def run_sql_query(intent: str, params: dict | None = None) -> list[dict]:
-    """Run the SQL query for a detected intent. Returns [] on any failure so route() falls back to RAG."""
+    """Run the SQL query for a detected intent.
+
+    Returns [] on any failure so route() falls back to RAG.
+    """
     sql = SQL_QUERIES.get(intent)
     if not sql:
         return []

--- a/rag/experiments/mlflow_eval.py
+++ b/rag/experiments/mlflow_eval.py
@@ -321,15 +321,15 @@ if __name__ == "__main__":
     print("\n" + "=" * 46)
     print("  MonÉlu RAG — Phase B Results")
     print("=" * 46)
+    n_questions = len(results["phase_a_k5"]["per_question"])
+    print(f"  Phase A (cosine, {n_questions} questions):  {results['phase_a_k5']['score']:.3f}")
     print(
-        f"  Phase A (cosine, {len(results['phase_a_k5']['per_question'])} questions):  {results['phase_a_k5']['score']:.3f}"
-    )
-    print(
-        f"  Phase B (hybrid BM25):           {results['phase_b_hybrid']['score']:.3f}  ← regression, reverted"
+        f"  Phase B (hybrid BM25):           {results['phase_b_hybrid']['score']:.3f}"
+        "  ← regression, reverted"
     )
     print(f"  Phase B (cosine + B2 + B3):      {results['phase_b_final']['score']:.3f}")
     print(
-        f"  SQL routed questions:             {results['phase_a_k5']['sql_routed']}/{len(results['phase_a_k5']['per_question'])}"
+        f"  SQL routed questions:             {results['phase_a_k5']['sql_routed']}/{n_questions}"
     )
     print(f"  Routing accuracy:                 {results['phase_a_k5']['routing_accuracy']:.3f}")
     print("=" * 46)

--- a/rag/pipeline/chunk_law_summaries.py
+++ b/rag/pipeline/chunk_law_summaries.py
@@ -84,7 +84,8 @@ def build_law_chunk(vote: dict, breakdown: list[dict]) -> str:
     ]
     for p in breakdown:
         lines.append(
-            f"- {p['party']} : {p['pour']} pour, {p['contre']} contre, {p['abstention']} abstentions"
+            f"- {p['party']} : {p['pour']} pour, {p['contre']} contre, "
+            f"{p['abstention']} abstentions"
         )
     return "\n".join(lines)
 

--- a/rag/pipeline/chunk_notable_deputies.py
+++ b/rag/pipeline/chunk_notable_deputies.py
@@ -210,12 +210,15 @@ def build_notable_deputy_index(n: int = 100) -> dict:
                                COUNT(vp.position_id) as total_votes,
                                COUNT(vp.position_id) FILTER (WHERE vp.position='pour') as pour,
                                COUNT(vp.position_id) FILTER (WHERE vp.position='contre') as contre,
-                               COUNT(vp.position_id) FILTER (WHERE vp.position='abstention') as abstention,
+                               COUNT(vp.position_id) FILTER (
+                                   WHERE vp.position='abstention'
+                               ) as abstention,
                                -- canonical presence — see docs/decisions.md
                                ROUND(LEAST(
                                    COUNT(vp.position_id)::numeric / NULLIF((
                                        SELECT COUNT(*) FROM votes v
-                                       WHERE (d.mandate_start IS NULL OR v.voted_at >= d.mandate_start)
+                                       WHERE (d.mandate_start IS NULL
+                                              OR v.voted_at >= d.mandate_start)
                                          AND (d.mandate_end IS NULL OR v.voted_at <= d.mandate_end)
                                    ), 0),
                                    1

--- a/rag/pipeline/chunker.py
+++ b/rag/pipeline/chunker.py
@@ -140,9 +140,11 @@ def chunk_deputies(deputy_ids: set[str] | None = None) -> list[dict]:
     _DEPUTY_SELECT = """
                 SELECT d.deputy_id, d.full_name, d.party, d.department,
                        COUNT(vp.position_id) AS total_votes,
-                       COUNT(vp.position_id) FILTER (WHERE vp.position = 'pour')       AS pour_count,
-                       COUNT(vp.position_id) FILTER (WHERE vp.position = 'contre')     AS contre_count,
-                       COUNT(vp.position_id) FILTER (WHERE vp.position = 'abstention') AS abstention_count,
+                       COUNT(vp.position_id) FILTER (WHERE vp.position = 'pour') AS pour_count,
+                       COUNT(vp.position_id) FILTER (WHERE vp.position = 'contre') AS contre_count,
+                       COUNT(vp.position_id) FILTER (
+                           WHERE vp.position = 'abstention'
+                       ) AS abstention_count,
                        -- canonical presence: all recorded positions (incl.
                        -- nonVotant) over votes during the mandate window —
                        -- see docs/decisions.md
@@ -239,9 +241,11 @@ def chunk_party_summaries() -> list[dict]:
                 party_positions AS (
                     SELECT
                         d.party,
-                        COUNT(vp.position_id) FILTER (WHERE vp.position = 'pour')       AS total_pour,
-                        COUNT(vp.position_id) FILTER (WHERE vp.position = 'contre')     AS total_contre,
-                        COUNT(vp.position_id) FILTER (WHERE vp.position = 'abstention') AS total_abstention
+                        COUNT(vp.position_id) FILTER (WHERE vp.position = 'pour') AS total_pour,
+                        COUNT(vp.position_id) FILTER (WHERE vp.position = 'contre') AS total_contre,
+                        COUNT(vp.position_id) FILTER (
+                            WHERE vp.position = 'abstention'
+                        ) AS total_abstention
                     FROM deputies d
                     LEFT JOIN vote_positions vp ON d.deputy_id = vp.deputy_id
                     WHERE d.party IS NOT NULL
@@ -407,9 +411,10 @@ def chunk_notable_deputies() -> list[dict]:
                     d.full_name, d.party, d.department,
                     v.vote_id, v.vote_title, v.voted_at, v.result, vp.position,
                     CASE
-                        WHEN v.vote_title ILIKE '%%financement de la sécurité sociale%%' THEN 'plfss'
-                        WHEN v.vote_title ILIKE '%%projet de loi de finances%%'           THEN 'plf'
-                        WHEN v.vote_title ILIKE '%%motion de censure%%'                   THEN 'censure'
+                        WHEN v.vote_title ILIKE '%%financement de la sécurité sociale%%'
+                            THEN 'plfss'
+                        WHEN v.vote_title ILIKE '%%projet de loi de finances%%' THEN 'plf'
+                        WHEN v.vote_title ILIKE '%%motion de censure%%' THEN 'censure'
                         ELSE NULL
                     END AS key_category,
                     ROW_NUMBER() OVER (
@@ -418,9 +423,10 @@ def chunk_notable_deputies() -> list[dict]:
                     ROW_NUMBER() OVER (
                         PARTITION BY vp.deputy_id,
                         CASE
-                            WHEN v.vote_title ILIKE '%%financement de la sécurité sociale%%' THEN 'plfss'
-                            WHEN v.vote_title ILIKE '%%projet de loi de finances%%'           THEN 'plf'
-                            WHEN v.vote_title ILIKE '%%motion de censure%%'                   THEN 'censure'
+                            WHEN v.vote_title ILIKE '%%financement de la sécurité sociale%%'
+                                THEN 'plfss'
+                            WHEN v.vote_title ILIKE '%%projet de loi de finances%%' THEN 'plf'
+                            WHEN v.vote_title ILIKE '%%motion de censure%%' THEN 'censure'
                             ELSE NULL
                         END
                         ORDER BY v.voted_at DESC

--- a/rag/pipeline/index_manager.py
+++ b/rag/pipeline/index_manager.py
@@ -98,7 +98,8 @@ def build_index(since: str | None = None) -> None:
 
     if new_vote_ids:
         print(
-            f"New votes to index: {len(new_vote_ids)}  Affected deputies: {len(affected_deputy_ids)}"
+            f"New votes to index: {len(new_vote_ids)}  "
+            f"Affected deputies: {len(affected_deputy_ids)}"
         )
         chunks += chunk_votes(vote_ids=new_vote_ids)
         # Delete stale deputy chunks and rebuild for affected deputies only
@@ -128,7 +129,8 @@ def _delete_chunks_by_ids(chunk_type: str, id_key: str, ids: set[str]) -> None:
     try:
         with conn.cursor() as cur:
             cur.execute(
-                "DELETE FROM document_chunks WHERE metadata->>'chunk_type' = %s AND metadata->>%s = ANY(%s)",
+                "DELETE FROM document_chunks "
+                "WHERE metadata->>'chunk_type' = %s AND metadata->>%s = ANY(%s)",
                 (chunk_type, id_key, list(ids)),
             )
         conn.commit()

--- a/ruff.toml
+++ b/ruff.toml
@@ -3,7 +3,7 @@ target-version = "py311"
 
 [lint]
 select = [
-    "E",   # pycodestyle errors
+    "E",   # pycodestyle errors (includes E501 line-length, enforced — see MON-79)
     "W",   # pycodestyle warnings
     "F",   # pyflakes (unused imports, undefined names)
     "I",   # isort
@@ -11,7 +11,6 @@ select = [
     "T20", # flake8-print (no stray print() in library code)
 ]
 ignore = [
-    "E501", # line too long — handled by ruff-format
     "B008", # do not perform function calls in default args (FastAPI uses this pattern)
 ]
 

--- a/scripts/create_dbt_profile.py
+++ b/scripts/create_dbt_profile.py
@@ -24,5 +24,6 @@ profile = {
 
 pathlib.Path("transform/profiles.yml").write_text(yaml.safe_dump(profile))
 print(
-    f"transform/profiles.yml written (host={os.environ['DBT_HOST']}, dbname={os.environ['DBT_DBNAME']})"
+    f"transform/profiles.yml written "
+    f"(host={os.environ['DBT_HOST']}, dbname={os.environ['DBT_DBNAME']})"
 )

--- a/scripts/ingest_deputies.py
+++ b/scripts/ingest_deputies.py
@@ -122,7 +122,8 @@ def parse_deputy(item: dict) -> dict | None:
         circonscription = place.get("numCirco")
         department = place.get("numDepartement")
 
-        # Party (groupe politique) — separate call not available inline; store organeRef as party_short
+        # Party (groupe politique) — separate call not available inline;
+        # store organeRef as party_short
         party = None
         party_short = organe_ref
 

--- a/scripts/ingest_positions.py
+++ b/scripts/ingest_positions.py
@@ -152,7 +152,10 @@ def main() -> None:
     parser.add_argument(
         "--since",
         default=None,
-        help="Only ingest positions for votes on/after this date (YYYY-MM-DD). Default: all known votes.",
+        help=(
+            "Only ingest positions for votes on/after this date (YYYY-MM-DD). "
+            "Default: all known votes."
+        ),
     )
     parser.add_argument(
         "--zip-path",

--- a/scripts/ingest_votes.py
+++ b/scripts/ingest_votes.py
@@ -48,7 +48,10 @@ SCRUTINS_ZIP_PATH = "/static/openData/repository/17/loi/scrutins/Scrutins.json.z
 
 
 def fetch_all_scrutins(since: str | None = None, zip_path: str | None = None) -> list[dict]:
-    """Load scrutins from a local ZIP (zip_path) or download one, filtered to dateScrutin >= since."""
+    """Load scrutins from a local ZIP (zip_path) or download one.
+
+    Filtered to dateScrutin >= since.
+    """
     if zip_path:
         log.info("Reading scrutins ZIP from %s…", zip_path)
         with open(zip_path, "rb") as fh:

--- a/scripts/purge_test_fixtures.py
+++ b/scripts/purge_test_fixtures.py
@@ -42,9 +42,13 @@ STATEMENTS = [
     (
         "document_chunks of fixture votes",
         """SELECT COUNT(*) FROM document_chunks
-           WHERE metadata->>'vote_id' IN (SELECT vote_id FROM votes WHERE vote_title LIKE %(title)s)""",
+           WHERE metadata->>'vote_id' IN (
+               SELECT vote_id FROM votes WHERE vote_title LIKE %(title)s
+           )""",
         """DELETE FROM document_chunks
-           WHERE metadata->>'vote_id' IN (SELECT vote_id FROM votes WHERE vote_title LIKE %(title)s)""",
+           WHERE metadata->>'vote_id' IN (
+               SELECT vote_id FROM votes WHERE vote_title LIKE %(title)s
+           )""",
     ),
     (
         "document_chunks of fixture deputies",

--- a/scripts/update_party.py
+++ b/scripts/update_party.py
@@ -200,7 +200,8 @@ def print_summary(conn) -> None:
 
         print("\n  Top 10 departments:")
         cur.execute(
-            "SELECT department, COUNT(*) as n FROM deputies GROUP BY department ORDER BY n DESC LIMIT 10"
+            "SELECT department, COUNT(*) as n FROM deputies "
+            "GROUP BY department ORDER BY n DESC LIMIT 10"
         )
         for r in cur.fetchall():
             print(f"    {(r['department'] or 'NULL'):<35}  {r['n']}")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -307,7 +307,8 @@ def db_conn():
                 INSERT INTO analytics_intermediate.int_party_vote_majority
                     (party, vote_id, majority_position)
                 VALUES ('Rassemblement National', %(vote_id)s, %(majority)s)
-                ON CONFLICT (party, vote_id) DO UPDATE SET majority_position = EXCLUDED.majority_position
+                ON CONFLICT (party, vote_id)
+                    DO UPDATE SET majority_position = EXCLUDED.majority_position
                 """,
                 {"vote_id": v["vote_id"], "majority": majority},
             )
@@ -316,7 +317,8 @@ def db_conn():
                 INSERT INTO analytics_intermediate.int_party_vote_majority
                     (party, vote_id, majority_position)
                 VALUES ('La France Insoumise', %(vote_id)s, 'contre')
-                ON CONFLICT (party, vote_id) DO UPDATE SET majority_position = EXCLUDED.majority_position
+                ON CONFLICT (party, vote_id)
+                    DO UPDATE SET majority_position = EXCLUDED.majority_position
                 """,
                 {"vote_id": v["vote_id"]},
             )

--- a/tests/unit/test_integration_conftest_guard.py
+++ b/tests/unit/test_integration_conftest_guard.py
@@ -14,12 +14,14 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "integration"))
 
 from conftest import _assert_safe_test_database  # noqa: E402
 
+_SUPABASE_URL = (
+    "postgresql://postgres:pw@db.example.supabase.co:5432/postgres"  # pragma: allowlist secret
+)
+
 
 def test_rejects_supabase_host():
     with pytest.raises(pytest.fail.Exception):
-        _assert_safe_test_database(
-            "postgresql://postgres:pw@db.example.supabase.co:5432/postgres"  # pragma: allowlist secret
-        )
+        _assert_safe_test_database(_SUPABASE_URL)
 
 
 def test_rejects_unknown_remote_host():


### PR DESCRIPTION
## What

Fixes every `E501` (line too long) violation in the codebase and enables the rule permanently in `ruff.toml`, closing MON-79.

## Why

MON-79 was filed against 4 known violations, with the intent of keeping the lint gate meaningful ("zero known lint debt") and optionally enforcing `E501` afterward.
By the time this was picked up the codebase had drifted to 38 violations across 20 files — `E501` was in `ruff.toml`'s `ignore` list, so `ruff check .` never caught new ones.
The acceptance criteria is explicit: `ruff check --select E501 .` reports zero violations, and a decision is recorded on whether the rule stays enforced.

## Changes

- Reflowed all 38 over-length lines: docstrings split onto multiple lines, long f-strings and SQL literals broken into adjacent string-literal concatenation, over-length comments wrapped. No logic changes — purely formatting/string-splitting.
- `ruff.toml`: removed `E501` from `ignore`, with a comment pointing at MON-79. `E501` is now enforced by `ruff check .` going forward.
- `tests/unit/test_integration_conftest_guard.py`: extracted the long Supabase test URL into a module-level constant, keeping the `# pragma: allowlist secret` inline comment on the same line as the literal (required for `detect-secrets` to recognize the allowlist).
- Ran `ruff format .` afterward to normalize wrapping in `rag/chain/sql_router.py` and `rag/experiments/mlflow_eval.py`.

## Testing

- `ruff check --select E501 .` — zero violations.
- `ruff check .` (full rule set, with `E501` now enabled) — all checks passed.
- `ruff format --check .` — all 80 files formatted.
- `detect-secrets-hook --baseline .secrets.baseline <changed files>` — passed (verified the relocated Supabase test URL still gets allowlisted correctly).
- `python3 -m py_compile` on all 20 touched files — all parse cleanly.
- Manually traced every multi-line string/SQL concatenation to confirm no words got glued together or whitespace lost (e.g. the `to_tsvector` query in `api/routers/votes.py`).
- Did not run the full pytest suite locally (no local venv with project deps installed); relying on CI's `lint-and-test` job, which installs `requirements*.txt` and runs both unit and integration tiers.

## Risks / Notes

- Purely mechanical formatting change; no behavior should differ. The one non-string change is `rag/chain/rag_chain.py`, where a repeated dict lookup (`result['sources'][0]['similarity']`) was hoisted into a local variable to shorten the print line — same value, same output.
- `E501` is now enforced repo-wide, so any future PR with a line over 100 chars will fail CI lint. This is the intended outcome per the issue's acceptance criteria.

## Breaking Changes

None.
