### PR TITLE
feat: add solennel and voting-days participation metrics (MON-124)

### DIFF
--- a/api/routers/deputies.py
+++ b/api/routers/deputies.py
@@ -85,14 +85,24 @@ def get_deputy_stats(request: Request):
         with get_conn() as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "SELECT AVG(presence_rate) AS avg_presence_rate "
+                    "SELECT AVG(presence_rate) AS avg_presence_rate, "
+                    "AVG(solennel_participation_rate) AS avg_solennel_participation_rate, "
+                    "AVG(voting_days_rate) AS avg_voting_days_rate "
                     "FROM analytics_marts.mart_deputy_scorecard"
                 )
                 row = cur.fetchone()
     except psycopg2.errors.UndefinedTable:
         raise MART_UNAVAILABLE from None
-    avg = row["avg_presence_rate"]
-    return DeputyStats(avg_presence_rate=float(avg) if avg is not None else None)
+
+    def _avg(key: str) -> Optional[float]:
+        value = row[key]
+        return float(value) if value is not None else None
+
+    return DeputyStats(
+        avg_presence_rate=_avg("avg_presence_rate"),
+        avg_solennel_participation_rate=_avg("avg_solennel_participation_rate"),
+        avg_voting_days_rate=_avg("avg_voting_days_rate"),
+    )
 
 
 @router.get("/{deputy_id}", response_model=DeputyDetail)
@@ -175,7 +185,13 @@ def get_scorecard(request: Request, deputy_id: str):
                         total_contre                              AS votes_against,
                         total_abstention                          AS abstentions,
                         votes_for_pct,
