### PR TITLE
feat: public methodology page (MON-112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Lint config: `ruff.toml` — line length 100, `T201` (print) allowed in `scripts
 
 ## Data Notes
 
-- **`nonVotant` ≠ `abstention`** — present in chamber but did not vote; excluded from `presence_rate`
+- **`nonVotant` ≠ `abstention`** — present in chamber but did not vote; counts *toward* `presence_rate` (a nonVotant deputy was present) but is excluded from the pour/contre/abstention percentages (see ADR-019 in `docs/decisions.md`)
 - **Yaël Braun-Pivet at 100% presence** — Présidente de l'AN, recorded on every scrutin by the AN data system
 - **`rejeté` outnumbers `adopté`** — the 17th legislature has no stable majority
 - **Party names** — resolved from `Organes.json` GP mandats; 575/577 deputies covered (2 have no active parliamentary group — expected edge case)

--- a/frontend/src/app/methodologie/page.tsx
+++ b/frontend/src/app/methodologie/page.tsx
@@ -1,0 +1,169 @@
+import type { Metadata } from 'next'
+import { LegalPageLayout, LegalSection } from '@/components/LegalPageLayout'
+
+const REPO_BASE = 'https://github.com/Walid-peach/MonElu/blob/master'
+const LINEAGE_DOCS = 'https://walid-peach.github.io/MonElu/dbt-docs/'
+
+export const metadata: Metadata = {
+  title: 'Méthodologie - MonÉlu',
+  description:
+    "Comment MonÉlu calcule chaque chiffre affiché : présence, alignement de parti, majorité, et limites connues.",
+}
+
+const textStyle = { fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }
+const linkStyle = { color: '#1B2B50', fontWeight: 600 }
+const sourceLineStyle = { fontSize: '13.5px', color: '#6B7280', margin: '10px 0 0' }
+
+export default function MethodologiePage() {
+  return (
+    <LegalPageLayout eyebrow="Vérifiabilité" title="Méthodologie">
+      <LegalSection id="intro" title="Pourquoi cette page">
+        <p style={textStyle}>
+          Un chiffre affiché sans méthode n&apos;est qu&apos;une affirmation. Cette page décrit, en français
+          courant, comment chaque statistique de MonÉlu est calculée : la formule exacte, le code source qui
+          l&apos;implémente, et ses limites connues. Aucun calcul n&apos;est fait &laquo;&nbsp;à la main&nbsp;&raquo;
+          ni ajusté au cas par cas - tout part des données publiques de l&apos;Assemblée nationale et suit une
+          règle unique, appliquée de la même façon à chaque député et chaque groupe.
+        </p>
+      </LegalSection>
+
+      <LegalSection id="presence" title="Taux de présence">
+        <p style={{ ...textStyle, marginBottom: '10px' }}>
+          Le taux de présence d&apos;un député compte <strong>toute position enregistrée</strong> lors d&apos;un
+          scrutin : pour, contre, abstention, <strong>et non-votant</strong>. Un député &laquo;&nbsp;non-votant&nbsp;&raquo;
+          était présent dans l&apos;hémicycle sans exprimer de vote - c&apos;est une particularité documentée des
+          données de l&apos;Assemblée, pas une absence.
+        </p>
+        <p style={{ ...textStyle, marginBottom: '10px' }}>
+          Le dénominateur n&apos;est pas &laquo;&nbsp;tous les scrutins depuis juillet 2024&nbsp;&raquo; mais
+          uniquement les scrutins tenus <strong>pendant le mandat</strong> du député (entre sa date de début et sa
+          date de fin de mandat, le cas échéant). Un député élu en cours de législature n&apos;est donc pas
+          pénalisé pour des votes antérieurs à son entrée en fonction.
+        </p>
+        <p style={textStyle}>
+          Ce calcul unique est la <strong>seule</strong> définition de la présence utilisée sur MonÉlu - l&apos;API,
+          l&apos;assistant de recherche et les fiches députés s&apos;y conforment tous. C&apos;est pourquoi Yaël
+          Braun-Pivet, Présidente de l&apos;Assemblée nationale, affiche 100&nbsp;% de présence : elle est recensée
+          sur chaque scrutin par construction des données de l&apos;AN.
+        </p>
+        <p style={sourceLineStyle}>
+          Source :{' '}
+          <a href={`${REPO_BASE}/transform/models/marts/mart_deputy_scorecard.sql`} target="_blank" rel="noopener noreferrer" style={linkStyle}>
+            mart_deputy_scorecard.sql
+          </a>{' '}
+          ·{' '}
+          <a href={`${REPO_BASE}/docs/decisions.md`} target="_blank" rel="noopener noreferrer" style={linkStyle}>
+            ADR-019, décision architecturale
+          </a>
+        </p>
+      </LegalSection>
+
+      <LegalSection id="alignement" title="Alignement de parti et votes dissidents">
+        <p style={{ ...textStyle, marginBottom: '10px' }}>
+          Pour chaque scrutin, MonÉlu calcule la <strong>position majoritaire</strong> du groupe parlementaire du
+          député (pour, contre ou abstention - les non-votants ne comptent pas dans ce calcul). Un vote du député
+          est dit &laquo;&nbsp;dissident&nbsp;&raquo; lorsque sa position diffère de celle-ci.
+        </p>
+        <p style={{ ...textStyle, marginBottom: '10px' }}>
+          <strong>Limite connue :</strong> l&apos;historique complet du député est comparé à son groupe
+          parlementaire <strong>actuel</strong>, même s&apos;il en a changé en cours de mandat. Un député ayant
+          changé de groupe verra donc ses votes antérieurs au changement évalués par rapport à son nouveau groupe,
+          pas celui auquel il appartenait au moment du vote.
+        </p>
+        <p style={textStyle}>
+          En cas d&apos;égalité stricte entre deux positions au sein d&apos;un groupe (par exemple 40 pour /
+          40 contre), le départage suit une règle déterministe et documentée dans le code plutôt qu&apos;un
+          résultat arbitraire dépendant de l&apos;ordre de retour de la base de données.
+        </p>
+        <p style={sourceLineStyle}>
+          Source :{' '}
+          <a href={`${REPO_BASE}/transform/models/marts/mart_party_alignment.sql`} target="_blank" rel="noopener noreferrer" style={linkStyle}>
+            mart_party_alignment.sql
+          </a>{' '}
+          ·{' '}
+          <a href={`${REPO_BASE}/transform/models/intermediate/int_party_vote_majority.sql`} target="_blank" rel="noopener noreferrer" style={linkStyle}>
+            int_party_vote_majority.sql
+          </a>
+        </p>
+      </LegalSection>
+
+      <LegalSection id="adopte-rejete" title="Vote adopté ou rejeté">
+        <p style={textStyle}>
+          Le résultat d&apos;un scrutin (adopté ou rejeté) n&apos;est jamais recalculé par MonÉlu : il est repris
+          tel quel du champ officiel publié par l&apos;Assemblée nationale pour ce scrutin. La 17ᵉ législature
+          n&apos;ayant pas de majorité stable, les scrutins rejetés sont, à ce jour, plus nombreux que les scrutins
+          adoptés.
+        </p>
+        <p style={sourceLineStyle}>
+          Source :{' '}
+          <a href={`${REPO_BASE}/transform/models/staging/stg_votes.sql`} target="_blank" rel="noopener noreferrer" style={linkStyle}>
+            stg_votes.sql
+          </a>
+        </p>
+      </LegalSection>
+
+      <LegalSection id="horizon" title="Horizon des données et fréquence de mise à jour">
+        <p style={{ ...textStyle, marginBottom: '10px' }}>
+          La base de production couvre les scrutins depuis le <strong>1er juillet 2025</strong> (limite de
+          l&apos;offre gratuite de la base de données hébergée ; l&apos;historique complet depuis le début de la
+          législature, le 7 juillet 2024, est disponible en environnement de développement).
+        </p>
+        <p style={textStyle}>
+          Les données sont actualisées <strong>automatiquement chaque jour ouvré à 6h UTC</strong> : ingestion des
+          nouveaux scrutins et fiches de députés, reconstruction de l&apos;index de recherche sémantique, puis
+          recalcul des statistiques agrégées (présence, alignement, scorecards).
+        </p>
+      </LegalSection>
+
+      <LegalSection id="limites" title="Limites connues">
+        <ul style={{ fontSize: '15px', lineHeight: 1.85, color: '#4B5563', margin: 0, paddingLeft: '20px' }}>
+          <li>
+            <strong>Non-votant ≠ abstention</strong> : un non-votant était présent sans exprimer d&apos;opinion ;
+            une abstention est une position exprimée. Les pourcentages pour/contre/abstention affichés se
+            calculent uniquement sur les positions exprimées (non-votant exclu de ce calcul-là, mais inclus dans
+            la présence).
+          </li>
+          <li>
+            <strong>Parti actuel, pas parti historique</strong> : voir la limite décrite ci-dessus pour
+            l&apos;alignement de parti.
+          </li>
+          <li>
+            <strong>2 députés sur 577</strong> n&apos;ont pas de groupe parlementaire actif identifié dans les
+            données source - cas limite documenté, non un bug d&apos;ingestion.
+          </li>
+          <li>
+            <strong>Les réponses de l&apos;assistant de recherche</strong> (IA) sont une aide à la lecture, pas
+            une source officielle - la donnée brute et son scrutin d&apos;origine font toujours foi. Voir la{' '}
+            <a href="/licence-donnees" style={linkStyle}>licence des données</a>.
+          </li>
+        </ul>
+      </LegalSection>
+
+      <LegalSection id="code" title="Code source et traçabilité">
+        <p style={{ ...textStyle, marginBottom: '10px' }}>
+          L&apos;intégralité du code de transformation des données (ingestion, agrégation, API) est publique. Le
+          schéma de dépendances entre les modèles de données (lineage) est généré automatiquement à chaque
+          modification :
+        </p>
+        <p style={textStyle}>
+          <a href={LINEAGE_DOCS} target="_blank" rel="noopener noreferrer" style={linkStyle}>
+            Documentation et lineage dbt
+          </a>{' '}
+          ·{' '}
+          <a href="https://github.com/Walid-peach/MonElu" target="_blank" rel="noopener noreferrer" style={linkStyle}>
+            Code source sur GitHub
+          </a>
+        </p>
+      </LegalSection>
+
+      <LegalSection id="contact" title="Une erreur ou une incohérence à signaler ?">
+        <p style={textStyle}>
+          Écrivez à{' '}
+          <a href="mailto:walidelkhoukh99@gmail.com" style={{ color: '#1B2B50' }}>walidelkhoukh99@gmail.com</a> en
+          précisant le député, le scrutin ou la page concernée. Toute correction de méthode fait l&apos;objet
+          d&apos;une mise à jour de cette page.
+        </p>
+      </LegalSection>
+    </LegalPageLayout>
+  )
+}

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -67,6 +67,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${SITE_URL}/chat`, changeFrequency: 'monthly', priority: 0.5 },
     { url: `${SITE_URL}/a-propos`, changeFrequency: 'monthly', priority: 0.4 },
     { url: `${SITE_URL}/developpeurs`, changeFrequency: 'monthly', priority: 0.4 },
