### PR TITLE
feat: claim-verification chain and POST /verify endpoint (MON-126)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "CLAUDE.md",
         "hashed_secret": "ffddd4c9867f24ed207b1da5b50693e6d85a7889",
         "is_verified": false,
-        "line_number": 169
+        "line_number": 171
       }
     ],
     "README.md": [
@@ -158,7 +158,7 @@
         "filename": "README.md",
         "hashed_secret": "09b30f6138f119acf5e4d3d7ad571e8c0b9f2059",
         "is_verified": false,
-        "line_number": 178
+        "line_number": 181
       }
     ],
     "frontend/public/sw.js": [
@@ -252,5 +252,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-06T23:27:01Z"
+  "generated_at": "2026-07-14T21:55:39Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Assemblée Nationale Open Data (ZIPs)
 
 **`api/`** — FastAPI application
 - `main.py`: App factory, CORS (GET + POST — POST is needed for `/search`; an empty `CORS_ORIGINS` blocks all cross-origin requests and logs a startup warning), slowapi rate limiting (30 req/min global, 10 req/min on scorecard and search), global exception handler. `/health` returns DB status, record counts, last ingestion timestamp, and dbt mart row counts. The landing page is now the Next.js frontend (`frontend/`), not a FastAPI-served HTML page.
-- `routers/deputies.py`, `routers/votes.py`, `routers/search.py`: All DB queries — direct SQL, no ORM
+- `routers/deputies.py`, `routers/votes.py`, `routers/search.py`, `routers/verify.py`: All DB queries — direct SQL, no ORM. `verify.py` is the fact-check surface (MON-126, ADR-022): `POST /verify/` runs the verification chain and stores an immutable verdict snapshot; `GET /verify/{id}` serves stored verdicts with no LLM call.
 - `schemas.py`: Pydantic response models; all fields `Optional` to match DB NULLs
 - `limiter.py`: Shared slowapi `Limiter` instance imported by routers
 
@@ -131,6 +131,7 @@ Assemblée Nationale Open Data (ZIPs)
 - `chain/retriever.py`: Exact cosine similarity via pgvector `<=>`. Supports `chunk_type`, `deputy_id`, and auto-detected `result` filters (`adopté`/`rejeté`). Notable deputy names detected and their chunk pinned as first result. TTL-cached notable-deputy map (1h). Note: `register_vector` requires a plain psycopg2 cursor, not a `RealDictCursor`.
 - `chain/prompts.py`: TTL-cached system prompt (data horizon refreshed hourly) via `build_system_prompt()`. Call per request — do not cache the return value.
 - `chain/rag_chain.py`: `ask()` — retrieve → format → Groq `llama-3.3-70b-versatile` (temperature=0.2)
+- `chain/verify.py`: `verify_claim()` — claim verification (MON-126, ADR-022): deputy detection over all deputies, vote-chunk retrieval, positions join, structured JSON verdict (`vrai`/`faux`/`trompeur`/`inverifiable`). Cited vote_ids are validated against the votes table in code; low similarity, parse failure, or a factual verdict with no valid citation all force `inverifiable`.
 - `experiments/mlflow_eval.py`: 11 golden Q&A pairs split into router suite (live SQL ground truth) and retrieval suite (keyword scoring).
 - ~5,900 chunks in production (2026-07): 5,105 vote + 645 deputy + 12 party + 1 global_stats + 102 notable_deputy + 20 law_summary · party and global chunks count active mandates only
 
@@ -153,6 +154,7 @@ Assemblée Nationale Open Data (ZIPs)
 | `document_chunks` | Phase 2: content + JSONB metadata + vector(1536) |
 | `api_keys` | Manually-issued public API keys (sha256 hash, label, rate_limit_multiplier) |
 | `api_key_usage` | Per-key, per-endpoint, per-day request counters for usage accounting |
+| `verifications` | Stored fact-check verdicts (ADR-022): immutable snapshots behind `/verifier/v/<id>` share URLs |
 
 Important data quirks:
 - `nonVotant` ≠ `abstention`: present in chamber but did not vote vs. formally abstained

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The API tier is fully stateless. All state lives in Supabase (managed Postgres w
 | GET | `/votes/{id}` | Vote detail + all individual positions |
 | GET | `/health` | API status + live record counts + dbt mart row counts |
 | POST | `/search` | Natural language query over the legislative corpus *(Phase 2)* |
+| POST | `/verify` | Fact-check a claim about a deputy's votes — structured verdict + citations |
+| GET | `/verify/{id}` | Stored verdict snapshot (no LLM call) — backs the share URL |
 
 ---
 
@@ -66,6 +68,7 @@ Implemented with [slowapi](https://github.com/laurentS/slowapi), keyed by remote
 | Global default | 30 req / min |
 | `GET /deputies/{id}/scorecard` | 10 req / min |
 | `POST /search` | 10 req / min |
+| `POST /verify` | 10 req / min |
 
 On limit exceeded: HTTP 429 · `{"error": "Too Many Requests", "detail": "..."}` · `Retry-After` + `X-RateLimit-*` headers.
 
@@ -279,6 +282,7 @@ design.
 | `routers/deputies.py` | Deputy list, profile, and scorecard endpoints |
 | `routers/votes.py` | Vote list, latest, and detail endpoints |
 | `routers/search.py` | `POST /search` — RAG query endpoint |
+| `routers/verify.py` | `POST /verify` + `GET /verify/{id}` — fact-check verdicts (ADR-022) |
 | `schemas.py` | Pydantic response models (all fields `Optional` to match DB NULLs) |
 
 ### Frontend (`frontend/`)

--- a/api/main.py
+++ b/api/main.py
@@ -186,10 +186,12 @@ app.add_middleware(
 # ---------------------------------------------------------------------------
 from api.routers import deputies, keys, votes  # noqa: E402
 from api.routers.search import router as search_router  # noqa: E402
+from api.routers.verify import router as verify_router  # noqa: E402
 
 app.include_router(deputies.router, prefix="/deputies", tags=["Deputies"])
 app.include_router(votes.router, prefix="/votes", tags=["Votes"])
 app.include_router(search_router, prefix="/search", tags=["Search"])
+app.include_router(verify_router, prefix="/verify", tags=["Verify"])
 app.include_router(keys.router, prefix="/keys", tags=["API Keys"])
 
 

--- a/api/routers/verify.py
+++ b/api/routers/verify.py
@@ -1,0 +1,171 @@
+"""
+api/routers/verify.py
+
+Fact-check endpoints (MON-126, ADR-022). POST /verify/ runs the verification
+chain and persists the verdict as an immutable snapshot; GET /verify/{id}
+serves stored verdicts with no LLM call — this is what the share page and
+OG card read (share URL /verifier/v/<id>).
+"""
+
+import json
+import logging
+import os
+import uuid
+from typing import Literal
+
+import groq
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from api.db import get_conn
+from api.limiter import limiter, tiered_limit
+from rag.chain.verify import verify_claim
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+FRONTEND_BASE_URL = os.getenv("FRONTEND_BASE_URL", "https://mon-elu.vercel.app").rstrip("/")
+
+# Mirrors the startup check in api.main — the chain needs both providers.
+_PLACEHOLDER_PREFIXES = ("sk-...", "gsk_...", "your-", "changeme")
+
+
+def _is_placeholder(value: str | None) -> bool:
+    return (
+        not value
+        or not value.strip()
+        or any(value.strip().startswith(p) for p in _PLACEHOLDER_PREFIXES)
+    )
+
+
+class VerifyRequest(BaseModel):
+    claim: str = Field(
+        ...,
+        min_length=10,
+        max_length=500,
+        description="Affirmation à vérifier, en français (ex: 'le député X a voté contre Y')",
+    )
+
+
+class DeputyRef(BaseModel):
+    deputy_id: str
+    name: str
+    party: str | None = None
+
+
+class CitationItem(BaseModel):
+    vote_id: str
+    title: str
+    voted_at: str
+    result: str | None = None
+    deputy_position: str | None = None
+
+
+class VerifyResponse(BaseModel):
+    id: str
+    claim: str
+    verdict: Literal["vrai", "faux", "trompeur", "inverifiable"]
+    explanation: str
+    deputy: DeputyRef | None = None
+    citations: list[CitationItem]
+    confidence: Literal["ÉLEVÉ", "MOYEN", "FAIBLE"]
+    data_horizon: str | None = None
+    verified_at: str
+    share_url: str
+
+
+def _to_response(row: dict) -> VerifyResponse:
+    verification_id = str(row["id"])
+    return VerifyResponse(
+        id=verification_id,
+        claim=row["claim"],
+        verdict=row["verdict"],
+        explanation=row["explanation"],
+        deputy=DeputyRef(**row["deputy"]) if row["deputy"] else None,
+        citations=[CitationItem(**c) for c in row["citations"]],
+        confidence=row["confidence"],
+        data_horizon=str(row["data_horizon"]) if row["data_horizon"] else None,
+        verified_at=row["created_at"].isoformat(),
+        share_url=f"{FRONTEND_BASE_URL}/verifier/v/{verification_id}",
+    )
+
+
+@router.post(
+    "/",
+    response_model=VerifyResponse,
+    summary="Vérifiez une affirmation sur les votes d'un député",
+)
+@limiter.limit(tiered_limit(10))
+def verify(request: Request, body: VerifyRequest):
+    # Plain `def` on purpose: the chain does blocking psycopg2 + OpenAI + Groq
+    # I/O, so FastAPI must run it in the threadpool, not on the event loop.
+    if _is_placeholder(os.getenv("GROQ_API_KEY")) or _is_placeholder(os.getenv("OPENAI_API_KEY")):
+        raise HTTPException(
+            status_code=503,
+            detail="La vérification IA n'est pas configurée sur ce serveur.",
+        )
+    try:
+        result = verify_claim(body.claim)
+    except groq.APITimeoutError as e:
+        raise HTTPException(
+            status_code=504,
+            detail=(
+                "Le service de vérification est temporairement indisponible. "
+                "Réessayez dans quelques secondes."
+            ),
+        ) from e
+    except Exception:
+        logger.exception("Verification pipeline error for claim %r", body.claim)
+        raise HTTPException(
+            status_code=500,
+            detail="Service temporairement indisponible. Réessayez dans quelques secondes.",
+        ) from None
+
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO verifications
+                    (claim, verdict, explanation, deputy, citations, confidence, data_horizon)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                RETURNING id, claim, verdict, explanation, deputy, citations,
+                          confidence, data_horizon, created_at
+                """,
+                (
+                    result["claim"],
+                    result["verdict"],
+                    result["explanation"],
+                    json.dumps(result["deputy"]) if result["deputy"] else None,
+                    json.dumps(result["citations"]),
+                    result["confidence"],
+                    result["data_horizon"],
+                ),
+            )
+            row = cur.fetchone()
+        conn.commit()
+    return _to_response(row)
+
+
+@router.get(
+    "/{verification_id}",
+    response_model=VerifyResponse,
+    summary="Relisez un verdict enregistré (aucun appel IA)",
+)
+@limiter.limit(tiered_limit(30))
+def get_verification(request: Request, verification_id: uuid.UUID):
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, claim, verdict, explanation, deputy, citations,
+                       confidence, data_horizon, created_at
+                FROM verifications
+                WHERE id = %s
+                """,
+                (str(verification_id),),
+            )
+            row = cur.fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Vérification introuvable.")
+    return _to_response(row)

--- a/data/migrations/005_verifications.sql
+++ b/data/migrations/005_verifications.sql
@@ -1,0 +1,21 @@
+-- MonÉlu — stored fact-check verdicts (MON-126, ADR-022)
+-- Idempotent: CREATE TABLE/INDEX IF NOT EXISTS — safe to re-run.
+
+-- A verification is an immutable snapshot: the claim as verified, the verdict,
+-- and denormalized deputy/citation data frozen at verification time. Rows are
+-- never updated; a "re-vérifier" action creates a new row (ADR-022).
+-- No user identity is stored; UUIDs keep stored claims non-enumerable.
+CREATE TABLE IF NOT EXISTS verifications (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    claim TEXT NOT NULL,
+    verdict TEXT NOT NULL CHECK (verdict IN ('vrai', 'faux', 'trompeur', 'inverifiable')),
+    explanation TEXT NOT NULL,
+    -- {"deputy_id", "name", "party"} snapshot, or NULL when no deputy was identified.
+    deputy JSONB,
+    -- [{"vote_id", "title", "voted_at", "result", "deputy_position"}] — validated
+    -- against the votes table in code before insert (ADR-022: no fabricated ids).
+    citations JSONB NOT NULL DEFAULT '[]'::jsonb,
+    confidence TEXT NOT NULL,
+    data_horizon DATE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/rag/chain/prompts.py
+++ b/rag/chain/prompts.py
@@ -90,6 +90,53 @@ SUMMARY_PROMPT_PROCEDURAL = (
     "International | Autre"
 )
 
+
+def build_verify_system_prompt() -> str:
+    """System prompt for claim verification (MON-126). Call per request —
+    the data horizon is TTL-cached, not the returned string."""
+    horizon = get_data_horizon()
+    return f"""Tu es un vérificateur de faits spécialisé dans les votes de \
+l'Assemblée Nationale française.
+
+On te donne une affirmation et une liste de scrutins candidats extraits de la \
+base MonÉlu (avec, le cas échéant, la position réellement enregistrée du \
+député nommé). Tu rends un verdict structuré.
+
+Verdicts possibles :
+- "vrai" : l'affirmation est entièrement confirmée par les scrutins cités.
+- "faux" : l'affirmation est contredite par les positions enregistrées.
+- "trompeur" : l'affirmation contient une part de vrai mais déforme la \
+réalité (mauvais texte, contexte omis, exagération, confusion entre \
+abstention et vote contre, etc.).
+- "inverifiable" : les scrutins fournis ne permettent ni de confirmer ni \
+d'infirmer l'affirmation.
+
+Règles absolues :
+1. Tu te bases EXCLUSIVEMENT sur les scrutins fournis. Ne devine jamais, \
+n'utilise jamais tes connaissances générales.
+2. Chaque verdict "vrai", "faux" ou "trompeur" DOIT citer au moins un \
+vote_id de la liste fournie. Ne cite jamais un vote_id absent de la liste.
+3. "nonVotant" signifie présent mais n'a pas voté ; "abstention" est un \
+choix exprimé. Ne les confonds pas.
+4. Les données couvrent les votes {horizon}. Si l'affirmation porte sur une \
+période antérieure ou un sujet absent des scrutins fournis, réponds \
+"inverifiable" et dis-le dans l'explication.
+5. L'explication est factuelle, neutre, en français, sans jugement politique.
+6. Réponds UNIQUEMENT avec un objet JSON valide, sans texte autour."""
+
+
+VERIFY_TEMPLATE = """Affirmation à vérifier : {claim}
+
+{deputy_line}
+
+Scrutins candidats (extraits de la base MonÉlu) :
+{candidates}
+
+Réponds UNIQUEMENT avec un objet JSON valide de la forme :
+{{"verdict": "vrai|faux|trompeur|inverifiable", "explanation": "...", \
+"cited_vote_ids": ["..."]}}"""
+
+
 RAG_TEMPLATE = """Sources disponibles :
 {context}
 

--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -142,8 +142,13 @@ def retrieve(
     k: int = 5,
     chunk_type: str = None,
     deputy_id: str = None,
+    auto_result_filter: bool = True,
 ) -> list[dict]:
-    result_filter = detect_result_filter(question)
+    # auto_result_filter=False for claim verification: a claim's own
+    # "adopté"/"rejeté" wording must not exclude the scrutin that would
+    # contradict it (a false "la loi a été rejetée" claim needs the
+    # adopted scrutin retrieved to be judged "faux").
+    result_filter = detect_result_filter(question) if auto_result_filter else None
     recency = detect_recency_intent(question)
 
     response = _openai_client.embeddings.create(input=[question], model=EMBEDDING_MODEL)

--- a/rag/chain/verify.py
+++ b/rag/chain/verify.py
@@ -241,7 +241,9 @@ def verify_claim(claim: str) -> dict:
             "party": deputy_map[deputy_id]["party"],
         }
 
-    chunks = retrieve(claim, k=CANDIDATE_K, chunk_type="vote")
+    # No auto result filter: the claim's own "adopté"/"rejeté" wording must
+    # not exclude the scrutin that would contradict it.
+    chunks = retrieve(claim, k=CANDIDATE_K, chunk_type="vote", auto_result_filter=False)
     confidence = compute_confidence(chunks)
 
     if not chunks or chunks[0]["similarity"] < MIN_TOP_SIMILARITY:

--- a/rag/chain/verify.py
+++ b/rag/chain/verify.py
@@ -1,0 +1,294 @@
+"""
+rag/chain/verify.py
+
+Claim-verification chain (MON-126, ADR-022): given a claim about a deputy's
+votes, retrieve candidate scrutins, join the named deputy's actual recorded
+positions, and ask Groq for a structured verdict. Every cited vote_id is
+validated against the votes table in code — the LLM can only cite scrutins
+that were fetched from the DB, never fabricate one.
+
+Hard guards force the "inverifiable" verdict (never a guess) when:
+  - retrieval finds nothing relevant (top similarity below floor),
+  - the LLM output fails to parse or uses an unknown verdict,
+  - a vrai/faux/trompeur verdict cites no valid scrutin.
+"""
+
+import json
+import logging
+import os
+import re
+import threading
+import time
+
+import psycopg2.extras
+from dotenv import load_dotenv
+from groq import Groq
+
+load_dotenv()
+
+from rag.chain.prompts import (  # noqa: E402
+    VERIFY_TEMPLATE,
+    build_verify_system_prompt,
+)
+from rag.chain.rag_chain import compute_confidence  # noqa: E402
+from rag.chain.retriever import retrieve  # noqa: E402
+from rag.chain.sql_router import _get_pool  # noqa: E402
+from rag.constants import LLM_MODEL  # noqa: E402
+
+log = logging.getLogger(__name__)
+
+_groq_client = Groq(api_key=os.getenv("GROQ_API_KEY"), timeout=30.0)
+
+VERDICTS = {"vrai", "faux", "trompeur", "inverifiable"}
+
+# ADR-016: confidence comes from retrieval quality; ADR-022 exposes the
+# French labels in VerifyResponse.
+CONFIDENCE_LABELS = {"high": "ÉLEVÉ", "medium": "MOYEN", "low": "FAIBLE"}
+
+# Below this top similarity the candidates are noise — skip the LLM entirely.
+MIN_TOP_SIMILARITY = 0.35
+
+# How many vote chunks to consider as candidate scrutins.
+CANDIDATE_K = 8
+
+_INVERIFIABLE_NO_MATCH = (
+    "Aucun scrutin de la base MonÉlu ne correspond suffisamment à cette "
+    "affirmation pour la confirmer ou l'infirmer."
+)
+_INVERIFIABLE_PARSE = (
+    "L'analyse automatique n'a pas produit de verdict exploitable pour cette "
+    "affirmation. Réessayez en reformulant l'affirmation."
+)
+_INVERIFIABLE_NO_CITATION = (
+    " Aucun scrutin précis n'a pu être cité à l'appui : le verdict est donc "
+    "invérifiable avec nos données."
+)
+
+_DEPUTY_TTL = 3600.0  # refresh the deputy name map at most once per hour
+_deputy_cache: dict = {"value": None, "ts": 0.0}
+_deputy_lock = threading.Lock()
+
+
+def get_deputy_map() -> dict:
+    """{deputy_id: {"full_name", "party"}} for every deputy (incl. past mandates)."""
+    now = time.monotonic()
+    if _deputy_cache["value"] is not None and now - _deputy_cache["ts"] < _DEPUTY_TTL:
+        return _deputy_cache["value"]
+    with _deputy_lock:
+        if _deputy_cache["value"] is not None and now - _deputy_cache["ts"] < _DEPUTY_TTL:
+            return _deputy_cache["value"]
+        pool = _get_pool()
+        conn = pool.getconn()
+        broken = False
+        try:
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+                cur.execute("SELECT deputy_id, full_name, party FROM deputies")
+                result = {
+                    r["deputy_id"]: {"full_name": r["full_name"], "party": r["party"]}
+                    for r in cur.fetchall()
+                }
+            _deputy_cache["value"] = result
+            _deputy_cache["ts"] = now
+            return result
+        except Exception:
+            broken = True
+            raise
+        finally:
+            pool.putconn(conn, close=broken)
+
+
+def detect_deputy(claim: str, deputy_map: dict) -> str | None:
+    """Identify the deputy a claim names.
+
+    Full-name match wins outright; otherwise a last-name match (final word of
+    full_name, same heuristic as retriever.detect_notable_deputy) — but only
+    when it is unambiguous. Several deputies sharing the matched last name
+    with no full-name match returns None: guessing the wrong homonym would
+    produce a confidently wrong verdict.
+    """
+    q_lower = claim.lower()
+    last_name_hits: list[str] = []
+    for deputy_id, info in deputy_map.items():
+        full_name = (info.get("full_name") or "").lower()
+        if not full_name:
+            continue
+        if re.search(r"\b" + re.escape(full_name) + r"\b", q_lower):
+            return deputy_id
+        last_name = full_name.split()[-1]
+        if len(last_name) >= 3 and re.search(r"\b" + re.escape(last_name) + r"\b", q_lower):
+            last_name_hits.append(deputy_id)
+    if len(last_name_hits) == 1:
+        return last_name_hits[0]
+    return None
+
+
+def _fetch_candidates(vote_ids: list[str], deputy_id: str | None) -> list[dict]:
+    """Fetch candidate scrutins from the votes table, joined with the named
+    deputy's recorded position. Ids missing from the table are dropped here —
+    this is the code-level guarantee that every citation exists."""
+    if not vote_ids:
+        return []
+    pool = _get_pool()
+    conn = pool.getconn()
+    broken = False
+    try:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT v.vote_id,
+                       v.vote_title AS title,
+                       v.voted_at::date::text AS voted_at,
+                       v.result,
+                       vp.position AS deputy_position
+                FROM votes v
+                LEFT JOIN vote_positions vp
+                       ON vp.vote_id = v.vote_id AND vp.deputy_id = %s
+                WHERE v.vote_id = ANY(%s)
+                ORDER BY v.voted_at DESC
+                """,
+                (deputy_id, vote_ids),
+            )
+            return [dict(r) for r in cur.fetchall()]
+    except Exception:
+        broken = True
+        raise
+    finally:
+        pool.putconn(conn, close=broken)
+
+
+def get_data_horizon_start() -> str | None:
+    """Earliest vote date in the window, ISO string (VerifyResponse.data_horizon)."""
+    pool = _get_pool()
+    conn = pool.getconn()
+    broken = False
+    try:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute("SELECT MIN(voted_at)::date::text AS start FROM votes")
+            row = cur.fetchone()
+            return row["start"] if row else None
+    except Exception:
+        broken = True
+        raise
+    finally:
+        pool.putconn(conn, close=broken)
+
+
+def _parse_llm_verdict(raw: str) -> dict | None:
+    """Strict parse of the LLM JSON. Returns None on anything malformed —
+    the caller turns that into an 'inverifiable' verdict, never a guess."""
+    text = raw.strip()
+    # Tolerate a fenced ```json block, nothing looser.
+    fence = re.match(r"^```(?:json)?\s*(.*?)\s*```$", text, re.DOTALL)
+    if fence:
+        text = fence.group(1)
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    verdict = data.get("verdict")
+    explanation = data.get("explanation")
+    cited = data.get("cited_vote_ids")
+    if verdict not in VERDICTS or not isinstance(explanation, str) or not explanation.strip():
+        return None
+    if not isinstance(cited, list) or not all(isinstance(v, str) for v in cited):
+        return None
+    return {"verdict": verdict, "explanation": explanation.strip(), "cited_vote_ids": cited}
+
+
+def _format_candidates(candidates: list[dict], deputy_name: str | None) -> str:
+    lines = []
+    for c in candidates:
+        line = f"- [{c['vote_id']}] {c['title']} ({c['voted_at']}) — résultat : {c['result']}"
+        if deputy_name:
+            position = c["deputy_position"] or "aucune position enregistrée"
+            line += f" — position de {deputy_name} : {position}"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def _result(
+    claim: str,
+    verdict: str,
+    explanation: str,
+    deputy: dict | None,
+    citations: list[dict],
+    confidence: str,
+) -> dict:
+    return {
+        "claim": claim,
+        "verdict": verdict,
+        "explanation": explanation,
+        "deputy": deputy,
+        "citations": citations,
+        "confidence": CONFIDENCE_LABELS.get(confidence, "FAIBLE"),
+        "data_horizon": get_data_horizon_start(),
+    }
+
+
+def verify_claim(claim: str) -> dict:
+    """Verify a claim against the vote record. Returns the ADR-022 verdict
+    fields (id/verified_at/share_url are added by the API layer on insert)."""
+    claim = claim.strip()
+    deputy_map = get_deputy_map()
+    deputy_id = detect_deputy(claim, deputy_map)
+    deputy = None
+    if deputy_id:
+        deputy = {
+            "deputy_id": deputy_id,
+            "name": deputy_map[deputy_id]["full_name"],
+            "party": deputy_map[deputy_id]["party"],
+        }
+
+    chunks = retrieve(claim, k=CANDIDATE_K, chunk_type="vote")
+    confidence = compute_confidence(chunks)
+
+    if not chunks or chunks[0]["similarity"] < MIN_TOP_SIMILARITY:
+        return _result(claim, "inverifiable", _INVERIFIABLE_NO_MATCH, deputy, [], "low")
+
+    candidate_ids = [
+        c["metadata"]["vote_id"] for c in chunks if c.get("metadata", {}).get("vote_id")
+    ]
+    candidates = _fetch_candidates(candidate_ids, deputy_id)
+    if not candidates:
+        return _result(claim, "inverifiable", _INVERIFIABLE_NO_MATCH, deputy, [], "low")
+
+    deputy_line = (
+        f"Député identifié : {deputy['name']} ({deputy['party'] or 'groupe non renseigné'})"
+        if deputy
+        else "Aucun député identifié dans l'affirmation."
+    )
+    user_message = VERIFY_TEMPLATE.format(
+        claim=claim,
+        deputy_line=deputy_line,
+        candidates=_format_candidates(candidates, deputy["name"] if deputy else None),
+    )
+
+    response = _groq_client.chat.completions.create(
+        model=LLM_MODEL,
+        messages=[
+            {"role": "system", "content": build_verify_system_prompt()},
+            {"role": "user", "content": user_message},
+        ],
+        temperature=0.2,
+        max_tokens=1024,
+        response_format={"type": "json_object"},
+    )
+    parsed = _parse_llm_verdict(response.choices[0].message.content)
+    if parsed is None:
+        log.warning("verify_claim: unparseable LLM verdict for claim %r", claim)
+        return _result(claim, "inverifiable", _INVERIFIABLE_PARSE, deputy, [], "low")
+
+    # Citations restricted to the DB-fetched candidates — anything else is dropped.
+    by_id = {c["vote_id"]: c for c in candidates}
+    citations = [by_id[v] for v in parsed["cited_vote_ids"] if v in by_id]
+
+    verdict = parsed["verdict"]
+    explanation = parsed["explanation"]
+    if verdict != "inverifiable" and not citations:
+        # A factual verdict without a single valid citation is a guess.
+        verdict = "inverifiable"
+        explanation += _INVERIFIABLE_NO_CITATION
+
+    return _result(claim, verdict, explanation, deputy, citations, confidence)

--- a/rag/experiments/verify_eval.py
+++ b/rag/experiments/verify_eval.py
@@ -25,8 +25,6 @@ import psycopg2
 
 from rag.chain.verify import verify_claim
 
-_POSITION_WORDS = {"pour": "pour", "contre": "contre", "abstention": None, "nonVotant": None}
-
 
 def _live_golden_claims() -> list[dict]:
     """Build golden claims from a real, clear-cut position in the live DB."""

--- a/rag/experiments/verify_eval.py
+++ b/rag/experiments/verify_eval.py
@@ -1,0 +1,125 @@
+"""
+rag/experiments/verify_eval.py
+
+Golden-claim evaluation for the verification chain (MON-126).
+
+Claims are built from the live DB at eval time (same anti-rot approach as
+mlflow_eval.py): a real deputy/vote/position pair yields one true claim and
+its negated false claim; two fixed claims cover the unverifiable cases
+(period outside the data window, unknown person).
+
+Scores per claim:
+  - verdict_ok:        the verdict matches the expected set
+  - citations_valid:   every cited vote_id exists in the votes table
+
+Usage:
+    venv/bin/python -m rag.experiments.verify_eval
+Requires DATABASE_URL, OPENAI_API_KEY, GROQ_API_KEY. Costs a few cents at most
+(one embedding + one Groq call per claim).
+"""
+
+import os
+
+import mlflow
+import psycopg2
+
+from rag.chain.verify import verify_claim
+
+_POSITION_WORDS = {"pour": "pour", "contre": "contre", "abstention": None, "nonVotant": None}
+
+
+def _live_golden_claims() -> list[dict]:
+    """Build golden claims from a real, clear-cut position in the live DB."""
+    url = os.getenv("DATABASE_URL")
+    with psycopg2.connect(url) as conn:
+        with conn.cursor() as cur:
+            # A well-attended vote where a high-participation deputy voted
+            # pour or contre — an unambiguous ground truth pair.
+            cur.execute(
+                """
+                SELECT d.full_name, v.vote_title, vp.position, v.vote_id
+                FROM vote_positions vp
+                JOIN deputies d ON d.deputy_id = vp.deputy_id
+                JOIN votes v ON v.vote_id = vp.vote_id
+                WHERE vp.position IN ('pour', 'contre')
+                  AND v.total_voters >= 400
+                  AND d.mandate_end IS NULL
+                ORDER BY v.voted_at DESC
+                LIMIT 1
+                """
+            )
+            row = cur.fetchone()
+    if not row:
+        raise RuntimeError("No suitable vote/position pair found — is the DB populated?")
+    full_name, vote_title, position, vote_id = row
+    opposite = "contre" if position == "pour" else "pour"
+
+    return [
+        {
+            "label": "true claim (live position)",
+            "claim": f"{full_name} a voté {position} sur : {vote_title}",
+            "expected": {"vrai"},
+            "expect_citation": vote_id,
+        },
+        {
+            "label": "false claim (negated position)",
+            "claim": f"{full_name} a voté {opposite} sur : {vote_title}",
+            "expected": {"faux", "trompeur"},
+            "expect_citation": vote_id,
+        },
+        {
+            "label": "unverifiable — period outside window",
+            "claim": f"{full_name} a voté contre l'augmentation du SMIC en 2010",
+            "expected": {"inverifiable"},
+            "expect_citation": None,
+        },
+        {
+            "label": "unverifiable — unknown person",
+            "claim": "Le député Jean Dupontel a voté contre la réforme des retraites",
+            "expected": {"inverifiable"},
+            "expect_citation": None,
+        },
+    ]
+
+
+def _citation_ids_exist(citations: list[dict]) -> bool:
+    if not citations:
+        return True
+    ids = [c["vote_id"] for c in citations]
+    with psycopg2.connect(os.getenv("DATABASE_URL")) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM votes WHERE vote_id = ANY(%s)", (ids,))
+            return cur.fetchone()[0] == len(ids)
+
+
+def main() -> None:
+    golden = _live_golden_claims()
+    mlflow.set_experiment("monelu_verify_eval")
+
+    with mlflow.start_run(run_name="verify_golden_claims"):
+        verdict_scores, citation_scores = [], []
+        for case in golden:
+            result = verify_claim(case["claim"])
+            verdict_ok = result["verdict"] in case["expected"]
+            citations_valid = _citation_ids_exist(result["citations"])
+            cited_ids = [c["vote_id"] for c in result["citations"]]
+            expected_cited = case["expect_citation"] is None or case["expect_citation"] in cited_ids
+            verdict_scores.append(1.0 if verdict_ok else 0.0)
+            citation_scores.append(1.0 if (citations_valid and expected_cited) else 0.0)
+            print(f"[{'OK' if verdict_ok else 'MISS'}] {case['label']}")
+            print(f"      claim:    {case['claim']}")
+            print(f"      verdict:  {result['verdict']} (expected {case['expected']})")
+            print(f"      cited:    {cited_ids}")
+            print(f"      confidence: {result['confidence']}")
+
+        mlflow.log_metric("verdict_accuracy", sum(verdict_scores) / len(verdict_scores))
+        mlflow.log_metric("citation_validity", sum(citation_scores) / len(citation_scores))
+        mlflow.log_param("n_claims", len(golden))
+        print(
+            f"\nverdict_accuracy={sum(verdict_scores) / len(verdict_scores):.2f} "
+            f"citation_validity={sum(citation_scores) / len(citation_scores):.2f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -463,3 +463,109 @@ def test_health_degraded_when_openai_key_is_placeholder(client, mock_cursor):
     assert data["status"] == "degraded"
     assert data["openai"] == "degraded"
     assert data["db"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Verify (MON-126)
+# ---------------------------------------------------------------------------
+
+_VERIFY_KEYS_SET = {
+    "GROQ_API_KEY": "gsk_test_not_a_real_key",  # pragma: allowlist secret
+    "OPENAI_API_KEY": "sk-test-not-a-real-key",  # pragma: allowlist secret
+}
+
+_VERIFY_CHAIN_RESULT = {
+    "claim": "Gabriel Attal a voté contre l'augmentation du SMIC",
+    "verdict": "faux",
+    "explanation": "Le scrutin cité montre un vote pour.",
+    "deputy": {"deputy_id": "PA2", "name": "Gabriel Attal", "party": "EPR"},
+    "citations": [
+        {
+            "vote_id": "VTANR5L17V1",
+            "title": "Vote sur l'augmentation du SMIC",
+            "voted_at": "2025-09-01",
+            "result": "rejeté",
+            "deputy_position": "pour",
+        }
+    ],
+    "confidence": "ÉLEVÉ",
+    "data_horizon": "2025-07-01",
+}
+
+_VERIFY_ROW = {
+    "id": "3f0e8a4e-6f0f-4a63-9c40-df3a54d9c001",
+    "claim": _VERIFY_CHAIN_RESULT["claim"],
+    "verdict": _VERIFY_CHAIN_RESULT["verdict"],
+    "explanation": _VERIFY_CHAIN_RESULT["explanation"],
+    "deputy": _VERIFY_CHAIN_RESULT["deputy"],
+    "citations": _VERIFY_CHAIN_RESULT["citations"],
+    "confidence": "ÉLEVÉ",
+    "data_horizon": "2025-07-01",
+    "created_at": datetime(2026, 7, 14, 12, 0, 0),
+}
+
+
+def test_verify_post_persists_and_returns_verdict(client, mock_cursor):
+    mock_cursor.fetchone.return_value = dict(_VERIFY_ROW)
+    with (
+        patch("api.routers.verify.verify_claim", return_value=dict(_VERIFY_CHAIN_RESULT)),
+        patch.dict("os.environ", _VERIFY_KEYS_SET),
+    ):
+        resp = client.post("/verify/", json={"claim": _VERIFY_CHAIN_RESULT["claim"]})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["verdict"] == "faux"
+    assert data["id"] == _VERIFY_ROW["id"]
+    assert data["share_url"].endswith(f"/verifier/v/{_VERIFY_ROW['id']}")
+    assert data["citations"][0]["vote_id"] == "VTANR5L17V1"
+    assert data["citations"][0]["deputy_position"] == "pour"
+    assert data["deputy"]["name"] == "Gabriel Attal"
+    assert data["confidence"] == "ÉLEVÉ"
+    assert data["data_horizon"] == "2025-07-01"
+    assert data["verified_at"] == "2026-07-14T12:00:00"
+
+
+def test_verify_post_503_when_keys_unset(client):
+    placeholders = {
+        "GROQ_API_KEY": "gsk_...",  # pragma: allowlist secret
+        "OPENAI_API_KEY": "sk-...",  # pragma: allowlist secret
+    }
+    with patch.dict("os.environ", placeholders):
+        resp = client.post("/verify/", json={"claim": "Une affirmation à vérifier ici"})
+    assert resp.status_code == 503
+    assert "configurée" in resp.json()["detail"]
+
+
+def test_verify_post_claim_too_short_rejected(client):
+    resp = client.post("/verify/", json={"claim": "court"})
+    assert resp.status_code == 422
+
+
+def test_verify_post_groq_timeout_returns_504(client):
+    exc = groq.APITimeoutError(request=httpx.Request("POST", "https://api.groq.com"))
+    with (
+        patch("api.routers.verify.verify_claim", side_effect=exc),
+        patch.dict("os.environ", _VERIFY_KEYS_SET),
+    ):
+        resp = client.post("/verify/", json={"claim": "Une affirmation à vérifier ici"})
+    assert resp.status_code == 504
+
+
+def test_verify_get_found(client, mock_cursor):
+    mock_cursor.fetchone.return_value = dict(_VERIFY_ROW)
+    resp = client.get(f"/verify/{_VERIFY_ROW['id']}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["verdict"] == "faux"
+    assert data["share_url"].endswith(f"/verifier/v/{_VERIFY_ROW['id']}")
+
+
+def test_verify_get_not_found(client, mock_cursor):
+    mock_cursor.fetchone.return_value = None
+    resp = client.get("/verify/3f0e8a4e-6f0f-4a63-9c40-df3a54d9c999")
+    assert resp.status_code == 404
+
+
+def test_verify_get_invalid_uuid_rejected(client):
+    resp = client.get("/verify/not-a-uuid")
+    assert resp.status_code == 422

--- a/tests/unit/test_verify_chain.py
+++ b/tests/unit/test_verify_chain.py
@@ -1,0 +1,213 @@
+"""Unit tests for the claim-verification chain (MON-126) — no DB, no LLM."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import rag.chain.verify as verify_mod
+from rag.chain.verify import _parse_llm_verdict, detect_deputy, verify_claim
+
+_DEPUTY_MAP = {
+    "PA1": {"full_name": "Marine Le Pen", "party": "Rassemblement National"},
+    "PA2": {"full_name": "Gabriel Attal", "party": "Ensemble pour la République"},
+    "PA3": {"full_name": "Jean Martin", "party": "Les Républicains"},
+    "PA4": {"full_name": "Claire Martin", "party": "Socialistes"},
+    "PA5": {"full_name": "Li Wu", "party": None},
+}
+
+_CANDIDATE = {
+    "vote_id": "VTANR5L17V1",
+    "title": "Vote sur l'augmentation du SMIC",
+    "voted_at": "2025-09-01",
+    "result": "rejeté",
+    "deputy_position": "contre",
+}
+
+
+# ---------------------------------------------------------------------------
+# detect_deputy
+# ---------------------------------------------------------------------------
+
+
+def test_detect_deputy_unique_last_name():
+    assert detect_deputy("Attal a voté contre le SMIC", _DEPUTY_MAP) == "PA2"
+
+
+def test_detect_deputy_full_name_wins_over_ambiguous_last_name():
+    assert detect_deputy("Jean Martin a voté pour ce texte", _DEPUTY_MAP) == "PA3"
+
+
+def test_detect_deputy_ambiguous_last_name_returns_none():
+    # Two deputies named Martin and no full name — guessing would misattribute.
+    assert detect_deputy("le député Martin a voté pour", _DEPUTY_MAP) is None
+
+
+def test_detect_deputy_short_last_name_skipped():
+    # "Wu" is under the 3-char floor; substring "wu" in other words must not match.
+    assert detect_deputy("wu a voté pour", _DEPUTY_MAP) is None
+
+
+def test_detect_deputy_no_match():
+    assert detect_deputy("le SMIC a été rejeté", _DEPUTY_MAP) is None
+
+
+def test_detect_deputy_multiword_last_name_via_full_name():
+    assert detect_deputy("Marine Le Pen a voté contre", _DEPUTY_MAP) == "PA1"
+
+
+# ---------------------------------------------------------------------------
+# _parse_llm_verdict
+# ---------------------------------------------------------------------------
+
+
+def test_parse_valid_json():
+    raw = json.dumps(
+        {
+            "verdict": "faux",
+            "explanation": "Le vote cité montre le contraire.",
+            "cited_vote_ids": ["V1"],
+        }
+    )
+    parsed = _parse_llm_verdict(raw)
+    assert parsed == {
+        "verdict": "faux",
+        "explanation": "Le vote cité montre le contraire.",
+        "cited_vote_ids": ["V1"],
+    }
+
+
+def test_parse_fenced_json():
+    raw = '```json\n{"verdict": "vrai", "explanation": "ok", "cited_vote_ids": []}\n```'
+    assert _parse_llm_verdict(raw)["verdict"] == "vrai"
+
+
+def test_parse_unknown_verdict_rejected():
+    raw = '{"verdict": "peut-être", "explanation": "ok", "cited_vote_ids": []}'
+    assert _parse_llm_verdict(raw) is None
+
+
+def test_parse_missing_explanation_rejected():
+    raw = '{"verdict": "vrai", "cited_vote_ids": []}'
+    assert _parse_llm_verdict(raw) is None
+
+
+def test_parse_non_string_ids_rejected():
+    raw = '{"verdict": "vrai", "explanation": "ok", "cited_vote_ids": [1]}'
+    assert _parse_llm_verdict(raw) is None
+
+
+def test_parse_garbage_rejected():
+    assert _parse_llm_verdict("Je pense que c'est vrai.") is None
+
+
+# ---------------------------------------------------------------------------
+# verify_claim guards
+# ---------------------------------------------------------------------------
+
+
+def _mock_groq(payload: dict | str) -> MagicMock:
+    content = payload if isinstance(payload, str) else json.dumps(payload)
+    client = MagicMock()
+    client.chat.completions.create.return_value = MagicMock(
+        choices=[MagicMock(message=MagicMock(content=content))]
+    )
+    return client
+
+
+def _run_verify(claim: str, *, chunks, candidates, groq_payload) -> tuple[dict, MagicMock]:
+    client = _mock_groq(groq_payload)
+    with (
+        patch.object(verify_mod, "get_deputy_map", return_value=_DEPUTY_MAP),
+        patch.object(verify_mod, "retrieve", return_value=chunks),
+        patch.object(verify_mod, "_fetch_candidates", return_value=candidates),
+        patch.object(verify_mod, "get_data_horizon_start", return_value="2025-07-01"),
+        patch.object(verify_mod, "_groq_client", client),
+    ):
+        return verify_claim(claim), client
+
+
+_STRONG_CHUNK = {
+    "content": "…",
+    "metadata": {"chunk_type": "vote", "vote_id": "VTANR5L17V1"},
+    "similarity": 0.72,
+}
+
+
+def test_low_similarity_skips_llm_and_returns_inverifiable():
+    weak = [{"content": "…", "metadata": {"vote_id": "V9"}, "similarity": 0.2}]
+    result, client = _run_verify(
+        "Attal a voté contre le SMIC", chunks=weak, candidates=[], groq_payload={}
+    )
+    assert result["verdict"] == "inverifiable"
+    assert result["citations"] == []
+    assert result["confidence"] == "FAIBLE"
+    client.chat.completions.create.assert_not_called()
+
+
+def test_no_candidates_returns_inverifiable_without_llm():
+    result, client = _run_verify(
+        "Attal a voté contre le SMIC", chunks=[_STRONG_CHUNK], candidates=[], groq_payload={}
+    )
+    assert result["verdict"] == "inverifiable"
+    client.chat.completions.create.assert_not_called()
+
+
+def test_valid_verdict_keeps_only_db_backed_citations():
+    payload = {
+        "verdict": "faux",
+        "explanation": "Il a voté contre.",
+        "cited_vote_ids": ["VTANR5L17V1", "FABRICATED"],
+    }
+    result, _ = _run_verify(
+        "Attal a voté pour le SMIC",
+        chunks=[_STRONG_CHUNK, _STRONG_CHUNK],
+        candidates=[_CANDIDATE],
+        groq_payload=payload,
+    )
+    assert result["verdict"] == "faux"
+    assert [c["vote_id"] for c in result["citations"]] == ["VTANR5L17V1"]
+    assert result["deputy"] == {
+        "deputy_id": "PA2",
+        "name": "Gabriel Attal",
+        "party": "Ensemble pour la République",
+    }
+    assert result["confidence"] == "ÉLEVÉ"
+    assert result["data_horizon"] == "2025-07-01"
+
+
+def test_factual_verdict_without_valid_citation_downgraded_to_inverifiable():
+    payload = {"verdict": "vrai", "explanation": "C'est vrai.", "cited_vote_ids": ["FABRICATED"]}
+    result, _ = _run_verify(
+        "Attal a voté contre le SMIC",
+        chunks=[_STRONG_CHUNK],
+        candidates=[_CANDIDATE],
+        groq_payload=payload,
+    )
+    assert result["verdict"] == "inverifiable"
+    assert result["citations"] == []
+
+
+def test_unparseable_llm_output_returns_inverifiable():
+    result, _ = _run_verify(
+        "Attal a voté contre le SMIC",
+        chunks=[_STRONG_CHUNK],
+        candidates=[_CANDIDATE],
+        groq_payload="désolé, je ne peux pas répondre en JSON",
+    )
+    assert result["verdict"] == "inverifiable"
+    assert result["citations"] == []
+
+
+def test_inverifiable_verdict_allowed_without_citations():
+    payload = {
+        "verdict": "inverifiable",
+        "explanation": "Les scrutins fournis ne couvrent pas ce sujet.",
+        "cited_vote_ids": [],
+    }
+    result, _ = _run_verify(
+        "Attal a voté contre le SMIC en 2010",
+        chunks=[_STRONG_CHUNK],
+        candidates=[_CANDIDATE],
+        groq_payload=payload,
+    )
+    assert result["verdict"] == "inverifiable"
+    assert result["data_horizon"] == "2025-07-01"

--- a/tests/unit/test_verify_chain.py
+++ b/tests/unit/test_verify_chain.py
@@ -197,6 +197,18 @@ def test_unparseable_llm_output_returns_inverifiable():
     assert result["citations"] == []
 
 
+def test_retrieval_disables_auto_result_filter():
+    """A claim's own "adopté"/"rejeté" wording must not exclude the scrutin
+    that would contradict it — verify_claim opts out of the auto filter."""
+    with (
+        patch.object(verify_mod, "get_deputy_map", return_value=_DEPUTY_MAP),
+        patch.object(verify_mod, "retrieve", return_value=[]) as mock_retrieve,
+        patch.object(verify_mod, "get_data_horizon_start", return_value="2025-07-01"),
+    ):
+        verify_claim("Attal a voté pour la loi rejetée")
+    assert mock_retrieve.call_args.kwargs["auto_result_filter"] is False
+
+
 def test_inverifiable_verdict_allowed_without_citations():
     payload = {
         "verdict": "inverifiable",


### PR DESCRIPTION
## What

Backend half of the MON-111 fact-check feature, implementing the ADR-022 contract:

- **`rag/chain/verify.py`** - the verification chain: deputy detection over all 577 deputies (full-name match wins; ambiguous last names return no deputy rather than guessing a homonym), vote-chunk retrieval via the existing exact-cosine retriever, a `vote_positions` join for the named deputy's actual recorded position, and a structured JSON verdict from Groq (`vrai`/`faux`/`trompeur`/`inverifiable`).
- **Hard anti-hallucination guards in code, not prompts**: candidate scrutins are fetched from the `votes` table, so a cited `vote_id` can only be one that exists; LLM citations outside the candidate set are dropped; low top-similarity (< 0.35) skips the LLM entirely; an unparseable verdict, an unknown verdict value, or a factual verdict with zero valid citations all force `inverifiable`.
- **`data/migrations/005_verifications.sql`** - additive, idempotent `verifications` table (UUID pk, verdict CHECK, JSONB deputy/citation snapshots) per ADR-022's immutable-snapshot model.
- **`api/routers/verify.py`** - `POST /verify/` runs the chain, persists the snapshot, returns the canonical `VerifyResponse` (incl. `share_url` = `/verifier/v/<id>`); `GET /verify/{id}` serves stored verdicts with **no LLM call** (what MON-127/128 will read). 503 with a clear message when either API key is unset/placeholder.
- **`rag/chain/prompts.py`** - `build_verify_system_prompt()` (TTL-cached data horizon, verdict definitions, nonVotant≠abstention rule) + `VERIFY_TEMPLATE`, following the existing `SUMMARY_PROMPT` JSON pattern.
- **`rag/experiments/verify_eval.py`** - golden-claim MLflow eval built from live DB data (true/negated-false pair from a real position, two unverifiable cases); scores verdict accuracy and citation validity.
- README + CLAUDE.md doc sync (endpoint tables, rag layer, DB table list).

## Acceptance criteria mapping

- **POST /verify/ returns a valid VerifyResponse matching ADR-022** -> `VerifyResponse` in `api/routers/verify.py` implements the ADR field list verbatim (id, claim, verdict enum, explanation, deputy, citations with `voted_at`, French confidence labels per ADR-016 mapping, data_horizon, verified_at, share_url). Covered by `test_verify_post_persists_and_returns_verdict`.
- **Correct verdict with cited scrutin + actual position** -> chain joins `vote_positions` for the detected deputy and the citation carries `deputy_position`; exercised in unit tests and the golden-claim eval.
- **Out-of-window claim returns inverifiable with data horizon** -> system prompt states the horizon and instructs `inverifiable`; `data_horizon` is present on every response including `inverifiable` (`test_inverifiable_verdict_allowed_without_citations`).
- **No fabricated scrutin references (enforced in code)** -> citations are intersected with DB-fetched candidates (`test_valid_verdict_keeps_only_db_backed_citations`, `test_factual_verdict_without_valid_citation_downgraded_to_inverifiable`).
- **Rate limit 10 req/min + 503 when keys unset** -> `tiered_limit(10)` on POST (same as /search), explicit 503 check (`test_verify_post_503_when_keys_unset`).
- **Golden-claim eval via MLflow** -> `rag/experiments/verify_eval.py`. **Deferred to a manual run**: it needs a populated DB + real API keys (paid OpenAI embedding call), which this environment doesn't have. Run with `venv/bin/python -m rag.experiments.verify_eval` after `make start`/`make ingest` (or against prod env vars); costs a few cents at most.

## Test plan

- `pytest tests/ -m "not integration"` - **186 passed** locally (20 new: 13 chain unit tests, 7 endpoint tests).
- `ruff check .` and `ruff format --check .` clean repo-wide.

## Deploy / migration risk

Migration `005_verifications.sql` is **additive and idempotent** (`CREATE TABLE IF NOT EXISTS`), applied by `migrate.py` in the Railway start hook before uvicorn boots, so the table exists before the endpoint serves. No existing tables or dbt models touched. New optional env var `FRONTEND_BASE_URL` (defaults to https://mon-elu.vercel.app) controls the share URL host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsiwrLjnhvMAidpyGbYytj