### PR TITLE
feat: deputy comparison mode (MON-92)

### DIFF
--- a/api/routers/deputies.py
+++ b/api/routers/deputies.py
@@ -12,6 +12,7 @@ from api.schemas import (
     DeputyAlignment,
     DeputyDetail,
     DeputyDissidentVotesResponse,
+    DeputyDivergingVotesResponse,
     DeputyListResponse,
     DeputyScorecard,
     DeputyStats,
@@ -19,6 +20,7 @@ from api.schemas import (
     DeputyVoteItem,
     DeputyVotesResponse,
     DissidentVoteItem,
+    DivergingVoteItem,
 )
 
 router = APIRouter()
@@ -80,15 +82,28 @@ def list_deputies(
 
 @router.get("/stats", response_model=DeputyStats)
 @limiter.limit(tiered_limit(30))
-def get_deputy_stats(request: Request):
+def get_deputy_stats(
+    request: Request,
+    party: str = Query(
+        None,
+        description="Scope the averages to one party (for deputy-vs-party comparison, MON-92)",
+    ),
+):
+    where = sql.SQL(" WHERE party = %s") if party else sql.SQL("")
+    params = [party] if party else []
     try:
         with get_conn() as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "SELECT AVG(presence_rate) AS avg_presence_rate, "
-                    "AVG(solennel_participation_rate) AS avg_solennel_participation_rate, "
-                    "AVG(voting_days_rate) AS avg_voting_days_rate "
-                    "FROM analytics_marts.mart_deputy_scorecard"
+                    sql.SQL(
+                        "SELECT AVG(presence_rate) AS avg_presence_rate, "
+                        "AVG(solennel_participation_rate) AS avg_solennel_participation_rate, "
+                        "AVG(voting_days_rate) AS avg_voting_days_rate, "
+                        "AVG(votes_for_pct) AS avg_votes_for_pct, "
+                        "AVG(abstention_pct) AS avg_abstention_pct "
+                        "FROM analytics_marts.mart_deputy_scorecard{}"
+                    ).format(where),
+                    params,
                 )
                 row = cur.fetchone()
     except psycopg2.errors.UndefinedTable:
@@ -102,6 +117,8 @@ def get_deputy_stats(request: Request):
         avg_presence_rate=_avg("avg_presence_rate"),
         avg_solennel_participation_rate=_avg("avg_solennel_participation_rate"),
         avg_voting_days_rate=_avg("avg_voting_days_rate"),
+        avg_votes_for_pct=_avg("avg_votes_for_pct"),
+        avg_abstention_pct=_avg("avg_abstention_pct"),
     )
 
 
