### PR TITLE
feat: shareable verdict card OG image (MON-128)

### DIFF
--- a/frontend/src/app/verifier/v/[id]/opengraph-image.tsx
+++ b/frontend/src/app/verifier/v/[id]/opengraph-image.tsx
@@ -1,0 +1,128 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = 'Vérification MonÉlu — verdict sur une affirmation'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+// Verdicts are immutable snapshots (ADR-022): cache the card aggressively.
+export const revalidate = 86400
+
+const VERDICT_STYLES: Record<string, { label: string; color: string }> = {
+  vrai: { label: 'VRAI', color: '#059669' },
+  faux: { label: 'FAUX', color: '#C9302C' },
+  trompeur: { label: 'TROMPEUR', color: '#D97706' },
+  inverifiable: { label: 'INVÉRIFIABLE', color: '#6B7280' },
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? text.slice(0, max) + '…' : text
+}
+
+export default async function OGImage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const verdict = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL ?? 'https://monelu-production.up.railway.app'}/verify/${id}`
+  )
+    .then(r => (r.ok ? r.json() : null))
+    .catch(() => null)
+
+  const style = VERDICT_STYLES[verdict?.verdict] ?? VERDICT_STYLES.inverifiable
+  const claim = verdict ? truncate(verdict.claim, 150) : 'Vérification introuvable'
+  const citations = verdict?.citations?.length ?? 0
+  const horizon = verdict?.data_horizon ?? null
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: '#0D1F3C',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          padding: '80px',
+        }}
+      >
+        <div
+          style={{
+            color: 'rgba(255,255,255,0.55)',
+            fontSize: 18,
+            letterSpacing: '0.15em',
+            textTransform: 'uppercase',
+            marginBottom: 28,
+            fontFamily: 'sans-serif',
+          }}
+        >
+          MonÉlu — Vérification d&apos;une affirmation
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            marginBottom: 36,
+          }}
+        >
+          <div
+            style={{
+              background: style.color,
+              color: '#ffffff',
+              fontSize: 44,
+              fontWeight: 700,
+              fontFamily: 'sans-serif',
+              letterSpacing: '0.08em',
+              padding: '14px 36px',
+              borderRadius: 12,
+            }}
+          >
+            {style.label}
+          </div>
+        </div>
+
+        <div
+          style={{
+            color: '#ffffff',
+            fontSize: 40,
+            fontStyle: 'italic',
+            lineHeight: 1.3,
+            fontFamily: 'serif',
+            maxWidth: 1000,
+            marginBottom: 44,
+          }}
+        >
+          « {claim} »
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            color: 'rgba(255,255,255,0.6)',
+            fontSize: 22,
+            fontFamily: 'sans-serif',
+          }}
+        >
+          {citations > 0
+            ? `${citations} scrutin${citations > 1 ? 's' : ''} officiel${citations > 1 ? 's' : ''} cité${citations > 1 ? 's' : ''}`
+            : 'Vérifié contre les scrutins officiels'}
+          {horizon ? ` · données depuis le ${horizon}` : ''}
+          {' · mon-elu.vercel.app/verifier'}
+        </div>
+
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 60,
+            right: 80,
+            width: 8,
+            height: 200,
+            background: style.color,
+            borderRadius: 4,
+          }}
+        />
+      </div>
+    ),
+    { ...size }
+  )
+}


### PR DESCRIPTION
## What

Final piece of the MON-111 fact-check epic: when a `/verifier/v/<id>` share URL is posted on social media, the preview now shows a verdict card instead of the generic site image.

- New `frontend/src/app/verifier/v/[id]/opengraph-image.tsx` - 1200x630 `next/og` `ImageResponse` on the edge runtime, templated on the existing site `opengraph-image.tsx` (same navy background, serif/sans hierarchy, accent bar - the bar takes the verdict color).
- Card content: verdict label in its color (VRAI emerald / FAUX civic red / TROMPEUR amber / INVÉRIFIABLE gray), the quoted claim truncated at 150 chars, citation count, data horizon, and MonÉlu branding.
- Reads the stored verdict via `GET /verify/{id}` (**no LLM call** - ADR-022) with a 24h revalidate since verdicts are immutable snapshots; unknown ids degrade to a neutral 'Vérification introuvable' card rather than erroring the crawler.
- The share page's `<meta>` title/description were already wired in MON-127's `generateMetadata`; this route auto-registers the `og:image`.

## Acceptance criteria mapping

- **OG image URL returns a 1200x630 PNG with verdict, claim, branding** -> `ImageResponse` with `size = 1200x630`, `contentType image/png`.
- **All four verdicts render with distinct, legible styling** -> `VERDICT_STYLES` map; badge and accent bar per verdict color.
- **Generic site OG image unchanged for all other pages** -> only a new file under `verifier/v/[id]/`; root `opengraph-image.tsx` untouched.
- **lint and build pass** -> see test plan.

## Test plan

- `npm run lint` - clean. `npm test` - 85 passed. `npm run build` - succeeds; the OG route compiles on edge runtime.
- Visual check of the rendered PNG is part of the epic-wide end-to-end pass (screenshots to follow on the epic).

## Deploy risk

None - frontend-only, one new route file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsiwrLjnhvMAidpyGbYytj