### PR TITLE
fix: map department codes to names and drop duplicate stat tile (MON-122, MON-123)

### DIFF
--- a/frontend/__tests__/lib/departments.test.ts
+++ b/frontend/__tests__/lib/departments.test.ts
@@ -1,0 +1,47 @@
+import { departmentLabel } from '@/lib/departments'
+
+describe('departmentLabel', () => {
+  it('returns null for null, undefined, and empty input', () => {
+    expect(departmentLabel(null)).toBeNull()
+    expect(departmentLabel(undefined)).toBeNull()
+    expect(departmentLabel('')).toBeNull()
+    expect(departmentLabel('  ')).toBeNull()
+  })
+
+  it('maps a bare metropolitan code to "Name (code)"', () => {
+    expect(departmentLabel('69')).toBe('Rhône (69)')
+    expect(departmentLabel('01')).toBe('Ain (01)')
+    expect(departmentLabel('95')).toBe("Val-d'Oise (95)")
+  })
+
+  it('maps Corsica codes', () => {
+    expect(departmentLabel('2A')).toBe('Corse-du-Sud (2A)')
+    expect(departmentLabel('2b')).toBe('Haute-Corse (2B)')
+  })
+
+  it('maps overseas codes missing from the backend map', () => {
+    expect(departmentLabel('975')).toBe('Saint-Pierre-et-Miquelon (975)')
+    expect(departmentLabel('977')).toBe('Saint-Barthélemy et Saint-Martin (977)')
+    expect(departmentLabel('986')).toBe('Wallis-et-Futuna (986)')
+    expect(departmentLabel('987')).toBe('Polynésie française (987)')
+    expect(departmentLabel('988')).toBe('Nouvelle-Calédonie (988)')
+  })
+
+  it('handles the zero-padded citizens-abroad code without a code suffix', () => {
+    expect(departmentLabel('099')).toBe('Français établis hors de France')
+    expect(departmentLabel('99')).toBe('Français établis hors de France')
+  })
+
+  it('appends the code to an already-mapped full name', () => {
+    expect(departmentLabel('Rhône')).toBe('Rhône (69)')
+    expect(departmentLabel('La Réunion')).toBe('La Réunion (974)')
+  })
+
+  it('passes unknown values through unchanged', () => {
+    expect(departmentLabel('Français établis hors de France')).toBe(
+      'Français établis hors de France'
+    )
+    expect(departmentLabel('998')).toBe('998')
+    expect(departmentLabel('Atlantide')).toBe('Atlantide')
+  })
+})

--- a/frontend/src/app/deputes/DeputiesClient.tsx
+++ b/frontend/src/app/deputes/DeputiesClient.tsx
@@ -60,13 +60,16 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
     const items = q
       ? initial.items.filter(d =>
           d.full_name.toLowerCase().includes(q) ||
+          // Match the label users see ("Polynésie française (987)"), not just
+          // the raw stored value, which is still a bare code for some deputies
+          (departmentLabel(d.department)?.toLowerCase().includes(q) ?? false) ||
           (d.department?.toLowerCase().includes(q) ?? false) ||
           (d.party?.toLowerCase().includes(q) ?? false)
         )
       : [...initial.items]
 
     if (sort === 'nom')    return items.sort((a, b) => a.full_name.localeCompare(b.full_name, 'fr'))
-    if (sort === 'region') return items.sort((a, b) => (a.department ?? '').localeCompare(b.department ?? '', 'fr'))
+    if (sort === 'region') return items.sort((a, b) => (departmentLabel(a.department) ?? '').localeCompare(departmentLabel(b.department) ?? '', 'fr'))
     if (sort === 'parti')  return items.sort((a, b) => (a.party ?? '').localeCompare(b.party ?? '', 'fr'))
     return items
   }, [initial.items, debouncedSearch, resolvedDepartment, sort])

--- a/frontend/src/app/deputes/DeputiesClient.tsx
+++ b/frontend/src/app/deputes/DeputiesClient.tsx
@@ -6,6 +6,7 @@ import { Deputy } from '@/lib/api'
 import { getInitials, partyHex, partyShort } from '@/lib/utils'
 import { DeputyAvatar } from '@/components/DeputyAvatar'
 import { resolvePostalCode } from '@/lib/postal'
+import { departmentLabel } from '@/lib/departments'
 
 type DeputyList = { total: number; items: Deputy[]; limit: number; offset: number }
 type SortKey = 'nom' | 'region' | 'parti'