@@ -288,4 +305,62 @@ def get_dissident_votes(
         deputy_id=deputy_id,
         total=total,
         items=[DissidentVoteItem(**r) for r in rows],
+    )
+
+
+@router.get(
+    "/{deputy_id}/diverging-votes",
+    response_model=DeputyDivergingVotesResponse,
+)
+@limiter.limit(tiered_limit(10))
+def get_diverging_votes(
+    request: Request,
+    deputy_id: str,
+    other_deputy_id: str = Query(..., description="The other deputy to compare against (MON-92)"),
+    limit: int = Query(10, ge=1, le=50),
+):
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM vote_positions vpa
+                    JOIN vote_positions vpb
+                        ON vpb.vote_id = vpa.vote_id AND vpb.deputy_id = %s
+                    WHERE vpa.deputy_id = %s
+                      AND vpa.position IN ('pour', 'contre', 'abstention')
+                      AND vpb.position IN ('pour', 'contre', 'abstention')
+                      AND vpa.position != vpb.position
+                    """,
+                    (other_deputy_id, deputy_id),
+                )
+                total = cur.fetchone()["count"]
+
+                cur.execute(
+                    """
+                    SELECT vpa.vote_id, v.voted_at, v.vote_title, v.result, v.summary_plain,
+                           vpa.position AS position_a, vpb.position AS position_b
+                    FROM vote_positions vpa
+                    JOIN vote_positions vpb
+                        ON vpb.vote_id = vpa.vote_id AND vpb.deputy_id = %s
+                    JOIN analytics_marts.mart_vote_summary v ON v.vote_id = vpa.vote_id
+                    WHERE vpa.deputy_id = %s
+                      AND vpa.position IN ('pour', 'contre', 'abstention')
+                      AND vpb.position IN ('pour', 'contre', 'abstention')
+                      AND vpa.position != vpb.position
+                    ORDER BY v.voted_at DESC NULLS LAST
+                    LIMIT %s
+                    """,
+                    (other_deputy_id, deputy_id, limit),
+                )
+                rows = cur.fetchall()
+    except psycopg2.errors.UndefinedTable:
+        raise MART_UNAVAILABLE from None
+
+    return DeputyDivergingVotesResponse(
+        deputy_a_id=deputy_id,
+        deputy_b_id=other_deputy_id,
+        total=total,
+        items=[DivergingVoteItem(**r) for r in rows],
     )

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -108,6 +108,25 @@ class DeputyDissidentVotesResponse(_Base):
     items: list[DissidentVoteItem]
 
 
+class DivergingVoteItem(_Base):
+    """A vote where two deputies (a and b) cast opposite expressed positions."""
+
+    vote_id: str
+    voted_at: Optional[datetime] = None
+    vote_title: str
+    result: Optional[str] = None
+    summary_plain: Optional[str] = None
+    position_a: str
+    position_b: str
+
+
+class DeputyDivergingVotesResponse(_Base):
+    deputy_a_id: str
+    deputy_b_id: str
+    total: int
+    items: list[DivergingVoteItem]
+
+
 class DeputyStats(_Base):
     avg_presence_rate: Optional[float] = Field(
         None,
@@ -120,6 +139,14 @@ class DeputyStats(_Base):
     avg_voting_days_rate: Optional[float] = Field(
         None,
         description="Average voting_days_rate across all deputies, 0–1 (MON-124)",
+    )
+    avg_votes_for_pct: Optional[float] = Field(
+        None,
+        description="Average votes_for_pct, 0–1; scoped to `party` when set (MON-92)",
+    )
+    avg_abstention_pct: Optional[float] = Field(
+        None,
+        description="Average abstention_pct, 0–1; scoped to `party` when set (MON-92)",
     )
 
 

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -200,6 +200,17 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                   ariaLabel="Partager ce député"
                 />
                 <FollowDeputyButton deputyId={id} />
+                <Link
+                  href={`/deputes/comparer?a=${id}`}
+                  style={{
+                    display: 'inline-flex', alignItems: 'center', gap: 8,
+                    background: '#fff', border: `1px solid ${LINE}`, color: NAVY,
+                    padding: '12px 22px', borderRadius: 9, fontWeight: 600,
+                    fontSize: 15, textDecoration: 'none',
+                  }}
+                >
+                  Comparer
+                </Link>
               </div>
             </div>
           </div>

--- a/frontend/src/app/deputes/comparer/ComparerClient.tsx
+++ b/frontend/src/app/deputes/comparer/ComparerClient.tsx
@@ -1,0 +1,466 @@
+'use client'
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import {
+  api,
+  type Deputy,
+  type Scorecard,
+  type Alignment,
+  type DeputyStats,
+  type DivergingVoteItem,
+} from '@/lib/api'
+import { formatDate } from '@/lib/utils'
+import { positionStyle } from '@/lib/vote-position'
+import { DeputyAvatar } from '@/components/DeputyAvatar'
+import { ShareButton } from '@/components/ShareButton'
+
+const NAVY   = '#1B2B50'
+const CREAM  = '#F7F4ED'
+const LINE   = '#E4E6EA'
+const ACCENT = '#E0786E'
+const RED    = '#C9302A'
+
+type Mode = 'deputy' | 'party' | 'national'
+
+type Side = {
+  deputy: Deputy
+  scorecard: Scorecard | null
+  alignment: Alignment | null
+}
+
+function pct(v: number | null | undefined): number | null {
+  return v === null || v === undefined ? null : Math.round(v * 100)
+}
+
+// ── Deputy picker (search + dropdown) ───────────────────────────────────────
+
+function DeputyPicker({
+  placeholder,
+  onSelect,
+  selected,
+}: {
+  placeholder: string
+  onSelect: (d: Deputy) => void
+  selected: Deputy | null
+}) {
+  const [query, setQuery] = useState('')
+  const [debounced, setDebounced] = useState('')
+  const [results, setResults] = useState<Deputy[]>([])
+  const [open, setOpen] = useState(false)
+  const boxRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(query), 250)
+    return () => clearTimeout(t)
+  }, [query])
+
+  useEffect(() => {
+    const q = debounced.trim()
+    if (q.length < 2) return
+    let cancelled = false
+    api.deputies.list({ search: q, limit: 6 }).then(res => {
+      if (!cancelled) setResults(res.items)
+    }).catch(() => { if (!cancelled) setResults([]) })
+    return () => { cancelled = true }
+  }, [debounced])
+
+  useEffect(() => {
+    function onClickOutside(e: MouseEvent) {
+      if (boxRef.current && !boxRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', onClickOutside)
+    return () => document.removeEventListener('mousedown', onClickOutside)
+  }, [])
+
+  if (selected) {
+    return (
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 12, background: '#fff',
+        border: `1px solid ${LINE}`, borderRadius: 10, padding: '10px 14px',
+      }}>
+        <DeputyAvatar name={selected.full_name} photoUrl={selected.photo_url} size="sm" />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontWeight: 600, fontSize: 15, color: NAVY, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {selected.full_name}
+          </div>
+          <div style={{ fontSize: 12.5, color: '#9CA3AF' }}>{selected.party ?? '—'}</div>
+        </div>
+        <button
+          onClick={() => { setQuery(''); setResults([]); onSelect(null as unknown as Deputy) }}
+          aria-label="Changer de député"
+          style={{ color: '#9CA3AF', background: 'none', border: 'none', cursor: 'pointer', fontSize: 13 }}
+        >
+          Changer
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div ref={boxRef} style={{ position: 'relative' }}>
+      <input
+        type="search"
+        value={query}
+        placeholder={placeholder}
+        onChange={e => { setQuery(e.target.value); setOpen(true) }}
+        onFocus={() => setOpen(true)}
+        style={{
+          width: '100%', border: `1px solid ${LINE}`, borderRadius: 10,
+          padding: '13px 16px', fontSize: 15, color: '#1F2937', background: '#fff',
+        }}
+      />
+      {open && query.trim().length >= 2 && results.length > 0 && (
+        <div style={{
+          position: 'absolute', top: '100%', left: 0, right: 0, marginTop: 6,
+          background: '#fff', border: `1px solid ${LINE}`, borderRadius: 10,
+          boxShadow: '0 8px 24px rgba(0,0,0,0.12)', zIndex: 20, overflow: 'hidden',
+        }}>
+          {results.map(d => (
+            <button
+              key={d.deputy_id}
+              onClick={() => { onSelect(d); setOpen(false); setQuery('') }}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 10, width: '100%',
+                padding: '10px 14px', background: 'none', border: 'none', cursor: 'pointer',
+                textAlign: 'left',
+              }}
+            >
+              <DeputyAvatar name={d.full_name} photoUrl={d.photo_url} size="sm" />
+              <div style={{ minWidth: 0 }}>
+                <div style={{ fontSize: 14, fontWeight: 600, color: NAVY, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {d.full_name}
+                </div>
+                <div style={{ fontSize: 12, color: '#9CA3AF' }}>{d.party ?? '—'}</div>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Comparison bar row (A vs B, two stacked bars) ───────────────────────────
+
+function CompareRow({
+  label, aPct, bPct, aColor, bColor,
+}: {
+  label: string
+  aPct: number | null
+  bPct: number | null
+  aColor: string
+  bColor: string
+}) {
+  if (aPct === null && bPct === null) return null
+  return (
+    <div style={{ padding: '14px 0', borderBottom: `1px solid ${LINE}` }}>
+      <div style={{ fontSize: 13.5, color: '#6B7280', fontWeight: 500, marginBottom: 10 }}>{label}</div>
+      {[{ v: aPct, color: aColor }, { v: bPct, color: bColor }].map((row, i) => (
+        <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: i === 0 ? 6 : 0 }}>
+          <div style={{ flex: 1, height: 9, background: '#EEF0F2', borderRadius: 999, overflow: 'hidden' }}>
+            <div style={{ height: '100%', width: `${row.v ?? 0}%`, background: row.color, borderRadius: 999, transition: 'width 0.4s' }} />
+          </div>
+          <span className="font-mono" style={{ width: 44, textAlign: 'right', fontSize: 13.5, fontWeight: 700, color: NAVY }}>
+            {row.v === null ? '—' : `${row.v}%`}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ── Main component ──────────────────────────────────────────────────────────
+
+export function ComparerClient() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const aId = searchParams.get('a') || ''
+  const bId = searchParams.get('b') || ''
+  const mode: Mode = (searchParams.get('mode') as Mode) || 'deputy'
+
+  const [deputyA, setDeputyA] = useState<Deputy | null>(null)
+  const [deputyB, setDeputyB] = useState<Deputy | null>(null)
+  const [sideA, setSideA] = useState<Side | null>(null)
+  const [sideB, setSideB] = useState<Side | null>(null)
+  const [stats, setStats] = useState<DeputyStats | null>(null)
+  const [divergingVotes, setDivergingVotes] = useState<DivergingVoteItem[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const syncUrl = useCallback((next: { a?: string; b?: string; mode?: Mode }) => {
+    const p = new URLSearchParams()
+    const nextA = next.a !== undefined ? next.a : aId
+    const nextB = next.b !== undefined ? next.b : bId
+    const nextMode = next.mode !== undefined ? next.mode : mode
+    if (nextA) p.set('a', nextA)
+    if (nextMode === 'deputy' && nextB) p.set('b', nextB)
+    if (nextMode !== 'deputy') p.set('mode', nextMode)
+    router.replace(`/deputes/comparer${p.toString() ? `?${p}` : ''}`, { scroll: false })
+  }, [aId, bId, mode, router])
+
+  // Resolve deputy A / B from URL ids (deep-link support)
+  useEffect(() => {
+    let cancelled = false
+    async function run() {
+      if (!aId) return
+      if (deputyA && deputyA.deputy_id === aId) return
+      const d = await api.deputies.get(aId).catch(() => null)
+      if (!cancelled) setDeputyA(d)
+    }
+    run()
+    return () => { cancelled = true }
+  }, [aId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    let cancelled = false
+    async function run() {
+      if (mode !== 'deputy' || !bId) return
+      if (deputyB && deputyB.deputy_id === bId) return
+      const d = await api.deputies.get(bId).catch(() => null)
+      if (!cancelled) setDeputyB(d)
+    }
+    run()
+    return () => { cancelled = true }
+  }, [bId, mode]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Fetch comparison data
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadSide(d: Deputy): Promise<Side> {
+      const [scorecard, alignment] = await Promise.all([
+        api.deputies.scorecard(d.deputy_id).catch(() => null),
+        api.deputies.alignment(d.deputy_id).catch(() => null),
+      ])
+      return { deputy: d, scorecard, alignment }
+    }
+
+    async function run() {
+      if (!deputyA) return
+      setLoading(true)
+      const a = await loadSide(deputyA)
+      if (cancelled) return
+      setSideA(a)
+
+      if (mode === 'deputy' && deputyB) {
+        const [b, diverging] = await Promise.all([
+          loadSide(deputyB),
+          api.deputies.divergingVotes(deputyA.deputy_id, deputyB.deputy_id, 20).catch(() => null),
+        ])
+        if (cancelled) return
+        setSideB(b)
+        setDivergingVotes(diverging?.items ?? [])
+      } else if (mode === 'party') {
+        const s = await api.deputies.stats(deputyA.party ?? undefined).catch(() => null)
+        if (cancelled) return
+        setStats(s)
+      } else if (mode === 'national') {
+        const s = await api.deputies.stats().catch(() => null)
+        if (cancelled) return
+        setStats(s)
+      }
+      if (!cancelled) setLoading(false)
+    }
+    run()
+    return () => { cancelled = true }
+  }, [deputyA, deputyB, mode])
+
+  const scorecardA = sideA?.scorecard ?? null
+  const scorecardB = sideB?.scorecard ?? null
+
+  const bLabel = mode === 'deputy'
+    ? (deputyB?.full_name ?? 'Second député')
+    : mode === 'party'
+      ? `Moyenne du groupe${deputyA?.party ? ` (${deputyA.party})` : ''}`
+      : 'Moyenne nationale'
+
+  const rows = [
+    { key: 'presence', label: 'Taux de présence aux votes', a: pct(scorecardA?.presence_rate), b: mode === 'deputy' ? pct(scorecardB?.presence_rate) : pct(stats?.avg_presence_rate) },
+    { key: 'solennel', label: 'Participation aux scrutins solennels', a: pct(scorecardA?.solennel_participation_rate), b: mode === 'deputy' ? pct(scorecardB?.solennel_participation_rate) : pct(stats?.avg_solennel_participation_rate) },
+    { key: 'voting_days', label: 'Présence par jour de vote', a: pct(scorecardA?.voting_days_rate), b: mode === 'deputy' ? pct(scorecardB?.voting_days_rate) : pct(stats?.avg_voting_days_rate) },
+    { key: 'votes_for', label: 'Votes Pour (part des votes exprimés)', a: pct(scorecardA?.votes_for_pct), b: mode === 'deputy' ? pct(scorecardB?.votes_for_pct) : pct(stats?.avg_votes_for_pct) },
+    { key: 'abstention', label: 'Abstentions (part des votes exprimés)', a: pct(scorecardA?.abstention_pct), b: mode === 'deputy' ? pct(scorecardB?.abstention_pct) : pct(stats?.avg_abstention_pct) },
+  ]
+
+  const shareUrl = `/deputes/comparer${(() => {
+    const p = new URLSearchParams()
+    if (aId) p.set('a', aId)
+    if (mode === 'deputy' && bId) p.set('b', bId)
+    if (mode !== 'deputy') p.set('mode', mode)
+    return p.toString() ? `?${p}` : ''
+  })()}`
+
+  return (
+    <div style={{ background: CREAM, minHeight: '100vh' }}>
+      <div style={{ padding: '38px 24px 60px' }}>
+        <div style={{ maxWidth: 980, margin: '0 auto' }}>
+
+          {/* Header */}
+          <div style={{ fontWeight: 700, fontSize: 12, letterSpacing: '0.18em', textTransform: 'uppercase', color: RED }}>
+            Comparateur
+          </div>
+          <h1 className="font-newsreader" style={{ fontSize: 'clamp(28px,4vw,40px)', fontWeight: 600, color: NAVY, margin: '12px 0 8px', letterSpacing: '-0.01em' }}>
+            Comparer deux bilans
+          </h1>
+          <p style={{ fontSize: 15.5, color: '#4B5563', margin: '0 0 28px', maxWidth: 620 }}>
+            Présence, votes et alignement, côte à côte. Comparez un·e député·e à un·e autre, à son groupe, ou à la moyenne nationale.
+          </p>
+
+          {/* Mode tabs */}
+          <div style={{ display: 'flex', gap: 8, marginBottom: 20, flexWrap: 'wrap' }}>
+            {([
+              { key: 'deputy', label: 'Un autre député' },
+              { key: 'party', label: 'Son groupe' },
+              { key: 'national', label: 'Moyenne nationale' },
+            ] as { key: Mode; label: string }[]).map(t => (
+              <button
+                key={t.key}
+                onClick={() => syncUrl({ mode: t.key })}
+                style={{
+                  padding: '9px 18px', borderRadius: 999, fontSize: 13.5, fontWeight: 600, cursor: 'pointer',
+                  border: `1px solid ${mode === t.key ? NAVY : LINE}`,
+                  background: mode === t.key ? NAVY : '#fff',
+                  color: mode === t.key ? '#fff' : '#374151',
+                }}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Pickers */}
+          <div style={{ display: 'grid', gridTemplateColumns: mode === 'deputy' ? '1fr 1fr' : '1fr', gap: 16, marginBottom: 30 }}>
+            <DeputyPicker
+              placeholder="Rechercher le premier député…"
+              selected={deputyA}
+              onSelect={d => { setDeputyA(d); syncUrl({ a: d?.deputy_id ?? '' }) }}
+            />
+            {mode === 'deputy' && (
+              <DeputyPicker
+                placeholder="Rechercher le second député…"
+                selected={deputyB}
+                onSelect={d => { setDeputyB(d); syncUrl({ b: d?.deputy_id ?? '' }) }}
+              />
+            )}
+          </div>
+
+          {!deputyA && (
+            <div style={{ padding: '48px 0', textAlign: 'center', color: '#9CA3AF', fontSize: 15 }}>
+              Choisissez au moins un·e député·e pour démarrer la comparaison.
+            </div>
+          )}
+
+          {deputyA && loading && !sideA && (
+            <div style={{ padding: '48px 0', textAlign: 'center', color: '#9CA3AF', fontSize: 15 }}>
+              Chargement…
+            </div>
+          )}
+
+          {deputyA && sideA && (
+            <>
+              {/* Column headers */}
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginBottom: 4 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <span style={{ width: 10, height: 10, borderRadius: 999, background: NAVY }} />
+                  <Link href={`/deputes/${deputyA.deputy_id}`} style={{ fontWeight: 700, fontSize: 16, color: NAVY, textDecoration: 'none' }}>
+                    {deputyA.full_name}
+                  </Link>
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <span style={{ width: 10, height: 10, borderRadius: 999, background: ACCENT }} />
+                  {mode === 'deputy' && deputyB ? (
+                    <Link href={`/deputes/${deputyB.deputy_id}`} style={{ fontWeight: 700, fontSize: 16, color: NAVY, textDecoration: 'none' }}>
+                      {deputyB.full_name}
+                    </Link>
+                  ) : (
+                    <span style={{ fontWeight: 700, fontSize: 16, color: NAVY }}>{bLabel}</span>
+                  )}
+                </div>
+              </div>
+
+              {/* Stat rows */}
+              <div style={{ background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12, padding: '10px 26px', boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
+                {rows.map(r => (
+                  <CompareRow key={r.key} label={r.label} aPct={r.a} bPct={r.b} aColor={NAVY} bColor={ACCENT} />
+                ))}
+              </div>
+
+              {/* Party alignment (deputy-vs-deputy only) */}
+              {mode === 'deputy' && sideA.alignment && sideB?.alignment && (
+                <div style={{ marginTop: 24, background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12, padding: '20px 26px', boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
+                  <div style={{ fontSize: 13.5, color: '#6B7280', fontWeight: 500, marginBottom: 14 }}>
+                    Alignement avec son groupe politique
+                  </div>
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+                    <div>
+                      <span className="font-mono" style={{ fontWeight: 700, fontSize: 22, color: NAVY }}>
+                        {pct(sideA.alignment.party_alignment_rate)}%
+                      </span>
+                      <div style={{ fontSize: 12.5, color: '#9CA3AF' }}>{sideA.alignment.party ?? '—'}</div>
+                    </div>
+                    <div>
+                      <span className="font-mono" style={{ fontWeight: 700, fontSize: 22, color: NAVY }}>
+                        {pct(sideB.alignment.party_alignment_rate)}%
+                      </span>
+                      <div style={{ fontSize: 12.5, color: '#9CA3AF' }}>{sideB.alignment.party ?? '—'}</div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Diverging votes (deputy-vs-deputy only) */}
+              {mode === 'deputy' && deputyB && (
+                <div style={{ marginTop: 30 }}>
+                  <h2 className="font-newsreader" style={{ fontSize: 20, fontWeight: 600, color: NAVY, margin: '0 0 16px' }}>
+                    Votes où ils ont divergé
+                  </h2>
+                  {divergingVotes.length === 0 ? (
+                    <p style={{ fontSize: 14, color: '#9CA3AF' }}>
+                      Aucun vote divergent trouvé entre ces deux député·e·s (sur les scrutins récents).
+                    </p>
+                  ) : (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                      {divergingVotes.map(v => (
+                        <Link
+                          key={v.vote_id}
+                          href={`/votes/${v.vote_id}`}
+                          style={{ display: 'block', background: '#fff', border: `1px solid ${LINE}`, borderRadius: 10, padding: '14px 18px', textDecoration: 'none' }}
+                        >
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap', marginBottom: 6 }}>
+                            {v.voted_at && (
+                              <span className="font-mono" style={{ fontSize: 12, color: '#9CA3AF' }}>{formatDate(v.voted_at)}</span>
+                            )}
+                            <span style={{ fontSize: 12, fontWeight: 700, padding: '3px 10px', borderRadius: 999, color: positionStyle(v.position_a).color, background: positionStyle(v.position_a).bg }}>
+                              {deputyA.full_name.split(' ')[0]} : {positionStyle(v.position_a).label}
+                            </span>
+                            <span style={{ fontSize: 12, fontWeight: 700, padding: '3px 10px', borderRadius: 999, color: positionStyle(v.position_b).color, background: positionStyle(v.position_b).bg }}>
+                              {deputyB.full_name.split(' ')[0]} : {positionStyle(v.position_b).label}
+                            </span>
+                          </div>
+                          <div style={{ fontSize: 15, color: NAVY, lineHeight: 1.35 }}>{v.vote_title}</div>
+                          {v.summary_plain && (
+                            <div style={{ fontSize: 13, color: '#6B7280', marginTop: 6, lineHeight: 1.4 }}>{v.summary_plain}</div>
+                          )}
+                        </Link>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              <div style={{ marginTop: 30, display: 'flex', justifyContent: 'flex-end' }}>
+                <ShareButton
+                  url={shareUrl}
+                  title="Comparaison de bilans - MonÉlu"
+                  text={`Comparaison de ${deputyA.full_name}${mode === 'deputy' && deputyB ? ` et ${deputyB.full_name}` : ''} sur MonÉlu`}
+                  ariaLabel="Partager cette comparaison"
+                />
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/deputes/comparer/ComparerClient.tsx
+++ b/frontend/src/app/deputes/comparer/ComparerClient.tsx
@@ -41,7 +41,7 @@ function DeputyPicker({
   selected,
 }: {
   placeholder: string
-  onSelect: (d: Deputy) => void
+  onSelect: (d: Deputy | null) => void
   selected: Deputy | null
 }) {
   const [query, setQuery] = useState('')
@@ -87,7 +87,7 @@ function DeputyPicker({
           <div style={{ fontSize: 12.5, color: '#9CA3AF' }}>{selected.party ?? '—'}</div>
         </div>
         <button
-          onClick={() => { setQuery(''); setResults([]); onSelect(null as unknown as Deputy) }}
+          onClick={() => { setQuery(''); setResults([]); onSelect(null) }}
           aria-label="Changer de député"
           style={{ color: '#9CA3AF', background: 'none', border: 'none', cursor: 'pointer', fontSize: 13 }}
         >
@@ -251,10 +251,14 @@ export function ComparerClient() {
         if (cancelled) return
         setSideB(b)
         setDivergingVotes(diverging?.items ?? [])
-      } else if (mode === 'party') {
-        const s = await api.deputies.stats(deputyA.party ?? undefined).catch(() => null)
+      } else if (mode === 'party' && deputyA.party) {
+        const s = await api.deputies.stats(deputyA.party).catch(() => null)
         if (cancelled) return
         setStats(s)
+      } else if (mode === 'party') {
+        // No party ("non inscrit") — never substitute the national average under a
+        // "group" label, that would silently misrepresent whose data is shown.
+        setStats(null)
       } else if (mode === 'national') {
         const s = await api.deputies.stats().catch(() => null)
         if (cancelled) return
@@ -269,10 +273,12 @@ export function ComparerClient() {
   const scorecardA = sideA?.scorecard ?? null
   const scorecardB = sideB?.scorecard ?? null
 
+  const noPartyForComparison = mode === 'party' && !!deputyA && !deputyA.party
+
   const bLabel = mode === 'deputy'
     ? (deputyB?.full_name ?? 'Second député')
     : mode === 'party'
-      ? `Moyenne du groupe${deputyA?.party ? ` (${deputyA.party})` : ''}`
+      ? (deputyA?.party ? `Moyenne du groupe (${deputyA.party})` : 'Aucun groupe')
       : 'Moyenne nationale'
 
   const rows = [
@@ -380,11 +386,17 @@ export function ComparerClient() {
               </div>
 
               {/* Stat rows */}
-              <div style={{ background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12, padding: '10px 26px', boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
-                {rows.map(r => (
-                  <CompareRow key={r.key} label={r.label} aPct={r.a} bPct={r.b} aColor={NAVY} bColor={ACCENT} />
-                ))}
-              </div>
+              {noPartyForComparison ? (
+                <div style={{ background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12, padding: '24px 26px', color: '#6B7280', fontSize: 14 }}>
+                  {deputyA.full_name} n&apos;est rattaché·e à aucun groupe politique — la comparaison par groupe n&apos;est pas disponible. Essayez la moyenne nationale, ou comparez à un autre député.
+                </div>
+              ) : (
+                <div style={{ background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12, padding: '10px 26px', boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
+                  {rows.map(r => (
+                    <CompareRow key={r.key} label={r.label} aPct={r.a} bPct={r.b} aColor={NAVY} bColor={ACCENT} />
+                  ))}
+                </div>
+              )}
 
               {/* Party alignment (deputy-vs-deputy only) */}
               {mode === 'deputy' && sideA.alignment && sideB?.alignment && (

--- a/frontend/src/app/deputes/comparer/page.tsx
+++ b/frontend/src/app/deputes/comparer/page.tsx
@@ -1,0 +1,11 @@
+'use client'
+import { Suspense } from 'react'
+import { ComparerClient } from './ComparerClient'
+
+export default function ComparerPage() {
+  return (
+    <Suspense fallback={<div style={{ padding: 32, color: '#9CA3AF', fontSize: 14 }}>Chargement…</div>}>
+      <ComparerClient />
+    </Suspense>
+  )
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -59,6 +59,8 @@ export type DeputyStats = {
   avg_presence_rate: number
   avg_solennel_participation_rate: number | null
   avg_voting_days_rate: number | null
+  avg_votes_for_pct: number | null
+  avg_abstention_pct: number | null
 }
 
 export type Alignment = {
@@ -86,6 +88,23 @@ export type DissidentVotesResponse = {
   deputy_id: string
   total: number
   items: DissidentVoteItem[]
+}
+
+export type DivergingVoteItem = {
+  vote_id: string
+  voted_at: string | null
+  vote_title: string
+  result: string | null
+  summary_plain: string | null
+  position_a: string
+  position_b: string
+}
+
+export type DivergingVotesResponse = {
+  deputy_a_id: string
+  deputy_b_id: string
+  total: number
+  items: DivergingVoteItem[]
 }
 
 export type DeputyVoteItem = {
@@ -170,7 +189,12 @@ export const api = {
     },
     get: (id: string) => apiFetch<Deputy>(`/deputies/${id}/`, { revalidate: 86400 }),
     scorecard: (id: string) => apiFetch<Scorecard>(`/deputies/${id}/scorecard/`, { revalidate: 86400 }),
-    stats: () => apiFetch<DeputyStats>('/deputies/stats/', { revalidate: 3600 }),
+    stats: (party?: string) => {
+      const q = new URLSearchParams()
+      if (party) q.set('party', party)
+      const qs = q.toString()
+      return apiFetch<DeputyStats>(`/deputies/stats/${qs ? `?${qs}` : ''}`, { revalidate: 3600 })
+    },
     votes: (id: string, limit = 10, since?: string) => {
       const q = new URLSearchParams({ limit: String(limit) })
       if (since) q.set('since', since)
@@ -180,6 +204,11 @@ export const api = {
       apiFetch<Alignment>(`/deputies/${id}/alignment/`, { revalidate: 86400 }),
     dissidentVotes: (id: string, limit = 10) =>
       apiFetch<DissidentVotesResponse>(`/deputies/${id}/dissident-votes/?limit=${limit}`, { revalidate: 86400 }),
+    divergingVotes: (id: string, otherId: string, limit = 10) =>
+      apiFetch<DivergingVotesResponse>(
+        `/deputies/${id}/diverging-votes/?other_deputy_id=${encodeURIComponent(otherId)}&limit=${limit}`,
+        { revalidate: 86400 }
+      ),
   },
   votes: {
     list: (params?: { result?: string; theme?: string; search?: string; limit?: number; offset?: number; before?: string }) => {

--- a/tests/integration/test_diverging_votes.py
+++ b/tests/integration/test_diverging_votes.py
@@ -1,0 +1,65 @@
+"""
+Integration tests for the deputy-vs-deputy diverging-votes SQL used by
+GET /deputies/{deputy_id}/diverging-votes (MON-92).
+
+Fixtures (see conftest.py): PA001 voted 'pour' on all 25 seeded votes,
+PA002 voted 'contre' on all 25 — every vote diverges between the two.
+"""
+
+import pytest
+
+_DIVERGING_VOTES_COUNT_SQL = """
+SELECT COUNT(*)
+FROM vote_positions vpa
+JOIN vote_positions vpb
+    ON vpb.vote_id = vpa.vote_id AND vpb.deputy_id = %s
+WHERE vpa.deputy_id = %s
+  AND vpa.position IN ('pour', 'contre', 'abstention')
+  AND vpb.position IN ('pour', 'contre', 'abstention')
+  AND vpa.position != vpb.position
+"""
+
+_DIVERGING_VOTES_SQL = """
+SELECT vpa.vote_id, v.voted_at, v.vote_title, v.result, v.summary_plain,
+       vpa.position AS position_a, vpb.position AS position_b
+FROM vote_positions vpa
+JOIN vote_positions vpb
+    ON vpb.vote_id = vpa.vote_id AND vpb.deputy_id = %s
+JOIN analytics_marts.mart_vote_summary v ON v.vote_id = vpa.vote_id
+WHERE vpa.deputy_id = %s
+  AND vpa.position IN ('pour', 'contre', 'abstention')
+  AND vpb.position IN ('pour', 'contre', 'abstention')
+  AND vpa.position != vpb.position
+ORDER BY v.voted_at DESC
+LIMIT %s
+"""
+
+
+@pytest.mark.integration
+def test_diverging_votes_count_matches_full_split(db_conn):
+    with db_conn.cursor() as cur:
+        cur.execute(_DIVERGING_VOTES_COUNT_SQL, ("PA002", "PA001"))
+        row = cur.fetchone()
+
+    assert row["count"] == 25
+
+
+@pytest.mark.integration
+def test_diverging_votes_rows_carry_both_positions(db_conn):
+    with db_conn.cursor() as cur:
+        cur.execute(_DIVERGING_VOTES_SQL, ("PA002", "PA001", 5))
+        rows = cur.fetchall()
+
+    assert len(rows) == 5
+    for row in rows:
+        assert row["position_a"] == "pour"
+        assert row["position_b"] == "contre"
+
+
+@pytest.mark.integration
+def test_diverging_votes_is_empty_for_same_deputy(db_conn):
+    with db_conn.cursor() as cur:
+        cur.execute(_DIVERGING_VOTES_COUNT_SQL, ("PA001", "PA001"))
+        row = cur.fetchone()
+
+    assert row["count"] == 0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -217,6 +217,73 @@ def test_get_dissident_votes_empty(client, mock_cursor):
     assert data["items"] == []
 
 
+def test_get_diverging_votes(client, mock_cursor):
+    mock_cursor.fetchone.return_value = {"count": 1}
+    mock_cursor.fetchall.return_value = [
+        {
+            "vote_id": "VTANR5L17V1",
+            "voted_at": "2024-07-16T15:00:00",
+            "vote_title": "Vote sur le projet de loi de finances",
+            "result": "adopté",
+            "summary_plain": "Ce texte prévoit...",
+            "position_a": "pour",
+            "position_b": "contre",
+        }
+    ]
+    resp = client.get("/deputies/PA1/diverging-votes?other_deputy_id=PA2")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["deputy_a_id"] == "PA1"
+    assert data["deputy_b_id"] == "PA2"
+    assert data["total"] == 1
+    assert data["items"][0]["position_a"] == "pour"
+    assert data["items"][0]["position_b"] == "contre"
+
+
+def test_get_diverging_votes_requires_other_deputy_id(client, mock_cursor):
+    resp = client.get("/deputies/PA1/diverging-votes")
+    assert resp.status_code == 422
+
+
+def test_get_diverging_votes_empty(client, mock_cursor):
+    mock_cursor.fetchone.return_value = {"count": 0}
+    mock_cursor.fetchall.return_value = []
+    resp = client.get("/deputies/PA1/diverging-votes?other_deputy_id=PA2")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 0
+    assert data["items"] == []
+
+
+def test_get_deputy_stats(client, mock_cursor):
+    mock_cursor.fetchone.return_value = {
+        "avg_presence_rate": 0.8,
+        "avg_solennel_participation_rate": 0.75,
+        "avg_voting_days_rate": 0.7,
+        "avg_votes_for_pct": 0.6,
+        "avg_abstention_pct": 0.1,
+    }
+    resp = client.get("/deputies/stats")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["avg_votes_for_pct"] == 0.6
+    assert data["avg_abstention_pct"] == 0.1
+
+
+def test_get_deputy_stats_scoped_to_party(client, mock_cursor):
+    mock_cursor.fetchone.return_value = {
+        "avg_presence_rate": 0.85,
+        "avg_solennel_participation_rate": 0.8,
+        "avg_voting_days_rate": 0.75,
+        "avg_votes_for_pct": 0.65,
+        "avg_abstention_pct": 0.05,
+    }
+    resp = client.get("/deputies/stats?party=Renaissance")
+    assert resp.status_code == 200
+    select_params = mock_cursor.execute.call_args_list[-1].args[1]
+    assert select_params == ["Renaissance"]
+
+
 def test_get_deputy_votes_includes_summary_plain(client, mock_cursor):
     mock_cursor.fetchone.return_value = {"count": 1}
     mock_cursor.fetchall.return_value = [


### PR DESCRIPTION
## What
Adds a deputy comparison page, `/deputes/comparer`, that puts two deputies side by side (presence, votes for/against/abstentions, party alignment, diverging votes) — or compares one deputy against their party's average or the national average.

## Why
Comparison is how citizens actually evaluate deputies ("is mine better than the neighbor's?") and how journalists build stories. The June audit ranked comparison among the top gaps, and all the underlying metrics already exist per deputy. Shareable comparison URLs are also an organic acquisition loop.

## Changes
- **API** (`api/routers/deputies.py`, `api/schemas.py`):
  - New `GET /deputies/{deputy_id}/diverging-votes?other_deputy_id=` — finds votes where two deputies cast opposite expressed positions (pour/contre/abstention) on the same scrutin, joining `vote_positions` to itself and `mart_vote_summary` for title/summary. Mirrors the existing `dissident-votes` endpoint's shape and error handling (`MART_UNAVAILABLE` on missing mart).
  - `GET /deputies/stats` gains an optional `party` query param, scoping the national averages to one parliamentary group (used for deputy-vs-party mode). Also extended with `avg_votes_for_pct` / `avg_abstention_pct` so the comparison page has the same metrics for both "vs deputy" and "vs average" modes.
  - New schemas: `DivergingVoteItem`, `DeputyDivergingVotesResponse`.
- **Frontend**:
  - `frontend/src/app/deputes/comparer/` — client-rendered page (mirrors the `/chat` page's `Suspense` + `useSearchParams` pattern) reading `?a=&b=` (deputy vs deputy) or `?a=&mode=party` / `?a=&mode=national`.
  - Searchable deputy picker (debounced `api.deputies.list` search), mode tabs, side-by-side stat bars reusing the profile page's color scheme, a diverging-votes list linking to `/votes/{id}`, and a `ShareButton` for the current comparison URL.
  - `frontend/src/lib/api.ts`: `stats()` now accepts an optional `party` filter, new `divergingVotes()` method, new `DeputyStats`/`DivergingVoteItem`/`DivergingVotesResponse` types.
  - "Comparer" entry-point button added next to Share/Follow on the deputy profile page (`frontend/src/app/deputes/[id]/page.tsx`), linking to `/deputes/comparer?a={id}`.

## Acceptance criteria
- Any two deputies comparable via a shareable URL → `?a={id}&b={id}` (deputy mode), deep-linkable and resolved from the URL on load.
- Diverging votes listed with plain summaries and links → diverging-votes list under the stat comparison, each item links to `/votes/{id}` and shows `summary_plain` when available.
- Deputy-vs-party and deputy-vs-national modes work → `?mode=party` scopes `/deputies/stats` to the deputy's own party; `?mode=national` uses the unscoped average.

## Testing
- Backend: `pytest tests/ -m "not integration" -q` — 166 passed (added `test_get_diverging_votes*`, `test_get_deputy_stats*`).
- Backend: added `tests/integration/test_diverging_votes.py`, mirroring `test_alignment.py`'s pattern against the existing seeded fixtures (PA001 votes "pour" on all 25 seeded votes, PA002 votes "contre" — a deterministic full-divergence case). Not run locally (Docker Postgres was stopped mid-session by a parallel worktree); will run in CI's `integration` job.
- `ruff check .` and `ruff format --check .` — clean, repo-wide.
- Frontend: `npm run lint`, `npx tsc --noEmit`, `npm test` (75 passed), `npm run build` (118 static pages, including `/deputes/comparer`) — all clean.
- Manually verified `GET /deputies/stats` (with and without `?party=`) and `GET /deputies` against a live local Postgres instance before Docker was stopped.
- Did not exercise the frontend page in a running browser (no `npm run dev` session in this pass) — recommend a quick click-through of all three modes before merge.

## Risks / Notes
- Deputy-vs-party and deputy-vs-national modes intentionally omit the party-alignment comparison row (alignment is inherently deputy-vs-own-party, not meaningful as an averaged metric) — only the deputy-vs-deputy mode shows it.
- The comparison page is a client component (`'use client'`), so it has no server-rendered content/SEO for the comparison itself, unlike the deputy profile page — acceptable given it's a utility/sharing surface, not a primary indexed page.
- No dbt/mart changes — `mart_deputy_scorecard` already carries a `party` column, so the new `stats?party=` filter needed no transform-layer changes.

## Breaking Changes
None — both extended endpoints (`/deputies/stats`, and the new `/deputies/{id}/diverging-votes`) are additive; existing consumers of `/deputies/stats` are unaffected by the new optional query param and response fields.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AiTCAFULuRrZDcsyP3XFS