### PR TITLE
fix: remove notable-deputy retrieval pin, exact cosine scan has perfect recall (MON-76)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,13 +237,15 @@ Key architectural choices made during the build and why. Consult this before pro
 
 **Why:** OpenAI embeddings are the quality baseline for French text and are cheap at this corpus size ($0.006 per full re-index). Groq inference is free-tier, significantly faster than OpenAI Chat, and produces adequate quality for civic Q&A at temperature=0.2. Separating the embedding and inference providers gives independent cost and quality control over each.
 
-### 5. IVFFlat + notable-deputy pin for RAG retrieval
+### 5. IVFFlat dropped; notable-deputy retrieval pin removed (MON-76)
 
-**Decision (revised 2026-06-11):** the IVFFlat index was dropped (migration 003) — it had been built on an empty table (degenerate clustering) and at ~3.7k chunks an exact cosine scan is faster *and* exact. The notable-deputy pin (hard-coded name list) remains for now; re-evaluating it is part of the RAG-axis remediation.
+**Decision (revised 2026-07-13):** the IVFFlat index was dropped (migration 003) — it had been built on an empty table (degenerate clustering) and at ~3.7k chunks an exact cosine scan is faster *and* exact. The notable-deputy retrieval pin was re-evaluated with a local MLflow run (pin-on vs pin-off, retrieval suite) and removed: pin-off matched pin-on on keyword_score (0.875 = 0.875) and scored *higher* on average top similarity (0.622 vs 0.571) — the exact cosine scan alone already ranks the deputy's own chunk first. See decision ADR-008 in `docs/decisions.md` for the full eval writeup.
 
-**Original decision:** pgvector uses IVFFlat (not HNSW) with `ivfflat.probes=10`. A hard-coded name list (Attal, Le Pen, etc.) pins the named deputy's chunk as the first result, bypassing the index.
+**Original decision:** pgvector uses IVFFlat (not HNSW) with `ivfflat.probes=10`. A DB-backed map of indexed `notable_deputy` chunks pins the named deputy's chunk as the first result, bypassing the index.
 
-**Why:** At 3 741 chunks, IVFFlat is fast enough and simpler to tune than HNSW. However, IVFFlat has known recall gaps for high-profile deputies whose names appear across many chunks — the index can return a generic vote chunk instead of the deputy profile. The pin is a targeted workaround: it adds one exact-match lookup before the vector search and is cheaper than retuning the entire index. This should be revisited if the corpus grows substantially or if HNSW becomes the default.
+**Why it existed:** At 3 741 chunks, IVFFlat had known recall gaps for high-profile deputies whose names appear across many chunks — the index could return a generic vote chunk instead of the deputy profile. The pin was a targeted workaround: it added one exact-match lookup before the vector search, cheaper than retuning the entire index.
+
+**Why it's gone:** IVFFlat itself is gone (see above), so the recall gap the pin was compensating for no longer exists. `get_notable_deputy_ids()` / `detect_notable_deputy()` still live in `rag/chain/retriever.py` — they're used by `rag/chain/llm_router.py` to route deputy-specific questions to RAG instead of a ranking-intent SQL query, which is a routing concern, not a retrieval-ranking one.
 
 ### 6. dbt for the transform layer
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -168,10 +168,22 @@ revealed that aggregate facts (total deputies = 577, party counts) were not
 in any individual chunk, causing 3 of 4 retrieval failures. Adding party
 chunks and a global stats chunk raised keyword_score from 0.58 to 0.80+.
 
