### PR TITLE
fix: make non-critical ingestion steps non-fatal to the daily pipeline

### DIFF
--- a/.github/workflows/ingest_prod.yml
+++ b/.github/workflows/ingest_prod.yml
@@ -120,6 +120,36 @@ jobs:
       - name: Notify success
         run: echo "Ingestion completed at $(date)"
 
+      - name: Notify soft failures
+        # Non-critical steps (party/department enrichment, vote summaries) can fail
+        # without failing the job, so this run still shows green and the RAG/dbt
+        # steps above still ran. Surface it anyway, or it goes unnoticed like the
+        # 2026-07 organeRef incident did.
+        if: steps.ingest.outputs.soft_failures != ''
+        run: |
+          echo "::warning::Non-critical ingestion steps failed: ${{ steps.ingest.outputs.soft_failures }}"
+          echo "## ⚠️ Ingestion succeeded with warnings" >> "$GITHUB_STEP_SUMMARY"
+          echo "Core data (deputies/votes/positions) ingested fine. These non-critical steps failed and should be checked: ${{ steps.ingest.outputs.soft_failures }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Email soft-failure alert
+        if: steps.ingest.outputs.soft_failures != '' && secrets.MAIL_SERVER != '' && secrets.NOTIFY_EMAIL_TO != ''
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: ${{ secrets.MAIL_SERVER }}
+          server_port: ${{ secrets.MAIL_PORT }}
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          subject: "MonÉlu: ingestion succeeded with warnings"
+          to: ${{ secrets.NOTIFY_EMAIL_TO }}
+          from: MonÉlu CI <${{ secrets.MAIL_USERNAME }}>
+          body: |
+            Core data (deputies/votes/positions) ingested successfully, but the
+            following non-critical steps failed and should be investigated:
+
+            ${{ steps.ingest.outputs.soft_failures }}
+
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
       - name: Notify failure
         if: failure()
         run: |

--- a/scripts/run_ingestion_prod.py
+++ b/scripts/run_ingestion_prod.py
@@ -81,8 +81,20 @@ def row_count(conn, table: str) -> int:
         return cur.fetchone()[0]
 
 
-def run_step(label: str, script: str, extra_args: list[str] | None = None) -> float:
-    """Run a script file as a subprocess, streaming its output. Returns elapsed seconds."""
+def run_step(
+    label: str, script: str, extra_args: list[str] | None = None, critical: bool = True
+) -> float | None:
+    """Run a script file as a subprocess, streaming its output. Returns elapsed seconds.
+
+    Non-critical steps (party/department enrichment, vote summaries) must not take
+    down the whole pipeline: deputies/votes/positions have already committed by the
+    time these run, and a crash here previously aborted main() before the `new_votes`
+    GITHUB_OUTPUT was written, which silently skipped the downstream RAG rebuild and
+    dbt run/test/snapshot workflow steps too (2026-07 incident: an unrelated organeRef
+    parsing bug in the party step blocked mart refreshes for days even though votes
+    and positions had ingested fine). A non-critical failure logs a `::error::`
+    annotation, visible in the run summary, and returns None instead of raising.
+    """
     script_path = os.path.join(PROJECT_ROOT, "scripts", script)
     cmd = [sys.executable, script_path] + (extra_args or [])
     log.info("━━━ Starting: %s ━━━", label)
@@ -91,7 +103,12 @@ def run_step(label: str, script: str, extra_args: list[str] | None = None) -> fl
     result = subprocess.run(cmd, cwd=PROJECT_ROOT, env=env)
     elapsed = time.perf_counter() - t0
     if result.returncode != 0:
-        raise RuntimeError(f"{label} failed with exit code {result.returncode}")
+        message = f"{label} failed with exit code {result.returncode}"
+        if critical:
+            raise RuntimeError(message)
+        print(f"::error::{message} (non-critical - pipeline continues)")
+        log.error("━━━ Failed (non-critical): %s ━━━", label)
+        return None
     log.info("━━━ Done: %s (%.1fs) ━━━", label, elapsed)
     return elapsed
 
@@ -122,6 +139,11 @@ def main() -> None:
     log.info("Advisory lock acquired (key=%d).", _INGESTION_LOCK_KEY)
     total_start = time.perf_counter()
 
