### PR TITLE
fix: back off and retry on API 429 so Vercel production builds stop failing

### DIFF
--- a/frontend/__tests__/lib/api.test.ts
+++ b/frontend/__tests__/lib/api.test.ts
@@ -66,6 +66,45 @@ describe('api.deputies.votes', () => {
   })
 })
 
+describe('apiFetch 429 backoff (via api.health)', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  function mockResponse(status: number, body: unknown = {}) {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+    } as Response
+  }
+
+  it('retries a 429 with backoff and succeeds once the limiter clears', async () => {
+    jest.useFakeTimers()
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(mockResponse(429))
+      .mockResolvedValueOnce(mockResponse(429))
+      .mockResolvedValueOnce(mockResponse(200, { deputies: 577 }))
+    const promise = api.health()
+    await jest.runAllTimersAsync()
+    const result = await promise
+    expect(result.deputies).toBe(577)
+    expect(global.fetch).toHaveBeenCalledTimes(3)
+  })
+
+  it('throws after exhausting 429 retries', async () => {
+    jest.useFakeTimers()
+    global.fetch = jest.fn().mockResolvedValue(mockResponse(429))
+    const promise = api.health()
+    const assertion = expect(promise).rejects.toThrow('API error: 429')
+    await jest.runAllTimersAsync()
+    await assertion
+    // 1 initial attempt + 4 backoff retries
+    expect(global.fetch).toHaveBeenCalledTimes(5)
+  })
+})
+
 describe('apiFetch (via api.health)', () => {
   it('throws on a non-ok response', async () => {
     mockFetch(503, { detail: 'Service Unavailable' })

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -111,18 +111,34 @@ export type SearchResult = {
   sources: Array<{ content: string; metadata: Record<string, string>; similarity: number }>
 }
 
+// 5xx: transient upstream hiccups, short retries.
+// 429: the API rate limiter (30 req/min per IP) — hit hard during `next build`,
+// where prerendering ~117 pages from one IP exceeds the budget and fails the
+// whole Vercel deploy. Long waits let the per-minute window reset; build time
+// is the only cost.
+const SERVER_ERROR_DELAYS_MS = [200, 400]
+const RATE_LIMIT_DELAYS_MS = [2_000, 15_000, 30_000, 61_000]
+
 async function apiFetch<T>(path: string, opts?: { revalidate?: number }): Promise<T> {
-  const delays = [200, 400]
   let lastStatus = 0
-  for (let attempt = 0; attempt <= delays.length; attempt++) {
+  let serverErrorAttempt = 0
+  let rateLimitAttempt = 0
+  for (;;) {
     const res = await fetch(`${API_BASE}${path}`, {
       headers: { 'Content-Type': 'application/json' },
       next: { revalidate: opts?.revalidate ?? 300 },
     })
     if (res.ok) return res.json()
     lastStatus = res.status
-    if (res.status < 500 || attempt === delays.length) break
-    await new Promise(r => setTimeout(r, delays[attempt]))
+    if (res.status === 429 && rateLimitAttempt < RATE_LIMIT_DELAYS_MS.length) {
+      await new Promise(r => setTimeout(r, RATE_LIMIT_DELAYS_MS[rateLimitAttempt++]))
+      continue
+    }
+    if (res.status >= 500 && serverErrorAttempt < SERVER_ERROR_DELAYS_MS.length) {
+      await new Promise(r => setTimeout(r, SERVER_ERROR_DELAYS_MS[serverErrorAttempt++]))
+      continue
+    }
+    break
   }
   throw new Error(`API error: ${lastStatus}`)
 }


### PR DESCRIPTION
## What
`apiFetch` now retries 429 responses with a long backoff schedule (2s/15s/30s/61s) instead of failing immediately. 5xx keeps the existing short retries (200/400 ms).

## Why
Production is currently **undeployable**: prerendering ~117 pages during `next build` exceeds the prod API's 30 req/min per-IP rate limit, and `apiFetch` treated 429 as fatal. Five consecutive Vercel production builds failed on 2026-07-12 (`Error: API error: 429` on `/votes`), including the deploy of merged PR #189, which is therefore not live. The 61s max wait guarantees the per-minute limiter window resets between retries; the only cost is a slower build.

## Testing
- 2 new Jest tests (fake timers): 429 retried then succeeds; throws after exhausting the 4 retries (5 fetch calls total).
- Full suite: 69 tests, 9 suites green; `eslint` and `tsc --noEmit` clean.
- Real-world validation is the Vercel build itself after merge.

## Risks / Notes
- Runtime (non-build) requests that hit a 429 will now wait up to ~108s worst case instead of erroring fast. In practice users are far below the limit; the build was the only consumer hitting it. If that ever matters, a build-only flag can shorten the runtime schedule.
- Follow-up alternative if builds grow: reduce prerendered `/votes/[id]` pages or exempt the build IP server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RE8akiXPxb5pznWzr25En