-**Notable deputy pinning:** Retriever bypasses cosine search for known
-deputy names (Attal, Le Pen) and fetches their chunk directly, then fills
-remaining slots with semantic search. Solves IVFFlat recall gap on rare
-named entities.
+**Notable deputy pinning (removed MON-76):** Retriever used to bypass cosine
+search for known deputy names (Attal, Le Pen) and fetch their chunk
+directly, then fill remaining slots with semantic search — a workaround for
+an IVFFlat recall gap on rare named entities. Migration 003 dropped IVFFlat
+in favor of an exact cosine scan (perfect recall at this corpus size, see
+decision 5 in CLAUDE.md), so the pin became scaffolding around a problem
+that no longer existed. Re-evaluated with a local MLflow run comparing
+pin-on vs pin-off on the retrieval suite: identical keyword_score (0.875 =
+0.875) and *higher* average top similarity with the pin off (0.622 vs
+0.571) — the plain cosine scan on its own ranks the richer `deputy` chunk
+above the hand-authored `notable_deputy` chunk. The pin, its DB-backed
+notable-deputy map, and the forced-first-result logic in `retrieve()` were
+removed; `get_notable_deputy_ids()` / `detect_notable_deputy()` remain in
+`rag/chain/retriever.py` because `rag/chain/llm_router.py` still uses them
+to route deputy-specific questions to RAG instead of a ranking-intent SQL
+query — that is a routing concern, not a retrieval-ranking one.
 
 **Total index:** 3,739 chunks. Cost: $0.0064 one-time (OpenAI
 text-embedding-3-small). Per-query cost: ~$0 (question embedding only).

--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -53,6 +53,11 @@ def get_notable_deputy_ids() -> dict:
     Fetch all notable_deputy chunk deputy_ids from document_chunks.
     Returns {deputy_id: full_name} for all indexed notable deputies.
     Refreshed at most once per hour so the serving process stays current.
+
+    Used by rag.chain.llm_router to route deputy-specific questions to RAG
+    instead of a ranking-intent SQL query — not for retrieval pinning
+    (removed in MON-76: exact cosine scan has perfect recall at this corpus
+    size, see decision 5 in docs/decisions.md).
     """
     now = time.monotonic()
     if _notable_cache["value"] is not None and now - _notable_cache["ts"] < _NOTABLE_TTL:
@@ -141,13 +146,6 @@ def retrieve(
     result_filter = detect_result_filter(question)
     recency = detect_recency_intent(question)
 
-    notable_id = None
-    if not deputy_id:
-        notable_map = get_notable_deputy_ids()
-        notable_id = detect_notable_deputy(question, notable_map)
-        if notable_id:
-            log.debug("[retriever] Notable deputy pinned: %s", notable_map[notable_id])
-
     response = _openai_client.embeddings.create(input=[question], model=EMBEDDING_MODEL)
     query_vector = np.array(response.data[0].embedding, dtype=np.float32)
 
@@ -160,34 +158,11 @@ def retrieve(
         with conn.cursor(cursor_factory=psycopg2.extensions.cursor) as plain_cur:
             register_vector(plain_cur)
         with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
-            pinned = []
-            if notable_id:
-                cur.execute(
-                    """
-                    SELECT content, metadata,
-                           1 - (embedding <=> %s::vector) AS similarity
-                    FROM document_chunks
-                    WHERE metadata->>'chunk_type' = 'notable_deputy'
-                      AND metadata->>'deputy_id' = %s
-                    """,
-                    (query_vector, notable_id),
-                )
-                for row in cur.fetchall():
-                    pinned.append(
-                        {
-                            "content": row["content"],
-                            "metadata": dict(row["metadata"]),
-                            "similarity": float(row["similarity"]),
-                        }
-                    )
-
-            semantic_k = k - len(pinned)
-            pinned_ids = {p["metadata"].get("deputy_id") for p in pinned}
             # "récemment"/"dernier" etc. carry no signal for cosine similarity —
             # widen the candidate pool so a post-hoc sort by voted_at has
             # actually-recent votes to pick from, instead of just whatever
             # happens to be closest in embedding space.
-            fetch_limit = (semantic_k + len(pinned)) * 4 if recency else semantic_k + len(pinned)
+            fetch_limit = k * 4 if recency else k
             cur.execute(
                 """
                 SELECT content, metadata,