+    { url: `${SITE_URL}/methodologie`, changeFrequency: 'monthly', priority: 0.5 },
   ]
 
   const [deputies, votes] = await Promise.all([deputyUrls(), voteUrls()])

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -49,6 +49,7 @@ export function Footer() {
         <Link href="/deputes" style={{ color: '#6B7280', textDecoration: 'none' }}>Députés</Link>
         <Link href="/votes" style={{ color: '#6B7280', textDecoration: 'none' }}>Votes</Link>
         <Link href="/developpeurs" style={{ color: '#6B7280', textDecoration: 'none' }}>Développeurs</Link>
+        <Link href="/methodologie" style={{ color: '#6B7280', textDecoration: 'none' }}>Méthodologie</Link>
         <a href="https://github.com/Walid-peach" target="_blank" rel="noopener noreferrer" style={{ color: '#6B7280', textDecoration: 'none' }}>GitHub</a>
         {legalLinks.map((l) => (
           <Link key={l.href} href={l.href} style={{ color: '#6B7280', textDecoration: 'none' }}>{l.label}</Link>

--- a/frontend/src/components/LegalPageLayout.tsx
+++ b/frontend/src/components/LegalPageLayout.tsx
@@ -27,9 +27,17 @@ export function LegalPageLayout({ eyebrow, title, children }: LegalPageLayoutPro
   )
 }
 
-export function LegalSection({ title, children }: { title: string; children: ReactNode }) {
+export function LegalSection({
+  id,
+  title,
+  children,
+}: {
+  id?: string
+  title: string
+  children: ReactNode
+}) {
   return (
-    <section>
+    <section id={id} style={id ? { scrollMarginTop: '88px' } : undefined}>
       <h2 style={{ fontWeight: 700, fontSize: '17px', color: '#1B2B50', margin: '0 0 12px' }}>{title}</h2>
       {children}
     </section>

--- a/frontend/src/components/LegalPageLayout.tsx
+++ b/frontend/src/components/LegalPageLayout.tsx
@@ -36,6 +36,8 @@ export function LegalSection({
   title: string
   children: ReactNode
 }) {
+  // 88px = Nav.tsx's NAV_HEIGHT_PX (64) + 24px breathing room, so an anchor
+  // jump doesn't land the heading under the sticky nav.
   return (
     <section id={id} style={id ? { scrollMarginTop: '88px' } : undefined}>
       <h2 style={{ fontWeight: 700, fontSize: '17px', color: '#1B2B50', margin: '0 0 12px' }}>{title}</h2>


### PR DESCRIPTION
## What
Adds a public `/methodologie` page (French) that states, in plain language, how every displayed MonÉlu number is computed: presence, party alignment/dissident votes, vote adoption, data horizon and refresh cadence, and known limitations. Each section links to its source dbt model on GitHub. Adds a "Méthodologie" footer link and a sitemap entry.

## Why
Regards Citoyens (NosDéputés) argues civic tech is only credible when anyone can verify no algorithm treats a parliamentarian or group differently. MonÉlu already has rigorously specified metrics (ADR-019 presence definition, mandate-windowed denominators, deterministic majority tiebreaks) but that rigor lives only in ADRs and dbt code — invisible to the public. This page makes it visible and citable.

Closes MON-112 (https://linear.app/monelu/issue/MON-112/public-methodology-page-every-score-verifiable-every-stat-reproducible)

## Changes
- `frontend/src/app/methodologie/page.tsx`: new static page reusing the existing `LegalPageLayout`/`LegalSection` pattern (same as `/mentions-legales`, `/licence-donnees`, `/developpeurs`). Sections: présence, alignement de parti, adopté/rejeté, horizon des données, limites connues, code source et traçabilité, contact.
- `frontend/src/components/LegalPageLayout.tsx`: `LegalSection` now accepts an optional `id` prop (with `scrollMarginTop` to clear the sticky nav) so each methodology section is deep-linkable — the anchors planned for the in-context tooltips in MON-81.
- `frontend/src/components/Footer.tsx`: added a "Méthodologie" link next to "Développeurs".
- `frontend/src/app/sitemap.ts`: added `/methodologie` alongside the other static content pages already listed there.

## Testing
- `npx tsc --noEmit`: passes.
- `npm run lint`: no warnings or errors.
- `npm run build`: fails at the pre-existing `/sitemap.xml` prerender step in this sandboxed environment (`deputyUrls()`/`voteUrls()` fetch the live production API during static generation and get a transient error) — this is unrelated to this change: my sitemap.ts edit only adds one static entry to an array untouched by that fetch path, no `ci.yml` workflow builds the frontend, and the failing code path predates this PR.
- Manual: started `next dev`, fetched `/methodologie` and `/` over HTTP, confirmed all sections render with expected content and the footer link resolves to the new page. No headless browser available in this environment for a visual screenshot.

## Risks / Notes
- Content is derived from `docs/decisions.md` (ADR-019) and the current dbt models — if either drifts, this page needs a follow-up edit; it's static content, not generated from the ADRs.
- The GitHub Pages dbt lineage docs URL (`https://walid-peach.github.io/MonElu/dbt-docs/`) is inferred from `dbt_docs.yml`'s `peaceiris/actions-gh-pages` config (publishes the `gh-pages` branch, which exists) — worth a quick manual click-through once deployed to confirm the exact published path.
- Noticed `README.md`'s "Data Notes" section still says nonVotant is "excluded from presence_rate", which contradicts ADR-019 (nonVotant counts as present) — did not fix as it's out of scope for this PR, but worth a follow-up since it's a real doc inconsistency.

## Breaking Changes
None.