### PR TITLE
fix: daily ingestion cron never fires — invalid secrets context in step if:

### DIFF
--- a/.github/workflows/ingest_prod.yml
+++ b/.github/workflows/ingest_prod.yml
@@ -13,6 +13,11 @@ jobs:
   ingest:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      # Promoted from secrets so step-level `if:` conditions below can check
+      # them — the `secrets` context isn't allowed in step `if:` expressions.
+      MAIL_SERVER: ${{ secrets.MAIL_SERVER }}
+      NOTIFY_EMAIL_TO: ${{ secrets.NOTIFY_EMAIL_TO }}
     steps:
       - uses: actions/checkout@v4
 
@@ -132,7 +137,7 @@ jobs:
           echo "Core data (deputies/votes/positions) ingested fine. These non-critical steps failed and should be checked: ${{ steps.ingest.outputs.soft_failures }}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Email soft-failure alert
-        if: steps.ingest.outputs.soft_failures != '' && secrets.MAIL_SERVER != '' && secrets.NOTIFY_EMAIL_TO != ''
+        if: steps.ingest.outputs.soft_failures != '' && env.MAIL_SERVER != '' && env.NOTIFY_EMAIL_TO != ''
         uses: dawidd6/action-send-mail@v3
         with:
           server_address: ${{ secrets.MAIL_SERVER }}
@@ -163,7 +168,7 @@ jobs:
         # "dbt snapshot + source freshness" (error_after thresholds in
         # transform/models/staging/_sources.yml). Skipped entirely if the mail
         # secrets aren't configured yet (e.g. before MON-99 setup is finished).
-        if: failure() && secrets.MAIL_SERVER != '' && secrets.NOTIFY_EMAIL_TO != ''
+        if: failure() && env.MAIL_SERVER != '' && env.NOTIFY_EMAIL_TO != ''
         uses: dawidd6/action-send-mail@v3
         with:
           server_address: ${{ secrets.MAIL_SERVER }}


### PR DESCRIPTION
## Summary
- The daily ingestion cron (`ingest_prod.yml`, 06:00 UTC weekdays) has not fired since 2026-07-07, despite being `state: active` with a valid cron expression.
- Root cause: two step-level `if:` conditions (added in PR #184 for MON-99 email alerts) reference `secrets.MAIL_SERVER` / `secrets.NOTIFY_EMAIL_TO` directly. GitHub Actions disallows the `secrets` context in step `if:` expressions — this makes the whole workflow file invalid on GitHub's side. Confirmed via the Actions API: this workflow's `name` field falls back to its file path, unlike all 5 other workflows in the repo (which correctly show their YAML `name:`). An invalid workflow file silently never triggers on `schedule`.
- Fix: promote `MAIL_SERVER`/`NOTIFY_EMAIL_TO` to job-level `env` (sourced from the same secrets) and reference `env.*` in the two `if:` conditions instead of `secrets.*`. Verified clean with `actionlint`.

## Test plan
- [x] `actionlint .github/workflows/ingest_prod.yml` — no more "context secrets is not allowed here" errors (only a pre-existing unrelated shellcheck warning remains)
- [ ] After merge, confirm via GitHub API that the workflow's `name` now correctly shows "MonÉlu Production Ingestion" instead of falling back to the file path
- [ ] Confirm the cron fires on the next weekday 06:00 UTC (`gh run list --workflow=ingest_prod.yml`)