@@ -218,8 +193,6 @@ def retrieve(
                     "similarity": float(row["similarity"]),
                 }
                 for row in cur.fetchall()
-                if row["metadata"].get("deputy_id") not in pinned_ids
-                or row["metadata"].get("chunk_type") != "notable_deputy"
             ]
             if recency:
                 # Sort candidates with a voted_at by recency first; chunks
@@ -228,14 +201,14 @@ def retrieve(
                 dated = [r for r in semantic_rows if r["metadata"].get("voted_at")]
                 undated = [r for r in semantic_rows if not r["metadata"].get("voted_at")]
                 dated.sort(key=lambda r: r["metadata"]["voted_at"], reverse=True)
-                semantic_rows = (dated + undated)[: semantic_k + len(pinned)]
+                semantic_rows = (dated + undated)[:k]
     except Exception:
         broken = True
         raise
     finally:
         pool.putconn(conn, close=broken)
 
-    results = (pinned + semantic_rows)[:k]
+    results = semantic_rows[:k]
 
     top_sim = results[0]["similarity"] if results else 0.0
     log.debug(

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -91,8 +91,7 @@ def test_ask_stage_ordering():
 def _make_retriever_mocks(semantic_rows: list[dict]):
     """Build (mock_openai_client, mock_pool) for use in retrieve() tests.
 
-    Patches _openai_client (already created at import time, not the class),
-    get_notable_deputy_ids (bypasses DB for notable-deputy lookup),
+    Patches _openai_client (already created at import time, not the class)
     and _get_retriever_pool (bypasses real connection pool creation).
     """
     embedding_resp = MagicMock()
@@ -105,8 +104,6 @@ def _make_retriever_mocks(semantic_rows: list[dict]):
     cursor = MagicMock()
     cursor.__enter__ = lambda s: s
     cursor.__exit__ = MagicMock(return_value=False)
-    # With get_notable_deputy_ids returning {} there is no pin query; only the
-    # semantic fetchall runs (one call).
     cursor.fetchall.return_value = semantic_rows
 
     conn = MagicMock()
@@ -130,7 +127,6 @@ def test_retrieve_returns_list_with_correct_keys():
 
     with (
         patch("rag.chain.retriever._openai_client", mock_openai),
-        patch("rag.chain.retriever.get_notable_deputy_ids", return_value={}),
         patch("rag.chain.retriever._get_retriever_pool", return_value=mock_pool),
         patch("rag.chain.retriever.register_vector"),
     ):
@@ -151,10 +147,35 @@ def test_retrieve_returns_empty_list_when_no_chunks():
 
     with (
         patch("rag.chain.retriever._openai_client", mock_openai),
-        patch("rag.chain.retriever.get_notable_deputy_ids", return_value={}),
         patch("rag.chain.retriever._get_retriever_pool", return_value=mock_pool),
         patch("rag.chain.retriever.register_vector"),
     ):
         results = retrieve("Question sans résultat")
 
     assert results == []
+
+
+def test_retrieve_runs_single_semantic_query_no_pin():
+    """MON-76: the notable-deputy pin (a second, separate query that forced a
+    notable_deputy chunk to the front) was removed — exact cosine scan has
+    perfect recall at this corpus size (see decision 5 in docs/decisions.md).
+    retrieve() must issue exactly one SELECT against document_chunks."""
+    semantic_rows = [
+        {
+            "content": "Yaël Braun-Pivet est député(e) des Yvelines.",
+            "metadata": {"chunk_type": "deputy", "deputy_id": "PA1"},
+            "similarity": 0.65,
+        }
+    ]
+    mock_openai, mock_pool = _make_retriever_mocks(semantic_rows)
+    cursor = mock_pool.getconn.return_value.cursor.return_value
+
+    with (
+        patch("rag.chain.retriever._openai_client", mock_openai),
+        patch("rag.chain.retriever._get_retriever_pool", return_value=mock_pool),
+        patch("rag.chain.retriever.register_vector"),
+    ):
+        results = retrieve("Quel est le taux de présence de Yaël Braun-Pivet ?")
+
+    assert cursor.execute.call_count == 1
+    assert results[0]["metadata"]["chunk_type"] == "deputy"


### PR DESCRIPTION
## What
Removes the notable-deputy retrieval pin from `rag/chain/retriever.py`, now that migration 003 dropped IVFFlat in favor of an exact cosine scan.

## Why
The pin was a workaround for IVFFlat's recall gaps on high-profile deputy names (decision 5, ADR-008). IVFFlat itself was already dropped for an exact cosine scan with perfect recall. MON-76 asked for the pin to be re-evaluated now that its original justification no longer applies.

A local MLflow run (90-day local dataset, 2,808 chunks) compared `retrieve()` with the pin on (current code) vs off (monkeypatched `get_notable_deputy_ids` to return `{}`) on the retrieval-suite golden questions:

| | keyword_score | avg top similarity |
|---|---|---|
| Pin ON (baseline) | 0.875 | 0.571 |
| Pin OFF | 0.875 | **0.622** |

Keyword score is identical; similarity is *higher* with the pin off — the exact cosine scan already ranks the deputy's own chunk first without help, and does so via the richer `deputy` chunk type rather than the hand-authored `notable_deputy` chunk. Full writeup in `docs/decisions.md` ADR-008.

## Changes
- `rag/chain/retriever.py`: removed the forced-pin branch inside `retrieve()` — no more separate pinned-chunk query, no `pinned`/`semantic_k` bookkeeping. `retrieve()` now issues exactly one query against `document_chunks`.
- Kept `get_notable_deputy_ids()` and `detect_notable_deputy()` in `retriever.py` — `rag/chain/llm_router.py` still depends on them to route deputy-specific questions to RAG instead of a ranking-intent SQL query. That's a routing concern, separate from retrieval ranking, and out of scope for this issue.
- `docs/decisions.md` (ADR-008) and `CLAUDE.md` (decision 5): updated to record the pin's removal and the eval evidence.
- `tests/test_rag.py`: removed now-unnecessary `get_notable_deputy_ids` patches from the two existing `retrieve()` tests, added `test_retrieve_runs_single_semantic_query_no_pin` asserting `retrieve()` issues exactly one SQL query and surfaces the `deputy` chunk on its own.

## Testing
- `ruff check` / `ruff format --check` on `rag/`, `tests/`, `api/`, `scripts/`: clean.
- `pytest tests/ -m "not integration"`: 160 passed (including the 16 in `test_rag.py` + `test_llm_router.py`, which cover both the retrieval and routing paths touched by this change).
- MLflow eval evidence above, run against a local Docker Postgres seeded with ~90 days of real ingested data (577 deputies, 2,096 votes, 237k positions, full 2,808-chunk RAG index including notable_deputy and law_summary chunks) — not against prod, which had sandbox credential-access friction this session. The eval driver was a scratch script, deleted after use; results are recorded in ADR-008 rather than a checked-in MLflow run.

## Risks / Notes
- No schema, deploy, or API-contract changes.
- `rag/pipeline/chunk_notable_deputies.py` still calls `get_notable_deputy_ids.cache_clear()` in a try/except that silently swallows the `AttributeError` (the TTL cache was never an `lru_cache`, so this call has been a no-op since it was written) — pre-existing, unrelated to this change, left as-is.
- The repo's committed `venv/` is currently broken on this machine (Python 3.14, `openai==1.40.0`'s pydantic-v1 compat shim hangs on import) — unrelated pre-existing environment issue, worth a separate follow-up. All verification here used a parallel Python 3.12 venv.

## Breaking Changes
None.
