### PR TITLE
feat: wire up the feedback button in chat answers (MON-70)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -184,13 +184,14 @@ app.add_middleware(
 # ---------------------------------------------------------------------------
 # Routers
 # ---------------------------------------------------------------------------
-from api.routers import deputies, keys, votes  # noqa: E402
+from api.routers import deputies, feedback, keys, votes  # noqa: E402
 from api.routers.search import router as search_router  # noqa: E402
 
 app.include_router(deputies.router, prefix="/deputies", tags=["Deputies"])
 app.include_router(votes.router, prefix="/votes", tags=["Votes"])
 app.include_router(search_router, prefix="/search", tags=["Search"])
 app.include_router(keys.router, prefix="/keys", tags=["API Keys"])
+app.include_router(feedback.router, prefix="/feedback", tags=["Feedback"])
 
 
 # ---------------------------------------------------------------------------

--- a/api/routers/feedback.py
+++ b/api/routers/feedback.py
@@ -16,7 +16,7 @@ class ChatFeedbackRequest(BaseModel):
     vote: str = Field(..., pattern="^(up|down)$")
     question: str = Field(..., min_length=1, max_length=500)
     answer: str = Field(..., min_length=1, max_length=8000)
-    sources: list[dict] = Field(default_factory=list)
+    sources: list[dict] = Field(default_factory=list, max_length=10)
 
 
 class FeedbackResponse(BaseModel):

--- a/api/routers/feedback.py
+++ b/api/routers/feedback.py
@@ -1,0 +1,53 @@
+import logging
+
+from fastapi import APIRouter, HTTPException, Request
+from psycopg2.extras import Json
+from pydantic import BaseModel, Field
+
+from api.db import get_conn
+from api.limiter import limiter, tiered_limit
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class ChatFeedbackRequest(BaseModel):
+    vote: str = Field(..., pattern="^(up|down)$")
+    question: str = Field(..., min_length=1, max_length=500)
+    answer: str = Field(..., min_length=1, max_length=8000)
+    sources: list[dict] = Field(default_factory=list)
+
+
+class FeedbackResponse(BaseModel):
+    status: str = "ok"
+
+
+@router.post(
+    "/chat",
+    response_model=FeedbackResponse,
+    summary="Envoyer un retour (pouce haut/bas) sur une réponse du chat",
+)
+@limiter.limit(tiered_limit(10))
+def submit_chat_feedback(request: Request, body: ChatFeedbackRequest):
+    payload = {
+        "vote": body.vote,
+        "question": body.question,
+        "answer": body.answer,
+        "sources": body.sources,
+    }
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO feedback (type, payload) VALUES (%s, %s)",
+                    ("chat", Json(payload)),
+                )
+            conn.commit()
+    except Exception:
+        logger.exception("Failed to persist chat feedback")
+        raise HTTPException(
+            status_code=500,
+            detail="Service temporairement indisponible. Réessayez dans quelques secondes.",
+        ) from None
+    return FeedbackResponse()

--- a/data/migrations/005_feedback.sql
+++ b/data/migrations/005_feedback.sql
@@ -1,0 +1,14 @@
+-- MonÉlu — user feedback loop (MON-70)
+-- Idempotent: CREATE TABLE IF NOT EXISTS — safe to re-run.
+
+-- Generic feedback sink: `type` distinguishes sources (e.g. 'chat'), `payload`
+-- carries the type-specific context as JSONB so new feedback sources (e.g. the
+-- data-page report channel in MON-101) don't need a schema migration.
+CREATE TABLE IF NOT EXISTS feedback (
+    id SERIAL PRIMARY KEY,
+    type TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_feedback_type_created ON feedback (type, created_at);

--- a/frontend/__tests__/lib/api.test.ts
+++ b/frontend/__tests__/lib/api.test.ts
@@ -49,6 +49,26 @@ describe('api.search', () => {
   })
 })
 