-                        abstention_pct
+                        abstention_pct,
+                        eligible_solennels,
+                        total_solennels_cast                      AS solennels_cast,
+                        solennel_participation_rate,
+                        eligible_voting_days,
+                        total_voting_days_present                 AS voting_days_present,
+                        voting_days_rate
                     FROM analytics_marts.mart_deputy_scorecard
                     WHERE deputy_id = %s
                     """,

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -59,6 +59,22 @@ class DeputyScorecard(_Base):
     abstentions: int
     votes_for_pct: float = Field(description="votes_for / present_votes, 0–1")
     abstention_pct: float = Field(description="abstentions / present_votes, 0–1")
+    eligible_solennels: int = Field(
+        description="Scrutins solennels held during the deputy's mandate window"
+    )
+    solennels_cast: int = Field(description="Of those, how many the deputy voted on")
+    solennel_participation_rate: float = Field(
+        description="solennels_cast / eligible_solennels, 0–1 (see MON-124)"
+    )
+    eligible_voting_days: int = Field(
+        description="Distinct calendar days with at least one scrutin during the mandate window"
+    )
+    voting_days_present: int = Field(
+        description="Of those, how many days the deputy cast at least one vote"
+    )
+    voting_days_rate: float = Field(
+        description="voting_days_present / eligible_voting_days, 0–1 (see MON-124)"
+    )
 
 
 class DeputyAlignment(_Base):
@@ -96,6 +112,14 @@ class DeputyStats(_Base):
     avg_presence_rate: Optional[float] = Field(
         None,
         description="Average presence_rate across all deputies, 0–1; null when the mart is empty",
+    )
+    avg_solennel_participation_rate: Optional[float] = Field(
+        None,
+        description="Average solennel_participation_rate across all deputies, 0–1 (MON-124)",
+    )
+    avg_voting_days_rate: Optional[float] = Field(
+        None,
+        description="Average voting_days_rate across all deputies, 0–1 (MON-124)",
     )
 
 

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -276,6 +276,11 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                         <div style={{ position: 'absolute', top: -9, height: 9, width: 2, background: 'rgba(0,0,0,0.25)', left: `${avgSolennelPct}%` }} aria-hidden="true" />
                       </div>
                     )}
+                    {avgSolennelPct !== null && (
+                      <p style={{ fontSize: 11, color: '#9CA3AF', marginTop: 8 }}>
+                        Trait vertical = moyenne nationale ({avgSolennelPct}%)
+                      </p>
+                    )}
                   </div>
                 )}
 
@@ -311,6 +316,11 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                       <div style={{ position: 'relative', height: 0 }}>
                         <div style={{ position: 'absolute', top: -9, height: 9, width: 2, background: 'rgba(0,0,0,0.25)', left: `${avgVotingDaysPct}%` }} aria-hidden="true" />
                       </div>
+                    )}
+                    {avgVotingDaysPct !== null && (
+                      <p style={{ fontSize: 11, color: '#9CA3AF', marginTop: 8 }}>
+                        Trait vertical = moyenne nationale ({avgVotingDaysPct}%)
+                      </p>
                     )}
                   </div>
                 )}

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -51,6 +51,19 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
 
   const presencePct    = scorecard ? Math.round((scorecard.presence_rate ?? 0) * 100) : null
   const avgPresencePct = deputyStats ? Math.round((deputyStats.avg_presence_rate ?? 0) * 100) : null
+
+  // MON-124: the all-scrutins presence_rate above is dominated by amendment
+  // scrutins where only ~15% of deputies vote, which reads as absenteeism
+  // even for deputies with strong attendance. These two metrics have
+  // denominators where absence is actually meaningful — see
+  // notes/dispatch/presence_kpi_comparison_2026-07-09.md.
+  const solennelPct    = scorecard ? Math.round((scorecard.solennel_participation_rate ?? 0) * 100) : null
+  const avgSolennelPct = deputyStats?.avg_solennel_participation_rate != null
+    ? Math.round(deputyStats.avg_solennel_participation_rate * 100) : null
+  const votingDaysPct    = scorecard ? Math.round((scorecard.voting_days_rate ?? 0) * 100) : null
+  const avgVotingDaysPct = deputyStats?.avg_voting_days_rate != null
+    ? Math.round(deputyStats.avg_voting_days_rate * 100) : null
+
   const denom          = scorecard ? (scorecard.present_votes || 1) : 1
   const pourPct        = scorecard ? Math.round(scorecard.votes_for     / denom * 100) : 0
   const contrePct      = scorecard ? Math.round(scorecard.votes_against / denom * 100) : 0
@@ -230,7 +243,79 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                   ))}
                 </div>
 
-                {/* Presence bar */}
+                {/* Participation aux scrutins solennels (MON-124) */}
+                {solennelPct !== null && (
+                  <div style={{ marginTop: 28, paddingTop: 24, borderTop: `1px solid ${LINE}` }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
+                      <span style={{ fontSize: 14, color: '#6B7280', fontWeight: 500, display: 'flex', alignItems: 'center', gap: 8 }}>
+                        Participation aux scrutins solennels
+                        <InfoTooltip
+                          text="Les scrutins solennels sont des votes programmés sur l'ensemble d'un texte, où la présence de tous les groupes est attendue — contrairement aux scrutins d'amendements, votés en petit comité. C'est la mesure la plus proche de « présence aux votes qui comptent »."
+                          href="/methodologie#presence"
+                        />
+                      </span>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                        {avgSolennelPct !== null && (
+                          <span style={{ fontSize: 13, color: solennelPct >= avgSolennelPct ? '#1F8A5B' : RED }}>
+                            {solennelPct >= avgSolennelPct ? '↑' : '↓'} moy. {avgSolennelPct}%
+                          </span>
+                        )}
+                        <span className="font-mono" style={{ fontWeight: 700, fontSize: 18, color: NAVY }}>
+                          {solennelPct}%
+                          <span style={{ fontWeight: 400, fontSize: 13, color: '#9CA3AF', marginLeft: 6 }}>
+                            ({scorecard?.solennels_cast}/{scorecard?.eligible_solennels})
+                          </span>
+                        </span>
+                      </div>
+                    </div>
+                    <div style={{ position: 'relative', height: 9, background: '#EEF0F2', borderRadius: 999, overflow: 'hidden' }}>
+                      <div style={{ height: '100%', background: NAVY, borderRadius: 999, width: `${solennelPct}%`, transition: 'width 0.4s' }} />
+                    </div>
+                    {avgSolennelPct !== null && (
+                      <div style={{ position: 'relative', height: 0 }}>
+                        <div style={{ position: 'absolute', top: -9, height: 9, width: 2, background: 'rgba(0,0,0,0.25)', left: `${avgSolennelPct}%` }} aria-hidden="true" />
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Présence par jour de vote (MON-124) */}
+                {votingDaysPct !== null && (
+                  <div style={{ marginTop: 28, paddingTop: 24, borderTop: `1px solid ${LINE}` }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
+                      <span style={{ fontSize: 14, color: '#6B7280', fontWeight: 500, display: 'flex', alignItems: 'center', gap: 8 }}>
+                        Présence par jour de vote
+                        <InfoTooltip
+                          text="Une journée de séance peut contenir plusieurs dizaines de scrutins sur un même texte. Ce taux compte les journées où le·la député·e a voté au moins une fois, plutôt que chaque scrutin séparément — un meilleur indicateur de présence physique."
+                          href="/methodologie#presence"
+                        />
+                      </span>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                        {avgVotingDaysPct !== null && (
+                          <span style={{ fontSize: 13, color: votingDaysPct >= avgVotingDaysPct ? '#1F8A5B' : RED }}>
+                            {votingDaysPct >= avgVotingDaysPct ? '↑' : '↓'} moy. {avgVotingDaysPct}%
+                          </span>
+                        )}
+                        <span className="font-mono" style={{ fontWeight: 700, fontSize: 18, color: NAVY }}>
+                          {votingDaysPct}%
+                          <span style={{ fontWeight: 400, fontSize: 13, color: '#9CA3AF', marginLeft: 6 }}>
+                            ({scorecard?.voting_days_present}/{scorecard?.eligible_voting_days} jours)
+                          </span>
+                        </span>
+                      </div>
+                    </div>
+                    <div style={{ position: 'relative', height: 9, background: '#EEF0F2', borderRadius: 999, overflow: 'hidden' }}>
+                      <div style={{ height: '100%', background: NAVY, borderRadius: 999, width: `${votingDaysPct}%`, transition: 'width 0.4s' }} />
+                    </div>
+                    {avgVotingDaysPct !== null && (
+                      <div style={{ position: 'relative', height: 0 }}>
+                        <div style={{ position: 'absolute', top: -9, height: 9, width: 2, background: 'rgba(0,0,0,0.25)', left: `${avgVotingDaysPct}%` }} aria-hidden="true" />
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Presence bar (all scrutins — see MON-124 for the copy/demotion follow-up) */}
                 {presencePct !== null && (
                   <div style={{ marginTop: 28, paddingTop: 24, borderTop: `1px solid ${LINE}` }}>
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -24,6 +24,12 @@ export type Scorecard = {
   abstentions: number
   votes_for_pct: number
   abstention_pct: number
+  eligible_solennels: number
+  solennels_cast: number
+  solennel_participation_rate: number
+  eligible_voting_days: number
+  voting_days_present: number
+  voting_days_rate: number
 }
 
 export type Vote = {
@@ -50,6 +56,8 @@ export type VoteDetail = Vote & {
 
 export type DeputyStats = {
   avg_presence_rate: number
+  avg_solennel_participation_rate: number | null
+  avg_voting_days_rate: number | null
 }
 
 export type Alignment = {

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -47,16 +47,22 @@ _MART_DDL = """
 CREATE SCHEMA IF NOT EXISTS analytics_marts;
 
 CREATE TABLE IF NOT EXISTS analytics_marts.mart_deputy_scorecard (
-    deputy_id        TEXT PRIMARY KEY,
-    full_name        TEXT,
-    total_votes_cast INTEGER,
-    total_nonvotant  INTEGER,
-    presence_rate    NUMERIC,
-    total_pour       INTEGER,
-    total_contre     INTEGER,
-    total_abstention INTEGER,
-    votes_for_pct    NUMERIC,
-    abstention_pct   NUMERIC
+    deputy_id                    TEXT PRIMARY KEY,
+    full_name                    TEXT,
+    total_votes_cast             INTEGER,
+    total_nonvotant              INTEGER,
+    presence_rate                NUMERIC,
+    total_pour                   INTEGER,
+    total_contre                 INTEGER,
+    total_abstention             INTEGER,
+    votes_for_pct                NUMERIC,
+    abstention_pct               NUMERIC,
+    eligible_solennels           INTEGER DEFAULT 0,
+    total_solennels_cast         INTEGER DEFAULT 0,
+    solennel_participation_rate  NUMERIC DEFAULT 0,
+    eligible_voting_days         INTEGER DEFAULT 0,
+    total_voting_days_present    INTEGER DEFAULT 0,
+    voting_days_rate             NUMERIC DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS analytics_marts.mart_vote_summary (

--- a/tests/integration/test_scorecard.py
+++ b/tests/integration/test_scorecard.py
@@ -18,7 +18,13 @@ SELECT
     total_contre                              AS votes_against,
     total_abstention                          AS abstentions,
     votes_for_pct,
-    abstention_pct
+    abstention_pct,
+    eligible_solennels,
+    total_solennels_cast                      AS solennels_cast,
+    solennel_participation_rate,
+    eligible_voting_days,
+    total_voting_days_present                 AS voting_days_present,
+    voting_days_rate
 FROM analytics_marts.mart_deputy_scorecard
 WHERE deputy_id = %s
 """
@@ -39,6 +45,9 @@ def test_scorecard_row_returned(db_conn):
     assert float(row["presence_rate"]) == 1.0
     assert row["votes_for"] == 25
     assert row["votes_against"] == 0
+    assert row["eligible_solennels"] == 0  # seed row has no solennel data
+    assert float(row["solennel_participation_rate"]) == 0.0
+    assert float(row["voting_days_rate"]) == 0.0
 
 
 @pytest.mark.integration

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -140,12 +140,20 @@ def test_get_scorecard(client, mock_cursor):
         "abstentions": 10,
         "votes_for_pct": 0.667,
         "abstention_pct": 0.111,
+        "eligible_solennels": 35,
+        "solennels_cast": 32,
+        "solennel_participation_rate": 0.914,
+        "eligible_voting_days": 126,
+        "voting_days_present": 77,
+        "voting_days_rate": 0.611,
     }
     resp = client.get("/deputies/PA1/scorecard")
     assert resp.status_code == 200
     data = resp.json()
     assert 0.0 <= data["presence_rate"] <= 1.0
     assert data["total_votes"] == 100
+    assert data["solennel_participation_rate"] == 0.914
+    assert data["voting_days_rate"] == 0.611
 
 
 def test_get_scorecard_not_found(client, mock_cursor):
@@ -372,11 +380,19 @@ def test_scorecard_zero_votes(client, mock_cursor):
         "abstentions": 0,
         "votes_for_pct": 0.0,
         "abstention_pct": 0.0,
+        "eligible_solennels": 0,
+        "solennels_cast": 0,
+        "solennel_participation_rate": 0.0,
+        "eligible_voting_days": 0,
+        "voting_days_present": 0,
+        "voting_days_rate": 0.0,
     }
     resp = client.get("/deputies/PA99/scorecard")
     assert resp.status_code == 200
     data = resp.json()
     assert data["total_votes"] == 0
+    assert data["solennel_participation_rate"] == 0.0
+    assert data["voting_days_rate"] == 0.0
     assert data["presence_rate"] == 0.0
     assert data["votes_for_pct"] == 0.0
     assert data["abstention_pct"] == 0.0

--- a/transform/models/marts/mart_deputy_scorecard.sql
+++ b/transform/models/marts/mart_deputy_scorecard.sql
@@ -28,6 +28,41 @@ eligible_votes as (
     group by d.deputy_id
 ),
 
+-- Scrutins solennels only (vote_type = 'sps') — scheduled whole-text votes
+-- where chamber-wide attendance is expected, unlike the amendment-by-
+-- amendment scrutins publics ordinaires that dominate eligible_votes.
+-- Motions de censure ('moc') are excluded: only the motion's supporters
+-- vote on those by design, so counting them punishes majority deputies
+-- for a strategic choice, not an absence (see MON-124's empirical writeup
+-- in notes/dispatch/presence_kpi_comparison_2026-07-09.md, finding #3).
+eligible_solennels as (
+    select
+        d.deputy_id,
+        count(v.vote_id) as eligible
+    from deputies d
+    left join votes v
+        on v.vote_type = 'sps'
+        and (d.mandate_started_at is null or v.voted_at >= d.mandate_started_at)
+        and (d.mandate_ended_at is null or v.voted_at <= d.mandate_ended_at)
+    group by d.deputy_id
+),
+
+-- Voting-day denominator: distinct calendar days on which at least one
+-- scrutin was held during the mandate window. Collapses same-day amendment
+-- marathons (a single sitting can hold dozens of scrutins) into one
+-- observation, so this proxies physical attendance far better than
+-- per-scrutin counting.
+eligible_voting_days as (
+    select
+        d.deputy_id,
+        count(distinct date_trunc('day', v.voted_at)) as eligible
+    from deputies d
+    left join votes v
+        on (d.mandate_started_at is null or v.voted_at >= d.mandate_started_at)
+        and (d.mandate_ended_at is null or v.voted_at <= d.mandate_ended_at)
+    group by d.deputy_id
+),
+
 deputy_stats as (
     select
         p.deputy_id,
@@ -40,6 +75,19 @@ deputy_stats as (
             where p.position in ('pour', 'contre', 'abstention')
         )                                                     as votes_expressed
     from positions p
+    group by p.deputy_id
+),
+
+-- Solennel participation and voting-day presence both require the vote's
+-- vote_type / voted_at, so this joins positions to votes rather than
+-- reusing deputy_stats (which aggregates over positions alone).
+deputy_solennel_stats as (
+    select
+        p.deputy_id,
+        count(*) filter (where v.vote_type = 'sps')            as solennels_cast,
+        count(distinct date_trunc('day', v.voted_at))          as voting_days_present
+    from positions p
+    join votes v on v.vote_id = p.vote_id
     group by p.deputy_id
 ),
 
@@ -88,12 +136,33 @@ final as (
             else 0
         end                                                  as abstention_pct,
 
+        -- solennels: eligible=0 (no scrutin solennel yet in the deputy's
+        -- window) reads as 0, matching the presence_rate convention above.
+        coalesce(so.solennels_cast, 0)                       as total_solennels_cast,
+        coalesce(es.eligible, 0)                             as eligible_solennels,
+        case
+            when es.eligible > 0
+            then least(round(coalesce(so.solennels_cast, 0)::numeric / es.eligible, 4), 1)
+            else 0
+        end                                                  as solennel_participation_rate,
+
+        coalesce(so.voting_days_present, 0)                  as total_voting_days_present,
+        coalesce(ed.eligible, 0)                             as eligible_voting_days,
+        case
+            when ed.eligible > 0
+            then least(round(coalesce(so.voting_days_present, 0)::numeric / ed.eligible, 4), 1)
+            else 0
+        end                                                  as voting_days_rate,
+
         -- metadata: reflects last ingest, not query time — makes recency test meaningful
         l.ingested_at                                        as updated_at
 
     from deputies d
     left join deputy_stats s on d.deputy_id = s.deputy_id
     left join eligible_votes e on d.deputy_id = e.deputy_id
+    left join eligible_solennels es on d.deputy_id = es.deputy_id
+    left join eligible_voting_days ed on d.deputy_id = ed.deputy_id
+    left join deputy_solennel_stats so on d.deputy_id = so.deputy_id
     cross join last_ingested l
 )
 

--- a/transform/models/marts/schema.yml
+++ b/transform/models/marts/schema.yml
@@ -8,7 +8,12 @@ models:
       recorded position counts as present (including nonVotant), and the
       denominator is the number of votes held during the deputy's mandate
       window. votes_for_pct / abstention_pct divide by expressed positions
-      (pour + contre + abstention) only.
+      (pour + contre + abstention) only. solennel_participation_rate and
+      voting_days_rate are complementary participation metrics (MON-124):
+      the former restricts to scrutins solennels only (scheduled whole-text
+      votes where absence is meaningful), the latter to distinct voting
+      days rather than per-scrutin counts, so a single sitting with dozens
+      of amendment scrutins doesn't inflate or deflate the denominator.
     tests:
       - dbt_utils.recency:
           datepart: day
@@ -37,6 +42,18 @@ models:
               max_value: 1
       - name: total_votes_cast
         tests: [not_null]
+      - name: solennel_participation_rate
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              max_value: 1
+      - name: voting_days_rate
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              max_value: 1
 
   - name: mart_vote_summary
     description: "One row per vote — result, participation, pct breakdown"


### PR DESCRIPTION
## Summary

Deputy pages currently headline "Taux de présence aux votes" against all 5,106 scrutins publics in the mandate window. Most of those scrutins are amendment votes attended by only ~15% of deputies, so the metric reads as absenteeism even for deputies with strong attendance — verified empirically (`notes/dispatch/presence_kpi_comparison_2026-07-09.md`): a former Prime Minister (Attal) and an ordinary backbencher (Lahmar) both score ~15% under the current metric.

This PR ships the first two of MON-124's four options — the two new metrics with denominators where absence is actually meaningful:

- **`solennel_participation_rate`** — positions recorded on scrutins solennels only (`vote_type = 'sps'`), out of scrutins solennels held during the mandate window. Motions de censure (`moc`) are deliberately excluded: only the motion's supporters vote on those by design, so counting them would punish majority deputies for a strategic choice, not an absence.
- **`voting_days_rate`** — distinct calendar days with at least one recorded position, out of voting days held during the mandate window. Collapses same-day amendment marathons (one sitting can hold dozens of scrutins) into a single observation, which proxies physical attendance far better than per-scrutin counting.

Both values were validated read-only against production for 5 example deputies before implementation and match exactly post-implementation (see table below).

## Acceptance criteria mapping (MON-124)

| Criterion | Status |
|---|---|
| Two new participation KPIs with meaningful denominators | ✅ this PR (options A + B) |
| "Présence" wording no longer misleading | ⏳ deferred — the old all-scrutins bar stays as-is for now; rename/demotion is the follow-up PR |
| `vote_type` verified populated + exposed | ✅ verified populated in prod (SPO 5057 / SPS 35 / MOC 14); mart-internal exposure only in this PR — `/votes` API exposure is the follow-up PR |
| New ADR superseding ADR-019 | ⏳ follow-up PR |
| `/methodologie` updated | ⏳ follow-up PR (new tooltips link to the existing `#presence` anchor for now) |

## Changes

- `transform/models/marts/mart_deputy_scorecard.sql`: two new CTEs (`eligible_solennels`, `eligible_voting_days`) and `deputy_solennel_stats`, following the existing `eligible_votes`/`presence_rate` pattern exactly (same `least(...,1)` cap, same 0-when-no-eligible convention)
- `transform/models/marts/schema.yml`: `not_null` + `accepted_range 0-1` tests for both new columns, updated model description
- `api/schemas.py`, `api/routers/deputies.py`: `DeputyScorecard` and `DeputyStats` extended with the new fields (counts + rates); `/deputies/stats` now also returns national averages for both
- `frontend/src/lib/api.ts`, `frontend/src/app/deputes/[id]/page.tsx`: two new metric bars in the "Bilan de mandat" card, styled identically to the existing presence bar (national-average marker, InfoTooltip), placed above it
- `tests/test_api.py`, `tests/integration/conftest.py`, `tests/integration/test_scorecard.py`: mocks and the stub mart table/SQL copy updated for the new columns

## Validation (5 example deputies, read-only prod query)

| Deputy | Current (all scrutins) | Solennels (this PR) | Jours de vote (this PR) |
|---|---|---|---|
| Abdelkader Lahmar | 15.3% | **88.6%** (31/35) | 48.4% (61/126) |
| Gabriel Attal | 15.0% | **91.4%** (32/35) | 61.1% (77/126) |
| Marine Le Pen | 11.8% | **97.1%** (34/35) | 46.0% (58/126) |
| Mathilde Panot | 33.8% | **97.1%** (34/35) | 85.7% (108/126) |
| Yaël Braun-Pivet | 100% | 100% | 100% |

## Test plan

- [x] `venv/bin/python -m pytest tests/ -m "not integration" -q` — 150 passed
- [x] `venv/bin/ruff check .` / `ruff format --check .` — clean
- [x] Read-only prod query reproducing the new mart CTEs — values match the pre-implementation analysis exactly
- [x] `cd frontend && npm run lint` — no warnings
- [x] `cd frontend && npm test -- --ci` — 51 passed
- [x] `cd frontend && npm run build` — succeeds (type-checks the new `Scorecard`/`DeputyStats` fields)
- [ ] dbt run/test against a live warehouse (not available in this environment; CI's `dbt-data-health` job will validate the new range tests on merge)

## Deploy notes

No schema migration — these are dbt-derived mart columns, materialized on the next `dbt run` (CI `deploy.yml` on merge to master, per existing convention). No env var or config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)