### PR TITLE
feat: always-visible source citations, confidence tooltip, and caveats in chat (MON-83)

### DIFF
--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -532,7 +532,7 @@ function ChatInner() {
                         <div style={{ fontSize: 15, lineHeight: 1.75, color: dk ? 'rgba(255,255,255,0.85)' : '#1F2937' }} dangerouslySetInnerHTML={{ __html: mdToHtml(msg.result.answer) }} />
                         {msg.result.caveat && (
                           <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', marginTop: 12, padding: '9px 12px', borderRadius: 8, background: dk ? 'rgba(251,191,36,0.10)' : '#FFFBEB', border: `1px solid ${dk ? 'rgba(251,191,36,0.22)' : '#FDE68A'}` }}>
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke={dk ? '#FBBF24' : '#B45309'} strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0, marginTop: 2 }}>
+                            <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke={dk ? '#FBBF24' : '#B45309'} strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0, marginTop: 2 }}>
                               <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
                               <line x1="12" y1="9" x2="12" y2="13" />
                               <line x1="12" y1="17" x2="12.01" y2="17" />

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -7,6 +7,7 @@ import { useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { api } from '@/lib/api'
 import type { SearchResult } from '@/lib/api'
+import { InfoTooltip } from '@/components/InfoTooltip'
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -108,22 +109,22 @@ type SourceCard = { dot: string; label: string; sub: string; badge: string; badg
 function mapSource(src: SearchResult['sources'][0]): SourceCard {
   const meta = src.metadata || {}
   const type = meta.chunk_type || 'stat'
-  if (type === 'deputy') {
+  if (type === 'deputy' || type === 'notable_deputy') {
     return {
       dot: meta.group_color || '#1B2B50',
-      label: meta.deputy_name || meta.name || 'Député',
-      sub: [meta.department, meta.circonscription].filter(Boolean).join(' · ') || '',
-      badge: meta.group_short || meta.group || '',
+      label: meta.deputy_name || meta.full_name || meta.name || 'Député',
+      sub: [meta.department, meta.circonscription, meta.party].filter(Boolean).join(' · ') || '',
+      badge: meta.group_short || meta.group || meta.party || '',
       badgeBg: '#F1F5F9', badgeColor: '#475569',
       href: meta.deputy_id ? `/deputes/${meta.deputy_id}` : undefined,
     }
   }
-  if (type === 'vote') {
+  if (type === 'vote' || type === 'law_summary') {
     const adopted = (meta.result || '').toLowerCase().includes('adopt')
     return {
       dot: adopted ? '#15803D' : '#DC2626',
-      label: meta.title || src.content.slice(0, 60),
-      sub: meta.date || '',
+      label: meta.title || meta.vote_title || src.content.slice(0, 60),
+      sub: meta.date || meta.voted_at || '',
       badge: meta.result || '',
       badgeBg: adopted ? '#DCFCE7' : '#FEE2E2',
       badgeColor: adopted ? '#15803D' : '#DC2626',
@@ -137,6 +138,23 @@ function mapSource(src: SearchResult['sources'][0]): SourceCard {
     badge: type, badgeBg: '#EFF3FB', badgeColor: '#1B2B50',
   }
 }
+
+// ── Confidence badge helpers ────────────────────────────────────────────────
+// compute_confidence() in rag/chain/rag_chain.py derives this from retrieval
+// quality (top similarity + supporting chunk count), not LLM self-rating.
+
+const CONFIDENCE_META: Record<string, { label: string; bg: string; color: string; bgDark: string; colorDark: string }> = {
+  high:   { label: 'Haute confiance',   bg: '#DCFCE7', color: '#15803D', bgDark: 'rgba(21,128,61,0.20)', colorDark: '#4ADE80' },
+  medium: { label: 'Confiance moyenne', bg: '#FEF3C7', color: '#92400E', bgDark: 'rgba(180,83,9,0.20)',  colorDark: '#FBBF24' },
+  low:    { label: 'Basse confiance',   bg: '#FEE2E2', color: '#B91C1C', bgDark: 'rgba(185,28,28,0.20)', colorDark: '#F87171' },
+}
+
+const CONFIDENCE_EXPLANATION =
+  "La confiance reflète la qualité des sources retrouvées dans la base de données (similarité et nombre), " +
+  "pas l'auto-évaluation du modèle. " +
+  'Haute confiance : plusieurs sources très proches de la question. ' +
+  'Confiance moyenne : sources partiellement pertinentes. ' +
+  'Basse confiance : peu de sources vraiment pertinentes — vérifiez la réponse à la source.'
 
 // ── Main component ─────────────────────────────────────────────────────────
 
@@ -498,11 +516,30 @@ function ChatInner() {
 
                 if (msg.role === 'assistant') {
                   const sources = (msg.result.sources || []).slice(0, 3).map(mapSource)
+                  const conf = CONFIDENCE_META[msg.result.confidence]
                   return (
                     <div key={i} style={{ display: 'flex', gap: 13, marginBottom: 28, alignItems: 'flex-start' }}>
                       <AiAvatar />
                       <div style={{ flex: 1, minWidth: 0, marginTop: 4 }}>
+                        {conf && (
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 10 }}>
+                            <span style={{ display: 'inline-flex', alignItems: 'center', fontSize: 11, fontWeight: 700, padding: '3px 9px', borderRadius: 999, letterSpacing: '0.02em', background: dk ? conf.bgDark : conf.bg, color: dk ? conf.colorDark : conf.color }}>
+                              {conf.label}
+                            </span>
+                            <InfoTooltip text={CONFIDENCE_EXPLANATION} ariaLabel="Qu'est-ce que la confiance ?" />
+                          </div>
+                        )}
                         <div style={{ fontSize: 15, lineHeight: 1.75, color: dk ? 'rgba(255,255,255,0.85)' : '#1F2937' }} dangerouslySetInnerHTML={{ __html: mdToHtml(msg.result.answer) }} />
+                        {msg.result.caveat && (
+                          <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', marginTop: 12, padding: '9px 12px', borderRadius: 8, background: dk ? 'rgba(251,191,36,0.10)' : '#FFFBEB', border: `1px solid ${dk ? 'rgba(251,191,36,0.22)' : '#FDE68A'}` }}>
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke={dk ? '#FBBF24' : '#B45309'} strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0, marginTop: 2 }}>
+                              <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+                              <line x1="12" y1="9" x2="12" y2="13" />
+                              <line x1="12" y1="17" x2="12.01" y2="17" />
+                            </svg>
+                            <span style={{ fontSize: 12.5, lineHeight: 1.55, color: dk ? 'rgba(255,255,255,0.75)' : '#92400E' }}>{msg.result.caveat}</span>
+                          </div>
+                        )}
                         {sources.length > 0 && (
                           <div style={{ marginTop: 18 }}>
                             <div style={{ fontSize: 10.5, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: txt3, marginBottom: 9 }}>Sources</div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -109,6 +109,7 @@ export type SearchResult = {
   chunks_retrieved: number
   confidence: string
   data_source: string
+  caveat?: string | null
   sources: Array<{ content: string; metadata: Record<string, string>; similarity: number }>
 }
 


### PR DESCRIPTION
## What

Makes every chat answer verifiable at a glance: a confidence badge with an explanatory tooltip, a visible caveat note when the API returns one, and clickable source cards for every chunk type that carries a linkable ID.

## Why

An AI answer about how an elected official voted must be checkable, or it's a liability for a transparency brand.
The backend already computes confidence from retrieval quality (`compute_confidence` in `rag/chain/rag_chain.py`) and returns `caveat` on `SearchResponse`, but the live chat UI never rendered either field, and two of five chunk types (`notable_deputy`, `law_summary`) had no clickable link despite carrying `deputy_id`/`vote_id`.

The issue named `frontend/src/components/chat/Bubbles.tsx` as the file to rework.
That component has been dead code since it was added in #137 — it's never imported anywhere and isn't wired into any page.
The actual chat answer bubble is rendered inline inside `frontend/src/app/chat/page.tsx` (`ChatInner`, the `assistant` message branch), so this PR targets that file instead.
`Bubbles.tsx` was left untouched — fixing unused code doesn't move the acceptance criteria and is out of scope for this issue.

## Changes

- `frontend/src/app/chat/page.tsx`
  - Added a confidence badge (`Haute confiance` / `Confiance moyenne` / `Basse confiance`) rendered above every assistant answer, colored per level, with an `InfoTooltip` (existing shared component) explaining that confidence reflects retrieval quality (similarity + supporting chunk count), not LLM self-rating.
  - Added a distinct caveat note (amber box + icon) rendered whenever `SearchResult.caveat` is present — covers the SQL-router path, which always returns a caveat explaining the answer was computed directly from the database, not generated.
  - Fixed `mapSource()` so `notable_deputy` chunks link to `/deputes/[id]` (previously only `deputy` did) and `law_summary` chunks link to `/votes/[id]` (previously only `vote` did), using each chunk's actual metadata field (`full_name`/`party` for notable deputies, `vote_title` for law summaries).
- `frontend/src/lib/api.ts`
  - Added the missing `caveat?: string | null` field to the `SearchResult` type so it matches `SearchResponse` on the backend.

## Testing

- `npm run lint` — no ESLint warnings or errors.
- `npx tsc --noEmit` — no type errors.
- `npm test` — 75/75 tests passing across 10 suites.
- `npm run build` — compiles successfully; the `/sitemap.xml` prerender step fails with an `API error: 500` because no local backend is running during a static build — this is a pre-existing, known flake unrelated to this change (no local Postgres/API in this environment).
- No backend files were touched, so the Python test suite wasn't re-run for this PR.
- Not manually verified in a running browser — no local backend/DB was available in this environment to drive `POST /search` end-to-end. Recommend a quick manual check in a review environment: ask a RAG question (see a confidence badge + tooltip + clickable source cards) and a SQL-router question like "combien de députés RN" (see the "Haute confiance" badge + the "Données calculées directement..." caveat note).

## Risks / Notes

- No backend or schema changes — purely a frontend presentation fix consuming fields the API already returns.
- `Bubbles.tsx` remains dead code; flagging it here in case the team wants a follow-up cleanup issue to delete it, but out of scope for MON-83.
- Depends on MON-74 (confidence value contract: API returns lowercase `high|medium|low`) — confirmed already merged and Done before starting this work.

## Breaking Changes

None.
