### PR TITLE
feat: add JSON-LD structured data to home, deputy, and vote pages (MON-95)

### DIFF
--- a/frontend/__tests__/lib/seo.test.ts
+++ b/frontend/__tests__/lib/seo.test.ts
@@ -1,0 +1,86 @@
+import {
+  SITE_URL,
+  buildWebsiteJsonLd,
+  buildPersonJsonLd,
+  buildVoteJsonLd,
+  buildBreadcrumbJsonLd,
+} from '@/lib/seo'
+import type { Deputy, Vote } from '@/lib/api'
+
+const deputy: Deputy = {
+  deputy_id: 'PA123',
+  full_name: 'Jeanne Dupont',
+  first_name: 'Jeanne',
+  last_name: 'Dupont',
+  party: 'Renaissance',
+  department: '69',
+  photo_url: 'https://example.com/photo.jpg',
+  mandate_start: '2024-07-07',
+  mandate_end: null,
+}
+
+const vote: Vote = {
+  vote_id: 'VTANR5L17V1',
+  vote_title: 'Motion de censure',
+  result: 'rejeté',
+  voted_at: '2026-01-15T00:00:00',
+  votes_for: 100,
+  votes_against: 300,
+  abstentions: 20,
+  total_voters: 420,
+  summary_plain: 'Rejetée par 300 voix contre 100.',
+  theme: null,
+}
+
+describe('buildWebsiteJsonLd', () => {
+  it('includes a SearchAction targeting /chat', () => {
+    const data = buildWebsiteJsonLd()
+    expect(data['@type']).toBe('WebSite')
+    expect(data.url).toBe(SITE_URL)
+    expect(data.potentialAction.target.urlTemplate).toBe(`${SITE_URL}/chat?q={search_term_string}`)
+  })
+})
+
+describe('buildPersonJsonLd', () => {
+  it('includes memberOf and image when present', () => {
+    const data = buildPersonJsonLd(deputy)
+    expect(data['@type']).toBe('Person')
+    expect(data.jobTitle).toBe('Député')
+    expect(data.memberOf).toEqual({ '@type': 'Organization', name: 'Renaissance' })
+    expect(data.image).toBe(deputy.photo_url)
+  })
+
+  it('omits memberOf and image when party/photo are null', () => {
+    const data = buildPersonJsonLd({ ...deputy, party: null, photo_url: null })
+    expect(data).not.toHaveProperty('memberOf')
+    expect(data).not.toHaveProperty('image')
+  })
+})
+
+describe('buildVoteJsonLd', () => {
+  it('builds an Event with the vote title and summary', () => {
+    const data = buildVoteJsonLd(vote)
+    expect(data['@type']).toBe('Event')
+    expect(data.name).toBe(vote.vote_title)
+    expect(data.description).toBe(vote.summary_plain)
+    expect(data.url).toBe(`${SITE_URL}/votes/${vote.vote_id}`)
+  })
+
+  it('omits description when summary_plain is missing', () => {
+    const data = buildVoteJsonLd({ ...vote, summary_plain: null })
+    expect(data).not.toHaveProperty('description')
+  })
+})
+
+describe('buildBreadcrumbJsonLd', () => {
+  it('numbers items starting at 1', () => {
+    const data = buildBreadcrumbJsonLd([
+      { name: 'Accueil', url: SITE_URL },
+      { name: 'Votes', url: `${SITE_URL}/votes` },
+    ])
+    expect(data.itemListElement).toEqual([
+      { '@type': 'ListItem', position: 1, name: 'Accueil', item: SITE_URL },
+      { '@type': 'ListItem', position: 2, name: 'Votes', item: `${SITE_URL}/votes` },
+    ])
+  })
+})

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -11,6 +11,8 @@ import { ShareButton } from '@/components/ShareButton'
 import { InfoTooltip } from '@/components/InfoTooltip'
 import { FollowDeputyButton } from '@/components/FollowDeputyButton'
 import { VoteTimelineItem } from '@/components/VoteTimelineItem'
+import { JsonLd } from '@/components/JsonLd'
+import { SITE_URL, buildPersonJsonLd, buildBreadcrumbJsonLd } from '@/lib/seo'
 
 export const dynamicParams = true
 export const revalidate = 86400