+describe('api.feedback.chat', () => {
+  it('posts the vote, question, answer, and sources and returns the response', async () => {
+    mockFetch(200, { status: 'ok' })
+    const result = await api.feedback.chat('up', 'question', 'answer', [])
+    expect(result.status).toBe('ok')
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${API_BASE}/feedback/chat`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ vote: 'up', question: 'question', answer: 'answer', sources: [] }),
+      })
+    )
+  })
+
+  it('throws on a non-ok HTTP response', async () => {
+    mockFetch(500, { detail: 'Internal Server Error' })
+    await expect(api.feedback.chat('down', 'q', 'a', [])).rejects.toThrow('API error: 500')
+  })
+})
+
 describe('api.deputies.votes', () => {
   it('omits since from the query string when not provided', async () => {
     mockFetch(200, { deputy_id: 'PA1', total: 0, items: [] })

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -155,6 +155,7 @@ function ChatInner() {
   })
   const [activeConvId, setActiveConvId]   = useState<string | null>(null)
   const [copied, setCopied]       = useState(false)
+  const [feedbackByMsg, setFeedbackByMsg] = useState<Record<number, 'pending' | 'up' | 'down' | 'error'>>({})
 
   const scrollRef     = useRef<HTMLDivElement>(null)
   const textareaRef   = useRef<HTMLTextAreaElement>(null)
@@ -289,6 +290,13 @@ function ChatInner() {
       setTimeout(() => setCopied(false), 1800)
     })
   }, [messages])
+
+  const submitFeedback = useCallback((i: number, vote: 'up' | 'down', result: SearchResult) => {
+    setFeedbackByMsg(prev => ({ ...prev, [i]: 'pending' }))
+    api.feedback.chat(vote, result.question, result.answer, result.sources)
+      .then(() => setFeedbackByMsg(prev => ({ ...prev, [i]: vote })))
+      .catch(() => setFeedbackByMsg(prev => ({ ...prev, [i]: 'error' })))
+  }, [])
 
   const hasMessages = messages.length > 0
   const canSend = inputVal.trim().length > 0 && !loading
@@ -535,12 +543,31 @@ function ChatInner() {
                             </svg>
                             {copied ? 'Copié !' : 'Copier'}
                           </ActionBtn>
-                          <ActionBtn dark={dk}>
-                            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                              <path d="M7 11 C7 7.13 10.13 4 14 4 C17.87 4 21 7.13 21 11 C21 14.87 17.87 18 14 18 L7 18 L3 22 L3 11 Z"/>
-                            </svg>
-                            Feedback
-                          </ActionBtn>
+                          {feedbackByMsg[i] === 'pending' && (
+                            <span style={{ fontSize: 12, color: txt3, padding: '5px 9px' }}>Envoi…</span>
+                          )}
+                          {(feedbackByMsg[i] === 'up' || feedbackByMsg[i] === 'down') && (
+                            <span style={{ fontSize: 12, color: txt3, padding: '5px 9px' }}>Merci pour votre retour !</span>
+                          )}
+                          {feedbackByMsg[i] === 'error' && (
+                            <ActionBtn onClick={() => setFeedbackByMsg(prev => { const next = { ...prev }; delete next[i]; return next })} dark={dk}>
+                              Erreur, réessayez
+                            </ActionBtn>
+                          )}
+                          {feedbackByMsg[i] === undefined && (
+                            <>
+                              <ActionBtn onClick={() => submitFeedback(i, 'up', msg.result)} dark={dk}>
+                                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                  <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/>
+                                </svg>
+                              </ActionBtn>
+                              <ActionBtn onClick={() => submitFeedback(i, 'down', msg.result)} dark={dk}>
+                                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                  <path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3zm7-13h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17"/>
+                                </svg>
+                              </ActionBtn>
+                            </>
+                          )}
                         </div>
                       </div>
                     </div>

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -258,6 +258,7 @@ function ChatInner() {
 
   const newChat = useCallback(() => {
     setMessages([])
+    setFeedbackByMsg({})
     setInputVal('')
     setActiveConvId(null)
     activeConvRef.current = null
@@ -267,6 +268,7 @@ function ChatInner() {
   const restoreConv = useCallback((conv: StoredConv) => {
     setActiveConvId(conv.id)
     setMessages(conv.messages as Message[])
+    setFeedbackByMsg({})
   }, [])
 
   const handleTextarea = (e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -199,5 +199,9 @@ export const api = {
     get: (id: string) => apiFetch<VoteDetail>(`/votes/${id}/`, { revalidate: 86400 }),
   },
   search: (question: string) => apiPost<SearchResult>('/search/', { question }),
+  feedback: {
+    chat: (vote: 'up' | 'down', question: string, answer: string, sources: SearchResult['sources']) =>
+      apiPost<{ status: string }>('/feedback/chat', { vote, question, answer, sources }),
+  },
   health: () => apiFetch<Record<string, unknown>>('/health/', { revalidate: 300 }),
 }

--- a/tests/unit/test_feedback.py
+++ b/tests/unit/test_feedback.py
@@ -20,6 +20,14 @@ def test_chat_feedback_request_rejects_bad_vote():
         ChatFeedbackRequest(vote="maybe", question="Q", answer="A", sources=[])
 
 
+def test_chat_feedback_request_rejects_too_many_sources():
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        ChatFeedbackRequest(vote="up", question="Q", answer="A", sources=[{}] * 11)
+
+
 def test_submit_chat_feedback_inserts_row(client, mock_cursor):
     resp = client.post(
         "/feedback/chat",

--- a/tests/unit/test_feedback.py
+++ b/tests/unit/test_feedback.py
@@ -1,0 +1,40 @@
+"""Unit tests for the chat feedback endpoint (MON-70)."""
+
+from unittest.mock import patch
+
+from api.routers.feedback import ChatFeedbackRequest
+
+
+def test_chat_feedback_request_valid():
+    req = ChatFeedbackRequest(
+        vote="up", question="Qui a voté pour ?", answer="Réponse.", sources=[]
+    )
+    assert req.vote == "up"
+
+
+def test_chat_feedback_request_rejects_bad_vote():
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        ChatFeedbackRequest(vote="maybe", question="Q", answer="A", sources=[])
+
+
+def test_submit_chat_feedback_inserts_row(client, mock_cursor):
+    resp = client.post(
+        "/feedback/chat",
+        json={"vote": "up", "question": "Q", "answer": "A", "sources": [{"content": "c"}]},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+    args, _ = mock_cursor.execute.call_args
+    assert "INSERT INTO feedback" in args[0]
+
+
+def test_submit_chat_feedback_db_error_returns_500(client):
+    with patch("api.routers.feedback.get_conn", side_effect=RuntimeError("db down")):
+        resp = client.post(
+            "/feedback/chat",
+            json={"vote": "down", "question": "Q", "answer": "A", "sources": []},
+        )
+    assert resp.status_code == 500


### PR DESCRIPTION
## What
Wires up the previously dead "Feedback" button on chat answers into two distinct thumbs-up / thumbs-down actions that persist to a new `feedback` table via a new `POST /feedback/chat` endpoint.

## Why
MON-70: clicking the feedback button in the RAG chat UI did nothing — a dead click with no `onClick` handler and no backend to send it to. MON-101 (a related, broader issue: "close the user feedback loop") already specified the direction for this piece — a small POST endpoint writing to a generic `feedback` table (`type`, `payload` JSONB, `created_at`) — so this PR implements exactly that slice: the chat side. The data-page "Signaler une erreur" channel from MON-101 is out of scope here.

## Changes
- `data/migrations/005_feedback.sql`: new `feedback` table (`id`, `type`, `payload JSONB`, `created_at`) with an index on `(type, created_at)`. Generic by design — future feedback sources (e.g. MON-101's data-page reports) reuse the same table via a different `type` value, no new migration needed.
- `api/routers/feedback.py`: new `POST /feedback/chat` endpoint. Validates `vote` (`up`/`down` only via a Pydantic pattern), inserts `{vote, question, answer, sources}` as JSONB, rate-limited at the same tier as `/search/` (`tiered_limit(10)`).
- `api/main.py`: registers the new router under `/feedback`.
- `frontend/src/lib/api.ts`: adds `api.feedback.chat(vote, question, answer, sources)` following the existing `apiPost` pattern.
- `frontend/src/app/chat/page.tsx`: replaces the single dead "Feedback" `ActionBtn` with two thumbs icons (hand-authored inline SVG, matching the existing icon style — no icon library in this project). Tracks per-message feedback state (`pending` / `up` / `down` / `error`) so:
  - clicking triggers a real POST and shows "Envoi…" while in flight
  - a successful vote shows a "Merci pour votre retour !" confirmation and removes the buttons for that message (prevents duplicate votes)
  - a failed request shows a retry affordance
- `tests/unit/test_feedback.py`: request-model validation + endpoint tests (insert path, DB-error path) using the existing `client` / `mock_cursor` fixtures.
- `frontend/__tests__/lib/api.test.ts`: adds coverage for `api.feedback.chat`, mirroring the existing `api.search` tests.

## Testing
- `venv/bin/python -m pytest tests/ -m "not integration" -q` → 165 passed (CI-blocking selection).
- `venv/bin/ruff check .` / `ruff format --check .` → clean, repo-wide.
- `cd frontend && npm run lint && npx tsc --noEmit && npm test && npm run build` → all clean (the `/votes` prerender retry-after-60s is known noise, reproduces on master).
- Manual end-to-end: started local Docker Postgres (`make start` + `scripts/migrate.py`, confirms `005_feedback.sql` applies cleanly against a real DB), ran the API against it, `curl`'d `/feedback/chat` with a valid vote (200, row confirmed via `psql`) and an invalid vote (`"sideways"` → 422 with the expected Pydantic message). Started the Next dev server against that local API and confirmed `/chat` renders.

## Risks / Notes
- No DB migration risk beyond the standard idempotent `CREATE TABLE IF NOT EXISTS` pattern used by every other migration in this repo.
- The `feedback` table's generic `type`/`payload` shape is intentionally reusable by MON-101's data-page report channel — flagging for the reviewer that this is a deliberate forward-compat choice, not scope creep.
- Feedback state is per-message (keyed by array index) and resets on page reload — feedback isn't restored from `localStorage`-persisted conversation history. This matches the "quick interim" bar in the issue's acceptance criteria; a fuller feedback-history UX wasn't in scope.

## Breaking Changes
None.
