### PR TITLE
fix: add NULLS LAST ordering to vote list/latest queries (MON-78)

### DIFF
--- a/api/routers/deputies.py
+++ b/api/routers/deputies.py
@@ -152,7 +152,7 @@ def get_deputy_votes(
                                v.summary_plain
                         FROM vote_positions vp
                         JOIN analytics_marts.mart_vote_summary v ON v.vote_id = vp.vote_id
-                        {} ORDER BY v.voted_at DESC LIMIT %s
+                        {} ORDER BY v.voted_at DESC NULLS LAST LIMIT %s
                     """).format(where),
                     params + [limit],
                 )
@@ -275,7 +275,7 @@ def get_dissident_votes(
                     WHERE vp.deputy_id = %s
                       AND vp.position IN ('pour', 'contre', 'abstention')
                       AND vp.position != m.majority_position
-                    ORDER BY v.voted_at DESC
+                    ORDER BY v.voted_at DESC NULLS LAST
                     LIMIT %s
                     """,
                     (deputy_id, limit),

--- a/api/routers/votes.py
+++ b/api/routers/votes.py
@@ -15,18 +15,23 @@ from api.schemas import VoteDetail, VoteListResponse, VotePosition, VoteSummary
 router = APIRouter()
 
 
-def _encode_cursor(voted_at: datetime, vote_id: str) -> str:
-    """Opaque keyset cursor over the list's sort key (voted_at, vote_id)."""
-    raw = f"{voted_at.isoformat()}|{vote_id}"
+def _encode_cursor(voted_at: Optional[datetime], vote_id: str) -> str:
+    """Opaque keyset cursor over the list's sort key (voted_at, vote_id).
+
+    voted_at may be None — undated votes sort last (NULLS LAST) and still
+    need a cursor to page past them.
+    """
+    ts = voted_at.isoformat() if voted_at is not None else ""
+    raw = f"{ts}|{vote_id}"
     return base64.urlsafe_b64encode(raw.encode()).decode()
 
 
-def _decode_cursor(token: str) -> tuple[datetime, str]:
+def _decode_cursor(token: str) -> tuple[Optional[datetime], str]:
     """Reverse of _encode_cursor; raises 422 on a malformed token."""
     try:
         raw = base64.urlsafe_b64decode(token.encode()).decode()
         ts, vote_id = raw.rsplit("|", 1)
-        return datetime.fromisoformat(ts), vote_id
+        return (datetime.fromisoformat(ts) if ts else None), vote_id
     except (ValueError, binascii.Error) as exc:
         raise HTTPException(status_code=422, detail="Invalid cursor") from exc
 
@@ -92,7 +97,17 @@ def list_votes(
                 page_conditions = list(conditions)
                 page_params = list(params)
                 if cursor_key:
-                    page_conditions.append(sql.SQL("(voted_at, vote_id) < (%s, %s)"))
+                    # NULLS LAST puts undated votes after all dated ones; coalescing
+                    # both sides to '-infinity' before comparing keeps the row
+                    # constructor total-ordered even when voted_at is NULL — a bare
+                    # (voted_at, vote_id) < (%s, %s) comparison evaluates to NULL
+                    # (and silently drops the row) whenever either side is NULL.
+                    page_conditions.append(
+                        sql.SQL(
+                            "(COALESCE(voted_at, '-infinity'::timestamptz), vote_id) < "
+                            "(COALESCE(%s::timestamptz, '-infinity'::timestamptz), %s)"
+                        )
+                    )
                     page_params.extend(cursor_key)
 
                 where = (
@@ -111,7 +126,7 @@ def list_votes(
                                votes_for, votes_against, abstentions, total_voters,
                                summary_plain, theme
                         FROM analytics_marts.mart_vote_summary {}
-                        ORDER BY voted_at DESC, vote_id DESC LIMIT %s OFFSET %s
+                        ORDER BY voted_at DESC NULLS LAST, vote_id DESC LIMIT %s OFFSET %s
                     """).format(where),
                     page_params + [limit, effective_offset],
                 )
@@ -145,7 +160,7 @@ def latest_votes(request: Request):
                            votes_for, votes_against, abstentions, total_voters,
                            summary_plain, theme
                     FROM analytics_marts.mart_vote_summary
-                    ORDER BY voted_at DESC
+                    ORDER BY voted_at DESC NULLS LAST
                     LIMIT 10
                     """
                 )

--- a/tests/integration/test_pagination.py
+++ b/tests/integration/test_pagination.py
@@ -25,7 +25,12 @@ def _list_page(cur, *, limit: int, cursor=None, result_filter=None):
     page_conditions = list(conditions)
     page_params = list(params)
     if cursor_key:
-        page_conditions.append(sql.SQL("(voted_at, vote_id) < (%s, %s)"))
+        page_conditions.append(
+            sql.SQL(
+                "(COALESCE(voted_at, '-infinity'::timestamptz), vote_id) < "
+                "(COALESCE(%s::timestamptz, '-infinity'::timestamptz), %s)"
+            )
+        )
         page_params.extend(cursor_key)
 
     where = (
@@ -39,7 +44,7 @@ def _list_page(cur, *, limit: int, cursor=None, result_filter=None):
             """
             SELECT vote_id, voted_at, result
             FROM analytics_marts.mart_vote_summary {}
-            ORDER BY voted_at DESC, vote_id DESC
+            ORDER BY voted_at DESC NULLS LAST, vote_id DESC
             LIMIT %s
             """
         ).format(where),
@@ -112,6 +117,14 @@ def test_cursor_encode_decode_roundtrip(db_conn):
     assert decoded_id == vote_id
 
 
+def test_cursor_encode_decode_roundtrip_with_null_voted_at():
+    """A cursor built from an undated (voted_at=None) row must round-trip to None."""
+    vote_id = "VTANR5L17VNULL"
+    decoded_ts, decoded_id = _decode_cursor(_encode_cursor(None, vote_id))
+    assert decoded_ts is None
+    assert decoded_id == vote_id
+
+
 @pytest.mark.integration
 def test_result_filter_scopes_pages(db_conn):
     """Filtering by result='rejeté' must return only rejected votes."""
@@ -128,3 +141,45 @@ def test_result_filter_scopes_pages(db_conn):
 
     # conftest seeds i%3==0 as "rejeté": i=3,6,9,12,15,18,21,24 → 8 votes
     assert len(all_ids) == 8
+
+
+@pytest.mark.integration
+def test_null_voted_at_sorts_last_and_paginates_correctly(db_conn):
+    """A NULL-dated vote must never rank before dated votes, and the keyset
+    cursor must still reach it — without NULLS LAST, Postgres puts NULLs
+    first on DESC; without coalescing the cursor comparison, a bare
+    (voted_at, vote_id) < (%s, %s) evaluates to NULL (dropping the row)
+    whenever either side is NULL."""
+    null_vote_id = "VTANR5L17VNULL"
+    with db_conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO analytics_marts.mart_vote_summary
+                (vote_id, voted_at, vote_title, vote_type, result,
+                 votes_for, votes_against, abstentions, total_voters)
+            VALUES (%s, NULL, 'Vote de test sans date', 'SPO', 'adopté', 300, 100, 50, 450)
+            ON CONFLICT (vote_id) DO UPDATE SET voted_at = NULL
+            """,
+            (null_vote_id,),
+        )
+
+    try:
+        all_rows = []
+        cursor = None
+        with db_conn.cursor() as cur:
+            while True:
+                rows, cursor = _list_page(cur, limit=10, cursor=cursor)
+                all_rows.extend(rows)
+                if cursor is None:
+                    break
+
+        assert len(all_rows) == 26, "26 seeded votes (25 dated + 1 undated) must all be reachable"
+        assert all_rows[-1]["vote_id"] == null_vote_id, "undated vote must sort last, not first"
+        ids = [r["vote_id"] for r in all_rows]
+        assert len(ids) == len(set(ids)), "pagination must not skip or duplicate rows"
+    finally:
+        with db_conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM analytics_marts.mart_vote_summary WHERE vote_id = %s",
+                (null_vote_id,),
+            )


### PR DESCRIPTION
## Summary
- `voted_at` on `mart_vote_summary` is nullable (made so in PR #140), but `/votes`, `/votes/latest`, `/deputies/{id}/votes`, and `/deputies/{id}/dissident-votes` all ordered by it `DESC` without `NULLS LAST` — Postgres puts `NULL`s first on `DESC`, so undated votes floated to the top of every one of these listings.
- The keyset cursor in `/votes` also silently dropped `NULL`-dated rows: a bare `(voted_at, vote_id) < (%s, %s)` row-constructor comparison evaluates to `NULL` (excluding the row) whenever either side is `NULL`. Fixed by coalescing both sides to `'-infinity'::timestamptz` before comparing, which keeps the comparison total-ordered while matching `NULLS LAST` semantics.
- `_encode_cursor`/`_decode_cursor` now accept/round-trip `voted_at=None` so a cursor can be built from (and page past) an undated vote.

## Acceptance criteria
- ✅ `/votes` never lists NULL-dated votes before dated ones — `ORDER BY voted_at DESC NULLS LAST, vote_id DESC`.
- ✅ Keyset pagination remains stable across pages with a NULL `voted_at` row — new integration test `test_null_voted_at_sorts_last_and_paginates_correctly` seeds a 26th, undated vote and walks all pages, asserting it sorts last and appears exactly once.

## Scope
- `api/routers/votes.py`: `list_votes` (main ORDER BY + cursor condition) and `latest_votes`.
- `api/routers/deputies.py`: `get_deputy_votes` and the dissident-votes endpoint — both order by `v.voted_at DESC` and share the same NULL-ordering risk.
- No dbt mart changes needed — `mart_vote_summary` itself has no `ORDER BY`; sorting happens at API query time. The one `ORDER BY` in `transform/models/` (`int_party_vote_majority`) sorts on non-nullable tie-break columns and is unrelated.
- `tests/integration/test_pagination.py`: updated the duplicated keyset SQL to match the fix, added the NULL-`voted_at` pagination test, and a cursor round-trip test for `voted_at=None`.

## Test plan
- [x] `venv/bin/python -m pytest tests/ -m "not integration" -q` — 159 passed (CI-blocking selection, no regressions).
- [x] Full suite against local Postgres (`make start && make migrate`): `python -m pytest tests/ -q` — 188 passed, including the new NULL-`voted_at` integration test.
- [x] `ruff check .` and `ruff format --check .` — clean repo-wide.

## Deploy risk
None — no schema migration, no config change. Pure query-logic fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)