@@ -93,6 +95,12 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
 
   return (
     <div style={{ background: CREAM, minHeight: '100vh' }}>
+      <JsonLd data={buildPersonJsonLd(deputy)} />
+      <JsonLd data={buildBreadcrumbJsonLd([
+        { name: 'Accueil', url: SITE_URL },
+        { name: 'Députés', url: `${SITE_URL}/deputes` },
+        { name: deputy.full_name, url: `${SITE_URL}/deputes/${id}` },
+      ])} />
 
       {/* Hero band */}
       <div style={{

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -8,6 +8,8 @@ import { BottomNav } from '@/components/BottomNav'
 import { PageTransition } from '@/components/PageTransition'
 import { FreshnessBadge } from '@/components/FreshnessBadge'
 import { Footer } from '@/components/Footer'
+import { JsonLd } from '@/components/JsonLd'
+import { buildWebsiteJsonLd } from '@/lib/seo'
 
 const serif = DM_Serif_Display({
   subsets: ['latin'],
@@ -63,6 +65,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="fr" className={`${serif.variable} ${sans.variable} ${newsreader.variable}`}>
       <body className="bg-gray-off min-h-screen">
+        <JsonLd data={buildWebsiteJsonLd()} />
         <Nav />
         <FreshnessBadge />
         <main className="pb-20 md:pb-0"><PageTransition>{children}</PageTransition></main>

--- a/frontend/src/app/votes/[id]/page.tsx
+++ b/frontend/src/app/votes/[id]/page.tsx
@@ -4,6 +4,8 @@ import { Suspense } from 'react'
 import { api } from '@/lib/api'
 import { getInitials, groupVotesByParty, normalizePartyShort, partyHex, partyShort } from '@/lib/utils'
 import { VoteDetailClient } from './VoteDetailClient'
+import { JsonLd } from '@/components/JsonLd'
+import { SITE_URL, buildVoteJsonLd, buildBreadcrumbJsonLd } from '@/lib/seo'
 
 export const dynamicParams = true
 export const revalidate = 86400
@@ -125,27 +127,35 @@ export default async function VoteDetailPage({ params }: { params: Promise<{ id:
   })
 
   return (
-    <Suspense fallback={<div style={{ padding: '48px 32px', color: '#9CA3AF', fontSize: 14 }}>Chargement…</div>}>
-      <VoteDetailClient
-        voteId={vote.vote_id}
-        voteTitle={vote.vote_title}
-        result={vote.result}
-        votedAt={vote.voted_at}
-        summary={vote.summary_plain ?? null}
-        theme={vote.theme ?? null}
-        votesFor={vote.votes_for}
-        votesAgainst={vote.votes_against}
-        abstentions={vote.abstentions}
-        totalVoters={vote.total_voters}
-        pourPct={pourPct}
-        contrePct={contrePct}
-        abstPct={abstPct}
-        groups={groups}
-        dissidents={dissidents}
-        related={related}
-        apiUrl={apiUrl}
-        deputyLookup={deputyLookup}
-      />
-    </Suspense>
+    <>
+      <JsonLd data={buildVoteJsonLd(vote)} />
+      <JsonLd data={buildBreadcrumbJsonLd([
+        { name: 'Accueil', url: SITE_URL },
+        { name: 'Votes', url: `${SITE_URL}/votes` },
+        { name: vote.vote_title, url: `${SITE_URL}/votes/${vote.vote_id}` },
+      ])} />
+      <Suspense fallback={<div style={{ padding: '48px 32px', color: '#9CA3AF', fontSize: 14 }}>Chargement…</div>}>
+        <VoteDetailClient
+          voteId={vote.vote_id}
+          voteTitle={vote.vote_title}
+          result={vote.result}
+          votedAt={vote.voted_at}
+          summary={vote.summary_plain ?? null}
+          theme={vote.theme ?? null}
+          votesFor={vote.votes_for}
+          votesAgainst={vote.votes_against}
+          abstentions={vote.abstentions}
+          totalVoters={vote.total_voters}
+          pourPct={pourPct}
+          contrePct={contrePct}
+          abstPct={abstPct}
+          groups={groups}
+          dissidents={dissidents}
+          related={related}
+          apiUrl={apiUrl}
+          deputyLookup={deputyLookup}
+        />
+      </Suspense>
+    </>
   )
 }

--- a/frontend/src/components/JsonLd.tsx
+++ b/frontend/src/components/JsonLd.tsx
@@ -1,0 +1,12 @@
+type Props = {
+  data: Record<string, unknown> | Record<string, unknown>[]
+}
+
+export function JsonLd({ data }: Props) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  )
+}

--- a/frontend/src/components/JsonLd.tsx
+++ b/frontend/src/components/JsonLd.tsx
@@ -6,7 +6,7 @@ export function JsonLd({ data }: Props) {
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data).replace(/</g, '\\u003c') }}
     />
   )
 }

