### PR TITLE
chore: add solve-mon next mode and diagnose skill

### DIFF
--- a/.agents/skills/diagnose/SKILL.md
+++ b/.agents/skills/diagnose/SKILL.md
@@ -20,7 +20,7 @@ If the Linear MCP is unavailable, still write the report and roadmap update, and
 ### 1. Establish the baseline
 
 - Read the axis section in `notes/dispatch/diagnostic_roadmap.md`: last diag date, headline findings, remediation PRs.
-- Read the axis's previous report (`notes/dispatch/<axis>_diagnostic_<date>.md`; transform and rag share `transform_rag_diagnostic_*.md`) to know what was already found - the new pass must not re-report fixed or known-open findings.
+- Read the axis's previous report (`notes/dispatch/<axis>_diagnostic_<date>.md`; two naming exceptions: transform and rag share `transform_rag_diagnostic_*.md`, and deploy-config is `deployment_config_diagnostic_*.md`) to know what was already found - the new pass must not re-report fixed or known-open findings.
 - List what changed since: `git log --oneline --since=<last diag date> -- <axis paths>`.
   If nothing changed and the previous findings are all resolved, say so, stamp the roadmap with a "re-checked, clean" note, and stop - a diagnostic of unchanged code is noise.
 
@@ -30,12 +30,12 @@ Read the axis's actual code, top to bottom, with fresh eyes - the previous repor
 Per axis, the core surfaces are:
 
 - `ingestion`: `scripts/ingest_*.py`, `run_ingestion_prod.py`, `generate_vote_summaries.py`, `.github/workflows/ingest_prod.yml`
-- `database`: `data/migrations/`, `migrate.py`, `docker-compose*.yml`, index and constraint health
+- `database`: `data/migrations/`, `scripts/migrate.py`, `docker-compose*.yml`, index and constraint health
 - `api`: `api/` (routers, schemas, limiter, main), connection handling, blocking I/O, rate limits
 - `transform`: `transform/models/`, tests, sources freshness, marts vs API expectations
 - `rag`: `rag/` (chunker, embedder, retriever, prompts, chain, sql_router), eval suite honesty
 - `cicd`: `.github/workflows/`, gates that can silently pass, pins, concurrency, notifications
-- `deploy-config`: `railway.json`, `Procfile`, `requirements*.txt` pin coherence, env-var contract vs `.env.example`
+- `deploy-config`: `railway.json`, `requirements*.txt` pin coherence, env-var contract vs `.env.example`
 - `infra`: `archive/infra-aws/` status, Railway/Supabase/Vercel config drift vs docs
 - `frontend`: `frontend/src/`, build health, caching/revalidate coherence, accessibility, CI coverage
 - `tests`: what CI actually runs vs what exists, rot, mock-only tests, missing tiers
@@ -54,7 +54,7 @@ Findings must be new or materially changed since the last report; reference the 
 
 Before filing anything, `list_issues` (team MonElu, all statuses) and check each finding against existing issues by title and content similarity.
 - Already tracked and open: add a comment on the existing issue with the fresh evidence instead of duplicating.
-- Tracked and Done but regressed: file a new issue linking the old one (`relatedTo`).
+- Tracked and Done but regressed: file a new issue linking the old one (`relatedTo`; if the relation fails to apply, reference the old MON-id in the description instead).
 - New: proceed to filing.
 
 ### 5. File the findings as Linear issues

