### PR TITLE
feat: department pages - les députés de chez moi (MON-107)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Assemblée Nationale Open Data (ZIPs)
 
 **`api/`** — FastAPI application
 - `main.py`: App factory, CORS (GET + POST — POST is needed for `/search`; an empty `CORS_ORIGINS` blocks all cross-origin requests and logs a startup warning), slowapi rate limiting (30 req/min global, 10 req/min on scorecard and search), global exception handler. `/health` returns DB status, record counts, last ingestion timestamp, and dbt mart row counts. The landing page is now the Next.js frontend (`frontend/`), not a FastAPI-served HTML page.
-- `routers/deputies.py`, `routers/votes.py`, `routers/search.py`, `routers/verify.py`: All DB queries — direct SQL, no ORM. `verify.py` is the fact-check surface (MON-126, ADR-022): `POST /verify/` runs the verification chain and stores an immutable verdict snapshot; `GET /verify/{id}` serves stored verdicts with no LLM call.
+- `routers/deputies.py`, `routers/votes.py`, `routers/search.py`, `routers/verify.py`, `routers/departments.py`: All DB queries — direct SQL, no ORM. `verify.py` is the fact-check surface (MON-126, ADR-022): `POST /verify/` runs the verification chain and stores an immutable verdict snapshot; `GET /verify/{id}` serves stored verdicts with no LLM call. `departments.py` (MON-107) serves `GET /departments/{code}` — current deputies of a department with scorecard highlights, aggregates, and recent split votes; the code↔name map lives in `api/departments_data.py` (mirrors `scripts/update_party.py` DEPT_NAMES plus overseas collectivities; frontend copy in `frontend/src/lib/departments.ts`).
 - `schemas.py`: Pydantic response models; all fields `Optional` to match DB NULLs
 - `limiter.py`: Shared slowapi `Limiter` instance imported by routers
 

--- a/api/departments_data.py
+++ b/api/departments_data.py
@@ -1,0 +1,151 @@
+"""
+api/departments_data.py
+
+Department code → full name map used by the /departments router.
+
+Mirrors scripts/update_party.py DEPT_NAMES (same spellings — that script is
+what writes the names into deputies.department) plus the overseas
+collectivities that map lacks (975, 977, 986, 987, 988) and the "99"
+constituency for citizens abroad, both of which still reach the DB as raw
+codes. frontend/src/lib/departments.ts carries the same map for rendering.
+"""
+
+DEPT_NAMES = {
+    "01": "Ain",
+    "02": "Aisne",
+    "03": "Allier",
+    "04": "Alpes-de-Haute-Provence",
+    "05": "Hautes-Alpes",
+    "06": "Alpes-Maritimes",
+    "07": "Ardèche",
+    "08": "Ardennes",
+    "09": "Ariège",
+    "10": "Aube",
+    "11": "Aude",
+    "12": "Aveyron",
+    "13": "Bouches-du-Rhône",
+    "14": "Calvados",
+    "15": "Cantal",
+    "16": "Charente",
+    "17": "Charente-Maritime",
+    "18": "Cher",
+    "19": "Corrèze",
+    "2A": "Corse-du-Sud",
+    "2B": "Haute-Corse",
+    "21": "Côte-d'Or",
+    "22": "Côtes-d'Armor",
+    "23": "Creuse",
+    "24": "Dordogne",
+    "25": "Doubs",
+    "26": "Drôme",
+    "27": "Eure",
+    "28": "Eure-et-Loir",
+    "29": "Finistère",
+    "30": "Gard",
+    "31": "Haute-Garonne",
+    "32": "Gers",
+    "33": "Gironde",
+    "34": "Hérault",
+    "35": "Ille-et-Vilaine",
+    "36": "Indre",
+    "37": "Indre-et-Loire",
+    "38": "Isère",
+    "39": "Jura",
+    "40": "Landes",
+    "41": "Loir-et-Cher",
+    "42": "Loire",
+    "43": "Haute-Loire",
+    "44": "Loire-Atlantique",
+    "45": "Loiret",
+    "46": "Lot",
+    "47": "Lot-et-Garonne",
+    "48": "Lozère",
+    "49": "Maine-et-Loire",
+    "50": "Manche",
+    "51": "Marne",
+    "52": "Haute-Marne",
+    "53": "Mayenne",
+    "54": "Meurthe-et-Moselle",
+    "55": "Meuse",
+    "56": "Morbihan",
+    "57": "Moselle",
+    "58": "Nièvre",
+    "59": "Nord",
+    "60": "Oise",
+    "61": "Orne",
+    "62": "Pas-de-Calais",
+    "63": "Puy-de-Dôme",
+    "64": "Pyrénées-Atlantiques",
+    "65": "Hautes-Pyrénées",
+    "66": "Pyrénées-Orientales",
+    "67": "Bas-Rhin",
+    "68": "Haut-Rhin",
+    "69": "Rhône",
+    "70": "Haute-Saône",
+    "71": "Saône-et-Loire",
+    "72": "Sarthe",
+    "73": "Savoie",
+    "74": "Haute-Savoie",
+    "75": "Paris",
+    "76": "Seine-Maritime",
+    "77": "Seine-et-Marne",
+    "78": "Yvelines",
+    "79": "Deux-Sèvres",
+    "80": "Somme",
+    "81": "Tarn",
+    "82": "Tarn-et-Garonne",
+    "83": "Var",
+    "84": "Vaucluse",
+    "85": "Vendée",
+    "86": "Vienne",
+    "87": "Haute-Vienne",
+    "88": "Vosges",
+    "89": "Yonne",
+    "90": "Territoire de Belfort",
+    "91": "Essonne",
+    "92": "Hauts-de-Seine",
+    "93": "Seine-Saint-Denis",
+    "94": "Val-de-Marne",
+    "95": "Val-d'Oise",
+    "971": "Guadeloupe",
+    "972": "Martinique",
+    "973": "Guyane",
+    "974": "La Réunion",
+    "975": "Saint-Pierre-et-Miquelon",
+    "976": "Mayotte",
+    # Single AN constituency covering both collectivities
+    "977": "Saint-Barthélemy et Saint-Martin",
+    "986": "Wallis-et-Futuna",
+    "987": "Polynésie française",
+    "988": "Nouvelle-Calédonie",
+    "99": "Français établis hors de France",
+}
+
+
+def normalize_code(raw: str) -> str | None:
+    """Canonical department code from user input, or None if not code-shaped.
+
+    Accepts "33", "2a", "099" (AN data zero-pads some codes to three digits)
+    and returns "33" / "2A" / "99". Codes absent from DEPT_NAMES return None.
+    """
+    upper = raw.strip().upper()
+    if not upper or len(upper) > 3:
+        return None
+    # Strip the AN zero-padding ("099" → "99") but keep real 3-digit
+    # overseas codes ("971") intact.
+    if len(upper) == 3 and upper.startswith("0"):
+        upper = upper[1:]
+    return upper if upper in DEPT_NAMES else None
+
+
+def db_department_values(code: str) -> list[str]:
+    """All spellings under which deputies.department may store this code.
+
+    Most rows hold the full name (written by scripts/update_party.py), but
+    codes absent from that script's map — and the zero-padded "099" — are
+    stored raw, so the lookup must match every form.
+    """
+    values = [DEPT_NAMES[code], code]
+    if len(code) == 2 and code.isdigit():
+        values.append(f"0{code}")
+    return values