+    soft_failures: list[str] = []
+
+    def _fmt(elapsed: float | None) -> str:
+        return f"{elapsed:5.1f}s" if elapsed is not None else " skip "
+
     try:
         votes_before = row_count(lock_conn, "votes")
 
@@ -138,8 +160,13 @@ def main() -> None:
                 ["--since", args.since, "--zip-path", scrutins_zip],
             )
             t_party = run_step(
-                "Fix party + department names", "update_party.py", ["--zip-path", deputies_zip]
+                "Fix party + department names",
+                "update_party.py",
+                ["--zip-path", deputies_zip],
+                critical=False,
             )
+            if t_party is None:
+                soft_failures.append("Fix party + department names")
 
         n_deputies = row_count(lock_conn, "deputies")
         n_votes = row_count(lock_conn, "votes")
@@ -148,8 +175,8 @@ def main() -> None:
         new_votes = n_votes - votes_before
         log.info("New votes ingested this run: %d", new_votes)
 
-        # Write the output as soon as it is known — a summaries failure below must
-        # not lose the new_votes signal for downstream workflow steps.
+        # Write new_votes as soon as it is known — a summaries failure below must
+        # not lose this signal for downstream workflow steps.
         github_output = os.getenv("GITHUB_OUTPUT")
         if github_output:
             with open(github_output, "a") as f:
@@ -157,12 +184,22 @@ def main() -> None:
 
         # Always run summaries: the `summary_plain IS NULL` query no-ops when there is
         # nothing to do, and this retries summaries that failed on a previous run
-        # instead of waiting for the next new vote.
+        # instead of waiting for the next new vote. Non-critical: a Groq/OpenAI outage
+        # here must not block the dbt run/RAG rebuild that follows this script.
         t_summaries = run_step(
             "Vote summaries",
             "generate_vote_summaries.py",
             ["--since", args.since],
+            critical=False,
         )
+        if t_summaries is None:
+            soft_failures.append("Vote summaries")
+
+        # soft_failures is only fully known once every non-critical step has run,
+        # so it is written last, separately from new_votes above.
+        if github_output:
+            with open(github_output, "a") as f:
+                f.write(f"soft_failures={','.join(soft_failures)}\n")
 
         total_elapsed = time.perf_counter() - total_start
 
@@ -173,11 +210,18 @@ def main() -> None:
         log.info("║  Deputies  : %6d   (%5.1fs)      ║", n_deputies, t_deputies)
         log.info("║  Votes     : %6d   (%5.1fs)      ║", n_votes, t_votes)
         log.info("║  Positions : %6d   (%5.1fs)      ║", n_positions, t_positions)
-        log.info("║  Party fix :          (%5.1fs)      ║", t_party)
-        log.info("║  Summaries :          (%5.1fs)      ║", t_summaries)
+        log.info("║  Party fix :          (%s)      ║", _fmt(t_party))
+        log.info("║  Summaries :          (%s)      ║", _fmt(t_summaries))
         log.info("╠══════════════════════════════════════╣")
         log.info("║  Total time: %.1fs                   ║", total_elapsed)
         log.info("╚══════════════════════════════════════╝")
+
+        if soft_failures:
+            print(
+                f"::warning::Ingestion completed with non-critical failures: "
+                f"{', '.join(soft_failures)}. Core data (deputies/votes/positions) is fine; "
+                f"these steps should be re-run or fixed."
+            )
     except Exception:
         log.error("Ingestion failed — see above for details.")
         raise

--- a/tests/unit/test_run_ingestion_prod.py
+++ b/tests/unit/test_run_ingestion_prod.py
@@ -1,0 +1,45 @@
+"""
+Tests for run_step's critical/non-critical failure handling in
+scripts/run_ingestion_prod.py (2026-07 incident: a non-critical step's crash
+was aborting the whole pipeline, which silently skipped the downstream RAG
+rebuild and dbt run/test workflow steps even though core data had ingested).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from scripts.run_ingestion_prod import run_step
+
+
+def _fake_result(returncode: int):
+    class _Result:
+        pass
+
+    r = _Result()
+    r.returncode = returncode
+    return r
+
+
+def test_critical_success_returns_elapsed():
+    with patch("scripts.run_ingestion_prod.subprocess.run", return_value=_fake_result(0)):
+        elapsed = run_step("Votes", "ingest_votes.py")
+    assert isinstance(elapsed, float)
+
+
+def test_critical_failure_raises():
+    with patch("scripts.run_ingestion_prod.subprocess.run", return_value=_fake_result(1)):
+        with pytest.raises(RuntimeError, match="Votes failed with exit code 1"):
+            run_step("Votes", "ingest_votes.py")
+
+
+def test_non_critical_failure_does_not_raise():
+    with patch("scripts.run_ingestion_prod.subprocess.run", return_value=_fake_result(1)):
+        result = run_step("Fix party + department names", "update_party.py", critical=False)
+    assert result is None
+
+
+def test_non_critical_success_returns_elapsed():
+    with patch("scripts.run_ingestion_prod.subprocess.run", return_value=_fake_result(0)):
+        elapsed = run_step("Fix party + department names", "update_party.py", critical=False)
+    assert isinstance(elapsed, float)


### PR DESCRIPTION
## Summary

- While investigating why the daily ingestion cron was stalled (fixed in #183), found the underlying design flaw that made it stall so badly in the first place: `run_ingestion_prod.py` raises on *any* sub-step failure, including purely supplementary ones (party/department enrichment, vote summaries), which run **after** deputies/votes/positions have already committed.
- When the party or summaries step crashes, the whole script raises before writing the `new_votes` GITHUB_OUTPUT, which the workflow uses to gate the RAG rebuild and `dbt run`/`dbt test` steps. The job also fails outright, so GitHub Actions skips every subsequent step regardless of its own `if:` condition. Net effect: a crash in an enrichment step silently blocks mart refreshes and RAG re-indexing for as long as the crash goes unnoticed, even though the actual vote/position data ingested fine.
- This isn't hypothetical, it happened twice: the 2026-07 `organeRef` crash (#183) and, independently, an expired Groq API key in the vote-summaries step on 2026-06-23/24 (visible in the workflow's run history) had the identical blast radius.

## Changes

- `scripts/run_ingestion_prod.py`: `run_step()` takes a new `critical: bool = True` flag. Party/department enrichment and vote-summary generation are now `critical=False` — a failure there logs a `::error::` annotation and returns `None` instead of raising, so the pipeline keeps going.
- A new `soft_failures` output (comma-separated list of failed non-critical step labels, empty string if none) is written alongside `new_votes`.
- `.github/workflows/ingest_prod.yml`: two new steps surface soft failures without blocking anything else, mirroring the existing `continue-on-error: true` pattern already used for the frontend-cache-revalidation step in this same file:
  - a `::warning::` log annotation + job summary line
  - an email alert (reusing the existing MON-99 mail action) with a distinct subject so it reads differently from a hard failure

## Test plan

- [x] Added `tests/unit/test_run_ingestion_prod.py`: covers `run_step` for both critical (raises) and non-critical (returns `None`, doesn't raise) failure paths, plus both success paths.
- [x] End-to-end local repro: stubbed `update_party.py` to force a crash, ran the full pipeline against a local Postgres with real ingested votes/positions. Confirmed: pipeline completes, exit code 0, `new_votes` and `soft_failures` both written correctly to `GITHUB_OUTPUT`, `::error::`/`::warning::` annotations printed.
- [x] Re-ran with the real (non-stubbed) scripts: party fix now succeeds (post-#183), and incidentally the local env's missing `GROQ_API_KEY` made the *real* vote-summaries step fail too, an unplanned live confirmation that this exact non-critical path works correctly end to end.
- [x] Full unit suite: 93 passed. `ruff check` / `ruff format --check`: clean. YAML validated with `yaml.safe_load`.

## Open issue, not fixed by this PR

The scheduled trigger for `ingest_prod.yml` has not fired at all since 2026-07-07, including today (2026-07-10, a weekday), despite the workflow being active with a valid cron expression, and despite #183 merging to `master` earlier today. This is not a code or config bug I can find in this repo, it looks like a GitHub Actions-side scheduling gap. `workflow_dispatch` still works fine as a manual trigger in the meantime. This needs to be watched (or triggered manually) until the scheduled cron resumes on its own; if it's still silent after this merges, it needs its own investigation, possibly with GitHub support.