### PR TITLE
fix: resolve party_short to a real group code instead of raw organe ID (MON-119)

### DIFF
--- a/data/migrations/001_init.sql
+++ b/data/migrations/001_init.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS deputies (
     first_name      TEXT NOT NULL,
     last_name       TEXT NOT NULL,
     party           TEXT,                       -- full group name
-    party_short     TEXT,                       -- organeRef, e.g. "PO845401"
+    party_short     TEXT,                       -- short group code, e.g. "EPR" (see update_party.py)
     circonscription TEXT,
     department      TEXT,
     mandate_start   DATE,

--- a/frontend/__tests__/lib/utils.test.ts
+++ b/frontend/__tests__/lib/utils.test.ts
@@ -1,4 +1,4 @@
-import { formatDate, formatPct, getInitials, partyShort, partyColor } from '@/lib/utils'
+import { formatDate, formatPct, getInitials, groupVotesByParty, normalizePartyShort, partyColor, partyHex, partyShort } from '@/lib/utils'
 
 describe('formatDate', () => {
   it('formats a valid ISO date in French locale', () => {
@@ -58,6 +58,63 @@ describe('partyShort', () => {
 
   it('falls back to first 3 chars uppercase for unknown party', () => {
     expect(partyShort('Mouvement Indépendant')).toBe('MOU')
+  })
+})
+
+describe('normalizePartyShort', () => {
+  it('returns a resolved short code as-is', () => {
+    expect(normalizePartyShort('EPR')).toBe('EPR')
+  })
+
+  it('returns null for a raw unresolved organe ID', () => {
+    expect(normalizePartyShort('PO838901')).toBeNull()
+  })
+
+  it('returns null for null input', () => {
+    expect(normalizePartyShort(null)).toBeNull()
+  })
+})
+
+describe('groupVotesByParty', () => {
+  it('groups positions by party_short', () => {
+    const result = groupVotesByParty([
+      { party_short: 'EPR', position: 'pour' },
+      { party_short: 'EPR', position: 'contre' },
+      { party_short: 'RN', position: 'contre' },
+    ])
+    expect(result).toEqual({
+      EPR: { pour: 1, contre: 1, abstention: 0, nonVotant: 0 },
+      RN: { pour: 0, contre: 1, abstention: 0, nonVotant: 0 },
+    })
+  })
+
+  it('buckets unresolved raw organe IDs under Non inscrit instead of one row per ID', () => {
+    const result = groupVotesByParty([
+      { party_short: 'PO838901', position: 'pour' },
+      { party_short: 'PO111222', position: 'contre' },
+    ])
+    expect(result).toEqual({
+      'Non inscrit': { pour: 1, contre: 1, abstention: 0, nonVotant: 0 },
+    })
+  })
+})
+
+describe('partyHex', () => {
+  it('resolves a full party name to its color', () => {
+    expect(partyHex('Rassemblement National')).toBe('#003189')
+  })
+
+  it('resolves a short code to the same color as its full name', () => {
+    expect(partyHex('RN')).toBe(partyHex('Rassemblement National'))
+    expect(partyHex('LFI')).toBe(partyHex('La France insoumise - Nouveau Front Populaire'))
+  })
+
+  it('returns fallback gray for null', () => {
+    expect(partyHex(null)).toBe('#9CA3AF')
+  })
+
+  it('returns fallback gray for an unrecognized value', () => {
+    expect(partyHex('PO838901')).toBe('#6B7280')
   })
 })
 

--- a/frontend/src/app/votes/[id]/page.tsx
+++ b/frontend/src/app/votes/[id]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { Suspense } from 'react'
 import { api } from '@/lib/api'
-import { getInitials, groupVotesByParty, partyHex, partyShort } from '@/lib/utils'
+import { getInitials, groupVotesByParty, normalizePartyShort, partyHex, partyShort } from '@/lib/utils'
 import { VoteDetailClient } from './VoteDetailClient'
 
 export const dynamicParams = true
@@ -67,7 +67,7 @@ export default async function VoteDetailPage({ params }: { params: Promise<{ id:
     }
     for (const pos of vote.positions) {
       if (pos.position === 'nonVotant') continue
-      const party = pos.party_short || 'Non inscrit'
+      const party = normalizePartyShort(pos.party_short) || 'Non inscrit'
       const majority = majorityByParty[party]
       if (majority && pos.position !== majority && dissidents.length < 4) {
         dissidents.push({
@@ -118,7 +118,7 @@ export default async function VoteDetailPage({ params }: { params: Promise<{ id:
       // derived from the deputy's full party name — keeps the lookup card and
       // suggestion list visually consistent regardless of whether the deputy
       // voted on this scrutin.
-      party: pos?.party_short ?? partyShort(d.party),
+      party: normalizePartyShort(pos?.party_short ?? null) ?? partyShort(d.party),
       department: d.department,
       position: pos?.position ?? null,
     }

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -32,34 +32,63 @@ export function partyShort(party: string | null): string {
 }
 
 
+// Deputies ingested before update_party.py has resolved their group still
+// carry the raw AN organe ID in party_short (e.g. "PO838901") — treat that
+// as unresolved rather than rendering it as a group name (MON-119).
+const RAW_ORGANE_ID = /^PO\d+$/
+
+export function normalizePartyShort(partyShortValue: string | null): string | null {
+  if (!partyShortValue || RAW_ORGANE_ID.test(partyShortValue)) return null
+  return partyShortValue
+}
+
 export function groupVotesByParty(
   positions: Array<{ party_short: string | null; position: string }>
 ): Record<string, Record<string, number>> {
   const map: Record<string, Record<string, number>> = {}
   for (const p of positions) {
-    const party = p.party_short || 'Non inscrit'
+    const party = normalizePartyShort(p.party_short) || 'Non inscrit'
     if (!map[party]) map[party] = { pour: 0, contre: 0, abstention: 0, nonVotant: 0 }
     map[party][p.position] = (map[party][p.position] || 0) + 1
   }
   return map
 }
 
+const PARTY_HEX: Record<string, string> = {
+  'Rassemblement National':                           '#003189',
+  'Ensemble pour la République':                      '#C79A2E',
+  'La France insoumise - Nouveau Front Populaire':    '#C9302A',
+  'Socialistes et apparentés':                        '#E07A2E',
+  'Droite Républicaine':                              '#0066CC',
+  'Écologiste et Social':                             '#1F8A5B',
+  'Les Démocrates':                                   '#F97316',
+  'Horizons & Indépendants':                          '#0D9488',
+  'Libertés, Indépendants, Outre-mer et Territoires': '#7C3AED',
+  'Union des droites pour la République':             '#DC2626',
+  'Gauche Démocrate et Républicaine':                 '#B45309',
+}
+
+// party_short values (e.g. "EPR") resolve through this table before the
+// PARTY_HEX lookup, so partyHex() works whether it's given a full party
+// name (deputy profile pages) or a short code (vote group breakdown).
+const SHORT_TO_FULL_PARTY: Record<string, string> = {
+  RN: 'Rassemblement National',
+  EPR: 'Ensemble pour la République',
+  LFI: 'La France insoumise - Nouveau Front Populaire',
+  SOC: 'Socialistes et apparentés',
+  DR: 'Droite Républicaine',
+  ECS: 'Écologiste et Social',
+  DEM: 'Les Démocrates',
+  HOR: 'Horizons & Indépendants',
+  LIOT: 'Libertés, Indépendants, Outre-mer et Territoires',
+  UDR: 'Union des droites pour la République',
+  GDR: 'Gauche Démocrate et Républicaine',
+}
+
 export function partyHex(party: string | null): string {
   if (!party) return '#9CA3AF'
-  const map: Record<string, string> = {
-    'Rassemblement National':                           '#003189',
-    'Ensemble pour la République':                      '#C79A2E',
-    'La France insoumise - Nouveau Front Populaire':    '#C9302A',
-    'Socialistes et apparentés':                        '#E07A2E',
-    'Droite Républicaine':                              '#0066CC',
-    'Écologiste et Social':                             '#1F8A5B',
-    'Les Démocrates':                                   '#F97316',
-    'Horizons & Indépendants':                          '#0D9488',
-    'Libertés, Indépendants, Outre-mer et Territoires': '#7C3AED',
-    'Union des droites pour la République':             '#DC2626',
-    'Gauche Démocrate et Républicaine':                 '#B45309',
-  }
-  const color = map[party]
+  const fullName = SHORT_TO_FULL_PARTY[party] ?? party
+  const color = PARTY_HEX[fullName]
   if (!color && process.env.NODE_ENV === 'development') {
     console.warn(`partyHex: unknown party "${party}", using fallback. Add it to the map in lib/utils.ts.`)
   }

--- a/scripts/backfill_party_labels.py
+++ b/scripts/backfill_party_labels.py
@@ -56,6 +56,25 @@ CANONICAL_LABELS = {
     "Non inscrit",
 }
 
+# Canonical full name → short group code, one entry per CANONICAL_LABELS.
+# Keep in sync with frontend/src/lib/utils.ts::partyShort() — party_short is
+# read directly by the frontend (vote group breakdown, dissident detection)
+# and must match the keys that map/utils there expect.
+CANONICAL_SHORT_LABELS: dict[str, str] = {
+    "Rassemblement National": "RN",
+    "Ensemble pour la République": "EPR",
+    "La France insoumise - Nouveau Front Populaire": "LFI",
+    "Socialistes et apparentés": "SOC",
+    "Droite Républicaine": "DR",
+    "Écologiste et Social": "ECS",
+    "Les Démocrates": "DEM",
+    "Horizons & Indépendants": "HOR",
+    "Libertés, Indépendants, Outre-mer et Territoires": "LIOT",
+    "Union des droites pour la République": "UDR",
+    "Gauche Démocrate et Républicaine": "GDR",
+    "Non inscrit": "NI",
+}
+
 # Variant → canonical. Only mappings that hold for every deputy carrying
 # the variant label (verified against the deputies concerned, 2026-07).
 LABEL_MAP = {
@@ -132,8 +151,11 @@ def backfill(apply: bool) -> None:
             with conn.cursor() as cur:
                 execute_batch(
                     cur,
-                    "UPDATE deputies SET party = %s WHERE deputy_id = %s",
-                    [(new, deputy_id) for deputy_id, _, _, new in changes],
+                    "UPDATE deputies SET party = %s, party_short = %s WHERE deputy_id = %s",
+                    [
+                        (new, CANONICAL_SHORT_LABELS[new], deputy_id)
+                        for deputy_id, _, _, new in changes
+                    ],
                     page_size=200,
                 )
             conn.commit()

--- a/scripts/ingest_deputies.py
+++ b/scripts/ingest_deputies.py
@@ -113,19 +113,17 @@ def parse_deputy(item: dict) -> dict | None:
         mandate_start = mandat_start_raw[:10] if mandat_start_raw else None
         mandate_end = mandat_end_raw[:10] if mandat_end_raw else None
 
-        organe_ref = mandat.get("organes", {}).get("organeRef")
-        if isinstance(organe_ref, list):
-            organe_ref = organe_ref[0] if organe_ref else None
-
         # Circonscription / department
         place = mandat.get("election", {}).get("lieu", {})
         circonscription = place.get("numCirco")
         department = place.get("numDepartement")
 
-        # Party (groupe politique) — separate call not available inline;
-        # store organeRef as party_short
+        # Party (groupe politique) — not available inline in AMO10; both
+        # left NULL here and filled by update_party.py, which resolves them
+        # from the same canonical label so party_short never regresses to
+        # a raw organeRef (see MON-119).
         party = None
-        party_short = organe_ref
+        party_short = None
 
         numeric_id = uid.lstrip("PA")
         photo_url = (
@@ -173,7 +171,7 @@ ON CONFLICT (deputy_id) DO UPDATE SET
     -- label instead of wiping it, so a run where update_party fails (or
     -- a deputy leaves between the two steps) can't NULL out the party.
     party           = COALESCE(EXCLUDED.party, deputies.party),
-    party_short     = EXCLUDED.party_short,
+    party_short     = COALESCE(EXCLUDED.party_short, deputies.party_short),
     circonscription = EXCLUDED.circonscription,
     department      = EXCLUDED.department,
     mandate_start   = EXCLUDED.mandate_start,

--- a/scripts/update_party.py
+++ b/scripts/update_party.py
@@ -128,7 +128,7 @@ DEPT_NAMES = {
 
 
 def update_parties(conn, deputy_map: dict[str, str]) -> None:
-    from scripts.backfill_party_labels import CANONICAL_LABELS
+    from scripts.backfill_party_labels import CANONICAL_LABELS, CANONICAL_SHORT_LABELS
 
     # Never write a non-canonical label: the PARPOL fallback in
     # build_deputy_party_map can produce party spellings ("Renaissance",
@@ -141,12 +141,18 @@ def update_parties(conn, deputy_map: dict[str, str]) -> None:
         print(f"  WARNING: skipping non-canonical label {party!r} for {deputy_id}")
     deputy_map = {k: v for k, v in deputy_map.items() if k not in skipped}
 
+    # party_short is derived from the same canonical label used for party,
+    # not from the AN organe abbreviation — this guarantees it matches the
+    # keys the frontend's partyHex()/partyShort() already use, instead of
+    # depending on a separately-resolved string that could drift.
     print(f"\nUpdating party for {len(deputy_map)} deputies …")
-    rows = [(party, deputy_id) for deputy_id, party in deputy_map.items()]
+    rows = [
+        (party, CANONICAL_SHORT_LABELS[party], deputy_id) for deputy_id, party in deputy_map.items()
+    ]
     with conn.cursor() as cur:
         psycopg2.extras.execute_batch(
             cur,
-            "UPDATE deputies SET party = %s WHERE deputy_id = %s",
+            "UPDATE deputies SET party = %s, party_short = %s WHERE deputy_id = %s",
             rows,
             page_size=200,
         )

--- a/tests/integration/test_upsert.py
+++ b/tests/integration/test_upsert.py
@@ -47,6 +47,39 @@ def test_deputy_upsert_updates_row(db_conn):
 
 
 @pytest.mark.integration
+def test_deputy_upsert_preserves_party_short_when_omitted(db_conn):
+    """A re-ingest with party_short=NULL (AMO10 has no inline label) must not
+    wipe a previously-resolved value — the COALESCE guard added for MON-119."""
+    resolved = {
+        "deputy_id": "PA001",
+        "full_name": "Alice Martin",
+        "first_name": "Alice",
+        "last_name": "Martin",
+        "party": "Horizons & Indépendants",
+        "party_short": "HOR",
+        "circonscription": "1ère circonscription du Var",
+        "department": "Var",
+        "mandate_start": "2024-07-07",
+        "mandate_end": None,
+        "photo_url": None,
+    }
+    with db_conn.cursor() as cur:
+        cur.execute(DEPUTY_UPSERT_SQL, resolved)
+
+        # Simulate a daily ingest run, which never has a resolved party_short
+        reingested = {**resolved, "party_short": None}
+        cur.execute(DEPUTY_UPSERT_SQL, reingested)
+
+        cur.execute("SELECT party_short FROM deputies WHERE deputy_id = 'PA001'")
+        assert cur.fetchone()["party_short"] == "HOR"
+
+        # Restore original fixture value
+        cur.execute(
+            DEPUTY_UPSERT_SQL, {**resolved, "party": "Rassemblement National", "party_short": "RN"}
+        )
+
+
+@pytest.mark.integration
 def test_deputy_upsert_single_row(db_conn):
     """Three upserts of the same deputy_id must leave exactly one row."""
     row = {

--- a/tests/unit/test_party_labels.py
+++ b/tests/unit/test_party_labels.py
@@ -9,7 +9,12 @@ import io
 import json
 import zipfile
 
-from scripts.backfill_party_labels import CANONICAL_LABELS, LABEL_MAP, compute_changes
+from scripts.backfill_party_labels import (
+    CANONICAL_LABELS,
+    CANONICAL_SHORT_LABELS,
+    LABEL_MAP,
+    compute_changes,
+)
 from scripts.ingest_organes import build_deputy_party_map
 
 # ---------------------------------------------------------------------------
@@ -59,6 +64,20 @@ def test_unknown_label_is_reported_not_guessed():
 
 def test_label_map_targets_are_canonical():
     assert set(LABEL_MAP.values()) <= CANONICAL_LABELS
+
+
+def test_canonical_short_labels_cover_every_canonical_label():
+    # party_short is derived from this map for every canonical party (see
+    # update_party.py / backfill_party_labels.py) — a missing entry would
+    # raise a KeyError at write time, so the two sets must stay in lockstep.
+    assert set(CANONICAL_SHORT_LABELS.keys()) == CANONICAL_LABELS
+
+
+def test_canonical_short_labels_are_unique():
+    # Two full names collapsing to the same short code would silently merge
+    # distinct groups in the vote breakdown table.
+    codes = list(CANONICAL_SHORT_LABELS.values())
+    assert len(codes) == len(set(codes))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Fixes `party_short` being permanently stuck at the raw AN organe ID (e.g. `PO838901`) in production, which collapsed the vote detail page's "Comment chaque groupe a voté" table to a single unnamed row and made every dissident computation meaningless.

## Why
`scripts/ingest_deputies.py` wrote `organeRef` directly into `party_short` on every run, and the upsert had no `COALESCE` guard on that column (unlike `party`), so any manual or scripted repair was silently overwritten the next daily ingestion. `scripts/update_party.py` never resolved `party_short` at all — it only ever filled in `party`.

## Changes
- `scripts/ingest_deputies.py`: `parse_deputy()` now leaves `party_short` `NULL` at parse time, mirroring how `party` is already handled. The upsert now does `party_short = COALESCE(EXCLUDED.party_short, deputies.party_short)` so ingestion can no longer clobber a resolved value.
- `scripts/backfill_party_labels.py`: added `CANONICAL_SHORT_LABELS`, a canonical full party name → short code map (`"Rassemblement National" → "RN"`, etc.), kept in sync with `frontend/src/lib/utils.ts::partyShort()`. `backfill()`'s apply step now writes `party_short` alongside `party` whenever a deputy's label is normalized.
- `scripts/update_party.py`: `update_parties()` now derives `party_short` from the same canonical `party` value it already resolves (via `CANONICAL_SHORT_LABELS`), rather than depending on a separately-resolved AN abbreviation field that could drift out of sync with what the frontend expects.
- `data/migrations/001_init.sql`: corrected the `party_short` column comment, which described the old (buggy) intent of storing a raw organe ID.
- `frontend/src/lib/utils.ts`:
  - `partyHex()` now resolves short codes (`EPR`, `RN`, ...) to their full party name before the color lookup. Vote pages pass `party_short`, deputy pages pass the full `party` name — `partyHex` previously only matched the latter, so group-breakdown colors never matched even with a correctly resolved `party_short`.
  - Added `normalizePartyShort()`: treats any value matching `^PO\d+$` as unresolved and returns `null`, so a deputy that hasn't been backfilled yet buckets under "Non inscrit" instead of rendering its own spurious row. This is the frontend defense mentioned in the issue.
  - `groupVotesByParty()` uses `normalizePartyShort()` for its grouping key.
- `frontend/src/app/votes/[id]/page.tsx`: the dissident computation and the deputy-lookup roster now run `party_short` through `normalizePartyShort()` before falling back to `'Non inscrit'` / `partyShort(d.party)`.
- Added/extended unit tests: `tests/unit/test_party_labels.py` (parity + uniqueness of `CANONICAL_SHORT_LABELS`) and `frontend/__tests__/lib/utils.test.ts` (`normalizePartyShort`, `groupVotesByParty`, `partyHex` short-code resolution).

## Testing
- `venv/bin/python -m pytest tests/ -m "not integration" -q` — 154 passed
- `venv/bin/python -m pytest tests/unit/test_party_labels.py -q` — 13 passed (7 new)
- `venv/bin/ruff check .` / `venv/bin/ruff format --check .` — clean
- `cd frontend && npm run lint` — clean
- `cd frontend && npm test` — 60 passed (10 new)
- `cd frontend && npm run build` — succeeds, all 117 pages generated

## Risks / Notes
- **Production still needs a re-run of `update_party.py`** to backfill the existing rows that are stuck on the raw organe ID — not done as part of this PR per the guardrail against unrequested prod-mutating actions. Flagging for the user to run explicitly (`make fix-deputies` equivalent) once this merges and deploys.
- No schema migration needed — `party_short` keeps its existing `TEXT` type, only its resolution logic and column comment changed.
- The daily `ingest_prod.yml` cron will pick up the COALESCE fix automatically on its next run; no manual step needed there beyond the one-time prod backfill above.

## Breaking Changes
None.