### PR TITLE
feat: /verifier page with verdict UI and stored-verdict share page (MON-127)

### DIFF
--- a/frontend/__tests__/components/VerdictCard.test.tsx
+++ b/frontend/__tests__/components/VerdictCard.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react'
+
+import { VerdictCard } from '@/components/VerdictCard'
+import type { VerifyResult } from '@/lib/api'
+
+const BASE: VerifyResult = {
+  id: '3f0e8a4e-6f0f-4a63-9c40-df3a54d9c001',
+  claim: "Gabriel Attal a voté contre l'augmentation du SMIC",
+  verdict: 'faux',
+  explanation: 'Le scrutin cité montre un vote pour.',
+  deputy: { deputy_id: 'PA2', name: 'Gabriel Attal', party: 'EPR' },
+  citations: [
+    {
+      vote_id: 'VTANR5L17V1',
+      title: "Vote sur l'augmentation du SMIC",
+      voted_at: '2025-09-01',
+      result: 'rejeté',
+      deputy_position: 'pour',
+    },
+  ],
+  confidence: 'ÉLEVÉ',
+  data_horizon: '2025-07-01',
+  verified_at: '2026-07-14T12:00:00',
+  share_url: 'https://mon-elu.vercel.app/verifier/v/3f0e8a4e-6f0f-4a63-9c40-df3a54d9c001',
+}
+
+describe('VerdictCard', () => {
+  it.each([
+    ['vrai', 'Vrai'],
+    ['faux', 'Faux'],
+    ['trompeur', 'Trompeur'],
+    ['inverifiable', 'Invérifiable avec nos données'],
+  ] as const)('renders the %s verdict badge', (verdict, label) => {
+    render(<VerdictCard result={{ ...BASE, verdict }} />)
+    expect(screen.getByText(label)).toBeInTheDocument()
+  })
+
+  it('links each cited scrutin to its vote page', () => {
+    render(<VerdictCard result={BASE} />)
+    const link = screen.getByRole('link', { name: /Vote sur l'augmentation du SMIC/ })
+    expect(link).toHaveAttribute('href', '/votes/VTANR5L17V1')
+  })
+
+  it('shows the deputy recorded position on the citation', () => {
+    render(<VerdictCard result={BASE} />)
+    expect(screen.getByText(/position de Gabriel Attal : pour/)).toBeInTheDocument()
+  })
+
+  it('links the deputy to their profile', () => {
+    render(<VerdictCard result={BASE} />)
+    expect(screen.getByRole('link', { name: 'Gabriel Attal' })).toHaveAttribute(
+      'href',
+      '/deputes/PA2'
+    )
+  })
+
+  it('always shows the data horizon, including on inverifiable verdicts', () => {
+    render(
+      <VerdictCard
+        result={{ ...BASE, verdict: 'inverifiable', citations: [], confidence: 'FAIBLE' }}
+      />
+    )
+    expect(screen.getByText(/depuis le 1 juillet 2025/)).toBeInTheDocument()
+    expect(screen.getByText(/Confiance faible/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -491,6 +491,12 @@ function ChatInner() {
                   </button>
                 ))}
               </div>
+              <Link
+                href="/verifier"
+                style={{ marginTop: 28, fontSize: 13, color: txt2, textDecoration: 'underline' }}
+              >
+                Vous voulez vérifier une affirmation précise ? Essayez « Vérifier une affirmation » →
+              </Link>
             </div>
           )}
 

--- a/frontend/src/app/verifier/VerifierClient.tsx
+++ b/frontend/src/app/verifier/VerifierClient.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { api } from '@/lib/api'
+import type { VerifyResult } from '@/lib/api'
+import { VerdictCard } from '@/components/VerdictCard'
+
+const EXAMPLE_CLAIM = '« Le député X a voté contre l’augmentation du SMIC »'
+
+const MIN_CLAIM_LENGTH = 10
+const MAX_CLAIM_LENGTH = 500
+
+function errorMessage(err: unknown): string {
+  const msg = err instanceof Error ? err.message : ''
+  if (msg.includes('429')) {
+    return 'Trop de vérifications en peu de temps. Patientez une minute et réessayez.'
+  }
+  if (msg.includes('503')) {
+    return "La vérification IA n'est pas disponible pour le moment."
+  }
+  return 'La vérification a échoué. Réessayez dans quelques secondes.'
+}
+
+export function VerifierClient() {
+  const searchParams = useSearchParams()
+  const prefill = searchParams.get('claim') ?? ''
+
+  // Initial value only: a "re-vérifier" navigation from the share page mounts
+  // this component fresh, so useState(prefill) covers the prefill case.
+  const [claim, setClaim] = useState(prefill)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [result, setResult] = useState<VerifyResult | null>(null)
+
+  const tooShort = claim.trim().length < MIN_CLAIM_LENGTH
+
+  async function submit() {
+    if (tooShort || loading) return
+    setLoading(true)
+    setError(null)
+    setResult(null)
+    try {
+      setResult(await api.verify(claim.trim()))
+    } catch (err) {
+      setError(errorMessage(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-10 md:py-14">
+      <h1 className="font-serif text-3xl md:text-4xl font-extrabold text-navy tracking-tight mb-3">
+        Vérifier une affirmation
+      </h1>
+      <p className="text-gray-mid text-[15px] leading-relaxed mb-8 max-w-2xl">
+        Collez une affirmation lue sur les réseaux sociaux — par exemple {EXAMPLE_CLAIM} — et
+        confrontez-la aux votes réellement enregistrés à l&apos;Assemblée Nationale. Le verdict cite
+        les scrutins officiels, jamais une opinion.
+      </p>
+
+      <form
+        onSubmit={e => {
+          e.preventDefault()
+          submit()
+        }}
+        className="mb-8"
+      >
+        <label htmlFor="claim" className="sr-only">
+          Affirmation à vérifier
+        </label>
+        <textarea
+          id="claim"
+          value={claim}
+          onChange={e => setClaim(e.target.value.slice(0, MAX_CLAIM_LENGTH))}
+          rows={3}
+          placeholder="Le député X a voté contre l'augmentation du SMIC…"
+          className="w-full border border-gray-border rounded-xl p-4 text-[15px] text-navy focus:outline-none focus:border-navy resize-y"
+        />
+        <div className="flex items-center justify-between mt-3">
+          <span className="text-xs text-gray-mid">
+            {claim.length}/{MAX_CLAIM_LENGTH}
+          </span>
+          <button
+            type="submit"
+            disabled={tooShort || loading}
+            className="bg-navy text-white text-sm font-medium px-6 py-2.5 rounded-lg hover:bg-red-civic transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {loading ? 'Vérification en cours…' : 'Vérifier'}
+          </button>
+        </div>
+      </form>
+
+      {loading && (
+        <div
+          className="border border-gray-border rounded-xl p-6 text-sm text-gray-mid animate-pulse"
+          role="status"
+        >
+          Recherche des scrutins correspondants et de la position enregistrée du député…
+        </div>
+      )}
+
+      {error && (
+        <div className="border border-red-300 bg-red-50 text-red-800 rounded-xl p-4 text-sm" role="alert">
+          {error}
+        </div>
+      )}
+
+      {result && !loading && <VerdictCard result={result} />}
+    </main>
+  )
+}

--- a/frontend/src/app/verifier/page.tsx
+++ b/frontend/src/app/verifier/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+import { Suspense } from 'react'
+import { VerifierClient } from './VerifierClient'
+
+export const metadata: Metadata = {
+  title: 'Vérifier une affirmation - MonÉlu',
+  description:
+    "Vérifiez une affirmation sur les votes d'un député de l'Assemblée Nationale contre la source primaire : verdict structuré, scrutins cités, position réellement enregistrée.",
+  openGraph: {
+    title: 'Vérifier une affirmation - MonÉlu',
+    description:
+      "Vérifiez une affirmation sur les votes d'un député contre les données officielles de l'Assemblée Nationale.",
+    url: 'https://mon-elu.vercel.app/verifier',
+  },
+}
+
+export default function VerifierPage() {
+  return (
+    <Suspense fallback={<div className="text-gray-mid text-sm p-8">Chargement...</div>}>
+      <VerifierClient />
+    </Suspense>
+  )
+}

--- a/frontend/src/app/verifier/v/[id]/page.tsx
+++ b/frontend/src/app/verifier/v/[id]/page.tsx
@@ -1,0 +1,63 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { api } from '@/lib/api'
+import { VerdictCard } from '@/components/VerdictCard'
+
+// Verdicts are immutable snapshots (ADR-022): this page reads the stored
+// verdict via GET /verify/{id} — it must never trigger a new verification.
+export const dynamicParams = true
+export const revalidate = 86400
+
+const VERDICT_LABELS: Record<string, string> = {
+  vrai: 'Vrai',
+  faux: 'Faux',
+  trompeur: 'Trompeur',
+  inverifiable: 'Invérifiable',
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}): Promise<Metadata> {
+  const { id } = await params
+  const v = await api.verification(id).catch(() => null)
+  if (!v) return {}
+  const label = VERDICT_LABELS[v.verdict] ?? v.verdict
+  const shortClaim = v.claim.length > 90 ? v.claim.slice(0, 90) + '…' : v.claim
+  const title = `${label} - « ${shortClaim} » - MonÉlu Vérification`
+  const description = v.explanation.length > 160 ? v.explanation.slice(0, 160) + '…' : v.explanation
+  return {
+    title,
+    description,
+    openGraph: { title, description, url: `https://mon-elu.vercel.app/verifier/v/${id}` },
+    twitter: { card: 'summary_large_image', title, description },
+  }
+}
+
+export default async function VerificationPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const result = await api.verification(id).catch(() => null)
+  if (!result) notFound()
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-10 md:py-14">
+      <p className="text-xs uppercase tracking-wide text-gray-mid mb-4">
+        Vérification MonÉlu — verdict enregistré
+      </p>
+      <VerdictCard result={result} />
+      <div className="mt-6 flex flex-wrap items-center gap-4 text-sm">
+        <Link
+          href={`/verifier?claim=${encodeURIComponent(result.claim)}`}
+          className="border border-navy text-navy px-4 py-2 rounded-lg hover:bg-navy hover:text-white transition-colors"
+        >
+          Re-vérifier avec les données du jour
+        </Link>
+        <Link href="/verifier" className="text-gray-mid underline hover:text-navy">
+          Vérifier une autre affirmation
+        </Link>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -7,13 +7,14 @@ const items = [
   { href: '/deputes', label: 'Députés', icon: '◉' },
   { href: '/votes', label: 'Votes', icon: '◈' },
   { href: '/chat', label: 'Chat IA', icon: '◎' },
+  { href: '/verifier', label: 'Vérifier', icon: '✓' },
 ]
 
 export function BottomNav() {
   const path = usePathname()
   return (
     <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-gray-border z-50">
-      <div className="grid grid-cols-4">
+      <div className="grid grid-cols-5">
         {items.map(item => (
           <Link key={item.href} href={item.href}
             className={`flex flex-col items-center justify-center py-3 gap-0.5 text-xs font-medium transition-colors

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -12,6 +12,7 @@ const navLinks = [
   { href: '/deputes', label: 'Députés' },
   { href: '/votes', label: 'Votes' },
   { href: '/chat', label: 'Chat IA' },
+  { href: '/verifier', label: 'Vérifier' },
   { href: '/a-propos', label: 'À propos' },
 ]
 

--- a/frontend/src/components/VerdictCard.tsx
+++ b/frontend/src/components/VerdictCard.tsx
@@ -1,0 +1,103 @@
+import Link from 'next/link'
+import { ShareButton } from './ShareButton'
+import type { VerifyResult } from '@/lib/api'
+
+const VERDICT_STYLES: Record<VerifyResult['verdict'], { label: string; badge: string }> = {
+  vrai: { label: 'Vrai', badge: 'bg-emerald-100 text-emerald-800 border-emerald-300' },
+  faux: { label: 'Faux', badge: 'bg-red-100 text-red-800 border-red-300' },
+  trompeur: { label: 'Trompeur', badge: 'bg-amber-100 text-amber-800 border-amber-300' },
+  inverifiable: {
+    label: 'Invérifiable avec nos données',
+    badge: 'bg-gray-100 text-gray-700 border-gray-300',
+  },
+}
+
+const CONFIDENCE_LABELS: Record<VerifyResult['confidence'], string> = {
+  'ÉLEVÉ': 'Confiance élevée',
+  'MOYEN': 'Confiance moyenne',
+  'FAIBLE': 'Confiance faible',
+}
+
+function formatDate(iso: string | null): string | null {
+  if (!iso) return null
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return iso
+  return d.toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' })
+}
+
+export function VerdictCard({ result }: { result: VerifyResult }) {
+  const style = VERDICT_STYLES[result.verdict]
+  const verifiedAt = formatDate(result.verified_at)
+  const horizon = formatDate(result.data_horizon)
+
+  return (
+    <div className="bg-white border border-gray-border rounded-xl p-6 shadow-sm">
+      <div className="flex items-start justify-between gap-3 mb-4">
+        <span
+          className={`inline-block text-sm font-bold uppercase tracking-wide px-3 py-1.5 rounded-md border ${style.badge}`}
+        >
+          {style.label}
+        </span>
+        <ShareButton
+          url={`/verifier/v/${result.id}`}
+          title={`${style.label} — vérification MonÉlu`}
+          text={result.claim}
+          ariaLabel="Partager ce verdict"
+        />
+      </div>
+
+      <blockquote className="border-l-4 border-gray-border pl-4 text-navy font-medium italic mb-4">
+        « {result.claim} »
+      </blockquote>
+
+      {result.deputy && (
+        <p className="text-sm text-gray-mid mb-3">
+          Député concerné :{' '}
+          <Link
+            href={`/deputes/${result.deputy.deputy_id}`}
+            className="text-navy font-medium underline hover:text-red-civic"
+          >
+            {result.deputy.name}
+          </Link>
+          {result.deputy.party ? ` (${result.deputy.party})` : ''}
+        </p>
+      )}
+
+      <p className="text-[15px] leading-relaxed text-navy mb-5">{result.explanation}</p>
+
+      {result.citations.length > 0 && (
+        <div className="mb-5">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-mid mb-2">
+            Scrutins cités
+          </h3>
+          <ul className="space-y-2">
+            {result.citations.map(c => (
+              <li key={c.vote_id}>
+                <Link
+                  href={`/votes/${c.vote_id}`}
+                  className="block border border-gray-border rounded-lg p-3 hover:border-navy transition-colors"
+                >
+                  <span className="block text-sm font-medium text-navy">{c.title}</span>
+                  <span className="block text-xs text-gray-mid mt-1">
+                    {formatDate(c.voted_at)}
+                    {c.result ? ` · ${c.result}` : ''}
+                    {c.deputy_position && result.deputy
+                      ? ` · position de ${result.deputy.name} : ${c.deputy_position}`
+                      : ''}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <p className="text-xs text-gray-mid border-t border-gray-border pt-3">
+        {CONFIDENCE_LABELS[result.confidence]}
+        {verifiedAt ? ` · Vérifié le ${verifiedAt}` : ''}
+        {horizon ? ` · Sur la base des scrutins de l'Assemblée Nationale depuis le ${horizon}` : ''}
+        {' · '}Source : données ouvertes de l&apos;Assemblée Nationale.
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/components/VerdictCard.tsx
+++ b/frontend/src/components/VerdictCard.tsx
@@ -20,7 +20,9 @@ const CONFIDENCE_LABELS: Record<VerifyResult['confidence'], string> = {
 
 function formatDate(iso: string | null): string | null {
   if (!iso) return null
-  const d = new Date(iso)
+  // Date-only strings parse as UTC midnight — anchor to noon so viewers west
+  // of UTC don't see the previous day.
+  const d = new Date(/^\d{4}-\d{2}-\d{2}$/.test(iso) ? `${iso}T12:00:00` : iso)
   if (isNaN(d.getTime())) return iso
   return d.toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' })
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -132,6 +132,27 @@ export type SearchResult = {
   sources: Array<{ content: string; metadata: Record<string, string>; similarity: number }>
 }
 
+export type VerifyCitation = {
+  vote_id: string
+  title: string
+  voted_at: string
+  result: string | null
+  deputy_position: string | null
+}
+
+export type VerifyResult = {
+  id: string
+  claim: string
+  verdict: 'vrai' | 'faux' | 'trompeur' | 'inverifiable'
+  explanation: string
+  deputy: { deputy_id: string; name: string; party: string | null } | null
+  citations: VerifyCitation[]
+  confidence: 'ÉLEVÉ' | 'MOYEN' | 'FAIBLE'
+  data_horizon: string | null
+  verified_at: string
+  share_url: string
+}
+
 // 5xx: transient upstream hiccups, short retries.
 // 429: the API rate limiter (30 req/min per IP) — hit hard during `next build`,
 // where prerendering ~117 pages from one IP exceeds the budget and fails the
@@ -229,6 +250,9 @@ export const api = {
     get: (id: string) => apiFetch<VoteDetail>(`/votes/${id}/`, { revalidate: 86400 }),
   },
   search: (question: string) => apiPost<SearchResult>('/search/', { question }),
+  verify: (claim: string) => apiPost<VerifyResult>('/verify/', { claim }),
+  // Verdicts are immutable snapshots (ADR-022) — cache aggressively.
+  verification: (id: string) => apiFetch<VerifyResult>(`/verify/${id}`, { revalidate: 86400 }),
   feedback: {
     chat: (vote: 'up' | 'down', question: string, answer: string, sources: SearchResult['sources']) =>
       apiPost<{ status: string }>('/feedback/chat', { vote, question, answer, sources }),


### PR DESCRIPTION
## What

Frontend half of the MON-111 fact-check feature, consuming the MON-126 backend (PR #201) per ADR-022:

- **`/verifier`** (`app/verifier/page.tsx` + `VerifierClient.tsx`) - claim textarea (10-500 chars, live counter), submit with loading/error states (429 and 503 get specific French messages), result rendered as a verdict card. Supports `?claim=` prefill for the re-verify flow.
- **`VerdictCard`** (shared component) - color-coded badge for the four verdicts (Vrai / Faux / Trompeur / Invérifiable avec nos données), quoted claim, deputy link to their profile, explanation, one card per cited scrutin linking to `/votes/{vote_id}` with the deputy's recorded position, and an always-visible footer: confidence, verified-at date, **data horizon**, and source attribution. Reuses `ShareButton` with the `/verifier/v/<id>` share path.
- **`/verifier/v/[id]`** - the ADR-022 share page: reads the stored verdict via `GET /verify/{id}` (**no LLM call, never re-verifies on view**), `notFound()` on unknown ids, OG/twitter metadata from the verdict, and an explicit "Re-vérifier avec les données du jour" action that prefills `/verifier`.
- **API client** - `VerifyResult`/`VerifyCitation` types, `api.verify()` (POST) and `api.verification()` (GET, 24h revalidate - verdicts are immutable snapshots).
- **Discoverability** - nav entries in `Nav` and `BottomNav` (grid widened to 5), plus a link from the chat empty state.

## Acceptance criteria mapping

- **/verifier accepts a claim and renders verdict badge, explanation, cited scrutin cards from the live endpoint** -> `VerifierClient` + `VerdictCard`; badge rendering for all four verdicts covered by Jest.
- **Each cited scrutin links to the vote detail page** -> `/votes/{vote_id}` links, asserted in `VerdictCard.test.tsx`.
- **Data horizon visible on every verdict incl. inverifiable** -> card footer always renders it; dedicated test.
- **Share button produces the ADR URL format** -> `ShareButton` gets `/verifier/v/{id}`.
- **Reachable from the site nav** -> `Nav` + `BottomNav` entries.
- **lint/test/build green + Jest test for all four verdict values** -> see test plan.

## Test plan

- `npm run lint` - no warnings or errors.
- `npm test` - **85 passed** (8 new in `VerdictCard.test.tsx`: four badges, citation link, deputy position, profile link, horizon-on-inverifiable).
- `npm run build` - production build succeeds (`/verifier` static, `/verifier/v/[id]` dynamic).

## Deploy risk

None - frontend-only; no backend, schema, or workflow changes. The share page requires the MON-126 endpoints, already live on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsiwrLjnhvMAidpyGbYytj