### PR TITLE
Remove Vérifier link from nav menu

### DIFF
--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,29 +1,22 @@
 'use client'
 import Link from 'next/link'
-import { usePathname, useSearchParams } from 'next/navigation'
+import { usePathname } from 'next/navigation'
 
 const items = [
   { href: '/', label: 'Accueil', icon: '⌂' },
   { href: '/deputes', label: 'Députés', icon: '◉' },
   { href: '/votes', label: 'Votes', icon: '◈' },
   { href: '/chat', label: 'Chat IA', icon: '◎' },
-  { href: '/chat?mode=verify', label: 'Vérifier', icon: '✓' },
 ]
 
 export function BottomNav() {
   const path = usePathname()
-  const searchParams = useSearchParams()
-  const verifyMode = searchParams.get('mode') === 'verify'
   return (
     <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-gray-border z-50">
-      <div className="grid grid-cols-5">
+      <div className="grid grid-cols-4">
         {items.map(item => {
           const active =
-            item.href === '/chat'
-              ? path === '/chat' && !verifyMode
-              : item.href === '/chat?mode=verify'
-                ? path === '/chat' && verifyMode
-                : path === item.href || (item.href !== '/' && path.startsWith(item.href))
+            path === item.href || (item.href !== '/' && path.startsWith(item.href))
           return (
             <Link key={item.href} href={item.href}
               className={`flex flex-col items-center justify-center py-3 gap-0.5 text-xs font-medium transition-colors

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { usePathname, useSearchParams } from 'next/navigation'
+import { usePathname } from 'next/navigation'
 import { MonEluLogo } from './MonEluLogo'
 import { GlobalSearch } from './GlobalSearch'
 import { FollowedDeputyChip } from './FollowedDeputyChip'
@@ -12,14 +12,11 @@ const navLinks = [
   { href: '/deputes', label: 'Députés' },
   { href: '/votes', label: 'Votes' },
   { href: '/chat', label: 'Chat IA' },
-  { href: '/chat?mode=verify', label: 'Vérifier' },
   { href: '/a-propos', label: 'À propos' },
 ]
 
 export function Nav() {
   const pathname = usePathname()
-  const searchParams = useSearchParams()
-  const verifyMode = searchParams.get('mode') === 'verify'
 
   return (
     <nav
@@ -31,12 +28,7 @@ export function Nav() {
       </Link>
       <div className="flex items-center gap-8 text-sm font-medium text-gray-mid">
         {navLinks.map(({ href, label }) => {
-          const active =
-            href === '/chat'
-              ? pathname === '/chat' && !verifyMode
-              : href === '/chat?mode=verify'
-                ? pathname === '/chat' && verifyMode
-                : pathname === href || pathname.startsWith(href + '/')
+          const active = pathname === href || pathname.startsWith(href + '/')
           return (
             <Link
               key={href}


### PR DESCRIPTION
## Summary
- Removes the "Vérifier" entry from the top nav bar (`Nav.tsx`) and mobile bottom nav (`BottomNav.tsx`)
- Verify mode remains reachable via the chat nudge (ADR-023) and existing `/verifier/v/<id>` share links; only the standalone menu link is removed
- Simplifies now-unneeded verify-mode active-state branching in both nav components
- `BottomNav` grid updated from 5 to 4 columns to match the remaining items

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` on both changed files passes clean
- [ ] Visual check in browser (top nav on desktop, bottom nav on mobile)