### PR TITLE
feat: drop the position_id surrogate key on vote_positions (MON-77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,9 +256,8 @@ design.
 ### `vote_positions`
 | Column | Type | Notes |
 |---|---|---|
-| `position_id` | BIGSERIAL PK | |
-| `vote_id` | TEXT FK → votes | |
-| `deputy_id` | TEXT FK → deputies | |
+| `vote_id` | TEXT FK → votes | Composite PK with `deputy_id` |
+| `deputy_id` | TEXT FK → deputies | Composite PK with `vote_id` |
 | `position` | VARCHAR(15) | `pour` / `contre` / `abstention` / `nonVotant` |
 
 ### `document_chunks` *(Phase 2)*

--- a/api/routers/votes.py
+++ b/api/routers/votes.py
@@ -186,7 +186,7 @@ def get_vote(request: Request, vote_id: str):
 
                 cur.execute(
                     """
-                    SELECT vp.position_id, vp.deputy_id, d.full_name,
+                    SELECT vp.deputy_id, d.full_name,
                            d.party_short, vp.position
                     FROM vote_positions vp
                     JOIN deputies d ON d.deputy_id = vp.deputy_id

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -195,7 +195,6 @@ class VoteSummary(_Base):
 class VotePosition(_Base):
     """A single deputy's position on a vote."""
 
-    position_id: int
     deputy_id: str
     full_name: str
     party_short: Optional[str] = None

--- a/data/migrations/001_init.sql
+++ b/data/migrations/001_init.sql
@@ -30,14 +30,17 @@ CREATE TABLE IF NOT EXISTS votes (
     ingested_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+-- Natural primary key (vote_id, deputy_id): one position per deputy per
+-- vote, and the ON CONFLICT target of the ingestion upsert. A BIGSERIAL
+-- surrogate this file used to create was dropped in migration 006 (MON-77) —
+-- it was never referenced and wasted ~8 bytes/row plus a redundant index.
 CREATE TABLE IF NOT EXISTS vote_positions (
-    position_id     BIGSERIAL PRIMARY KEY,
     vote_id         TEXT NOT NULL REFERENCES votes(vote_id) ON DELETE CASCADE,
     deputy_id       TEXT NOT NULL REFERENCES deputies(deputy_id) ON DELETE CASCADE,
     position        VARCHAR(15) NOT NULL,       -- "pour" | "contre" | "abstention" | "nonVotant"
     ingested_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
-    UNIQUE (vote_id, deputy_id)                 -- one position per deputy per vote
+    PRIMARY KEY (vote_id, deputy_id)
 );
 
 -- Indexes for common query patterns.

--- a/data/migrations/006_drop_position_id.sql
+++ b/data/migrations/006_drop_position_id.sql
@@ -18,7 +18,8 @@ DO $$
 BEGIN
     IF EXISTS (
         SELECT 1 FROM information_schema.columns
-        WHERE table_name = 'vote_positions'
+        WHERE table_schema = 'public'
+          AND table_name = 'vote_positions'
           AND column_name = 'position_id'
     ) THEN
         -- dbt staging views select position_id and block the column drop.
@@ -27,11 +28,11 @@ BEGIN
         -- The API is unaffected: it only queries raw tables and the marts,
         -- which are materialized as tables.
         DROP VIEW IF EXISTS analytics_staging.stg_vote_positions CASCADE;
-        ALTER TABLE vote_positions DROP CONSTRAINT vote_positions_pkey;
-        ALTER TABLE vote_positions DROP COLUMN position_id;
-        ALTER TABLE vote_positions
+        ALTER TABLE public.vote_positions DROP CONSTRAINT vote_positions_pkey;
+        ALTER TABLE public.vote_positions DROP COLUMN position_id;
+        ALTER TABLE public.vote_positions
             ADD CONSTRAINT vote_positions_pkey PRIMARY KEY (vote_id, deputy_id);
-        ALTER TABLE vote_positions
+        ALTER TABLE public.vote_positions
             DROP CONSTRAINT vote_positions_vote_id_deputy_id_key;
     END IF;
 END $$;

--- a/data/migrations/006_drop_position_id.sql
+++ b/data/migrations/006_drop_position_id.sql
@@ -1,0 +1,37 @@
+-- MonÉlu — drop the position_id surrogate key on vote_positions (MON-77)
+-- Idempotent: guarded on the column's existence — safe to re-run, and a
+-- no-op on fresh databases where 001_init.sql already creates the table
+-- with the natural primary key.
+--
+-- The natural key (vote_id, deputy_id) already carried a UNIQUE constraint
+-- (the ON CONFLICT target of the ingestion upsert). The surrogate BIGSERIAL
+-- was never referenced by any query, FK, or ordering — it only cost 8 bytes
+-- per row plus a redundant btree index (~794k rows on the Supabase free
+-- tier). Promote the natural key to PRIMARY KEY and drop the surrogate.
+--
+-- The whole block runs in one transaction (migrate.py), so the upsert's
+-- ON CONFLICT (vote_id, deputy_id) target never observably disappears:
+-- the old UNIQUE constraint is only dropped after the new PK exists.
+-- Dropping the column also drops its sequence (owned by the column).
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'vote_positions'
+          AND column_name = 'position_id'
+    ) THEN
+        -- dbt staging views select position_id and block the column drop.
+        -- CASCADE takes any dependent intermediate views along; all of them
+        -- are recreated by the next `dbt run` (deploy.yml on the same merge).
+        -- The API is unaffected: it only queries raw tables and the marts,
+        -- which are materialized as tables.
+        DROP VIEW IF EXISTS analytics_staging.stg_vote_positions CASCADE;
+        ALTER TABLE vote_positions DROP CONSTRAINT vote_positions_pkey;
+        ALTER TABLE vote_positions DROP COLUMN position_id;
+        ALTER TABLE vote_positions
+            ADD CONSTRAINT vote_positions_pkey PRIMARY KEY (vote_id, deputy_id);
+        ALTER TABLE vote_positions
+            DROP CONSTRAINT vote_positions_vote_id_deputy_id_key;
+    END IF;
+END $$;

--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -207,7 +207,7 @@ _MIN_WINDOW_VOTES = 100
 _DEPUTY_PRESENCE_RANKING = f"""
     SELECT d.full_name, d.party,
            ROUND(LEAST(
-               COUNT(vp.position_id)::numeric / NULLIF(wv.window_votes, 0), 1
+               COUNT(vp.vote_id)::numeric / NULLIF(wv.window_votes, 0), 1
            ) * 100, 1) AS presence_pct
     FROM deputies d
     LEFT JOIN vote_positions vp ON d.deputy_id = vp.deputy_id
@@ -386,7 +386,7 @@ SQL_QUERIES = {
                 d.deputy_id,
                 d.party,
                 LEAST(
-                    COUNT(vp.position_id)::numeric / NULLIF((
+                    COUNT(vp.vote_id)::numeric / NULLIF((
                         SELECT COUNT(*) FROM votes v
                         WHERE (d.mandate_start IS NULL OR v.voted_at >= d.mandate_start)
                           AND (d.mandate_end IS NULL OR v.voted_at <= d.mandate_end)

--- a/rag/pipeline/chunk_notable_deputies.py
+++ b/rag/pipeline/chunk_notable_deputies.py
@@ -38,21 +38,21 @@ def get_top_deputies(n: int = 100) -> list[dict]:
                     d.full_name,
                     d.party,
                     d.department,
-                    COUNT(vp.position_id) as total_votes,
-                    COUNT(vp.position_id) FILTER (
+                    COUNT(vp.vote_id) as total_votes,
+                    COUNT(vp.vote_id) FILTER (
                         WHERE vp.position = 'pour'
                     ) as pour,
-                    COUNT(vp.position_id) FILTER (
+                    COUNT(vp.vote_id) FILTER (
                         WHERE vp.position = 'contre'
                     ) as contre,
-                    COUNT(vp.position_id) FILTER (
+                    COUNT(vp.vote_id) FILTER (
                         WHERE vp.position = 'abstention'
                     ) as abstention,
                     -- canonical presence: all recorded positions (incl.
                     -- nonVotant) over votes during the mandate window —
                     -- see docs/decisions.md
                     ROUND(LEAST(
-                        COUNT(vp.position_id)::numeric / NULLIF((
+                        COUNT(vp.vote_id)::numeric / NULLIF((
                             SELECT COUNT(*) FROM votes v
                             WHERE (d.mandate_start IS NULL OR v.voted_at >= d.mandate_start)
                               AND (d.mandate_end IS NULL OR v.voted_at <= d.mandate_end)
@@ -207,15 +207,15 @@ def build_notable_deputy_index(n: int = 100) -> dict:
                     cur.execute(
                         """
                         SELECT d.deputy_id, d.full_name, d.party, d.department,
-                               COUNT(vp.position_id) as total_votes,
-                               COUNT(vp.position_id) FILTER (WHERE vp.position='pour') as pour,
-                               COUNT(vp.position_id) FILTER (WHERE vp.position='contre') as contre,
-                               COUNT(vp.position_id) FILTER (
+                               COUNT(vp.vote_id) as total_votes,
+                               COUNT(vp.vote_id) FILTER (WHERE vp.position='pour') as pour,
+                               COUNT(vp.vote_id) FILTER (WHERE vp.position='contre') as contre,
+                               COUNT(vp.vote_id) FILTER (
                                    WHERE vp.position='abstention'
                                ) as abstention,
                                -- canonical presence — see docs/decisions.md
                                ROUND(LEAST(
-                                   COUNT(vp.position_id)::numeric / NULLIF((
+                                   COUNT(vp.vote_id)::numeric / NULLIF((
                                        SELECT COUNT(*) FROM votes v
                                        WHERE (d.mandate_start IS NULL
                                               OR v.voted_at >= d.mandate_start)

--- a/rag/pipeline/chunker.py
+++ b/rag/pipeline/chunker.py
@@ -139,17 +139,17 @@ def chunk_deputies(deputy_ids: set[str] | None = None) -> list[dict]:
     chunks = []
     _DEPUTY_SELECT = """
                 SELECT d.deputy_id, d.full_name, d.party, d.department,
-                       COUNT(vp.position_id) AS total_votes,
-                       COUNT(vp.position_id) FILTER (WHERE vp.position = 'pour') AS pour_count,
-                       COUNT(vp.position_id) FILTER (WHERE vp.position = 'contre') AS contre_count,
-                       COUNT(vp.position_id) FILTER (
+                       COUNT(vp.vote_id) AS total_votes,
+                       COUNT(vp.vote_id) FILTER (WHERE vp.position = 'pour') AS pour_count,
+                       COUNT(vp.vote_id) FILTER (WHERE vp.position = 'contre') AS contre_count,
+                       COUNT(vp.vote_id) FILTER (
                            WHERE vp.position = 'abstention'
                        ) AS abstention_count,
                        -- canonical presence: all recorded positions (incl.
                        -- nonVotant) over votes during the mandate window —
                        -- see docs/decisions.md
                        ROUND(LEAST(
-                           COUNT(vp.position_id)::numeric
+                           COUNT(vp.vote_id)::numeric
                            / NULLIF((
                                SELECT COUNT(*) FROM votes v
                                WHERE (d.mandate_start IS NULL OR v.voted_at >= d.mandate_start)
@@ -225,7 +225,7 @@ def chunk_party_summaries() -> list[dict]:
                     -- averages describe the current Assemblée
                     SELECT d.deputy_id, d.party,
                            LEAST(
-                               COUNT(vp.position_id)::numeric / NULLIF((
+                               COUNT(vp.vote_id)::numeric / NULLIF((
                                    SELECT COUNT(*) FROM votes v
                                    WHERE (d.mandate_start IS NULL OR v.voted_at >= d.mandate_start)
                                      AND (d.mandate_end IS NULL OR v.voted_at <= d.mandate_end)
@@ -241,9 +241,9 @@ def chunk_party_summaries() -> list[dict]:
                 party_positions AS (
                     SELECT
                         d.party,
-                        COUNT(vp.position_id) FILTER (WHERE vp.position = 'pour') AS total_pour,
-                        COUNT(vp.position_id) FILTER (WHERE vp.position = 'contre') AS total_contre,
-                        COUNT(vp.position_id) FILTER (
+                        COUNT(vp.vote_id) FILTER (WHERE vp.position = 'pour') AS total_pour,
+                        COUNT(vp.vote_id) FILTER (WHERE vp.position = 'contre') AS total_contre,
+                        COUNT(vp.vote_id) FILTER (
                             WHERE vp.position = 'abstention'
                         ) AS total_abstention
                     FROM deputies d
@@ -331,10 +331,10 @@ def chunk_global_stats() -> list[dict]:
             cur.execute(
                 """
                 SELECT d.full_name, d.party, d.department,
-                       COUNT(vp.position_id) AS total_votes,
+                       COUNT(vp.vote_id) AS total_votes,
                        -- canonical presence — see docs/decisions.md
                        ROUND(LEAST(
-                           COUNT(vp.position_id)::numeric
+                           COUNT(vp.vote_id)::numeric
                            / NULLIF((
                                SELECT COUNT(*) FROM votes v
                                WHERE (d.mandate_start IS NULL OR v.voted_at >= d.mandate_start)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -48,7 +48,6 @@ _VOTE_DETAIL = {
 }
 
 _POSITION = {
-    "position_id": 1,
     "deputy_id": "PA1",
     "full_name": "Jean Martin",
     "party_short": "RN",

--- a/transform/models/staging/schema.yml
+++ b/transform/models/staging/schema.yml
@@ -52,9 +52,12 @@ models:
 
   - name: stg_vote_positions
     description: "Cleaned individual vote positions"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - vote_id
+            - deputy_id
     columns:
-      - name: position_id
-        tests: [not_null, unique]
       - name: position
         tests:
           - not_null

--- a/transform/models/staging/sources.yml
+++ b/transform/models/staging/sources.yml
@@ -58,11 +58,12 @@ sources:
           # Same recess caveat as votes — see above.
           warn_after: { count: 4, period: day }
           error_after: { count: 30, period: day }
+        tests:
+          - dbt_utils.unique_combination_of_columns:
+              combination_of_columns:
+                - vote_id
+                - deputy_id
         columns:
-          - name: position_id
-            tests:
-              - not_null
-              - unique
           - name: vote_id
             tests:
               - not_null

--- a/transform/models/staging/stg_vote_positions.sql
+++ b/transform/models/staging/stg_vote_positions.sql
@@ -4,7 +4,6 @@ with source as (
 
 renamed as (
     select
-        position_id,
         vote_id,
         deputy_id,
         lower(trim(position))                    as position,
@@ -20,8 +19,7 @@ renamed as (
         end                                      as position_code
 
     from source
-    where position_id is not null
-      and vote_id is not null
+    where vote_id is not null
       and deputy_id is not null
 )
 


### PR DESCRIPTION
## What

Drops the `position_id` BIGSERIAL surrogate key on `vote_positions` and promotes the natural key `(vote_id, deputy_id)` to PRIMARY KEY (MON-77).

## Why

The surrogate was never referenced by any query, FK, or ordering.
At ~794k rows on Supabase's 500 MB free tier it wasted 8 bytes per row plus a redundant btree index, alongside the natural key's existing UNIQUE index.
Deferred from MON-13 / PR #140 with the trigger "free-tier pressure"; positions grew ~11% since June, so this lands it as a planned migration instead of during a storage incident.

## Changes

- `data/migrations/006_drop_position_id.sql`: guarded DO block - drops the dependent dbt staging view (CASCADE), the old PK, the column (and its owned sequence), then adds `PRIMARY KEY (vote_id, deputy_id)` and removes the now-redundant UNIQUE constraint. Idempotent and a no-op on fresh databases.
- `data/migrations/001_init.sql`: updated to the end state for fresh installs (same precedent as migration 003 - the ledger tracks filenames only, so editing is safe).
- `api/schemas.py` + `api/routers/votes.py`: `VotePosition.position_id` removed from the `GET /votes/{vote_id}` response.
- RAG SQL (`chunker.py`, `chunk_notable_deputies.py`, `sql_router.py`): `COUNT(vp.position_id)` -> `COUNT(vp.vote_id)`. Identical semantics including in LEFT joins, since `vote_id` is NOT NULL.
- dbt: `stg_vote_positions` no longer selects the column; the `position_id` not_null/unique tests on the source and staging model are replaced with `dbt_utils.unique_combination_of_columns` on `(vote_id, deputy_id)`, preserving the uniqueness guarantee.
- `README.md`: schema table updated.

## Acceptance criteria

- **Migration applies cleanly via `scripts/migrate.py` on local and prod**: applied on the local Docker DB (237k rows) and on a fresh scratch database (full 001-006 chain); the prod path is exercised by the Railway start hook on merge. The migration was also validated against prod's dependent-view situation: a first run against prod surfaced the `analytics_staging.stg_vote_positions` dependency and rolled back cleanly; the CASCADE drop now handles it.
- **Ingestion upsert still idempotent**: `ON CONFLICT (vote_id, deputy_id)` now resolves against the PK; re-inserting an existing row leaves the count unchanged. 32 integration tests pass.
- **Measured size reduction**: local, 237k rows - 47 MB -> 38 MB on migration (index drop), 34 MB after `VACUUM FULL` (heap 17 -> 16 MB, indexes 30 -> 18 MB), ~28% total. Scaled to prod's ~794k rows that is roughly 40-45 MB.

## Testing

- `pytest tests/ -m "not integration" -q`: 208 passed.
- `pytest tests/ -m integration -q` against the local Docker DB: 32 passed (two chunker tests flaked on the first run from test ordering, pass in isolation and on re-run; unrelated to this change).
- `ruff check .` and `ruff format --check .`: clean.
- Manual: migration applied to local + fresh scratch DB, schema verified with `\d`, upsert re-run idempotency confirmed, sizes measured before/after.
- dbt compile/test runs in CI (local dbt install is broken on Python 3.14, unrelated).

## Risks / Notes

- Deploy ordering: on merge, Railway's `migrate.py` and the deploy workflow's `dbt run` race. Either order converges - the migration drops the staging views and the next `dbt run` recreates them; the API only queries raw tables and marts (materialized as tables), so it is unaffected either way.
- Prod heap space is reclaimed lazily; an optional manual `VACUUM FULL vote_positions` (a few seconds of ACCESS EXCLUSIVE) reclaims it immediately. The index savings are immediate.
- The migration takes an ACCESS EXCLUSIVE lock on `vote_positions` while it rebuilds the PK index (~1-2 s at prod size) inside the Railway start hook, before uvicorn starts.

## Breaking Changes

- `position_id` is removed from the `GET /votes/{vote_id}` positions payload. The frontend never consumed it; external API consumers relying on it (unlikely - it carried no meaning) would need to key on `(vote_id, deputy_id)`.