--- a/frontend/src/lib/seo.ts
+++ b/frontend/src/lib/seo.ts
@@ -1,0 +1,88 @@
+import type { Deputy, Vote } from '@/lib/api'
+import { departmentLabel } from '@/lib/departments'
+
+export const SITE_URL = 'https://mon-elu.vercel.app'
+export const SITE_NAME = 'MonÉlu'
+
+export type BreadcrumbItem = { name: string; url: string }
+
+export function buildWebsiteJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: SITE_NAME,
+    url: SITE_URL,
+    potentialAction: {
+      '@type': 'SearchAction',
+      target: {
+        '@type': 'EntryPoint',
+        urlTemplate: `${SITE_URL}/chat?q={search_term_string}`,
+      },
+      'query-input': 'required name=search_term_string',
+    },
+  }
+}
+
+export function buildBreadcrumbJsonLd(items: BreadcrumbItem[]) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  }
+}
+
+export function buildPersonJsonLd(deputy: Deputy) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: deputy.full_name,
+    givenName: deputy.first_name,
+    familyName: deputy.last_name,
+    jobTitle: 'Député',
+    url: `${SITE_URL}/deputes/${deputy.deputy_id}`,
+    ...(deputy.photo_url ? { image: deputy.photo_url } : {}),
+    ...(deputy.party ? { memberOf: { '@type': 'Organization', name: deputy.party } } : {}),
+    workLocation: {
+      '@type': 'Place',
+      name: 'Assemblée nationale',
+      address: {
+        '@type': 'PostalAddress',
+        addressLocality: 'Paris',
+        addressCountry: 'FR',
+        ...(deputy.department ? { addressRegion: departmentLabel(deputy.department) } : {}),
+      },
+    },
+  }
+}
+
+export function buildVoteJsonLd(vote: Vote) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Event',
+    name: vote.vote_title,
+    startDate: vote.voted_at,
+    endDate: vote.voted_at,
+    eventStatus: 'https://schema.org/EventScheduled',
+    eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+    location: {
+      '@type': 'Place',
+      name: 'Assemblée nationale',
+      address: {
+        '@type': 'PostalAddress',
+        addressLocality: 'Paris',
+        addressCountry: 'FR',
+      },
+    },
+    organizer: {
+      '@type': 'GovernmentOrganization',
+      name: 'Assemblée nationale',
+    },
+    ...(vote.summary_plain ? { description: vote.summary_plain } : {}),
+    url: `${SITE_URL}/votes/${vote.vote_id}`,
+  }
+}


### PR DESCRIPTION
## What

Adds schema.org JSON-LD structured data to the home page, deputy detail pages, and vote detail pages.

## Why

Structured data earns rich results and knowledge-panel citations for the queries this product targets (people searching a deputy's name), and makes MonÉlu machine-readable for AI-assistant traffic that cites sources directly.

## Changes

- `frontend/src/components/JsonLd.tsx` — new server component rendering a `<script type="application/ld+json">` from a plain data object, following the existing convention of typed, directive-free presentational components (modeled on `VoteTimelineItem.tsx`).
- `frontend/src/lib/seo.ts` — new module with `SITE_URL`/`SITE_NAME` constants and builder functions:
  - `buildWebsiteJsonLd()` — `WebSite` + `SearchAction` targeting `/chat?q={search_term_string}` (the existing RAG search page already reads a `q` query param).
  - `buildPersonJsonLd(deputy)` — `Person` with `jobTitle: "Député"`, `memberOf` (party, when present), and `workLocation` (Assemblée nationale, with `addressRegion` from `departmentLabel()`).
  - `buildVoteJsonLd(vote)` — `Event` (schema.org has no dedicated "vote" type; `Legislation` is a pending/rarely-supported extension, so `Event` was used for broad Google Rich Results compatibility) with date, location, organizer, and summary.
  - `buildBreadcrumbJsonLd(items)` — generic `BreadcrumbList` builder.
- `frontend/src/app/layout.tsx` — renders the `WebSite` JSON-LD once, globally, in `<body>`.
- `frontend/src/app/deputes/[id]/page.tsx` — renders `Person` + `BreadcrumbList` (Accueil → Députés → deputy name).
- `frontend/src/app/votes/[id]/page.tsx` — renders `Event` + `BreadcrumbList` (Accueil → Votes → vote title); wrapped the existing `Suspense` block in a fragment to add the two script tags as siblings, no visual/behavioral change.

No new data fetching — all JSON-LD is built from data the pages already load via `generateMetadata()`/page loaders.

## Testing

- `npm run lint` — no ESLint warnings or errors.
- `npm test` — 9 suites / 69 tests passed, no regressions.
- `npm run build` — production build succeeds (type-checked via `next build`); pre-existing `fetch failed` connect-timeout noise against the production API is expected in this sandboxed environment and reproduces on master.
- Manually inspected generated static HTML (`.next/server/app/index.html`, `.next/server/app/votes/VTANR5L17V7979.html`) and confirmed valid, well-formed JSON-LD for `WebSite`, `Event`, and `BreadcrumbList`. Deputy pages are server-rendered on demand (not statically prerendered), so the `Person`/`BreadcrumbList` output wasn't inspectable in the static build output the same way, but the code path is identical to the verified vote-page path.
- Not run: Google's Rich Results test (external tool, requires a public deployed URL) — recommend running it against the preview deployment once this PR is up.

## Risks / Notes

- `SITE_URL` in `seo.ts` duplicates the hardcoded `'https://mon-elu.vercel.app'` string that already exists in `layout.tsx`, `sitemap.ts`, `robots.ts`, and the vote page's `generateMetadata` — no shared constant existed before this PR either, so this doesn't introduce new drift, just doesn't fully fix the pre-existing duplication (out of scope for this issue).
- `Event` (not `Legislation`) was chosen for vote pages — `Legislation` is a schema.org pending extension with poor real-world/Rich-Results tooling support, so `Event` (a scheduled vote in a legislative chamber) is the safer choice for actual rich-result eligibility. Worth confirming with the Google Rich Results test once deployed.

## Breaking Changes

None.