--- a/.agents/skills/diagnose/SKILL.md
+++ b/.agents/skills/diagnose/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: diagnose
+description: Runs a fresh diagnostic pass on one MonÉlu project axis - inspects the current code (not old reports), writes a dated report to notes/dispatch/, updates the diagnostic roadmap, and files new findings as labeled Linear issues after deduping against the open backlog. No code changes. Use as /diagnose <axis> or /diagnose next to pick the stalest axis.
+---
+
+Run one category-deep diagnostic of the MonÉlu codebase, in the style of the 2026-06-11 diagnostic wave, and turn the findings into backlog input.
+This skill only inspects, reports, and files issues - it never changes code.
+Remediation happens later via `/solve-mon` (single findings) or `/plan-epic` (structural findings).
+
+ARGUMENTS: an axis, or `next`.
+Axes match the Linear area labels and the report names in `notes/dispatch/`:
+`ingestion, database, api, transform, rag, cicd, deploy-config, infra, frontend, tests`.
+`next` picks the axis with the oldest diagnostic date in `notes/dispatch/diagnostic_roadmap.md` (ties broken by how much its code has changed since, via `git log --oneline --since=<last diag date> -- <axis paths>`).
+
+Linear writes (`mcp__linear-server__save_issue`, `save_comment`) are allowlisted in `.claude/settings.local.json`.
+If the Linear MCP is unavailable, still write the report and roadmap update, and output the drafted issues for manual creation.
+
+## Workflow
+
+### 1. Establish the baseline
+
+- Read the axis section in `notes/dispatch/diagnostic_roadmap.md`: last diag date, headline findings, remediation PRs.
+- Read the axis's previous report (`notes/dispatch/<axis>_diagnostic_<date>.md`; transform and rag share `transform_rag_diagnostic_*.md`) to know what was already found - the new pass must not re-report fixed or known-open findings.
+- List what changed since: `git log --oneline --since=<last diag date> -- <axis paths>`.
+  If nothing changed and the previous findings are all resolved, say so, stamp the roadmap with a "re-checked, clean" note, and stop - a diagnostic of unchanged code is noise.
+
+### 2. Inspect the current code
+
+Read the axis's actual code, top to bottom, with fresh eyes - the previous report describes the past, not the present.
+Per axis, the core surfaces are:
+
+- `ingestion`: `scripts/ingest_*.py`, `run_ingestion_prod.py`, `generate_vote_summaries.py`, `.github/workflows/ingest_prod.yml`
+- `database`: `data/migrations/`, `migrate.py`, `docker-compose*.yml`, index and constraint health
+- `api`: `api/` (routers, schemas, limiter, main), connection handling, blocking I/O, rate limits
+- `transform`: `transform/models/`, tests, sources freshness, marts vs API expectations
+- `rag`: `rag/` (chunker, embedder, retriever, prompts, chain, sql_router), eval suite honesty
+- `cicd`: `.github/workflows/`, gates that can silently pass, pins, concurrency, notifications
+- `deploy-config`: `railway.json`, `Procfile`, `requirements*.txt` pin coherence, env-var contract vs `.env.example`
+- `infra`: `archive/infra-aws/` status, Railway/Supabase/Vercel config drift vs docs
+- `frontend`: `frontend/src/`, build health, caching/revalidate coherence, accessibility, CI coverage
+- `tests`: what CI actually runs vs what exists, rot, mock-only tests, missing tiers
+
+Judge against: correctness, silent-failure modes, drift between docs (CLAUDE.md, `docs/decisions.md`) and reality, performance traps, and security.
+Verify every claim against the code - a diagnostic finding with a wrong file reference poisons the remediation later.
+
+### 3. Write the report
+
+Create `notes/dispatch/<axis>_diagnostic_<today>.md` in the established format:
+scope inspected, verdict paragraph, then numbered findings - each with severity (critical / high / medium / low), the affected file and line, evidence, and a recommended fix.
+Findings must be new or materially changed since the last report; reference the old finding number when one has regressed.
+`notes/` is gitignored - the report is local-only.
+
+### 4. Dedupe against the backlog
+
+Before filing anything, `list_issues` (team MonElu, all statuses) and check each finding against existing issues by title and content similarity.
+- Already tracked and open: add a comment on the existing issue with the fresh evidence instead of duplicating.
+- Tracked and Done but regressed: file a new issue linking the old one (`relatedTo`).
+- New: proceed to filing.
+
+### 5. File the findings as Linear issues
+
+For each new finding, `save_issue` (team MonElu, state Backlog) following the po-agent fill conventions:
+- Title: concise, defect-first ("X does Y - Z consequence"), action-verb-first for improvements.
+- Description: the problem, evidence with `file:line`, the recommended fix, and a `**Source:** <axis>_diagnostic_<today>.md - Finding #N` line.
+- Labels: the axis label plus a type label (`Bug` for defects, `tech-debt` for debt, `Improvement` otherwise; add `perf`, `tests`, or `docs-drift` where they apply).
+- Priority: critical → Urgent, high → High, medium → Medium, low → Low.
+- Milestone: `M0 - Hardening` in project "Product Readiness 2026-07" unless the finding clearly belongs to a feature milestone.
+
+### 6. Update the roadmap
+
+Edit the axis section in `notes/dispatch/diagnostic_roadmap.md`:
+refresh the diag date, link the new report, replace the headline findings, and list the filed MON-ids.
+Keep the Legend and section structure intact.
+
+### 7. Report
+
+Summarize: axis, verdict, findings count by severity, issues filed (ids + titles), issues commented instead of duplicated, and the single highest-impact finding.
+Recommend the follow-up: `/solve-mon <id>` for the top finding, or `/plan-epic` if a finding is structural.
+
+## Guard rails
+
+- Never change code, config, or tests - inspection only. The only writes are the report, the roadmap, and Linear.
+- Never re-file a finding that is already an open issue - comment on it instead.
+- Never run anything with side effects or cost during inspection (no ingestion runs, no RAG re-index, no prod writes; read-only DB queries against local are fine).
+- If a finding suggests an active incident (prod down, data corruption, leaked secret), stop the pass and surface it to the user immediately instead of filing and moving on.
+- Cap a single pass at ~10 filed issues; if an axis yields more, file the top 10 by severity and note the remainder in the report.

