### PR TITLE
fix: rename presence copy, expose vote_type, add ADR-022 (MON-124)

### DIFF
--- a/api/routers/votes.py
+++ b/api/routers/votes.py
@@ -107,7 +107,7 @@ def list_votes(
 
                 cur.execute(
                     sql.SQL("""
-                        SELECT vote_id, voted_at, vote_title, result,
+                        SELECT vote_id, voted_at, vote_title, vote_type, result,
                                votes_for, votes_against, abstentions, total_voters,
                                summary_plain, theme
                         FROM analytics_marts.mart_vote_summary {}
@@ -141,7 +141,7 @@ def latest_votes(request: Request):
             with conn.cursor() as cur:
                 cur.execute(
                     """
-                    SELECT vote_id, voted_at, vote_title, result,
+                    SELECT vote_id, voted_at, vote_title, vote_type, result,
                            votes_for, votes_against, abstentions, total_voters,
                            summary_plain, theme
                     FROM analytics_marts.mart_vote_summary

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -156,6 +156,9 @@ class VoteSummary(_Base):
     vote_id: str
     voted_at: Optional[datetime] = None
     vote_title: str
+    vote_type: Optional[str] = Field(
+        None, description="'spo' (ordinaire), 'sps' (solennel), or 'moc' (motion de censure)"
+    )
     result: Optional[str] = None
     votes_for: Optional[int] = None
     votes_against: Optional[int] = None
@@ -178,7 +181,6 @@ class VotePosition(_Base):
 class VoteDetail(VoteSummary):
     """Full vote — used in GET /votes/{vote_id}."""
 
-    vote_type: Optional[str] = None
     dossier_id: Optional[str] = None
     ingested_at: Optional[datetime] = None
     positions: list[VotePosition] = []

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -443,6 +443,60 @@ FastAPI app — a different module set than what's archived here.
 
 ---
 
+## ADR-022 — Three participation metrics, not one misleading "presence" number (supersedes ADR-019's framing)
+**Date:** 2026-07-10
+**Status:** Final
+
+**Decision:** ADR-019's formula for `mart_deputy_scorecard.presence_rate` is
+still correct and unchanged — every recorded position counts (including
+`nonVotant`), denominator is the deputy's mandate window, capped at 1. What
+changes is that MonÉlu now computes and displays **three** participation
+metrics side by side instead of headlining that one number as "présence":
+
+1. **`presence_rate`** (unchanged from ADR-019) — every scrutin in the
+   mandate window. Renamed in UI/RAG copy from "taux de présence" to
+   "participation aux scrutins publics (tous types)"; demoted to a detail
+   stat, no longer the headline.
+2. **`solennel_participation_rate`** (new) — restricted to `vote_type = 'sps'`
+   (scrutins solennels), explicitly excluding `'moc'` (motions de censure,
+   where only the motion's supporters vote by design — including them would
+   punish majority deputies for a strategic abstention, not measure absence).
+3. **`voting_days_rate`** (new) — distinct calendar days with at least one
+   recorded position, over distinct voting days in the mandate window.
+   Collapses same-day amendment marathons into one observation.
+
+All three live in `mart_deputy_scorecard` (see
+`transform/models/marts/mart_deputy_scorecard.sql`), follow the same
+`least(round(...,4),1)` cap and 0-when-no-eligible-scrutins convention, and
+are covered by `not_null` + `accepted_range 0-1` dbt tests.
+
+**Reason:** empirical analysis on 5 example deputies
+(`notes/dispatch/presence_kpi_comparison_2026-07-09.md`) showed
+`presence_rate` alone is misleading, not wrong: a former Prime Minister and
+an ordinary backbencher both scored ~15%, because most scrutins are
+amendment votes only ~15% of deputies attend structurally. Marine Le Pen
+scored lowest of the five on `presence_rate` (11.8%) but highest on
+`solennel_participation_rate` (97.1%) — the all-scrutins number was
+presenting a big-votes-only voting pattern as the least "present" deputy of
+the five. A single renamed number would still mislead; three metrics with
+different denominators tell the real story.
+
+**Rule (supersedes ADR-019's rule):** any new consumer of participation data
+reads one of the three `mart_deputy_scorecard` rate columns above, or copies
+the exact matching formula. Do not invent a fourth definition. Do not
+display `presence_rate` as a citizen-facing headline without
+`solennel_participation_rate` or `voting_days_rate` alongside it — shown
+alone, it reads as absenteeism.
+
+**Where "présence" wording still appears intentionally:** the SQL router's
+regex intent patterns (`rag/chain/sql_router.py`) still match user questions
+containing "présence" — that is ordinary French for what citizens ask about,
+and matching their phrasing is correct. Only *our own generated output*
+(chunker prose, formatter response text, UI labels) was renamed to
+"participation aux scrutins publics".
+
+---
+
 ## Rules for future development sessions
 
 1. Read this file before writing any code

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -73,7 +73,7 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
 
   const stats = scorecard ? [
     { value: scorecard.total_votes.toLocaleString('fr-FR'),    label: 'scrutins votés' },
-    { value: `${presencePct ?? '—'}%`,                        label: 'présence aux votes' },
+    { value: `${presencePct ?? '—'}%`,                        label: 'participation (tous scrutins)' },
     { value: scorecard.votes_for.toLocaleString('fr-FR'),      label: 'votes Pour' },
     { value: scorecard.votes_against.toLocaleString('fr-FR'),  label: 'votes Contre' },
     { value: scorecard.abstentions.toLocaleString('fr-FR'),    label: 'abstentions' },
@@ -325,14 +325,17 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                   </div>
                 )}
 
-                {/* Presence bar (all scrutins — see MON-124 for the copy/demotion follow-up) */}
+                {/* Participation rate — all scrutins. Demoted below the two metrics above
+                    (MON-124): its denominator includes amendment scrutins that only ~15%
+                    of deputies attend, so it reads as absenteeism on its own. Kept as
+                    detail context, no longer the headline. */}
                 {presencePct !== null && (
                   <div style={{ marginTop: 28, paddingTop: 24, borderTop: `1px solid ${LINE}` }}>
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
                       <span style={{ fontSize: 14, color: '#6B7280', fontWeight: 500, display: 'flex', alignItems: 'center', gap: 8 }}>
-                        Taux de présence aux votes
+                        Participation aux scrutins publics (tous types)
                         <InfoTooltip
-                          text="Un·e député·e est compté·e présent·e dès qu'une position est enregistrée, y compris non-votant (présent en séance sans prise de position). Le dénominateur ne compte que les scrutins tenus pendant son mandat."
+                          text="Un·e député·e est compté·e comme ayant participé dès qu'une position est enregistrée, y compris non-votant (présent en séance sans prise de position). Le dénominateur inclut tous les scrutins, y compris les amendements auxquels seule une minorité de députés participe généralement — voir les deux mesures ci-dessus pour une lecture plus fidèle de l'assiduité."
                           href="/methodologie#presence"
                         />
                       </span>

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -71,9 +71,14 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
 
   const hex = partyHex(deputy.party)
 
+  // MON-124: the hero strip headlines solennel participation, not the
+  // all-scrutins presence_rate — that number reads as absenteeism on its
+  // own (see notes/dispatch/presence_kpi_comparison_2026-07-09.md and
+  // ADR-022). The all-scrutins rate is still shown, demoted, further down
+  // in the "Bilan de mandat" card.
   const stats = scorecard ? [
     { value: scorecard.total_votes.toLocaleString('fr-FR'),    label: 'scrutins votés' },
-    { value: `${presencePct ?? '—'}%`,                        label: 'participation (tous scrutins)' },
+    { value: `${solennelPct ?? '—'}%`,                        label: 'scrutins solennels' },
     { value: scorecard.votes_for.toLocaleString('fr-FR'),      label: 'votes Pour' },
     { value: scorecard.votes_against.toLocaleString('fr-FR'),  label: 'votes Contre' },
     { value: scorecard.abstentions.toLocaleString('fr-FR'),    label: 'abstentions' },

--- a/frontend/src/app/methodologie/page.tsx
+++ b/frontend/src/app/methodologie/page.tsx
@@ -27,24 +27,45 @@ export default function MethodologiePage() {
         </p>
       </LegalSection>
 
-      <LegalSection id="presence" title="Taux de présence">
+      <LegalSection id="presence" title="Participation et présence : trois mesures, trois usages">
         <p style={{ ...textStyle, marginBottom: '10px' }}>
-          Le taux de présence d&apos;un député compte <strong>toute position enregistrée</strong> lors d&apos;un
-          scrutin : pour, contre, abstention, <strong>et non-votant</strong>. Un député &laquo;&nbsp;non-votant&nbsp;&raquo;
-          était présent dans l&apos;hémicycle sans exprimer de vote - c&apos;est une particularité documentée des
-          données de l&apos;Assemblée, pas une absence.
+          MonÉlu affiche trois mesures complémentaires plutôt qu&apos;un seul &laquo;&nbsp;taux de
+          présence&nbsp;&raquo;, parce qu&apos;aucune donnée de scrutin ne peut à elle seule répondre à &laquo;&nbsp;ce
+          député est-il assidu ?&nbsp;&raquo;. Toutes trois comptent <strong>toute position enregistrée</strong> comme
+          participation : pour, contre, abstention, <strong>et non-votant</strong>. Un député
+          &laquo;&nbsp;non-votant&nbsp;&raquo; était présent dans l&apos;hémicycle sans exprimer de vote - c&apos;est
+          une particularité documentée des données de l&apos;Assemblée, pas une absence.
         </p>
         <p style={{ ...textStyle, marginBottom: '10px' }}>
-          Le dénominateur n&apos;est pas &laquo;&nbsp;tous les scrutins depuis juillet 2024&nbsp;&raquo; mais
-          uniquement les scrutins tenus <strong>pendant le mandat</strong> du député (entre sa date de début et sa
-          date de fin de mandat, le cas échéant). Un député élu en cours de législature n&apos;est donc pas
-          pénalisé pour des votes antérieurs à son entrée en fonction.
+          <strong>Participation aux scrutins solennels</strong> ne compte que les votes programmés sur
+          l&apos;ensemble d&apos;un texte, où la présence de tous les groupes est attendue - c&apos;est la mesure la
+          plus proche de &laquo;&nbsp;présence aux votes qui comptent&nbsp;&raquo;, et la plus comparable à ce que
+          publient d&apos;autres sites de transparence parlementaire.
+        </p>
+        <p style={{ ...textStyle, marginBottom: '10px' }}>
+          <strong>Présence par jour de vote</strong> compte les journées de séance où le député a voté au moins une
+          fois, plutôt que chaque scrutin séparément. Une seule journée peut contenir plusieurs dizaines de scrutins
+          sur un même texte (amendements successifs) : les compter un par un ferait paraître absent un député qui a
+          suivi toute la séance mais n&apos;a pas voté sur chaque amendement.
+        </p>
+        <p style={{ ...textStyle, marginBottom: '10px' }}>
+          <strong>Participation aux scrutins publics (tous types)</strong> compte l&apos;ensemble des scrutins,
+          amendements compris. C&apos;est la mesure la plus complète mais aussi la plus trompeuse prise seule : la
+          plupart des scrutins sont des votes sur amendements auxquels seule une minorité de députés (souvent moins de
+          20&nbsp;%) participe généralement, si bien qu&apos;un taux de 15&nbsp;% peut correspondre à une assiduité
+          tout à fait normale. Nous l&apos;affichons en complément, jamais seule.
+        </p>
+        <p style={{ ...textStyle, marginBottom: '10px' }}>
+          Pour les trois mesures, le dénominateur n&apos;est pas &laquo;&nbsp;tous les scrutins depuis juillet
+          2024&nbsp;&raquo; mais uniquement les scrutins tenus <strong>pendant le mandat</strong> du député (entre sa
+          date de début et sa date de fin de mandat, le cas échéant). Un député élu en cours de législature
+          n&apos;est donc pas pénalisé pour des votes antérieurs à son entrée en fonction.
         </p>
         <p style={textStyle}>
-          Ce calcul unique est la <strong>seule</strong> définition de la présence utilisée sur MonÉlu - l&apos;API,
-          l&apos;assistant de recherche et les fiches députés s&apos;y conforment tous. C&apos;est pourquoi Yaël
-          Braun-Pivet, Présidente de l&apos;Assemblée nationale, affiche 100&nbsp;% de présence : elle est recensée
-          sur chaque scrutin par construction des données de l&apos;AN.
+          Ces calculs sont la <strong>seule</strong> définition de la participation utilisée sur MonÉlu -
+          l&apos;API, l&apos;assistant de recherche et les fiches députés s&apos;y conforment tous. C&apos;est
+          pourquoi Yaël Braun-Pivet, Présidente de l&apos;Assemblée nationale, affiche 100&nbsp;% sur les trois
+          mesures : elle est recensée sur chaque scrutin par construction des données de l&apos;AN.
         </p>
         <p style={sourceLineStyle}>
           Source :{' '}
@@ -53,7 +74,7 @@ export default function MethodologiePage() {
           </a>{' '}
           ·{' '}
           <a href={`${REPO_BASE}/docs/decisions.md`} target="_blank" rel="noopener noreferrer" style={linkStyle}>
-            ADR-019, décision architecturale
+            ADR-022, décision architecturale
           </a>
         </p>
       </LegalSection>

--- a/frontend/src/app/mon-depute/page.tsx
+++ b/frontend/src/app/mon-depute/page.tsx
@@ -222,7 +222,7 @@ export default function MonDeputePage() {
           <section style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20 }}>
             {presencePct !== null && (
               <div style={{ background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12, padding: '22px 24px' }}>
-                <div style={{ fontSize: 13, color: '#6B7280', fontWeight: 500, marginBottom: 10 }}>Taux de présence</div>
+                <div style={{ fontSize: 13, color: '#6B7280', fontWeight: 500, marginBottom: 10 }}>Participation aux scrutins publics</div>
                 <div className="font-mono" style={{ fontWeight: 700, fontSize: 28, color: NAVY }}>{presencePct}%</div>
                 <div style={{ position: 'relative', height: 8, background: '#EEF0F2', borderRadius: 999, overflow: 'hidden', marginTop: 12 }}>
                   <div style={{ height: '100%', background: NAVY, borderRadius: 999, width: `${presencePct}%` }} />

--- a/frontend/src/app/votes/VotesClient.tsx
+++ b/frontend/src/app/votes/VotesClient.tsx
@@ -233,6 +233,11 @@ export function VotesClient({ initial, heroStats }: { initial: VoteList; heroSta
                         <span style={{ fontSize: 12, fontWeight: 700, letterSpacing: '0.05em', padding: '3px 10px', borderRadius: 999, background: adopted ? '#EAF5EF' : '#FBE9E7', color: adopted ? '#1F8A5B' : '#C9302A' }}>
                           {adopted ? 'Adopté' : 'Rejeté'}
                         </span>
+                        {vote.vote_type === 'sps' && (
+                          <span style={{ fontSize: 11, fontWeight: 600, padding: '3px 9px', borderRadius: 999, background: '#EEF0F7', color: '#1B2B50' }}>
+                            Solennel
+                          </span>
+                        )}
                         <span className="font-mono" style={{ fontSize: 11.5, color: '#6B7280' }}>
                           {vote.votes_for} pour · {vote.votes_against} contre
                         </span>

--- a/frontend/src/app/votes/[id]/VoteDetailClient.tsx
+++ b/frontend/src/app/votes/[id]/VoteDetailClient.tsx
@@ -46,6 +46,7 @@ interface RelatedVote {
 interface Props {
   voteId: string
   voteTitle: string
+  voteType: string | null
   result: string
   votedAt: string
   summary: string | null
@@ -77,7 +78,7 @@ function shortDate(dateStr: string): string {
 
 export function VoteDetailClient(props: Props) {
   const {
-    voteId, voteTitle, result, votedAt, summary, theme,
+    voteId, voteTitle, voteType, result, votedAt, summary, theme,
     votesFor, votesAgainst, abstentions, totalVoters,
     pourPct, contrePct, abstPct,
     groups, dissidents, related, apiUrl, deputyLookup,
@@ -194,6 +195,11 @@ export function VoteDetailClient(props: Props) {
                 <span style={{ display: 'inline-flex', alignItems: 'center', fontSize: 13, fontWeight: 600, padding: '6px 14px', borderRadius: 999, background: adopted ? '#EAF5EF' : '#FBE9E7', color: adopted ? '#1F8A5B' : '#C9302A' }}>
                   {adopted ? 'Adopté' : 'Rejeté'}
                 </span>
+                {voteType === 'sps' && (
+                  <span style={{ display: 'inline-flex', alignItems: 'center', fontSize: 13, fontWeight: 600, padding: '6px 14px', borderRadius: 999, background: '#EEF0F7', color: '#1B2B50' }}>
+                    Scrutin solennel
+                  </span>
+                )}
                 {theme && (
                   <span style={{ display: 'inline-flex', alignItems: 'center', fontSize: 13, fontWeight: 600, padding: '6px 14px', borderRadius: 999, background: '#E8EFFE', color: '#2A5DB0' }}>
                     {theme}

--- a/frontend/src/app/votes/[id]/page.tsx
+++ b/frontend/src/app/votes/[id]/page.tsx
@@ -129,6 +129,7 @@ export default async function VoteDetailPage({ params }: { params: Promise<{ id:
       <VoteDetailClient
         voteId={vote.vote_id}
         voteTitle={vote.vote_title}
+        voteType={vote.vote_type ?? null}
         result={vote.result}
         votedAt={vote.voted_at}
         summary={vote.summary_plain ?? null}

--- a/frontend/src/components/home/AssemblyScrollExperience.tsx
+++ b/frontend/src/components/home/AssemblyScrollExperience.tsx
@@ -794,7 +794,7 @@ function CinematicExperience({ stats, leadVote, deputyInfo }: Props) {
               <div style={{ width: 1, background: 'rgba(120,150,210,0.2)' }} />
               <div style={{ textAlign: 'center' }}>
                 <div style={{ fontFamily: 'monospace', fontWeight: 500, fontSize: 'clamp(17px,2vw,22px)', color: '#fff' }}>{deputyInfo ? `${deputyInfo.presenceRate}%` : `${stats.deputies}`}</div>
-                <div style={{ fontSize: 12, color: 'rgba(180,196,228,0.66)', marginTop: 3, letterSpacing: '0.04em' }}>{deputyInfo ? 'présence' : 'sièges'}</div>
+                <div style={{ fontSize: 12, color: 'rgba(180,196,228,0.66)', marginTop: 3, letterSpacing: '0.04em' }}>{deputyInfo ? 'participation' : 'sièges'}</div>
               </div>
               <div style={{ width: 1, background: 'rgba(120,150,210,0.2)' }} />
               <div style={{ textAlign: 'center' }}>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -35,6 +35,7 @@ export type Scorecard = {
 export type Vote = {
   vote_id: string
   vote_title: string
+  vote_type?: string | null // 'spo' (ordinaire), 'sps' (solennel), 'moc' (motion de censure)
   result: string
   voted_at: string
   votes_for: number

--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -451,7 +451,7 @@ def _fmt_vote_line(r: dict) -> str:
 
 FORMATTERS = {
     "deputy_top_presence": lambda rows: (
-        "Députés en exercice avec le meilleur taux de présence "
+        "Députés en exercice avec la meilleure participation aux scrutins publics "
         f"(au moins {_MIN_WINDOW_VOTES} votes sur leur mandat) :\n"
         + "\n".join(
             f"- {r['full_name']} ({r['party'] or 'groupe non renseigné'}) : {r['presence_pct']}%"
@@ -459,7 +459,7 @@ FORMATTERS = {
         )
     ),
     "deputy_bottom_presence": lambda rows: (
-        "Députés en exercice avec le plus faible taux de présence "
+        "Députés en exercice avec la plus faible participation aux scrutins publics "
         f"(au moins {_MIN_WINDOW_VOTES} votes sur leur mandat) :\n"
         + "\n".join(
             f"- {r['full_name']} ({r['party'] or 'groupe non renseigné'}) : {r['presence_pct']}%"
@@ -579,7 +579,7 @@ FORMATTERS = {
         )
     ),
     "party_presence_rate": lambda rows: (
-        "Taux de présence moyen par groupe parlementaire :\n"
+        "Participation moyenne aux scrutins publics par groupe parlementaire :\n"
         + "\n".join(
             f"- {r['party']} : {r['avg_presence_pct']}% ({r['deputies']} députés)" for r in rows
         )

--- a/rag/pipeline/chunk_notable_deputies.py
+++ b/rag/pipeline/chunk_notable_deputies.py
@@ -136,7 +136,7 @@ def build_chunk(deputy: dict, votes: list[dict]) -> str:
         f"Sur {deputy['total_votes']} votes enregistrés : "
         f"{deputy['pour']} pour, {deputy['contre']} contre, "
         f"{deputy['abstention']} abstentions.",
-        f"Taux de présence : {presence}%.",
+        f"Participation aux scrutins publics : {presence}%.",
         "",
         "Votes récents et votes clés :",
     ]

--- a/rag/pipeline/chunker.py
+++ b/rag/pipeline/chunker.py
@@ -192,7 +192,7 @@ def chunk_deputies(deputy_ids: set[str] | None = None) -> list[dict]:
             f"{name} est député(e) {prep}{sep}{dept}, membre du parti {party}.\n"
             f"Sur {total} votes enregistrés, il/elle a voté pour {pour} fois, "
             f"contre {contre} fois, abstention {abst} fois.\n"
-            f"Taux de présence : {rate_pct}%."
+            f"Participation aux scrutins publics : {rate_pct}%."
         )
         metadata = {
             "chunk_type": "deputy",
@@ -283,7 +283,7 @@ def chunk_party_summaries() -> list[dict]:
             f"- Pour : {pour:,} fois\n"
             f"- Contre : {contre:,} fois\n"
             f"- Abstention : {abst:,} fois\n"
-            f"Taux de présence moyen du groupe : {avg_p}%."
+            f"Participation moyenne aux scrutins publics du groupe : {avg_p}%."
         )
         metadata = {
             "chunk_type": "party",
@@ -373,7 +373,8 @@ def chunk_global_stats() -> list[dict]:
         sep = "" if prep.endswith("'") else " "
         ybp_block = (
             f"\n{ybp_name} est la Présidente de l'Assemblée Nationale.\n"
-            f"Son taux de présence est de {ybp_rate}% sur {ybp_votes} votes enregistrés.\n"
+            f"Sa participation aux scrutins publics est de {ybp_rate}% "
+            f"sur {ybp_votes} votes enregistrés.\n"
             f"Elle est membre du parti {ybp_party}, députée {prep}{sep}{ybp_dept}."
         )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -33,6 +33,7 @@ _VOTE_SUMMARY = {
     "vote_id": "VTANR5L17V1",
     "voted_at": "2024-07-16T15:00:00",
     "vote_title": "Vote sur le projet de loi de finances",
+    "vote_type": "spo",
     "result": "adopté",
     "votes_for": 289,
     "votes_against": 250,
@@ -42,7 +43,6 @@ _VOTE_SUMMARY = {
 
 _VOTE_DETAIL = {
     **_VOTE_SUMMARY,
-    "vote_type": None,
     "dossier_id": None,
     "ingested_at": None,
 }
@@ -284,6 +284,7 @@ def test_list_votes(client, mock_cursor):
     assert "total" in data
     assert "items" in data
     assert len(data["items"]) == 1
+    assert data["items"][0]["vote_type"] == "spo"
     # Partial page (1 row < default limit) → no further pages.
     assert data["next_cursor"] is None
 


### PR DESCRIPTION
## Summary

Second and final part of MON-124, stacked on **#181** (metrics A + B) since that PR is still open and already scoped/reviewed — this one is intentionally kept separate so #181's review isn't re-triggered by an unrelated concern. **Base branch is #181's branch, not master** — merge #181 first, then this one; the diff below is only the incremental change.

Completes MON-124's remaining two acceptance criteria:

### 1. Copy fix — rename the misleading "présence" wording

"Taux de présence" / "présence aux votes" is renamed to **"participation aux scrutins publics"** everywhere it displayed the all-scrutins rate:

- Deputy page: bar renamed and demoted below the two new metrics from #181; stat tile relabeled
- `/mon-depute` personalized dashboard
- Landing page hero stat (the "présence" caption under the highlighted deputy)
- RAG chunker prose — both `rag/pipeline/chunker.py` (deputy/party/notable-Braun-Pivet chunks) and `rag/pipeline/chunk_notable_deputies.py`
- SQL router response formatters (`deputy_top_presence`, `deputy_bottom_presence`, `party_presence_rate`)

**Left untouched, deliberately:** the SQL router's regex intent patterns and existing test fixtures that match *how citizens phrase questions* ("quel est le taux de présence de X ?") — that's ordinary French for the concept and correct to match. Only our own generated output/labels were renamed.

### 2. `vote_type` exposure

Investigation found the gap was narrower than MON-124's original description assumed: `GET /votes/{id}` **already returned `vote_type` correctly** (verified against prod: returns `"moc"` for a motion de censure) via `SELECT *` + a schema field already declared on `VoteDetail`. The actual gap was only in the **list endpoints** (`list_votes`, `latest_votes` → `VoteSummary`), which explicitly enumerated columns without it.

- Added `vote_type` to `VoteSummary` (the base class `VoteDetail` inherits from) and removed the now-redundant redeclaration on `VoteDetail`
- Added `vote_type` to both list SQL `SELECT`s
- Added the field to the frontend `Vote` type
- Added a small "Solennel" / "Scrutin solennel" badge on the votes list and detail pages, so the newly-exposed field has a visible consumer rather than shipping dead data

No mart change needed — `mart_vote_summary.vote_type` was already there.

### 3. ADR-022 (docs/decisions.md)

Documents all three participation metrics together (presence_rate unchanged from ADR-019; the two new ones from #181), and explains the empirical case for the change: Marine Le Pen scores lowest of 5 example deputies on the all-scrutins rate (11.8%) but highest on the solennel rate (97.1%) — a single renamed number would still mislead, hence three metrics. Supersedes ADR-019's rule to require the new metrics alongside any `presence_rate` headline.

Note: ADR-020 and ADR-021 already exist in the file (deploy-race and infra-archive decisions) — this is **ADR-022**, not ADR-020 as MON-124's issue body assumed.

### 4. `/methodologie`

The `#presence` section now explains all three metrics instead of just `presence_rate` — kept at the same anchor (`#presence`) so the InfoTooltips added in #181 don't need updating.

## Acceptance criteria mapping (MON-124)

| Criterion | Status |
|---|---|
| Two new participation KPIs | ✅ #181 |
| "Présence" wording no longer misleading | ✅ this PR |
| `vote_type` verified populated + exposed | ✅ this PR (list endpoints; detail was already correct) |
| New ADR superseding ADR-019 | ✅ this PR (ADR-022) |
| `/methodologie` updated | ✅ this PR |

## Test plan

- [x] `venv/bin/python -m pytest tests/ -m "not integration" -q` — 150 passed (added a `vote_type` assertion to `test_list_votes`)
- [x] `venv/bin/ruff check .` / `ruff format --check .` — clean
- [x] `cd frontend && npm run lint` — no warnings
- [x] `cd frontend && npm test -- --ci` — 51 passed
- [x] `cd frontend && npm run build` — succeeds
- [x] Confirmed `/votes/{id}` already returns real `vote_type` in prod before touching it (`moc` for VTANR5L17V7979)

## Deploy notes

No schema/mart changes in this PR — `mart_vote_summary.vote_type` already existed. Pure API/frontend/RAG/docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)