@@ -312,7 +313,7 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
                               {d.full_name}
                             </div>
                             <div style={{ fontSize: 13, color: '#9CA3AF', marginTop: 3 }}>
-                              {d.department ?? '—'}
+                              {departmentLabel(d.department) ?? '—'}
                             </div>
                           </div>
                         </div>

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { api } from '@/lib/api'
 import type { DissidentVoteItem } from '@/lib/api'
 import { partyHex, formatDate } from '@/lib/utils'
+import { departmentLabel } from '@/lib/departments'
 import { positionStyle } from '@/lib/vote-position'
 import { DeputyAvatar } from '@/components/DeputyAvatar'
 import { ShareButton } from '@/components/ShareButton'
@@ -25,7 +26,7 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
   const deputy = await api.deputies.get(id).catch(() => null)
   if (!deputy) return {}
   const description = `Bilan de mandat, votes et présence de ${deputy.full_name}${
-    deputy.party ? ` (${deputy.party})` : deputy.department ? ` - ${deputy.department}` : ''
+    deputy.party ? ` (${deputy.party})` : deputy.department ? ` - ${departmentLabel(deputy.department)}` : ''
   }.`
   return {
     title: `${deputy.full_name} - MonÉlu`,
@@ -70,14 +71,24 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
   const abstPct        = scorecard ? Math.round(scorecard.abstentions   / denom * 100) : 0
 
   const hex = partyHex(deputy.party)
+  const deptLabel = departmentLabel(deputy.department)
 
-  const stats = scorecard ? [
+  // MON-123: "votes exprimés" (present_votes = pour + contre + abstention)
+  // duplicated "scrutins votés" whenever the deputy has no non-votant
+  // position — show the non-votant count instead.
+  const nonVotant = scorecard ? scorecard.total_votes - scorecard.present_votes : 0
+
+  const stats: { value: string; label: string; tooltip?: string }[] = scorecard ? [
     { value: scorecard.total_votes.toLocaleString('fr-FR'),    label: 'scrutins votés' },
     { value: `${presencePct ?? '—'}%`,                        label: 'présence aux votes' },
     { value: scorecard.votes_for.toLocaleString('fr-FR'),      label: 'votes Pour' },
     { value: scorecard.votes_against.toLocaleString('fr-FR'),  label: 'votes Contre' },
     { value: scorecard.abstentions.toLocaleString('fr-FR'),    label: 'abstentions' },
-    { value: scorecard.present_votes.toLocaleString('fr-FR'),  label: 'votes exprimés' },
+    {
+      value: nonVotant.toLocaleString('fr-FR'),
+      label: 'non-votant',
+      tooltip: "Présent·e en séance sans exprimer de vote — distinct de l'abstention, qui est une position exprimée.",
+    },
   ] : []
 
   return (
@@ -114,14 +125,6 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
               <div style={{ borderRadius: 14, overflow: 'hidden', border: `1px solid #ECE7DC`, boxShadow: '0 6px 20px rgba(27,43,80,0.12)' }}>
                 <DeputyAvatar name={deputy.full_name} photoUrl={deputy.photo_url} size="2xl" priority />
               </div>
-              {deputy.department && (
-                <div style={{ marginTop: 14, fontSize: 12.5, color: '#6B7280', display: 'flex', alignItems: 'center', gap: 8 }}>
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#9CA3AF" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
-                    <path d="M12 21s-7-5.6-7-11a7 7 0 0 1 14 0c0 5.4-7 11-7 11Z"/><circle cx="12" cy="10" r="2.4"/>
-                  </svg>
-                  {deputy.department}
-                </div>
-              )}
             </div>
 
             {/* Right: identity */}
@@ -135,9 +138,12 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
               }}>
                 {deputy.full_name}
               </h1>
-              {deputy.department && (
-                <div style={{ fontSize: 20, color: '#4B5563', marginTop: 10 }}>
-                  {deputy.department}
+              {deptLabel && (
+                <div style={{ fontSize: 20, color: '#4B5563', marginTop: 10, display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#9CA3AF" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+                    <path d="M12 21s-7-5.6-7-11a7 7 0 0 1 14 0c0 5.4-7 11-7 11Z"/><circle cx="12" cy="10" r="2.4"/>
+                  </svg>
+                  {deptLabel}
                 </div>
               )}
               {deputy.party && (
@@ -198,8 +204,9 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                   <div className="font-newsreader text-[34px]" style={{ fontWeight: 600, color: NAVY, letterSpacing: '-0.01em', lineHeight: 1 }}>
                     {s.value}
                   </div>
-                  <div style={{ fontSize: 12.5, color: '#6B7280', marginTop: 4, lineHeight: 1.35 }}>
+                  <div style={{ fontSize: 12.5, color: '#6B7280', marginTop: 4, lineHeight: 1.35, display: 'flex', alignItems: 'center', gap: 6 }}>
                     {s.label}
+                    {s.tooltip && <InfoTooltip text={s.tooltip} href="/methodologie" />}
                   </div>
                 </div>
               ))}

--- a/frontend/src/app/mon-depute/page.tsx
+++ b/frontend/src/app/mon-depute/page.tsx
@@ -12,6 +12,7 @@ import {
   setLastSeenAt,
 } from '@/lib/mon-depute'
 import { DeputyAvatar } from '@/components/DeputyAvatar'
+import { departmentLabel } from '@/lib/departments'
 import { InfoTooltip } from '@/components/InfoTooltip'
 import { VoteTimelineItem } from '@/components/VoteTimelineItem'
 
@@ -153,7 +154,7 @@ export default function MonDeputePage() {
               </h1>
               <div style={{ display: 'flex', gap: 10, alignItems: 'center', marginTop: 8, flexWrap: 'wrap' }}>
                 {deputy.department && (
-                  <span style={{ fontSize: 14, color: '#6B7280' }}>{deputy.department}</span>
+                  <span style={{ fontSize: 14, color: '#6B7280' }}>{departmentLabel(deputy.department)}</span>
                 )}
                 {deputy.party && (
                   <span style={{

--- a/frontend/src/components/home/AssemblyScrollExperience.tsx
+++ b/frontend/src/components/home/AssemblyScrollExperience.tsx
@@ -12,6 +12,7 @@ import { HeroSearch } from '@/components/HeroSearch'
 import { TrustRow } from './TrustRow'
 import type { DeputyInfo } from '@/app/page'
 import { NAV_HEIGHT_PX } from '@/components/Nav'
+import { departmentLabel } from '@/lib/departments'
 
 type Props = {
   stats: AssemblyStats
@@ -777,7 +778,7 @@ function CinematicExperience({ stats, leadVote, deputyInfo }: Props) {
               </div>
             </div>
             <div style={{ textAlign: 'center', fontFamily: 'DM Serif Display, Georgia, serif', fontWeight: 700, fontSize: 'clamp(18px,2.2vw,24px)', color: '#fff', letterSpacing: '-0.01em', lineHeight: 1.2 }}>{deputyInfo?.name ?? '17ème Législature'}</div>
-            <div style={{ textAlign: 'center', fontSize: 'clamp(12px,1.3vw,15px)', color: 'rgba(220,228,245,0.78)', marginTop: 6 }}>{deputyInfo?.department ?? 'Assemblée Nationale'}</div>
+            <div style={{ textAlign: 'center', fontSize: 'clamp(12px,1.3vw,15px)', color: 'rgba(220,228,245,0.78)', marginTop: 6 }}>{departmentLabel(deputyInfo?.department) ?? 'Assemblée Nationale'}</div>
             <div style={{ textAlign: 'center', fontSize: 'clamp(12px,1.3vw,14px)', color: '#7fd9b6', marginTop: 6 }}>{deputyInfo?.party ?? `${stats.deputies} députés actifs`}</div>
             <div style={{ display: 'flex', justifyContent: 'center', margin: '14px 0 4px' }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: 10, background: voteResultBg, border: `1px solid ${voteResultBorder}`, padding: '8px 20px', borderRadius: 999 }}>

--- a/frontend/src/lib/departments.ts
+++ b/frontend/src/lib/departments.ts
@@ -1,0 +1,155 @@
+// Department code → name map, mirroring scripts/update_party.py DEPT_NAMES
+// (same spellings) plus the overseas collectivities the backend map lacks
+// (975, 977, 986, 987, 988). The DB stores full names for most deputies
+// (make fix-deputies), but codes absent from the backend map — and the
+// zero-padded "099" — still reach the API raw, so the frontend maps both
+// forms defensively.
+const DEPARTMENT_NAMES: Record<string, string> = {
+  '01': 'Ain',
+  '02': 'Aisne',
+  '03': 'Allier',
+  '04': 'Alpes-de-Haute-Provence',
+  '05': 'Hautes-Alpes',
+  '06': 'Alpes-Maritimes',
+  '07': 'Ardèche',
+  '08': 'Ardennes',
+  '09': 'Ariège',
+  '10': 'Aube',
+  '11': 'Aude',
+  '12': 'Aveyron',
+  '13': 'Bouches-du-Rhône',
+  '14': 'Calvados',
+  '15': 'Cantal',
+  '16': 'Charente',
+  '17': 'Charente-Maritime',
+  '18': 'Cher',
+  '19': 'Corrèze',
+  '2A': 'Corse-du-Sud',
+  '2B': 'Haute-Corse',
+  '21': "Côte-d'Or",
+  '22': "Côtes-d'Armor",
+  '23': 'Creuse',
+  '24': 'Dordogne',
+  '25': 'Doubs',
+  '26': 'Drôme',
+  '27': 'Eure',
+  '28': 'Eure-et-Loir',
+  '29': 'Finistère',
+  '30': 'Gard',
+  '31': 'Haute-Garonne',
+  '32': 'Gers',
+  '33': 'Gironde',
+  '34': 'Hérault',
+  '35': 'Ille-et-Vilaine',
+  '36': 'Indre',
+  '37': 'Indre-et-Loire',
+  '38': 'Isère',
+  '39': 'Jura',
+  '40': 'Landes',
+  '41': 'Loir-et-Cher',
+  '42': 'Loire',
+  '43': 'Haute-Loire',
+  '44': 'Loire-Atlantique',
+  '45': 'Loiret',
+  '46': 'Lot',
+  '47': 'Lot-et-Garonne',
+  '48': 'Lozère',
+  '49': 'Maine-et-Loire',
+  '50': 'Manche',
+  '51': 'Marne',
+  '52': 'Haute-Marne',
+  '53': 'Mayenne',
+  '54': 'Meurthe-et-Moselle',
+  '55': 'Meuse',
+  '56': 'Morbihan',
+  '57': 'Moselle',
+  '58': 'Nièvre',
+  '59': 'Nord',
+  '60': 'Oise',
+  '61': 'Orne',
+  '62': 'Pas-de-Calais',
+  '63': 'Puy-de-Dôme',
+  '64': 'Pyrénées-Atlantiques',
+  '65': 'Hautes-Pyrénées',
+  '66': 'Pyrénées-Orientales',
+  '67': 'Bas-Rhin',
+  '68': 'Haut-Rhin',
+  '69': 'Rhône',
+  '70': 'Haute-Saône',
+  '71': 'Saône-et-Loire',
+  '72': 'Sarthe',
+  '73': 'Savoie',
+  '74': 'Haute-Savoie',
+  '75': 'Paris',
+  '76': 'Seine-Maritime',
+  '77': 'Seine-et-Marne',
+  '78': 'Yvelines',
+  '79': 'Deux-Sèvres',
+  '80': 'Somme',
+  '81': 'Tarn',
+  '82': 'Tarn-et-Garonne',
+  '83': 'Var',
+  '84': 'Vaucluse',
+  '85': 'Vendée',
+  '86': 'Vienne',
+  '87': 'Haute-Vienne',
+  '88': 'Vosges',
+  '89': 'Yonne',
+  '90': 'Territoire de Belfort',
+  '91': 'Essonne',
+  '92': 'Hauts-de-Seine',
+  '93': 'Seine-Saint-Denis',
+  '94': 'Val-de-Marne',
+  '95': "Val-d'Oise",
+  '971': 'Guadeloupe',
+  '972': 'Martinique',
+  '973': 'Guyane',
+  '974': 'La Réunion',
+  '975': 'Saint-Pierre-et-Miquelon',
+  '976': 'Mayotte',
+  // Single AN constituency covering both collectivities
+  '977': 'Saint-Barthélemy et Saint-Martin',
+  '986': 'Wallis-et-Futuna',
+  '987': 'Polynésie française',
+  '988': 'Nouvelle-Calédonie',
+  '99': 'Français établis hors de France',
+}
+
+const NAME_TO_CODE = new Map(
+  Object.entries(DEPARTMENT_NAMES).map(([code, name]) => [name, code])
+)
+
+// "99" is a constituency for citizens abroad, not a department — showing
+// its code would only confuse.
+const CODES_WITHOUT_SUFFIX = new Set(['99'])
+
+function normalizeCode(value: string): string | null {
+  const upper = value.toUpperCase()
+  if (!/^(2A|2B|\d{2,3})$/.test(upper)) return null
+  // AN data zero-pads some codes to three digits ("099")
+  return /^0\d\d$/.test(upper) ? upper.slice(1) : upper
+}
+
+/**
+ * Human-readable department label: "Rhône (69)".
+ * Accepts either a raw code ("69", "099", "2A") or an already-mapped full
+ * name ("Rhône") and returns the same "Name (code)" form for both, so no
+ * bare code is ever rendered. Unknown values pass through unchanged.
+ */
+export function departmentLabel(raw: string | null | undefined): string | null {
+  if (!raw) return null
+  const value = raw.trim()
+  if (!value) return null
+
+  const code = normalizeCode(value)
+  if (code) {
+    const name = DEPARTMENT_NAMES[code]
+    if (!name) return value
+    return CODES_WITHOUT_SUFFIX.has(code) ? name : `${name} (${code})`
+  }
+
+  const codeForName = NAME_TO_CODE.get(value)
+  return codeForName && !CODES_WITHOUT_SUFFIX.has(codeForName)
+    ? `${value} (${codeForName})`
+    : value
+}


### PR DESCRIPTION
# fix: map department codes to names and drop duplicate stat tile (MON-122, MON-123)

## What
On the deputy pages and everywhere a deputy's department is shown, raw department codes ("69", "099", "987") now render as human-readable labels ("Rhône (69)"), shown once in the header instead of twice.
The "votes exprimés" stat tile, which duplicated "scrutins votés" for most deputies, is replaced by a "non-votant" count tile.

## Why
- **MON-122**: the deputy header showed a bare department code as the subtitle and repeated the same code under the photo. A citizen reads neither as "Rhône". Prod data is mostly fixed server-side (`make fix-deputies`), but 20 deputies still return bare codes because the backend `DEPT_NAMES` map misses the overseas collectivities (975, 977, 986, 987, 988) and the zero-padded citizens-abroad code ("099" vs "99").
- **MON-123**: "votes exprimés" is `present_votes = pour + contre + abstention`, which equals "scrutins votés" (`total_votes`) whenever a deputy has zero non-votant positions - two identical tiles out of six read as a bug.

## Changes
- New `frontend/src/lib/departments.ts`: full code-to-name map (mirrors `scripts/update_party.py` spellings, plus the missing overseas entries) and a `departmentLabel()` helper that renders "Name (code)" for both raw codes and already-mapped names; "Français établis hors de France" gets no code suffix (not a department). Unknown values pass through unchanged.
- `frontend/src/app/deputes/[id]/page.tsx`:
  - subtitle renders `departmentLabel(...)` once with the map-pin icon; the duplicate under the photo is removed (MON-122)
  - "votes exprimés" tile replaced by a non-votant count (`total_votes - present_votes`) with an InfoTooltip explaining non-votant vs abstention, linking to /methodologie (MON-123)
  - metadata description uses the label too
- Label applied at the other deputy-display sites: deputies list rows (`DeputiesClient.tsx`), mon-depute card, home scroll experience card.
- New unit tests `frontend/__tests__/lib/departments.test.ts` (metropolitan, Corsica, overseas, 099, name passthrough, unknowns).

## Acceptance criteria mapping
- *No two tiles on the deputy page ever display the same metric under different labels* - "votes exprimés" removed; the six tiles are now total, presence %, pour, contre, abstentions, non-votant.
- *Definitions consistent with /methodologie* - /methodologie already defines non-votant as "présent sans exprimer de vote"; the tooltip states exactly that and links there.
- *No bare department codes visible on deputy pages or list rows* - `departmentLabel()` maps every code the AN data carries, including the 20 deputies prod still serves with bare codes (099/975/977/986/987/988), verified against the live API.
- *Department renders once in the header, human-readable* - single subtitle line "Rhône (69)"; photo duplicate removed.

## Testing
- `npm run lint`, `npm test` (67 tests, 9 suites, incl. new departments suite), `npm run build` - all green.
- Repo-wide `ruff check` / `ruff format --check` - clean (no Python touched).
- Manual: served the production build and verified rendered HTML for `/deputes/PA841729` ("Rhône (69)", no "votes exprimés", non-votant tile present), `/deputes/PA721158` ("Français établis hors de France", no "099"), `/deputes/PA840235` ("Polynésie française (987)").

## Risks / Notes
- Frontend-only; no API, schema, or deploy config changes.
- 977 is labeled "Saint-Barthélemy et Saint-Martin" (the single AN constituency covering both), matching AN usage rather than the INSEE split.
- MON-122's optional "move stat tiles into the header right side" idea was deferred - the header dead space is a separate layout concern and the tiles row already sits directly under the header.
- Follow-up worth filing: add the missing overseas codes to `scripts/update_party.py DEPT_NAMES` so the DB itself stores names.

## Breaking Changes
None