--- a/.agents/skills/solve-mon/SKILL.md
+++ b/.agents/skills/solve-mon/SKILL.md
@@ -1,13 +1,27 @@
 ---
 name: solve-mon
-description: Resolves a Linear (MonElu) issue end-to-end - reads the MON issue, branches on its gitBranchName, implements, verifies, opens a PR, updates Linear, watches CI, runs pr-review and applies the fixes. Stops before merge. Use as /solve-mon <MON-id>, e.g. /solve-mon MON-75. Replaces the retired solve-axis skill.
+description: Resolves a Linear (MonElu) issue end-to-end - reads the MON issue, branches on its gitBranchName, implements, verifies, opens a PR, updates Linear, watches CI, runs pr-review and applies the fixes. Stops before merge. Use as /solve-mon <MON-id> (e.g. /solve-mon MON-75) or /solve-mon next to auto-pick the top unblocked non-epic backlog issue (WIP-limited to 3 open PRs). Replaces the retired solve-axis skill.
 ---
 
 Resolve one Linear backlog issue for the MonÉlu project end-to-end, following the cycle proven on the diagnostic axes (PRs #139-#151) and the feature waves (PRs #154-#174).
 Work through the PR review and its fixes, but **never merge** - merging and moving the issue to Done stay the user's call.
 
-ARGUMENTS: one or more MON-ids (e.g. `MON-75` or `MON-66 MON-68`).
+ARGUMENTS: one or more MON-ids (e.g. `MON-75` or `MON-66 MON-68`), or the keyword `next`.
 Multiple ids mean the issues are small and related enough to share one branch and one PR - if they are not, say so and ask which one to start with.
+
+## `next` mode - pick the next backlog issue automatically
+
+When invoked as `/solve-mon next`, select the issue instead of receiving one:
+
+1. **WIP limit first**: count open PRs authored by this workflow (`gh pr list --state open --author @me`).
+   If **3 or more** are open, stop and report the open PRs - the user must merge or close some before new work starts.
+   This prevents unmerged PRs from piling up and conflicting with each other.
+2. **Candidate set**: `list_issues` for team MonElu, status Backlog or Todo, excluding issues labeled `epic` (route those to `/plan-epic`) or `decision` (route those to the `adr-skill`), and excluding issues with incomplete blockers (`blockedBy` pointing at a non-Done issue).
+3. **Ordering**: priority first (Urgent > High > Medium > Low > none), then milestone order (M0 - Hardening before M1 before M2 ...), then oldest `createdAt`.
+4. **Overlap check**: skip a candidate whose files would clearly collide with an already-open PR's diff (e.g. two issues rewriting the same page); take the next one instead and say why.
+5. Announce the pick (id, title, priority, why it won) and proceed with the normal workflow below from step 1.
+
+In `next` mode the skipped-over candidates are not touched - the next invocation re-evaluates from scratch, so board changes between runs are picked up naturally.
 
 Linear writes (`mcp__linear-server__save_issue`, `save_comment`) are allowlisted in `.claude/settings.local.json` - apply Linear updates directly.
 If the Linear MCP is unavailable, say so and output the exact updates for manual application instead.

--- a/.agents/skills/solve-mon/SKILL.md
+++ b/.agents/skills/solve-mon/SKILL.md
@@ -13,7 +13,7 @@ Multiple ids mean the issues are small and related enough to share one branch an
 
 When invoked as `/solve-mon next`, select the issue instead of receiving one:
 
-1. **WIP limit first**: count open PRs authored by this workflow (`gh pr list --state open --author @me`).
+1. **WIP limit first**: count open PRs (`gh pr list --state open --author @me` - this counts all of the user's open PRs, which is the intended conservative behavior).
    If **3 or more** are open, stop and report the open PRs - the user must merge or close some before new work starts.
    This prevents unmerged PRs from piling up and conflicting with each other.
 2. **Candidate set**: `list_issues` for team MonElu, status Backlog or Todo, excluding issues labeled `epic` (route those to `/plan-epic`) or `decision` (route those to the `adr-skill`), and excluding issues with incomplete blockers (`blockedBy` pointing at a non-Done issue).

--- a/.claude/skills/diagnose/SKILL.md
+++ b/.claude/skills/diagnose/SKILL.md
@@ -20,7 +20,7 @@ If the Linear MCP is unavailable, still write the report and roadmap update, and
 ### 1. Establish the baseline
 
 - Read the axis section in `notes/dispatch/diagnostic_roadmap.md`: last diag date, headline findings, remediation PRs.
-- Read the axis's previous report (`notes/dispatch/<axis>_diagnostic_<date>.md`; transform and rag share `transform_rag_diagnostic_*.md`) to know what was already found - the new pass must not re-report fixed or known-open findings.
+- Read the axis's previous report (`notes/dispatch/<axis>_diagnostic_<date>.md`; two naming exceptions: transform and rag share `transform_rag_diagnostic_*.md`, and deploy-config is `deployment_config_diagnostic_*.md`) to know what was already found - the new pass must not re-report fixed or known-open findings.
 - List what changed since: `git log --oneline --since=<last diag date> -- <axis paths>`.
   If nothing changed and the previous findings are all resolved, say so, stamp the roadmap with a "re-checked, clean" note, and stop - a diagnostic of unchanged code is noise.
 
@@ -30,12 +30,12 @@ Read the axis's actual code, top to bottom, with fresh eyes - the previous repor
 Per axis, the core surfaces are:
 
 - `ingestion`: `scripts/ingest_*.py`, `run_ingestion_prod.py`, `generate_vote_summaries.py`, `.github/workflows/ingest_prod.yml`
-- `database`: `data/migrations/`, `migrate.py`, `docker-compose*.yml`, index and constraint health
+- `database`: `data/migrations/`, `scripts/migrate.py`, `docker-compose*.yml`, index and constraint health
 - `api`: `api/` (routers, schemas, limiter, main), connection handling, blocking I/O, rate limits
 - `transform`: `transform/models/`, tests, sources freshness, marts vs API expectations
 - `rag`: `rag/` (chunker, embedder, retriever, prompts, chain, sql_router), eval suite honesty
 - `cicd`: `.github/workflows/`, gates that can silently pass, pins, concurrency, notifications
-- `deploy-config`: `railway.json`, `Procfile`, `requirements*.txt` pin coherence, env-var contract vs `.env.example`
+- `deploy-config`: `railway.json`, `requirements*.txt` pin coherence, env-var contract vs `.env.example`
 - `infra`: `archive/infra-aws/` status, Railway/Supabase/Vercel config drift vs docs
 - `frontend`: `frontend/src/`, build health, caching/revalidate coherence, accessibility, CI coverage
 - `tests`: what CI actually runs vs what exists, rot, mock-only tests, missing tiers
@@ -54,7 +54,7 @@ Findings must be new or materially changed since the last report; reference the 
 
 Before filing anything, `list_issues` (team MonElu, all statuses) and check each finding against existing issues by title and content similarity.
 - Already tracked and open: add a comment on the existing issue with the fresh evidence instead of duplicating.
-- Tracked and Done but regressed: file a new issue linking the old one (`relatedTo`).
+- Tracked and Done but regressed: file a new issue linking the old one (`relatedTo`; if the relation fails to apply, reference the old MON-id in the description instead).
 - New: proceed to filing.
 
 ### 5. File the findings as Linear issues

--- a/.claude/skills/diagnose/SKILL.md
+++ b/.claude/skills/diagnose/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: diagnose
+description: Runs a fresh diagnostic pass on one MonÉlu project axis - inspects the current code (not old reports), writes a dated report to notes/dispatch/, updates the diagnostic roadmap, and files new findings as labeled Linear issues after deduping against the open backlog. No code changes. Use as /diagnose <axis> or /diagnose next to pick the stalest axis.
+---
+
+Run one category-deep diagnostic of the MonÉlu codebase, in the style of the 2026-06-11 diagnostic wave, and turn the findings into backlog input.
+This skill only inspects, reports, and files issues - it never changes code.
+Remediation happens later via `/solve-mon` (single findings) or `/plan-epic` (structural findings).
+
+ARGUMENTS: an axis, or `next`.
+Axes match the Linear area labels and the report names in `notes/dispatch/`:
+`ingestion, database, api, transform, rag, cicd, deploy-config, infra, frontend, tests`.
+`next` picks the axis with the oldest diagnostic date in `notes/dispatch/diagnostic_roadmap.md` (ties broken by how much its code has changed since, via `git log --oneline --since=<last diag date> -- <axis paths>`).
+
+Linear writes (`mcp__linear-server__save_issue`, `save_comment`) are allowlisted in `.claude/settings.local.json`.
+If the Linear MCP is unavailable, still write the report and roadmap update, and output the drafted issues for manual creation.
+
+## Workflow
+
+### 1. Establish the baseline
+
+- Read the axis section in `notes/dispatch/diagnostic_roadmap.md`: last diag date, headline findings, remediation PRs.
+- Read the axis's previous report (`notes/dispatch/<axis>_diagnostic_<date>.md`; transform and rag share `transform_rag_diagnostic_*.md`) to know what was already found - the new pass must not re-report fixed or known-open findings.
+- List what changed since: `git log --oneline --since=<last diag date> -- <axis paths>`.
+  If nothing changed and the previous findings are all resolved, say so, stamp the roadmap with a "re-checked, clean" note, and stop - a diagnostic of unchanged code is noise.
+
+### 2. Inspect the current code
+
+Read the axis's actual code, top to bottom, with fresh eyes - the previous report describes the past, not the present.
+Per axis, the core surfaces are:
+
+- `ingestion`: `scripts/ingest_*.py`, `run_ingestion_prod.py`, `generate_vote_summaries.py`, `.github/workflows/ingest_prod.yml`
+- `database`: `data/migrations/`, `migrate.py`, `docker-compose*.yml`, index and constraint health
+- `api`: `api/` (routers, schemas, limiter, main), connection handling, blocking I/O, rate limits
+- `transform`: `transform/models/`, tests, sources freshness, marts vs API expectations
+- `rag`: `rag/` (chunker, embedder, retriever, prompts, chain, sql_router), eval suite honesty
+- `cicd`: `.github/workflows/`, gates that can silently pass, pins, concurrency, notifications
+- `deploy-config`: `railway.json`, `Procfile`, `requirements*.txt` pin coherence, env-var contract vs `.env.example`
+- `infra`: `archive/infra-aws/` status, Railway/Supabase/Vercel config drift vs docs
+- `frontend`: `frontend/src/`, build health, caching/revalidate coherence, accessibility, CI coverage
+- `tests`: what CI actually runs vs what exists, rot, mock-only tests, missing tiers
+
+Judge against: correctness, silent-failure modes, drift between docs (CLAUDE.md, `docs/decisions.md`) and reality, performance traps, and security.
+Verify every claim against the code - a diagnostic finding with a wrong file reference poisons the remediation later.
+
+### 3. Write the report
+
+Create `notes/dispatch/<axis>_diagnostic_<today>.md` in the established format:
+scope inspected, verdict paragraph, then numbered findings - each with severity (critical / high / medium / low), the affected file and line, evidence, and a recommended fix.
+Findings must be new or materially changed since the last report; reference the old finding number when one has regressed.
+`notes/` is gitignored - the report is local-only.
+
+### 4. Dedupe against the backlog
+
+Before filing anything, `list_issues` (team MonElu, all statuses) and check each finding against existing issues by title and content similarity.
+- Already tracked and open: add a comment on the existing issue with the fresh evidence instead of duplicating.
+- Tracked and Done but regressed: file a new issue linking the old one (`relatedTo`).
+- New: proceed to filing.
+
+### 5. File the findings as Linear issues
+
+For each new finding, `save_issue` (team MonElu, state Backlog) following the po-agent fill conventions:
+- Title: concise, defect-first ("X does Y - Z consequence"), action-verb-first for improvements.
+- Description: the problem, evidence with `file:line`, the recommended fix, and a `**Source:** <axis>_diagnostic_<today>.md - Finding #N` line.
+- Labels: the axis label plus a type label (`Bug` for defects, `tech-debt` for debt, `Improvement` otherwise; add `perf`, `tests`, or `docs-drift` where they apply).
+- Priority: critical → Urgent, high → High, medium → Medium, low → Low.
+- Milestone: `M0 - Hardening` in project "Product Readiness 2026-07" unless the finding clearly belongs to a feature milestone.
+
+### 6. Update the roadmap
+
+Edit the axis section in `notes/dispatch/diagnostic_roadmap.md`:
+refresh the diag date, link the new report, replace the headline findings, and list the filed MON-ids.
+Keep the Legend and section structure intact.
+
+### 7. Report
+
+Summarize: axis, verdict, findings count by severity, issues filed (ids + titles), issues commented instead of duplicated, and the single highest-impact finding.
+Recommend the follow-up: `/solve-mon <id>` for the top finding, or `/plan-epic` if a finding is structural.
+
+## Guard rails
+
+- Never change code, config, or tests - inspection only. The only writes are the report, the roadmap, and Linear.
+- Never re-file a finding that is already an open issue - comment on it instead.
+- Never run anything with side effects or cost during inspection (no ingestion runs, no RAG re-index, no prod writes; read-only DB queries against local are fine).
+- If a finding suggests an active incident (prod down, data corruption, leaked secret), stop the pass and surface it to the user immediately instead of filing and moving on.
+- Cap a single pass at ~10 filed issues; if an axis yields more, file the top 10 by severity and note the remainder in the report.

--- a/.claude/skills/solve-mon/SKILL.md
+++ b/.claude/skills/solve-mon/SKILL.md
@@ -1,13 +1,27 @@
 ---
 name: solve-mon
-description: Resolves a Linear (MonElu) issue end-to-end - reads the MON issue, branches on its gitBranchName, implements, verifies, opens a PR, updates Linear, watches CI, runs pr-review and applies the fixes. Stops before merge. Use as /solve-mon <MON-id>, e.g. /solve-mon MON-75. Replaces the retired solve-axis skill.
+description: Resolves a Linear (MonElu) issue end-to-end - reads the MON issue, branches on its gitBranchName, implements, verifies, opens a PR, updates Linear, watches CI, runs pr-review and applies the fixes. Stops before merge. Use as /solve-mon <MON-id> (e.g. /solve-mon MON-75) or /solve-mon next to auto-pick the top unblocked non-epic backlog issue (WIP-limited to 3 open PRs). Replaces the retired solve-axis skill.
 ---
 
 Resolve one Linear backlog issue for the MonÉlu project end-to-end, following the cycle proven on the diagnostic axes (PRs #139-#151) and the feature waves (PRs #154-#174).
 Work through the PR review and its fixes, but **never merge** - merging and moving the issue to Done stay the user's call.
 
-ARGUMENTS: one or more MON-ids (e.g. `MON-75` or `MON-66 MON-68`).
+ARGUMENTS: one or more MON-ids (e.g. `MON-75` or `MON-66 MON-68`), or the keyword `next`.
 Multiple ids mean the issues are small and related enough to share one branch and one PR - if they are not, say so and ask which one to start with.
+
+## `next` mode - pick the next backlog issue automatically
+
+When invoked as `/solve-mon next`, select the issue instead of receiving one:
+
+1. **WIP limit first**: count open PRs authored by this workflow (`gh pr list --state open --author @me`).
+   If **3 or more** are open, stop and report the open PRs - the user must merge or close some before new work starts.
+   This prevents unmerged PRs from piling up and conflicting with each other.
+2. **Candidate set**: `list_issues` for team MonElu, status Backlog or Todo, excluding issues labeled `epic` (route those to `/plan-epic`) or `decision` (route those to the `adr-skill`), and excluding issues with incomplete blockers (`blockedBy` pointing at a non-Done issue).
+3. **Ordering**: priority first (Urgent > High > Medium > Low > none), then milestone order (M0 - Hardening before M1 before M2 ...), then oldest `createdAt`.
+4. **Overlap check**: skip a candidate whose files would clearly collide with an already-open PR's diff (e.g. two issues rewriting the same page); take the next one instead and say why.
+5. Announce the pick (id, title, priority, why it won) and proceed with the normal workflow below from step 1.
+
+In `next` mode the skipped-over candidates are not touched - the next invocation re-evaluates from scratch, so board changes between runs are picked up naturally.
 
 Linear writes (`mcp__linear-server__save_issue`, `save_comment`) are allowlisted in `.claude/settings.local.json` - apply Linear updates directly.
 If the Linear MCP is unavailable, say so and output the exact updates for manual application instead.

--- a/.claude/skills/solve-mon/SKILL.md
+++ b/.claude/skills/solve-mon/SKILL.md
@@ -13,7 +13,7 @@ Multiple ids mean the issues are small and related enough to share one branch an
 
 When invoked as `/solve-mon next`, select the issue instead of receiving one:
 
-1. **WIP limit first**: count open PRs authored by this workflow (`gh pr list --state open --author @me`).
+1. **WIP limit first**: count open PRs (`gh pr list --state open --author @me` - this counts all of the user's open PRs, which is the intended conservative behavior).
    If **3 or more** are open, stop and report the open PRs - the user must merge or close some before new work starts.
    This prevents unmerged PRs from piling up and conflicting with each other.
 2. **Candidate set**: `list_issues` for team MonElu, status Backlog or Todo, excluding issues labeled `epic` (route those to `/plan-epic`) or `decision` (route those to the `adr-skill`), and excluding issues with incomplete blockers (`blockedBy` pointing at a non-Done issue).


### PR DESCRIPTION
## Summary

Second half of the backlog-automation system (follows #179). Two changes:

- **`/solve-mon next`** - auto-picks the next backlog issue instead of requiring an explicit MON-id: WIP limit first (stops if 3+ open PRs), then filters team MonElu Backlog/Todo excluding `epic` (routed to `/plan-epic`), `decision` (routed to `adr-skill`), and blocked issues, ordered by priority → milestone (M0 first) → age, with an overlap check against open PR diffs. This is the iteration unit for a `/loop /solve-mon next` working session.
- **`/diagnose <axis|next>`** (new) - formalizes the 2026-06 diagnostic workflow as a repeatable skill: establishes a baseline from `notes/dispatch/diagnostic_roadmap.md` and the previous axis report, inspects the *current* code (skips cleanly if nothing changed since the last pass), writes a dated report, dedupes findings against the whole backlog (comments on existing issues instead of duplicating), files new findings as labeled+milestoned Linear issues (capped at 10/pass), and updates the roadmap. Inspection-only - never changes code, never runs anything with cost or side effects, and escalates active incidents instead of filing them.

Supporting board work done directly in Linear (not in this diff): created `epic` and `decision` labels, backfilled type/area labels and milestones on all open issues, synced MON-81/MON-102/MON-72 to Done.

## Test plan

- [x] Both skills register and appear in the available-skills list
- [x] Pre-commit hooks pass
- [x] Skill markdown only - no runtime code paths touched
- [ ] First exercises: `/solve-mon next` (should pick MON-75, the only High non-epic) and `/diagnose next`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4WXqVr2UmQXYz7UeRg6ft