--- a/api/main.py
+++ b/api/main.py
@@ -184,11 +184,12 @@ app.add_middleware(
 # ---------------------------------------------------------------------------
 # Routers
 # ---------------------------------------------------------------------------
-from api.routers import deputies, feedback, keys, votes  # noqa: E402
+from api.routers import departments, deputies, feedback, keys, votes  # noqa: E402
 from api.routers.search import router as search_router  # noqa: E402
 from api.routers.verify import router as verify_router  # noqa: E402
 
 app.include_router(deputies.router, prefix="/deputies", tags=["Deputies"])
+app.include_router(departments.router, prefix="/departments", tags=["Departments"])
 app.include_router(votes.router, prefix="/votes", tags=["Votes"])
 app.include_router(search_router, prefix="/search", tags=["Search"])
 app.include_router(verify_router, prefix="/verify", tags=["Verify"])

--- a/api/routers/departments.py
+++ b/api/routers/departments.py
@@ -1,0 +1,170 @@
+"""
+api/routers/departments.py
+
+Department pages — "les députés de chez moi" (MON-107).
+
+One read endpoint returning everything the /departements/[code] frontend
+page needs: the department's current deputies with scorecard highlights,
+department-level aggregates, and recent votes where the deputies split.
+
+Mart-derived fields (presence, alignment) degrade to None when the dbt
+marts are absent, mirroring /health rather than failing the whole page.
+"""
+
+from collections import Counter
+
+import psycopg2.errors
+from fastapi import APIRouter, HTTPException, Query
+from starlette.requests import Request
+
+from api.db import get_conn
+from api.departments_data import DEPT_NAMES, db_department_values, normalize_code
+from api.limiter import limiter, tiered_limit
+from api.schemas import (
+    DepartmentDeputy,
+    DepartmentDetail,
+    DepartmentPartyCount,
+    DepartmentSplitVote,
+)
+
+router = APIRouter()
+
+
+def _fetch_mart_rates(cur, deputy_ids: list[str]) -> dict[str, dict]:
+    """Per-deputy scorecard + alignment rates, {} when the marts are absent.
+
+    Runs in its own savepoint-free branch: an UndefinedTable aborts the
+    transaction, so callers must run this on a dedicated connection.
+    """
+    cur.execute(
+        """
+        SELECT s.deputy_id,
+               s.presence_rate,
+               s.solennel_participation_rate,
+               a.party_alignment_rate,
+               a.dissident_rate
+        FROM analytics_marts.mart_deputy_scorecard s
+        LEFT JOIN analytics_marts.mart_party_alignment a
+            ON a.deputy_id = s.deputy_id
+        WHERE s.deputy_id = ANY(%s)
+        """,
+        (deputy_ids,),
+    )
+    return {r["deputy_id"]: r for r in cur.fetchall()}
+
+
+@router.get("/{code}", response_model=DepartmentDetail)
+@limiter.limit(tiered_limit(30))
+def get_department(
+    request: Request,
+    code: str,
+    split_votes_limit: int = Query(10, ge=1, le=50),
+):
+    canonical = normalize_code(code)
+    if canonical is None:
+        raise HTTPException(status_code=404, detail="Unknown department code")
+
+    dept_values = db_department_values(canonical)
+
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            # Current deputies only (mandate_end IS NULL) — the page answers
+            # "who represents me now", not the historical roster.
+            cur.execute(
+                """
+                SELECT deputy_id, full_name, party, party_short,
+                       department, circonscription, photo_url
+                FROM deputies
+                WHERE department = ANY(%s) AND mandate_end IS NULL
+                -- circonscription is TEXT holding a bare number ("1", "10"):
+                -- sort numerically, not lexicographically
+                ORDER BY NULLIF(regexp_replace(circonscription, '[^0-9]', '', 'g'), '')::int
+                         NULLS LAST,
+                         last_name, first_name
+                """,
+                (dept_values,),
+            )
+            deputy_rows = cur.fetchall()
+
+            if not deputy_rows:
+                raise HTTPException(
+                    status_code=404, detail="No active deputies for this department"
+                )
+
+            deputy_ids = [r["deputy_id"] for r in deputy_rows]
+
+            # Recent votes where the department's deputies expressed opposing
+            # positions (at least one pour and one contre). Raw tables only —
+            # this works even when the dbt marts are missing.
+            cur.execute(
+                """
+                SELECT v.vote_id, v.voted_at, v.vote_title, v.result,
+                       COUNT(*) FILTER (WHERE vp.position = 'pour')       AS pour,
+                       COUNT(*) FILTER (WHERE vp.position = 'contre')     AS contre,
+                       COUNT(*) FILTER (WHERE vp.position = 'abstention') AS abstention
+                FROM vote_positions vp
+                JOIN votes v ON v.vote_id = vp.vote_id
+                WHERE vp.deputy_id = ANY(%s)
+                  AND vp.position IN ('pour', 'contre', 'abstention')
+                GROUP BY v.vote_id, v.voted_at, v.vote_title, v.result
+                HAVING COUNT(*) FILTER (WHERE vp.position = 'pour') > 0
+                   AND COUNT(*) FILTER (WHERE vp.position = 'contre') > 0
+                ORDER BY v.voted_at DESC NULLS LAST
+                LIMIT %s
+                """,
+                (deputy_ids, split_votes_limit),
+            )
+            split_rows = cur.fetchall()
+
+    # Mart highlights on a fresh connection: an UndefinedTable error aborts
+    # the whole transaction, which would poison the queries above if shared.
+    rates: dict[str, dict] = {}
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                rates = _fetch_mart_rates(cur, deputy_ids)
+    except psycopg2.errors.UndefinedTable:
+        rates = {}
+
+    deputies = [
+        DepartmentDeputy(
+            **row,
+            presence_rate=_rate(rates, row["deputy_id"], "presence_rate"),
+            solennel_participation_rate=_rate(
+                rates, row["deputy_id"], "solennel_participation_rate"
+            ),
+            party_alignment_rate=_rate(rates, row["deputy_id"], "party_alignment_rate"),
+            dissident_rate=_rate(rates, row["deputy_id"], "dissident_rate"),
+        )
+        for row in deputy_rows
+    ]
+
+    presence_values = [d.presence_rate for d in deputies if d.presence_rate is not None]
+    avg_presence = sum(presence_values) / len(presence_values) if presence_values else None
+
+    party_counts = Counter(d.party for d in deputies)
+    party_distribution = [
+        DepartmentPartyCount(party=party, count=count)
+        for party, count in party_counts.most_common()
+    ]
+
+    dissidents = [d for d in deputies if d.dissident_rate is not None]
+    most_dissident = max(dissidents, key=lambda d: d.dissident_rate) if dissidents else None
+
+    return DepartmentDetail(
+        code=canonical,
+        name=DEPT_NAMES[canonical],
+        deputy_count=len(deputies),
+        deputies=deputies,
+        avg_presence_rate=avg_presence,
+        party_distribution=party_distribution,
+        most_dissident=most_dissident,
+        split_votes=[DepartmentSplitVote(**r) for r in split_rows],
+    )
+
+
+def _rate(rates: dict[str, dict], deputy_id: str, key: str) -> float | None:
+    row = rates.get(deputy_id)
+    if row is None or row.get(key) is None:
+        return None
+    return float(row[key])

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -173,6 +173,60 @@ class DeputyListResponse(_Base):
 
 
 # ---------------------------------------------------------------------------
+# Departments (MON-107)
+# ---------------------------------------------------------------------------
+
+
+class DepartmentDeputy(DeputySummary):
+    """Deputy row on a department page — summary plus scorecard highlights.
+
+    Mart-derived rates are None when the dbt marts are absent (the page
+    degrades gracefully instead of failing).
+    """
+
+    presence_rate: Optional[float] = None
+    solennel_participation_rate: Optional[float] = None
+    party_alignment_rate: Optional[float] = None
+    dissident_rate: Optional[float] = None
+
+
+class DepartmentPartyCount(_Base):
+    party: Optional[str] = None
+    count: int
+
+
+class DepartmentSplitVote(_Base):
+    """A recent vote where the department's deputies expressed opposing positions."""
+
+    vote_id: str
+    voted_at: Optional[datetime] = None
+    vote_title: str
+    result: Optional[str] = None
+    pour: int
+    contre: int
+    abstention: int
+
+
+class DepartmentDetail(_Base):
+    code: str
+    name: str
+    deputy_count: int
+    deputies: list[DepartmentDeputy]
+    avg_presence_rate: Optional[float] = Field(
+        default=None,
+        description="Mean presence_rate across the department's deputies; "
+        "None when the scorecard mart is unavailable.",
+    )
+    party_distribution: list[DepartmentPartyCount]
+    most_dissident: Optional[DepartmentDeputy] = Field(
+        default=None,
+        description="Deputy with the highest dissident_rate; None when the "
+        "alignment mart is unavailable or the department is empty.",
+    )
+    split_votes: list[DepartmentSplitVote]
+
+
+# ---------------------------------------------------------------------------
 # Votes (scrutins)
 # ---------------------------------------------------------------------------
 

--- a/frontend/__tests__/lib/departments.test.ts
+++ b/frontend/__tests__/lib/departments.test.ts
@@ -1,4 +1,4 @@
-import { departmentLabel } from '@/lib/departments'
+import { departmentCode, departmentLabel, departmentName } from '@/lib/departments'
 
 describe('departmentLabel', () => {
   it('returns null for null, undefined, and empty input', () => {
@@ -43,5 +43,42 @@ describe('departmentLabel', () => {
     )
     expect(departmentLabel('998')).toBe('998')
     expect(departmentLabel('Atlantide')).toBe('Atlantide')
+  })
+})
+
+describe('departmentCode', () => {
+  it('returns null for null, undefined, and empty input', () => {
+    expect(departmentCode(null)).toBeNull()
+    expect(departmentCode(undefined)).toBeNull()
+    expect(departmentCode('')).toBeNull()
+  })
+
+  it('canonicalizes raw codes', () => {
+    expect(departmentCode('69')).toBe('69')
+    expect(departmentCode('2a')).toBe('2A')
+    expect(departmentCode('099')).toBe('99')
+    expect(departmentCode('971')).toBe('971')
+  })
+
+  it('maps full names to their code', () => {
+    expect(departmentCode('Gironde')).toBe('33')
+    expect(departmentCode('La Réunion')).toBe('974')
+    expect(departmentCode('Français établis hors de France')).toBe('99')
+  })
+
+  it('returns null for unknown values', () => {
+    expect(departmentCode('998')).toBeNull()
+    expect(departmentCode('Atlantide')).toBeNull()
+  })
+})
+
+describe('departmentName', () => {
+  it('maps a canonical code to its full name', () => {
+    expect(departmentName('33')).toBe('Gironde')
+    expect(departmentName('2A')).toBe('Corse-du-Sud')
+  })
+
+  it('returns null for unknown codes', () => {
+    expect(departmentName('998')).toBeNull()
   })
 })

--- a/frontend/__tests__/lib/postal.test.ts
+++ b/frontend/__tests__/lib/postal.test.ts
@@ -1,4 +1,4 @@
-import { resolvePostalCode } from '@/lib/postal'
+import { resolvePostalCode, resolvePostalCodeToDepartment } from '@/lib/postal'
 
 function mockFetch(status: number, body: unknown) {
   global.fetch = jest.fn().mockResolvedValue({
@@ -45,5 +45,26 @@ describe('resolvePostalCode', () => {
     global.fetch = jest.fn().mockRejectedValue(new Error('network error'))
     const result = await resolvePostalCode('75001')
     expect(result).toBeNull()
+  })
+})
+
+describe('resolvePostalCodeToDepartment', () => {
+  it('resolves a valid postal code to its department code and name', async () => {
+    mockFetch(200, [{ departement: { code: '33', nom: 'Gironde' } }])
+    const result = await resolvePostalCodeToDepartment('33000')
+    expect(result).toEqual({ code: '33', nom: 'Gironde' })
+  })
+
+  it('returns null when the departement field is missing', async () => {
+    mockFetch(200, [{}])
+    const result = await resolvePostalCodeToDepartment('33000')
+    expect(result).toBeNull()
+  })
+
+  it('returns null for non-postal-code input without calling fetch', async () => {
+    global.fetch = jest.fn()
+    const result = await resolvePostalCodeToDepartment('Gironde')
+    expect(result).toBeNull()
+    expect(global.fetch).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/app/departements/[code]/page.tsx
+++ b/frontend/src/app/departements/[code]/page.tsx
@@ -1,0 +1,300 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { api } from '@/lib/api'
+import type { DepartmentDeputy } from '@/lib/api'
+import { partyHex, partyShort, formatDate } from '@/lib/utils'
+import { departmentCode } from '@/lib/departments'
+import { DeputyAvatar } from '@/components/DeputyAvatar'
+import { JsonLd } from '@/components/JsonLd'
+import { SITE_URL, buildBreadcrumbJsonLd } from '@/lib/seo'
+
+export const dynamicParams = true
+export const revalidate = 3600
+
+const NAVY   = '#1B2B50'
+const CREAM  = '#F7F4ED'
+const LINE   = '#E4E6EA'
+const RED    = '#C9302A'
+
+// "les députés de la Gironde" needs per-department articles the data does
+// not carry — every phrase below stays article-free on the department name.
+function pageTitle(name: string, code: string): string {
+  return code === '99' ? `Députés ${name}` : `Députés du département ${name} (${code})`
+}
+
+export async function generateMetadata(
+  { params }: { params: Promise<{ code: string }> }
+): Promise<Metadata> {
+  const { code } = await params
+  const canonical = departmentCode(decodeURIComponent(code))
+  if (!canonical) return {}
+  const data = await api.departments.get(canonical).catch(() => null)
+  if (!data) return {}
+  const title = `${pageTitle(data.name, data.code)} - MonÉlu`
+  const description =
+    `Les ${data.deputy_count} députés du département ${data.name} à l'Assemblée nationale : ` +
+    'bilan de vote, présence, groupes politiques et votes qui les divisent.'
+  return {
+    title,
+    description,
+    openGraph: { title, description },
+    twitter: { card: 'summary_large_image', title, description },
+  }
+}
+
+// circonscription is stored as a bare number string ("1", "10").
+function circoNumber(circonscription: string | null): number | null {
+  if (!circonscription) return null
+  const n = parseInt(circonscription, 10)
+  return Number.isNaN(n) ? null : n
+}
+
+// Anchor id for per-circonscription deep links: /departements/33#circo-1
+function circoAnchor(circonscription: string | null): string | undefined {
+  const n = circoNumber(circonscription)
+  return n === null ? undefined : `circo-${n}`
+}
+
+function circoLabel(circonscription: string | null): string | null {
+  const n = circoNumber(circonscription)
+  if (n === null) return circonscription
+  return n === 1 ? '1ère circonscription' : `${n}ème circonscription`
+}
+
+function pct(rate: number | null | undefined): number | null {
+  return rate == null ? null : Math.round(rate * 100)
+}
+
+export default async function DepartmentPage(
+  { params }: { params: Promise<{ code: string }> }
+) {
+  const { code } = await params
+  const canonical = departmentCode(decodeURIComponent(code))
+  if (!canonical) notFound()
+
+  const [data, nationalStats] = await Promise.all([
+    api.departments.get(canonical).catch(() => null),
+    api.deputies.stats().catch(() => null),
+  ])
+  if (!data) notFound()
+
+  const avgPresencePct = pct(data.avg_presence_rate)
+  const nationalPresencePct = pct(nationalStats?.avg_presence_rate)
+  const maxPartyCount = data.party_distribution[0]?.count ?? 1
+  const dissident = data.most_dissident
+  const dissidentPct = pct(dissident?.dissident_rate)
+
+  const breadcrumb = buildBreadcrumbJsonLd([
+    { name: 'Accueil', url: SITE_URL },
+    { name: 'Députés', url: `${SITE_URL}/deputes` },
+    { name: `${data.name} (${data.code})`, url: `${SITE_URL}/departements/${data.code}` },
+  ])
+
+  return (
+    <div style={{ background: CREAM, minHeight: '100vh' }}>
+      <JsonLd data={breadcrumb} />
+
+      {/* Hero */}
+      <div
+        className="px-5 sm:px-14 pt-8 sm:pt-[50px] pb-8 sm:pb-10"
+        style={{
+          background: `linear-gradient(180deg,#fff 0%,${CREAM} 100%)`,
+          borderBottom: '1px solid #ECE7DC',
+        }}
+      >
+        <div style={{ maxWidth: 1180, margin: '0 auto' }}>
+          <div style={{
+            fontWeight: 700, fontSize: 12, letterSpacing: '0.18em',
+            textTransform: 'uppercase', color: RED, marginBottom: 16,
+          }}>
+            {data.code === '99' ? 'Circonscriptions des Français de l’étranger' : `Département ${data.code}`}
+          </div>
+          <h1 className="font-newsreader text-[clamp(32px,4vw,48px)]" style={{
+            fontWeight: 600, lineHeight: 1.05, letterSpacing: '-0.015em',
+            color: NAVY, margin: 0, maxWidth: 760,
+          }}>
+            {data.name}
+          </h1>
+          <p style={{ margin: '16px 0 0', fontSize: 17, lineHeight: 1.6, color: '#4B5563', maxWidth: 560 }}>
+            Les {data.deputy_count} député{data.deputy_count !== 1 ? 's' : ''} de ce
+            territoire à l&apos;Assemblée nationale : bilan de vote, présence et votes
+            qui les divisent.
+          </p>
+
+          {/* Aggregate cards */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4" style={{ marginTop: 30, maxWidth: 900 }}>
+            {avgPresencePct !== null && (
+              <div style={{ background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12, padding: '20px 22px' }}>
+                <div style={{ fontSize: 13, color: '#6B7280', fontWeight: 500, marginBottom: 8 }}>
+                  Présence moyenne
+                </div>
+                <div className="font-mono" style={{ fontWeight: 700, fontSize: 26, color: NAVY }}>
+                  {avgPresencePct}%
+                </div>
+                {nationalPresencePct !== null && (
+                  <div style={{ fontSize: 12.5, color: '#9CA3AF', marginTop: 6 }}>
+                    Moyenne nationale : {nationalPresencePct}%
+                  </div>
+                )}
+              </div>
+            )}
+            {dissident && dissidentPct !== null && (
+              <div style={{ background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12, padding: '20px 22px' }}>
+                <div style={{ fontSize: 13, color: '#6B7280', fontWeight: 500, marginBottom: 8 }}>
+                  Député le plus dissident
+                </div>
+                <Link href={`/deputes/${dissident.deputy_id}`} style={{ fontWeight: 600, fontSize: 16, color: NAVY, textDecoration: 'none' }}>
+                  {dissident.full_name}
+                </Link>
+                <div style={{ fontSize: 12.5, color: '#9CA3AF', marginTop: 6 }}>
+                  Vote contre son groupe dans {dissidentPct}% des scrutins
+                </div>
+              </div>
+            )}
+            <div style={{ background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12, padding: '20px 22px' }}>
+              <div style={{ fontSize: 13, color: '#6B7280', fontWeight: 500, marginBottom: 12 }}>
+                Répartition par groupe
+              </div>
+              {data.party_distribution.map(g => (
+                <div key={g.party ?? 'Non inscrit'} style={{ marginBottom: 9 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontSize: 12.5, marginBottom: 4 }}>
+                    <span style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+                      <span style={{ width: 8, height: 8, borderRadius: 999, flexShrink: 0, background: partyHex(g.party) }} />
+                      <span style={{ color: '#374151', fontWeight: 600 }}>{partyShort(g.party) || 'Non inscrit'}</span>
+                    </span>
+                    <span className="font-mono" style={{ color: '#9CA3AF' }}>{g.count}</span>
+                  </div>
+                  <div style={{ height: 5, borderRadius: 999, background: '#F0F1F3', overflow: 'hidden' }}>
+                    <div style={{ height: '100%', width: `${(g.count / maxPartyCount) * 100}%`, background: partyHex(g.party), borderRadius: 999 }} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="px-5 sm:px-14 pt-10 pb-14 sm:pb-[72px]">
+        <div style={{ maxWidth: 1180, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 48 }}>
+
+          {/* Deputies */}
+          <section>
+            <div style={{ fontWeight: 700, fontSize: 12, letterSpacing: '0.18em', textTransform: 'uppercase', color: RED }}>
+              Vos élus
+            </div>
+            <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: NAVY, margin: '12px 0 22px', letterSpacing: '-0.01em' }}>
+              Député{data.deputy_count !== 1 ? 's' : ''} par circonscription
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+              {data.deputies.map((d: DepartmentDeputy) => {
+                const hex = partyHex(d.party)
+                const presence = pct(d.presence_rate)
+                const alignment = pct(d.party_alignment_rate)
+                return (
+                  <Link
+                    key={d.deputy_id}
+                    id={circoAnchor(d.circonscription)}
+                    href={`/deputes/${d.deputy_id}`}
+                    style={{
+                      display: 'block', background: '#fff', border: `1px solid ${LINE}`,
+                      borderRadius: 12, padding: '20px 22px', textDecoration: 'none',
+                      boxShadow: '0 1px 3px rgba(0,0,0,0.05)',
+                    }}
+                  >
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 14, minWidth: 0 }}>
+                      <DeputyAvatar name={d.full_name} photoUrl={d.photo_url} size="sm" />
+                      <div style={{ minWidth: 0 }}>
+                        <div style={{ fontWeight: 600, fontSize: 15.5, color: NAVY, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                          {d.full_name}
+                        </div>
+                        <div style={{ fontSize: 13, color: '#9CA3AF', marginTop: 3 }}>
+                          {circoLabel(d.circonscription) ?? '—'}
+                        </div>
+                      </div>
+                    </div>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 14, flexWrap: 'wrap' }}>
+                      <span style={{
+                        display: 'inline-flex', alignItems: 'center', gap: 6,
+                        padding: '3px 10px', borderRadius: 999,
+                        background: `${hex}14`, border: `1px solid ${hex}40`,
+                        color: hex, fontWeight: 600, fontSize: 12,
+                      }}>
+                        <span style={{ width: 7, height: 7, borderRadius: 999, background: hex }} />
+                        {partyShort(d.party) || 'NI'}
+                      </span>
+                      {presence !== null && (
+                        <span className="font-mono" style={{ fontSize: 12, color: '#6B7280' }}>
+                          Présence {presence}%
+                        </span>
+                      )}
+                      {alignment !== null && (
+                        <span className="font-mono" style={{ fontSize: 12, color: '#6B7280' }}>
+                          Groupe {alignment}%
+                        </span>
+                      )}
+                    </div>
+                  </Link>
+                )
+              })}
+            </div>
+          </section>
+
+          {/* Split votes */}
+          {data.split_votes.length > 0 && (
+            <section>
+              <div style={{ fontWeight: 700, fontSize: 12, letterSpacing: '0.18em', textTransform: 'uppercase', color: RED }}>
+                Là où ils se divisent
+              </div>
+              <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: NAVY, margin: '12px 0 8px', letterSpacing: '-0.01em' }}>
+                Votes récents où vos députés n&apos;étaient pas d&apos;accord
+              </h2>
+              <p style={{ margin: '0 0 22px', fontSize: 14.5, color: '#6B7280', maxWidth: 640 }}>
+                Scrutins où au moins un député du territoire a voté pour et un autre contre.
+              </p>
+              <div style={{
+                background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12,
+                overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
+              }}>
+                {data.split_votes.map((v, i) => (
+                  <Link
+                    key={v.vote_id}
+                    href={`/votes/${v.vote_id}`}
+                    style={{
+                      display: 'block', padding: '16px 22px', textDecoration: 'none',
+                      borderBottom: i < data.split_votes.length - 1 ? '1px solid #F0F1F3' : 'none',
+                    }}
+                  >
+                    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 16, alignItems: 'baseline', flexWrap: 'wrap' }}>
+                      <span style={{ fontWeight: 600, fontSize: 14.5, color: NAVY, flex: '1 1 380px', minWidth: 0 }}>
+                        {v.vote_title}
+                      </span>
+                      <span style={{ display: 'flex', gap: 12, alignItems: 'baseline', whiteSpace: 'nowrap' }}>
+                        <span className="font-mono" style={{ fontSize: 12.5, color: '#15803D' }}>{v.pour} pour</span>
+                        <span className="font-mono" style={{ fontSize: 12.5, color: RED }}>{v.contre} contre</span>
+                        {v.abstention > 0 && (
+                          <span className="font-mono" style={{ fontSize: 12.5, color: '#9CA3AF' }}>{v.abstention} abst.</span>
+                        )}
+                      </span>
+                    </div>
+                    <div style={{ fontSize: 12.5, color: '#9CA3AF', marginTop: 5 }}>
+                      {v.voted_at ? formatDate(v.voted_at) : ''}
+                      {v.result ? ` · ${v.result === 'adopté' ? 'Adopté' : 'Rejeté'}` : ''}
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Cross-link */}
+          <div>
+            <Link href="/deputes" style={{ fontSize: 14, color: NAVY, textDecoration: 'underline' }}>
+              ← Tous les députés de l&apos;Assemblée nationale
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/deputes/DeputiesClient.tsx
+++ b/frontend/src/app/deputes/DeputiesClient.tsx
@@ -6,7 +6,7 @@ import { Deputy } from '@/lib/api'
 import { getInitials, partyHex, partyShort } from '@/lib/utils'
 import { DeputyAvatar } from '@/components/DeputyAvatar'
 import { resolvePostalCode } from '@/lib/postal'
-import { departmentLabel } from '@/lib/departments'
+import { departmentCode, departmentLabel } from '@/lib/departments'
 
 type DeputyList = { total: number; items: Deputy[]; limit: number; offset: number }
 type SortKey = 'nom' | 'region' | 'parti'
@@ -44,6 +44,9 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
   const postalMatch = postalResult?.code === debouncedSearch ? postalResult : null
   const resolvedDepartment = postalMatch?.department ?? ''
   const postalNotFound = postalMatch !== null && postalMatch.department === null
+  // Department page cross-link (MON-107) — shown when the search resolves to
+  // a department, whether via a postal code or a typed name/code.
+  const matchedDeptCode = departmentCode(resolvedDepartment || debouncedSearch)
 
   const skipFirstSync = useRef(true)
   useEffect(() => {
@@ -241,6 +244,24 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
       {/* Table section */}
       <div className="px-5 sm:px-14 pt-8 pb-14 sm:pb-[72px]">
         <div style={{ maxWidth: 1180, margin: '0 auto' }}>
+
+          {/* Department page cross-link */}
+          {matchedDeptCode && (
+            <div style={{ padding: '0 4px 14px' }}>
+              <Link
+                href={`/departements/${matchedDeptCode}`}
+                style={{
+                  display: 'inline-flex', alignItems: 'center', gap: 8,
+                  background: '#fff', border: '1px solid ' + LINE, borderRadius: 999,
+                  padding: '8px 16px', fontSize: 13.5, fontWeight: 600,
+                  color: NAVY, textDecoration: 'none',
+                  boxShadow: '0 1px 3px rgba(0,0,0,0.05)',
+                }}
+              >
+                Voir la page du département {departmentLabel(matchedDeptCode)} →
+              </Link>
+            </div>
+          )}
 
           {/* Count row */}
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 4px 14px' }}>

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { api } from '@/lib/api'
 import type { DissidentVoteItem } from '@/lib/api'
 import { partyHex, formatDate } from '@/lib/utils'
-import { departmentLabel } from '@/lib/departments'
+import { departmentCode, departmentLabel } from '@/lib/departments'
 import { positionStyle } from '@/lib/vote-position'
 import { DeputyAvatar } from '@/components/DeputyAvatar'
 import { ShareButton } from '@/components/ShareButton'
@@ -74,6 +74,7 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
 
   const hex = partyHex(deputy.party)
   const deptLabel = departmentLabel(deputy.department)
+  const deptCode = departmentCode(deputy.department)
 
   // MON-123: "votes exprimés" (present_votes = pour + contre + abstention)
   // duplicated "scrutins votés" whenever the deputy has no non-votant
@@ -151,7 +152,13 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#9CA3AF" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
                     <path d="M12 21s-7-5.6-7-11a7 7 0 0 1 14 0c0 5.4-7 11-7 11Z"/><circle cx="12" cy="10" r="2.4"/>
                   </svg>
-                  {deptLabel}
+                  {deptCode ? (
+                    <Link href={`/departements/${deptCode}`} style={{ color: '#4B5563', textDecoration: 'underline', textDecorationColor: '#C4C9D2', textUnderlineOffset: 3 }}>
+                      {deptLabel}
+                    </Link>
+                  ) : (
+                    deptLabel
+                  )}
                 </div>
               )}
               {deputy.party && (

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from 'next'
 import { api, type Deputy, type Vote } from '@/lib/api'
+import { departmentCode } from '@/lib/departments'
 
 const SITE_URL = 'https://mon-elu.vercel.app'
 const PAGE_SIZE = 200
@@ -25,7 +26,7 @@ function toVoteUrl(v: Vote): MetadataRoute.Sitemap[number] {
   }
 }
 
-async function deputyUrls(): Promise<MetadataRoute.Sitemap> {
+async function deputyAndDepartmentUrls(): Promise<MetadataRoute.Sitemap> {
   const first = await api.deputies.list({ limit: PAGE_SIZE, offset: 0 })
   const offsets: number[] = []
   for (let offset = PAGE_SIZE; offset < first.total; offset += PAGE_SIZE) offsets.push(offset)
@@ -33,8 +34,22 @@ async function deputyUrls(): Promise<MetadataRoute.Sitemap> {
   const rest = await Promise.all(
     offsets.map(offset => api.deputies.list({ limit: PAGE_SIZE, offset }))
   )
+  const deputies = [first, ...rest].flatMap(page => page.items)
 
-  return [first, ...rest].flatMap(page => page.items.map(toDeputyUrl))
+  // Department pages (MON-107), derived from the same fetch so only
+  // departments that actually have deputies get a sitemap entry.
+  const codes = new Set<string>()
+  for (const d of deputies) {
+    const code = departmentCode(d.department)
+    if (code) codes.add(code)
+  }
+  const departmentUrls: MetadataRoute.Sitemap = [...codes].sort().map(code => ({
+    url: `${SITE_URL}/departements/${code}`,
+    changeFrequency: 'weekly',
+    priority: 0.7,
+  }))
+
+  return [...deputies.map(toDeputyUrl), ...departmentUrls]
 }
 
 async function voteUrls(): Promise<MetadataRoute.Sitemap> {
@@ -70,7 +85,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${SITE_URL}/methodologie`, changeFrequency: 'monthly', priority: 0.5 },
   ]
 
-  const [deputies, votes] = await Promise.all([deputyUrls(), voteUrls()])
+  const [deputiesAndDepartments, votes] = await Promise.all([
+    deputyAndDepartmentUrls(),
+    voteUrls(),
+  ])
 
-  return [...staticUrls, ...deputies, ...votes]
+  return [...staticUrls, ...deputiesAndDepartments, ...votes]
 }

--- a/frontend/src/components/HeroSearch.tsx
+++ b/frontend/src/components/HeroSearch.tsx
@@ -1,7 +1,8 @@
 'use client'
 import { useState, FormEvent } from 'react'
 import { useRouter } from 'next/navigation'
-import { resolvePostalCode } from '@/lib/postal'
+import { resolvePostalCodeToDepartment } from '@/lib/postal'
+import { departmentCode } from '@/lib/departments'
 
 type HeroSearchProps = {
   id?: string
@@ -23,9 +24,18 @@ export function HeroSearch({
     const trimmed = value.trim()
     if (!trimmed) return
     setLoading(true)
-    const resolved = await resolvePostalCode(trimmed)
-    const query = resolved ?? trimmed
-    router.push(`/deputes?search=${encodeURIComponent(query)}`)
+    // Postal codes and department names land on the department page
+    // ("les députés de chez moi", MON-107); everything else falls back to
+    // the deputy directory search.
+    const resolved = await resolvePostalCodeToDepartment(trimmed)
+    const code = resolved
+      ? (departmentCode(resolved.code) ?? departmentCode(resolved.nom))
+      : departmentCode(trimmed)
+    if (code) {
+      router.push(`/departements/${code}`)
+      return
+    }
+    router.push(`/deputes?search=${encodeURIComponent(trimmed)}`)
   }
 
   return (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -122,6 +122,41 @@ export type DeputyVotesResponse = {
   items: DeputyVoteItem[]
 }
 
+export type DepartmentDeputy = {
+  deputy_id: string
+  full_name: string
+  party: string | null
+  party_short: string | null
+  department: string | null
+  circonscription: string | null
+  photo_url: string | null
+  presence_rate: number | null
+  solennel_participation_rate: number | null
+  party_alignment_rate: number | null
+  dissident_rate: number | null
+}
+
+export type DepartmentSplitVote = {
+  vote_id: string
+  voted_at: string | null
+  vote_title: string
+  result: string | null
+  pour: number
+  contre: number
+  abstention: number
+}
+
+export type DepartmentDetail = {
+  code: string
+  name: string
+  deputy_count: number
+  deputies: DepartmentDeputy[]
+  avg_presence_rate: number | null
+  party_distribution: Array<{ party: string | null; count: number }>
+  most_dissident: DepartmentDeputy | null
+  split_votes: DepartmentSplitVote[]
+}
+
 export type SearchResult = {
   answer: string
   question: string
@@ -234,6 +269,10 @@ export const api = {
         `/deputies/${id}/diverging-votes/?other_deputy_id=${encodeURIComponent(otherId)}&limit=${limit}`,
         { revalidate: 86400 }
       ),
+  },
+  departments: {
+    get: (code: string) =>
+      apiFetch<DepartmentDetail>(`/departments/${encodeURIComponent(code)}`, { revalidate: 3600 }),
   },
   votes: {
     list: (params?: { result?: string; theme?: string; search?: string; limit?: number; offset?: number; before?: string }) => {

--- a/frontend/src/lib/departments.ts
+++ b/frontend/src/lib/departments.ts
@@ -153,3 +153,23 @@ export function departmentLabel(raw: string | null | undefined): string | null {
     ? `${value} (${codeForName})`
     : value
 }
+
+/**
+ * Canonical department code for a raw code ("33", "099", "2a") or a full
+ * name ("Gironde") — the slug used by /departements/[code]. Returns null
+ * for unknown values.
+ */
+export function departmentCode(raw: string | null | undefined): string | null {
+  if (!raw) return null
+  const value = raw.trim()
+  if (!value) return null
+
+  const code = normalizeCode(value)
+  if (code) return code in DEPARTMENT_NAMES ? code : null
+  return NAME_TO_CODE.get(value) ?? null
+}
+
+/** Full department name for a canonical code, or null if unknown. */
+export function departmentName(code: string): string | null {
+  return DEPARTMENT_NAMES[code] ?? null
+}

--- a/frontend/src/lib/postal.ts
+++ b/frontend/src/lib/postal.ts
@@ -1,8 +1,13 @@
-// Resolves a French postal code to its department name via geo.api.gouv.fr,
-// matching the full-name format stored in deputies.department (see
-// scripts/update_party.py DEPT_NAMES). Non-postal-code input (names,
+// Resolves a French postal code to its department via geo.api.gouv.fr.
+// The name matches the full-name format stored in deputies.department (see
+// scripts/update_party.py DEPT_NAMES); the code is the canonical INSEE code
+// used by the /departements/[code] pages. Non-postal-code input (names,
 // department names) is left for the caller to search on directly.
-export async function resolvePostalCode(input: string): Promise<string | null> {
+export type ResolvedDepartment = { code: string; nom: string }
+
+export async function resolvePostalCodeToDepartment(
+  input: string
+): Promise<ResolvedDepartment | null> {
   if (!/^\d{5}$/.test(input)) return null
 
   try {
@@ -11,8 +16,16 @@ export async function resolvePostalCode(input: string): Promise<string | null> {
     )
     if (!res.ok) return null
     const communes = await res.json()
-    return communes[0]?.departement?.nom ?? null
+    const departement = communes[0]?.departement
+    return departement?.code && departement?.nom
+      ? { code: departement.code, nom: departement.nom }
+      : null
   } catch {
     return null
   }
+}
+
+export async function resolvePostalCode(input: string): Promise<string | null> {
+  const resolved = await resolvePostalCodeToDepartment(input)
+  return resolved?.nom ?? null
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -653,3 +653,113 @@ def test_verify_get_not_found(client, mock_cursor):
 def test_verify_get_invalid_uuid_rejected(client):
     resp = client.get("/verify/not-a-uuid")
     assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Departments (MON-107)
+# ---------------------------------------------------------------------------
+
+_DEPT_DEPUTY_ROWS = [
+    {
+        "deputy_id": "PA1",
+        "full_name": "Jean Martin",
+        "party": "Rassemblement National",
+        "party_short": "RN",
+        "department": "Gironde",
+        "circonscription": "1ère circonscription",
+        "photo_url": None,
+    },
+    {
+        "deputy_id": "PA2",
+        "full_name": "Anne Durand",
+        "party": "La France insoumise",
+        "party_short": "LFI",
+        "department": "Gironde",
+        "circonscription": "2ème circonscription",
+        "photo_url": None,
+    },
+]
+
+_DEPT_SPLIT_ROWS = [
+    {
+        "vote_id": "VTANR5L17V1",
+        "voted_at": datetime(2025, 7, 16, 15, 0),
+        "vote_title": "Vote sur le projet de loi de finances",
+        "result": "adopté",
+        "pour": 1,
+        "contre": 1,
+        "abstention": 0,
+    },
+]
+
+_DEPT_RATE_ROWS = [
+    {
+        "deputy_id": "PA1",
+        "presence_rate": 0.8,
+        "solennel_participation_rate": 0.9,
+        "party_alignment_rate": 0.95,
+        "dissident_rate": 0.05,
+    },
+    {
+        "deputy_id": "PA2",
+        "presence_rate": 0.6,
+        "solennel_participation_rate": 0.7,
+        "party_alignment_rate": 0.85,
+        "dissident_rate": 0.15,
+    },
+]
+
+
+def test_get_department(client, mock_cursor):
+    mock_cursor.fetchall.side_effect = [_DEPT_DEPUTY_ROWS, _DEPT_SPLIT_ROWS, _DEPT_RATE_ROWS]
+    resp = client.get("/departments/33")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["code"] == "33"
+    assert data["name"] == "Gironde"
+    assert data["deputy_count"] == 2
+    assert data["deputies"][0]["presence_rate"] == 0.8
+    assert data["avg_presence_rate"] == 0.7
+    assert {p["party"]: p["count"] for p in data["party_distribution"]} == {
+        "Rassemblement National": 1,
+        "La France insoumise": 1,
+    }
+    assert data["most_dissident"]["deputy_id"] == "PA2"
+    assert data["split_votes"][0]["vote_id"] == "VTANR5L17V1"
+
+
+def test_get_department_zero_padded_code(client, mock_cursor):
+    mock_cursor.fetchall.side_effect = [_DEPT_DEPUTY_ROWS, _DEPT_SPLIT_ROWS, _DEPT_RATE_ROWS]
+    resp = client.get("/departments/099")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["code"] == "99"
+    assert data["name"] == "Français établis hors de France"
+
+
+def test_get_department_unknown_code(client, mock_cursor):
+    resp = client.get("/departments/xx")
+    assert resp.status_code == 404
+
+
+def test_get_department_no_active_deputies(client, mock_cursor):
+    mock_cursor.fetchall.side_effect = [[]]
+    resp = client.get("/departments/2A")
+    assert resp.status_code == 404
+
+
+def test_get_department_marts_missing(client, mock_cursor):
+    import psycopg2.errors
+
+    mock_cursor.fetchall.side_effect = [
+        _DEPT_DEPUTY_ROWS,
+        _DEPT_SPLIT_ROWS,
+        psycopg2.errors.UndefinedTable("mart missing"),
+    ]
+    resp = client.get("/departments/33")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["deputies"][0]["presence_rate"] is None
+    assert data["avg_presence_rate"] is None
+    assert data["most_dissident"] is None
+    assert data["split_votes"][0]["vote_id"] == "VTANR5L17V1"


### PR DESCRIPTION
## What

Department pages ("les députés de chez moi", MON-107): a new `GET /departments/{code}` API endpoint and a `/departements/[code]` frontend page listing all current deputies of a department with scorecard highlights, department-level aggregates, and recent votes where the department's deputies split.
The postal-code lookup now lands on these pages, and every department with deputies gets a sitemap entry.

## Why

The Cevipof 2026 barometer shows trust in national politics at a historic low while local figures keep ~60% trust - proximity is where citizens still engage.
MonÉlu had the postal-code → deputy lookup (MON-84) but no destination page for "my area": once you found your deputy, the local context ended.
These are also ~100 evergreen SEO pages ("députés de la Gironde") with local-press citation potential.

## Changes

**API**

- `api/routers/departments.py` (new): `GET /departments/{code}` returns the department's current deputies (`mandate_end IS NULL`) with per-deputy presence/solennel/alignment/dissident rates, average presence, party distribution, the most dissident deputy, and recent split votes (at least one pour and one contre among the department's deputies).
  Mart-derived fields run on a second connection and degrade to `null` (instead of 503) when the dbt marts are absent, so the page still renders from raw tables.
- `api/departments_data.py` (new): department code ↔ name map mirroring `scripts/update_party.py` `DEPT_NAMES` plus the overseas collectivities that map lacks; `normalize_code()` accepts `33` / `2a` / zero-padded `099`; `db_department_values()` matches every spelling under which `deputies.department` may store a department (full name, raw code, zero-padded code).
- `api/schemas.py`: `DepartmentDetail`, `DepartmentDeputy`, `DepartmentPartyCount`, `DepartmentSplitVote` response models.
- Circonscription is stored as a bare number string, so deputies are ordered numerically (`"2"` before `"10"`).

**Frontend**

- `frontend/src/app/departements/[code]/page.tsx` (new): server-rendered page (ISR 1h) with aggregate cards, party distribution, deputy cards per circonscription (with `#circo-N` anchors), split-votes section, breadcrumb JSON-LD, and metadata.
  Accepts codes and full names in the URL (`/departements/33`, `/departements/Gironde` both resolve; canonical URLs use the code).
- `frontend/src/lib/postal.ts`: `resolvePostalCodeToDepartment()` now returns `{code, nom}` from geo.api.gouv.fr; `resolvePostalCode()` kept as a name-only wrapper for the existing directory filter.
- `frontend/src/components/HeroSearch.tsx`: postal codes and typed department names/codes now land on `/departements/[code]`; other input falls back to the deputy directory search.
- `frontend/src/app/deputes/DeputiesClient.tsx`: when a search resolves to a department, a chip links to its page.
- `frontend/src/app/deputes/[id]/page.tsx`: the deputy's department label links to its department page.
- `frontend/src/lib/departments.ts`: exported `departmentCode()` / `departmentName()` helpers.
- `frontend/src/app/sitemap.ts`: department URLs derived from the same deputies fetch, so only departments that actually have deputies are listed.

**Docs**

- `CLAUDE.md`: router list updated with `departments.py` and the code↔name map locations.

## Testing

- `pytest tests/ -m "not integration"`: 213 passed (5 new tests: happy path, zero-padded code, unknown code 404, empty department 404, marts-missing degradation).
- `ruff check .` and `ruff format --check .` clean repo-wide.
- Frontend: `npm run lint`, `npm test` (94 passed, new tests for `departmentCode`/`departmentName` and `resolvePostalCodeToDepartment`), `npm run build` green with the new route.
- Exercised live against local Docker Postgres (full legislature): `/departments/33` (12 deputies, party distribution, split votes), `/departments/099` → code 99, `/departments/2a` → Corse-du-Sud, unknown codes → 404; marts empty locally, so the degraded path (null rates) was exercised for real.
- Rendered `/departements/33` through `next dev` against the local API: hero, party distribution, deputy cards, and split-votes section all present; unknown code renders the not-found page (same dev-mode status behavior as the existing `/deputes/[id]` route).

## Risks / Notes

- New read-only endpoint and pages; no schema migration, no deploy config change.
- `most_dissident` needs `mart_party_alignment`; in production the marts exist, and the field is `null` otherwise.
- Per-circonscription anchors are the "optional" part of the issue scope; deep-linking uses `#circo-N`.
- The department code↔name map now exists in three places (`scripts/update_party.py`, `api/departments_data.py`, `frontend/src/lib/departments.ts`); collapsing the two backend copies would change ingestion script imports and was left out of scope deliberately.

## Breaking Changes

None.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvxKgBLgWA9TdZrR2NzeEW
