### PR TITLE
docs: ADR-022 - stored fact-check verdicts + VerifyResponse schema (MON-125)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -455,6 +455,49 @@ FastAPI app — a different module set than what's archived here.
 
 ---
 
+## ADR-022 - Fact-check verdicts are stored, not recomputed (MON-125)
+**Date:** 2026-07-14
+**Status:** Final
+
+**Decision:** The "Vérifier une affirmation" feature (MON-111) persists each verification in a new `verifications` table.
+The share URL is `/verifier/v/<id>` where `<id>` is a server-generated UUID.
+A shared verdict is an immutable snapshot; it is never recomputed on view.
+
+**Reason:** The rejected alternative was a stateless share URL that encodes the claim in the query string and re-runs the verification chain on every load.
+It fails on three counts:
+
+- **The share moment is the product.** A verdict link posted under a viral claim gets hit by social-media crawlers and burst traffic. Stateless means every preview fetch and every click runs retrieval + a Groq call: seconds of latency behind a 10 req/min rate limit, exactly when the link matters most. Stored verdicts are indexed DB reads.
+- **Unauthenticated LLM-cost surface.** A URL that triggers an LLM call on arbitrary attacker-controlled text is an abuse vector (crawler loops, scripted hammering). Stored ids make shared pages LLM-free; only the explicit "vérifier" action costs a model call.
+- **Verdict integrity.** A fact-check that silently changes between the moment it was shared and the moment it is read undermines the trust the feature exists to build. The snapshot states "vérifié le \<date\>" and the data horizon; freshness is handled by an explicit "re-vérifier" action that creates a new verification, not by mutating the old one.
+
+Costs accepted: one additive migration (idempotent, follows the `schema_migrations` ledger pattern) and persisting short user-submitted claim text.
+Mitigations: no user identity is stored with a claim, UUIDs are unguessable so stored claims are not enumerable, and there is no public listing of verifications.
+
+**Canonical `VerifyResponse` schema** (MON-126 implements this verbatim; all fields present on every verdict, nullable where noted):
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | UUID string | Verification id; path segment of the share URL |
+| `claim` | string | The claim as verified (trimmed, length-capped) |
+| `verdict` | enum | `vrai` \| `faux` \| `trompeur` \| `inverifiable` |
+| `explanation` | string | French prose justification citing the scrutins |
+| `deputy` | object \| null | `{deputy_id, name, party}`; null when no deputy was identified |
+| `citations` | array | `[{vote_id, title, voted_at, result, deputy_position}]`; may be empty only when verdict is `inverifiable`; every `vote_id` must exist in `votes` (enforced in code) |
+| `confidence` | enum | `ÉLEVÉ` \| `MOYEN` \| `FAIBLE`, retrieval-based per ADR-016, never LLM self-rated |
+| `data_horizon` | string (ISO date) | Earliest vote date in the production window |
+| `verified_at` | string (ISO datetime) | When this verification was computed |
+| `share_url` | string | Absolute URL `/verifier/v/<id>` |
+
+**Impact:**
+- MON-126 adds the `verifications` table (additive migration) and `POST /verify/` returning this schema; `GET /verify/<id>` serves stored verdicts with no LLM call.
+- MON-127/MON-128 build the share page and OG card from the stored verdict only; they must not trigger verification on view.
+- Do NOT recompute a verdict on page load, and do NOT add a claim query-string mode that runs the chain on GET.
+- Do NOT add listing/browsing of stored verifications without a moderation decision first.
+
+**Trigger to revisit:** if verifications become a moderation or storage problem (spam volume, legal takedown requests), revisit retention and add an expiry policy; if the Supabase free tier nears its limit, verifications are the first table to get a TTL.
+
+---
+
 ## Rules for future development sessions
 
 1. Read this file before writing any code


### PR DESCRIPTION
## What

Adds **ADR-022** to `docs/decisions.md`, resolving the architectural decision that blocks the MON-111 fact-check feature: the verdict share model.

**Decision: stored `verifications` table** (share URL `/verifier/v/<id>`, immutable snapshot), rejecting the stateless recompute-on-view URL.

## Why stored wins

- The share moment is the product: a verdict link under a viral claim gets crawler + burst traffic; stateless would put a Groq call behind a 10 req/min rate limit on every view. Stored verdicts are DB reads.
- Stateless is an unauthenticated LLM-cost/abuse surface (arbitrary text in a GET URL triggers a model call).
- A fact-check that silently drifts between share and read undermines the trust the feature exists to build; freshness is an explicit "re-vérifier" action instead.

The ADR also fixes the canonical `VerifyResponse` schema (verdict enum, citations with existence enforcement, ADR-016 retrieval-based confidence, data horizon, share URL) that MON-126 implements verbatim.

## Acceptance criteria mapping

- **ADR states the chosen model with reasoning and the rejected alternative** -> ADR-022 Decision + Reason sections cover both models and the three deciding factors.
- **ADR includes the canonical VerifyResponse field list** -> the schema table in ADR-022.
- **No code changes** -> diff touches only `docs/decisions.md`.

## Test plan

Docs-only change; pre-commit hooks (whitespace, EOF, secrets) pass. No deploy or migration risk - the migration itself lands with MON-126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsiwrLjnhvMAidpyGbYytj