### PR TITLE
fix: stack deputy list layout and search row on mobile (MON-120)

### DIFF
--- a/frontend/src/app/deputes/DeputiesClient.tsx
+++ b/frontend/src/app/deputes/DeputiesClient.tsx
@@ -95,11 +95,13 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
     <div style={{ background: CREAM, minHeight: '100vh' }}>
 
       {/* Hero */}
-      <div style={{
-        padding: '50px 56px 40px',
-        background: 'linear-gradient(180deg,#fff 0%,' + CREAM + ' 100%)',
-        borderBottom: '1px solid #ECE7DC',
-      }}>
+      <div
+        className="px-5 sm:px-14 pt-8 sm:pt-[50px] pb-8 sm:pb-10"
+        style={{
+          background: 'linear-gradient(180deg,#fff 0%,' + CREAM + ' 100%)',
+          borderBottom: '1px solid #ECE7DC',
+        }}
+      >
         <div style={{ maxWidth: 1180, margin: '0 auto' }}>
           <div style={{
             fontWeight: 700, fontSize: 12, letterSpacing: '0.18em',
@@ -119,7 +121,7 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
           </p>
 
           {/* Search row */}
-          <div style={{ display: 'flex', gap: 12, marginTop: 28, maxWidth: 720 }}>
+          <div className="flex flex-col sm:flex-row gap-3 mt-7 max-w-[720px]">
             <label htmlFor="deputy-search" className="sr-only">Rechercher un député</label>
             <div style={{
               flex: 1, display: 'flex', alignItems: 'center', gap: 12,
@@ -154,6 +156,7 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
             </div>
             <button
               onClick={() => setDebouncedSearch(search)}
+              className="w-full sm:w-auto justify-center"
               style={{
                 display: 'flex', alignItems: 'center', background: ACCENT, color: '#fff',
                 height: 54, padding: '0 30px', borderRadius: 10, fontWeight: 600,
@@ -191,7 +194,7 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
       </div>
 
       {/* Table section */}
-      <div style={{ padding: '32px 56px 72px' }}>
+      <div className="px-5 sm:px-14 pt-8 pb-14 sm:pb-[72px]">
         <div style={{ maxWidth: 1180, margin: '0 auto' }}>
 
           {/* Count row */}
@@ -232,16 +235,17 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
                 boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
               }}>
                 {/* Header */}
-                <div style={{
-                  display: 'grid', gridTemplateColumns: '1fr 260px 34px',
-                  gap: 18, padding: '13px 26px',
-                  borderBottom: '1px solid ' + LINE, background: '#FBFAF6',
-                  font: '600 11.5px/1 var(--font-body)',
-                  letterSpacing: '0.08em', textTransform: 'uppercase', color: '#9CA3AF',
-                }}>
+                <div
+                  className="grid grid-cols-[1fr_20px] sm:grid-cols-[1fr_260px_34px] gap-3 sm:gap-[18px] px-4 sm:px-[26px] py-[13px]"
+                  style={{
+                    borderBottom: '1px solid ' + LINE, background: '#FBFAF6',
+                    font: '600 11.5px/1 var(--font-body)',
+                    letterSpacing: '0.08em', textTransform: 'uppercase', color: '#9CA3AF',
+                  }}
+                >
                   <span>Député·e</span>
-                  <span>Groupe</span>
-                  <span />
+                  <span className="hidden sm:inline">Groupe</span>
+                  <span className="hidden sm:inline" />
                 </div>
 
                 {/* Rows */}
@@ -250,9 +254,8 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
                   return (
                     <Link key={d.deputy_id} href={`/deputes/${d.deputy_id}`} style={{ textDecoration: 'none' }}>
                       <div
+                        className="grid grid-cols-[1fr_20px] sm:grid-cols-[1fr_260px_34px] gap-3 sm:gap-[18px] px-4 sm:px-[26px] py-[13px]"
                         style={{
-                          display: 'grid', gridTemplateColumns: '1fr 260px 34px',
-                          gap: 18, padding: '13px 26px',
                           borderBottom: '1px solid #F0F1F3',
                           alignItems: 'center', cursor: 'pointer',
                           background: '#fff', transition: 'background 0.12s',
@@ -274,15 +277,15 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
                         </div>
 
                         {/* Group */}
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 9 }} title={d.party ?? undefined}>
                           <span style={{ width: 9, height: 9, borderRadius: 999, flexShrink: 0, background: hex }} />
-                          <span style={{ fontSize: 14, color: '#374151', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          <span className="hidden sm:inline" style={{ fontSize: 14, color: '#374151', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                             {d.party ?? '—'}
                           </span>
                         </div>
 
                         {/* Arrow */}
-                        <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="#C4C9D2" strokeWidth="2.2" strokeLinecap="round" aria-hidden="true">
+                        <svg className="hidden sm:block" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="#C4C9D2" strokeWidth="2.2" strokeLinecap="round" aria-hidden="true">
                           <path d="m9 6 6 6-6 6"/>
                         </svg>
                       </div>


### PR DESCRIPTION
## What
Fixes the `/deputes` page at mobile widths (390px): the fixed 260px group column no longer overlaps deputy names, and the hero search button no longer overflows the viewport.

## Why
Production diagnostic screenshot at 390px (2026-07-09) showed every row's GROUPE column rendering on top of the deputy-name column, and the coral "Rechercher" button clipped by the right viewport edge. The page uses inline styles throughout with a fixed `gridTemplateColumns: '1fr 260px 34px'` and no responsive breakpoint, so the 260px column could never fit in a 390px viewport.

## Changes
- `frontend/src/app/deputes/DeputiesClient.tsx`
  - Table header and row grids: added a `sm:` breakpoint. Below 640px the grid collapses to `1fr 20px` (deputy info + party-color dot only); at `sm:` and above it stays `1fr 260px 34px` as before.
  - The full group/party name text and the row's chevron arrow are hidden below `sm:` (`hidden sm:inline` / `hidden sm:block`) so they don't try to render in the collapsed 2-column grid. The party name is preserved as a `title` tooltip on the dot's container for mobile discoverability.
  - Hero search row: `flex` row changed to `flex-col sm:flex-row` so the input and button stack on mobile; the button gets `w-full sm:w-auto justify-center` so it's never clipped.
  - Hero and table section outer padding: made responsive (`px-5 sm:px-14`, etc.) instead of a fixed 56px horizontal padding, since that was contributing to the cramped mobile layout.
  - All changes are additive Tailwind classes alongside the existing inline styles (the codebase already mixes both); no inline style property was left duplicated with a conflicting className.

## Testing
- `npm run lint` — no ESLint warnings or errors.
- `npm test -- --watchAll=false` — 8 suites / 51 tests passed.
- `npm run build` — compiles, type-checks, and generates all 117 static pages successfully.
- Manual verification: started a dev server on the branch, used Playwright (390x844 viewport) to load `/deputes`.
  - Horizontal overflow: 0px (no page-wide scroll).
  - Search button bounding box: fully within the 390px viewport (right edge at 370px, 20px margin remaining) and full-width.
  - Screenshot confirms deputy rows show name + department + a colored party dot with no overlapping text, and pagination/footer render correctly below.

## Risks / Notes
- The party name is only shown as a hover `title` tooltip on mobile now (no persistent text label) — acceptable given the fix's suggested approach ("reduced to the colored dot"), but flagging in case a persistent abbreviated label is preferred later.
- Purely a frontend styling change; no API, schema, or deploy config touched.

## Breaking Changes
None.
