### PR TITLE
fix: normalize organeRef list shape in party ingestion

### DIFF
--- a/scripts/ingest_organes.py
+++ b/scripts/ingest_organes.py
@@ -104,8 +104,14 @@ def build_deputy_party_map(zf: zipfile.ZipFile, gp_map: dict[str, str]) -> dict[
         for mandat in mandats_raw:
             type_organe = mandat.get("typeOrgane")
             date_fin = mandat.get("dateFin")
-            organe_ref = mandat.get("organes", {}).get("organeRef")
-            if not organe_ref or organe_ref not in gp_map:
+            organe_refs = mandat.get("organes", {}).get("organeRef")
+            # organeRef collapses to a bare string for a single occurrence but becomes
+            # a list when a mandat carries several (e.g. a MINISTERE mandat referencing
+            # more than one governmental organe) - normalize before the gp_map lookup.
+            if isinstance(organe_refs, str):
+                organe_refs = [organe_refs]
+            organe_ref = next((ref for ref in organe_refs or [] if ref in gp_map), None)
+            if not organe_ref:
                 continue
             if type_organe == "GP":
                 if date_fin:

--- a/tests/unit/test_party_labels.py
+++ b/tests/unit/test_party_labels.py
@@ -77,7 +77,7 @@ def _make_amo10_zip(mandats: list[dict]) -> zipfile.ZipFile:
 GP_MAP = {"ORG_GP1": "Groupe A", "ORG_GP2": "Groupe B", "ORG_PP": "Parti P"}
 
 
-def _mandat(type_organe: str, organe_ref: str, date_fin: str | None) -> dict:
+def _mandat(type_organe: str, organe_ref: str | list[str], date_fin: str | None) -> dict:
     return {
         "typeOrgane": type_organe,
         "dateFin": date_fin,
@@ -110,3 +110,23 @@ def test_latest_ended_gp_beats_active_parpol():
 def test_parpol_is_last_resort():
     zf = _make_amo10_zip([_mandat("PARPOL", "ORG_PP", None)])
     assert build_deputy_party_map(zf, GP_MAP) == {"PA1": "Parti P"}
+
+
+def test_organe_ref_list_does_not_crash():
+    # A MINISTERE mandat can carry several organeRefs (a minister sits in more
+    # than one governmental organe) - the AN export collapses this to a list
+    # instead of a scalar. This must not crash the GP/PARPOL lookup for the
+    # deputy's other, unrelated mandats (2026-07 incident: TypeError on
+    # `organe_ref not in gp_map` when organe_ref was a list).
+    zf = _make_amo10_zip(
+        [
+            _mandat("MINISTERE", ["ORG_UNRELATED_1", "ORG_UNRELATED_2"], None),
+            _mandat("GP", "ORG_GP1", None),
+        ]
+    )
+    assert build_deputy_party_map(zf, GP_MAP) == {"PA1": "Groupe A"}
+
+
+def test_gp_mandat_with_list_organe_ref_resolves_first_known_match():
+    zf = _make_amo10_zip([_mandat("GP", ["ORG_UNKNOWN", "ORG_GP1"], None)])
+    assert build_deputy_party_map(zf, GP_MAP) == {"PA1": "Groupe A"}


### PR DESCRIPTION
## Summary

- The daily production ingestion cron (`ingest_prod.yml`) has failed on every run since 2026-07-06 with `TypeError: unhashable type: 'list'` in `build_deputy_party_map` (`scripts/ingest_organes.py:108`).
- Root cause: the AN's JSON export collapses a repeated `organeRef` to a bare string when a mandat has one, but to a list when it has several (e.g. a `MINISTERE` mandat referencing multiple governmental organes). `organe_ref not in gp_map` throws instead of returning `False` when `organe_ref` is a list.
- Fix: normalize `organeRef` to a list before the lookup, the same pattern already used in this function for `mandats_raw` and `uid_field`, and take the first ref that resolves in `gp_map`.
- Found and reproduced against live AN data while auditing the three presence KPIs (`presence_rate`, `solennel_participation_rate`, `voting_days_rate`) for data quality; this bug is why production data has been stalling (last vote ingested 2026-07-06 as of this writing).

## Test plan

- [x] Reproduced the exact crash locally against a fresh download of the live AN deputies ZIP, confirmed fixed with the same data.
- [x] Ran `update_party.py` end-to-end against a local Postgres, no crash, all 577 deputies resolve including the deputy that previously crashed.
- [x] Added two regression tests in `tests/unit/test_party_labels.py` covering an unrelated mandat with a list `organeRef` (the actual crash shape) and a `GP` mandat with a list `organeRef` (defensive case).
- [x] Full unit suite: 89 passed.
- [x] `ruff check` / `ruff format --check`: clean.

## Note

The scheduled trigger for `ingest_prod.yml` also stopped firing entirely after 2026-07-07 (three missed weekdays) independent of this crash. That's a separate, unexplained gap worth watching after this merges, if the cron still doesn't fire on the next weekday it needs its own investigation.