### PR TITLE
feat: CSV export endpoints and dense scorecard table (MON-97)

### DIFF
--- a/api/csv_export.py
+++ b/api/csv_export.py
@@ -1,0 +1,38 @@
+"""
+api/csv_export.py
+Shared CSV response builder for the export endpoints (MON-97).
+
+Conventions (chosen for Excel/LibreOffice compatibility):
+- UTF-8 with BOM (U+FEFF) so Excel detects the encoding (accents in names/titles).
+- RFC 4180: comma delimiter, CRLF line endings, minimal quoting.
+"""
+
+import csv
+import io
+from collections.abc import Iterable, Iterator
+
+from fastapi.responses import StreamingResponse
+
+UTF8_BOM = chr(0xFEFF)
+
+
+def _iter_csv(fieldnames: list[str], rows: Iterable[dict]) -> Iterator[str]:
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=fieldnames, extrasaction="ignore")
+
+    writer.writeheader()
+    yield UTF8_BOM + buffer.getvalue()
+    for row in rows:
+        buffer.seek(0)
+        buffer.truncate()
+        writer.writerow(row)
+        yield buffer.getvalue()
+
+
+def csv_response(fieldnames: list[str], rows: Iterable[dict], filename: str) -> StreamingResponse:
+    """Build a text/csv attachment response from already-fetched rows."""
+    return StreamingResponse(
+        _iter_csv(fieldnames, rows),
+        media_type="text/csv; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/api/routers/deputies.py
+++ b/api/routers/deputies.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, HTTPException, Query
 from psycopg2 import sql
 from starlette.requests import Request
 
+from api.csv_export import csv_response
 from api.db import MART_UNAVAILABLE, get_conn
 from api.limiter import limiter, tiered_limit
 from api.schemas import (
@@ -15,6 +16,8 @@ from api.schemas import (
     DeputyDivergingVotesResponse,
     DeputyListResponse,
     DeputyScorecard,
+    DeputyScorecardListResponse,
+    DeputyScorecardRow,
     DeputyStats,
     DeputySummary,
     DeputyVoteItem,
@@ -24,6 +27,66 @@ from api.schemas import (
 )
 
 router = APIRouter()
+
+# One scorecard row per deputy with party/department context — shared by the
+# JSON table endpoint and the CSV export so both always agree (MON-97).
+_SCORECARD_ROWS_SQL = """
+    SELECT
+        s.deputy_id,
+        s.full_name,
+        d.party,
+        d.party_short,
+        d.department,
+        s.total_votes_cast                          AS total_votes,
+        (s.total_votes_cast - s.total_nonvotant)    AS present_votes,
+        s.presence_rate,
+        s.total_pour                                AS votes_for,
+        s.total_contre                              AS votes_against,
+        s.total_abstention                          AS abstentions,
+        s.votes_for_pct,
+        s.abstention_pct,
+        s.eligible_solennels,
+        s.total_solennels_cast                      AS solennels_cast,
+        s.solennel_participation_rate,
+        s.eligible_voting_days,
+        s.total_voting_days_present                 AS voting_days_present,
+        s.voting_days_rate
+    FROM analytics_marts.mart_deputy_scorecard s
+    JOIN deputies d ON d.deputy_id = s.deputy_id
+    ORDER BY d.last_name, d.first_name
+"""
+
+_SCORECARD_CSV_COLUMNS = [
+    "deputy_id",
+    "full_name",
+    "party",
+    "party_short",
+    "department",
+    "total_votes",
+    "present_votes",
+    "presence_rate",
+    "votes_for",
+    "votes_against",
+    "abstentions",
+    "votes_for_pct",
+    "abstention_pct",
+    "eligible_solennels",
+    "solennels_cast",
+    "solennel_participation_rate",
+    "eligible_voting_days",
+    "voting_days_present",
+    "voting_days_rate",
+]
+
+
+def _fetch_scorecard_rows() -> list[dict]:
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(_SCORECARD_ROWS_SQL)
+                return cur.fetchall()
+    except psycopg2.errors.UndefinedTable:
+        raise MART_UNAVAILABLE from None
 
 
 @router.get("/", response_model=DeputyListResponse)
@@ -122,6 +185,30 @@ def get_deputy_stats(
     )
 
 
+@router.get(
+    "/scorecards",
+    response_model=DeputyScorecardListResponse,
+    summary="All deputies' scorecards in one response — feeds the dense table view (MON-97)",
+)
+@limiter.limit(tiered_limit(10))
+def list_scorecards(request: Request):
+    rows = _fetch_scorecard_rows()
+    return DeputyScorecardListResponse(
+        total=len(rows),
+        items=[DeputyScorecardRow(**r) for r in rows],
+    )
+
+
+@router.get(
+    "/scorecard.csv",
+    summary="CSV export of every deputy's scorecard (MON-97)",
+)
+@limiter.limit(tiered_limit(10))
+def export_scorecards_csv(request: Request):
+    rows = _fetch_scorecard_rows()
+    return csv_response(_SCORECARD_CSV_COLUMNS, rows, "monelu_scorecard_deputes.csv")
+
+
 @router.get("/{deputy_id}", response_model=DeputyDetail)
 @limiter.limit(tiered_limit(30))
 def get_deputy(request: Request, deputy_id: str):
@@ -181,6 +268,45 @@ def get_deputy_votes(
         deputy_id=deputy_id,
         total=total,
         items=[DeputyVoteItem(**r) for r in rows],
+    )
+
+
+@router.get(
+    "/{deputy_id}/votes.csv",
+    summary="CSV export of a deputy's full voting record (MON-97)",
+)
+@limiter.limit(tiered_limit(10))
+def export_deputy_votes_csv(request: Request, deputy_id: str):
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT full_name FROM deputies WHERE deputy_id = %s",
+                    (deputy_id,),
+                )
+                deputy = cur.fetchone()
+                if deputy is None:
+                    raise HTTPException(status_code=404, detail="Deputy not found")
+
+                cur.execute(
+                    """
+                    SELECT vp.deputy_id, vp.vote_id, v.voted_at, v.vote_title,
+                           v.theme, v.result, vp.position
+                    FROM vote_positions vp
+                    JOIN analytics_marts.mart_vote_summary v ON v.vote_id = vp.vote_id
+                    WHERE vp.deputy_id = %s
+                    ORDER BY v.voted_at DESC NULLS LAST, vp.vote_id DESC
+                    """,
+                    (deputy_id,),
+                )
+                rows = cur.fetchall()
+    except psycopg2.errors.UndefinedTable:
+        raise MART_UNAVAILABLE from None
+
+    return csv_response(
+        ["deputy_id", "vote_id", "voted_at", "vote_title", "theme", "result", "position"],
+        rows,
+        f"monelu_depute_{deputy_id}_votes.csv",
     )
 
 

--- a/api/routers/votes.py
+++ b/api/routers/votes.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, HTTPException, Query
 from psycopg2 import sql
 from starlette.requests import Request
 
+from api.csv_export import csv_response
 from api.db import MART_UNAVAILABLE, get_conn
 from api.limiter import limiter, tiered_limit
 from api.schemas import VoteDetail, VoteListResponse, VotePosition, VoteSummary
@@ -168,6 +169,38 @@ def latest_votes(request: Request):
     except psycopg2.errors.UndefinedTable:
         raise MART_UNAVAILABLE from None
     return [VoteSummary(**r) for r in rows]
+
+
+@router.get(
+    "/{vote_id}/positions.csv",
+    summary="CSV export of every deputy's position on one vote (MON-97)",
+)
+@limiter.limit(tiered_limit(10))
+def export_vote_positions_csv(request: Request, vote_id: str):
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT vote_id FROM votes WHERE vote_id = %s", (vote_id,))
+            if cur.fetchone() is None:
+                raise HTTPException(status_code=404, detail="Vote not found")
+
+            cur.execute(
+                """
+                SELECT vp.vote_id, vp.deputy_id, d.full_name, d.party, d.party_short,
+                       d.department, vp.position
+                FROM vote_positions vp
+                JOIN deputies d ON d.deputy_id = vp.deputy_id
+                WHERE vp.vote_id = %s
+                ORDER BY vp.position, d.last_name, d.first_name
+                """,
+                (vote_id,),
+            )
+            rows = cur.fetchall()
+
+    return csv_response(
+        ["vote_id", "deputy_id", "full_name", "party", "party_short", "department", "position"],
+        rows,
+        f"monelu_scrutin_{vote_id}_positions.csv",
+    )
 
 
 @router.get("/{vote_id}", response_model=VoteDetail)

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -77,6 +77,19 @@ class DeputyScorecard(_Base):
     )
 
 
+class DeputyScorecardRow(DeputyScorecard):
+    """Scorecard plus party/department context — one row of the dense table (MON-97)."""
+
+    party: Optional[str] = None
+    party_short: Optional[str] = None
+    department: Optional[str] = None
+
+
+class DeputyScorecardListResponse(_Base):
+    total: int
+    items: list[DeputyScorecardRow]
+
+
 class DeputyAlignment(_Base):
     """Party alignment / dissident rate for a single deputy (mart_party_alignment)."""
 

--- a/frontend/src/app/deputes/DeputiesClient.tsx
+++ b/frontend/src/app/deputes/DeputiesClient.tsx
@@ -237,6 +237,21 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
               <option value="region">Région</option>
               <option value="parti">Groupe</option>
             </select>
+            {/* Dense table view for power users (MON-97) */}
+            <Link
+              href="/deputes/tableau"
+              style={{
+                display: 'inline-flex', alignItems: 'center', gap: 7,
+                background: '#fff', border: '1px solid ' + LINE, borderRadius: 999,
+                padding: '8px 16px', fontSize: 13.5, fontWeight: 600,
+                color: NAVY, textDecoration: 'none', whiteSpace: 'nowrap',
+              }}
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+                <path d="M3 6h18M3 12h18M3 18h18"/>
+              </svg>
+              Vue tableau
+            </Link>
           </div>
         </div>
       </div>

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
-import { api } from '@/lib/api'
+import { api, csvUrl } from '@/lib/api'
 import type { DissidentVoteItem } from '@/lib/api'
 import { partyHex, formatDate } from '@/lib/utils'
 import { departmentCode, departmentLabel } from '@/lib/departments'
@@ -218,6 +218,20 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                 >
                   Comparer
                 </Link>
+                <a
+                  href={csvUrl.deputyVotes(id)}
+                  download
+                  title="Télécharger l'historique de vote complet (CSV)"
+                  style={{
+                    display: 'inline-flex', alignItems: 'center', gap: 8,
+                    background: '#fff', border: `1px solid ${LINE}`, color: NAVY,
+                    padding: '12px 22px', borderRadius: 9, fontWeight: 600,
+                    fontSize: 15, textDecoration: 'none',
+                  }}
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                  CSV
+                </a>
               </div>
             </div>
           </div>

--- a/frontend/src/app/deputes/tableau/TableauClient.tsx
+++ b/frontend/src/app/deputes/tableau/TableauClient.tsx
@@ -38,13 +38,6 @@ const COLUMNS: Array<{ key: ColumnKey; label: string; numeric: boolean; title?: 
   { key: 'voting_days_rate', label: 'Jours de vote', numeric: true, title: 'Jours de scrutin avec au moins un vote' },
 ]
 
-const PCT_KEYS = new Set<ColumnKey>([
-  'presence_rate',
-  'votes_for_pct',
-  'solennel_participation_rate',
-  'voting_days_rate',
-])
-
 function formatPct(value: number | null | undefined): string {
   if (value === null || value === undefined) return '—'
   return `${(value * 100).toLocaleString('fr-FR', { minimumFractionDigits: 1, maximumFractionDigits: 1 })} %`

--- a/frontend/src/app/deputes/tableau/TableauClient.tsx
+++ b/frontend/src/app/deputes/tableau/TableauClient.tsx
@@ -1,0 +1,265 @@
+'use client'
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import { csvUrl, type ScorecardRow } from '@/lib/api'
+import { partyHex, partyShort } from '@/lib/utils'
+import { departmentLabel } from '@/lib/departments'
+
+type ScorecardList = { total: number; items: ScorecardRow[] }
+
+const NAVY = '#1B2B50'
+const CREAM = '#F7F4ED'
+const LINE = '#E4E6EA'
+
+type ColumnKey =
+  | 'full_name'
+  | 'party'
+  | 'department'
+  | 'total_votes'
+  | 'presence_rate'
+  | 'votes_for'
+  | 'votes_against'
+  | 'abstentions'
+  | 'votes_for_pct'
+  | 'solennel_participation_rate'
+  | 'voting_days_rate'
+
+const COLUMNS: Array<{ key: ColumnKey; label: string; numeric: boolean; title?: string }> = [
+  { key: 'full_name', label: 'Député·e', numeric: false },
+  { key: 'party', label: 'Groupe', numeric: false },
+  { key: 'department', label: 'Département', numeric: false },
+  { key: 'total_votes', label: 'Votes', numeric: true, title: 'Scrutins où le député pouvait voter' },
+  { key: 'presence_rate', label: 'Présence', numeric: true, title: 'Part des scrutins avec une position exprimée ou une abstention' },
+  { key: 'votes_for', label: 'Pour', numeric: true },
+  { key: 'votes_against', label: 'Contre', numeric: true },
+  { key: 'abstentions', label: 'Abst.', numeric: true },
+  { key: 'votes_for_pct', label: '% Pour', numeric: true, title: 'Votes pour / votes exprimés' },
+  { key: 'solennel_participation_rate', label: 'Solennels', numeric: true, title: 'Participation aux scrutins solennels' },
+  { key: 'voting_days_rate', label: 'Jours de vote', numeric: true, title: 'Jours de scrutin avec au moins un vote' },
+]
+
+const PCT_KEYS = new Set<ColumnKey>([
+  'presence_rate',
+  'votes_for_pct',
+  'solennel_participation_rate',
+  'voting_days_rate',
+])
+
+function formatPct(value: number | null | undefined): string {
+  if (value === null || value === undefined) return '—'
+  return `${(value * 100).toLocaleString('fr-FR', { minimumFractionDigits: 1, maximumFractionDigits: 1 })} %`
+}
+
+function cellValue(row: ScorecardRow, key: ColumnKey): string | number | null {
+  if (key === 'party') return row.party
+  if (key === 'department') return row.department
+  return row[key]
+}
+
+export function TableauClient({ initial }: { initial: ScorecardList }) {
+  const [sortKey, setSortKey] = useState<ColumnKey>('full_name')
+  const [sortAsc, setSortAsc] = useState(true)
+  const [filter, setFilter] = useState('')
+
+  function toggleSort(key: ColumnKey, numeric: boolean) {
+    if (key === sortKey) {
+      setSortAsc(a => !a)
+    } else {
+      setSortKey(key)
+      // Numeric columns open descending (biggest first) — that is the question
+      // a ranking answers; text columns open A→Z.
+      setSortAsc(!numeric)
+    }
+  }
+
+  const rows = useMemo(() => {
+    const q = filter.trim().toLowerCase()
+    const filtered = q
+      ? initial.items.filter(r =>
+          r.full_name.toLowerCase().includes(q) ||
+          (r.party?.toLowerCase().includes(q) ?? false) ||
+          partyShort(r.party).toLowerCase().includes(q) ||
+          (departmentLabel(r.department)?.toLowerCase().includes(q) ?? false) ||
+          (r.department?.toLowerCase().includes(q) ?? false)
+        )
+      : [...initial.items]
+
+    const dir = sortAsc ? 1 : -1
+    return filtered.sort((a, b) => {
+      const va = cellValue(a, sortKey)
+      const vb = cellValue(b, sortKey)
+      if (va === null || va === undefined) return 1
+      if (vb === null || vb === undefined) return -1
+      if (typeof va === 'number' && typeof vb === 'number') return (va - vb) * dir
+      return String(va).localeCompare(String(vb), 'fr') * dir
+    })
+  }, [initial.items, filter, sortKey, sortAsc])
+
+  return (
+    <div style={{ background: CREAM, minHeight: '100vh' }}>
+
+      {/* Header */}
+      <div
+        className="px-5 sm:px-14 pt-8 sm:pt-[50px] pb-8"
+        style={{
+          background: 'linear-gradient(180deg,#fff 0%,' + CREAM + ' 100%)',
+          borderBottom: '1px solid #ECE7DC',
+        }}
+      >
+        <div style={{ maxWidth: 1320, margin: '0 auto' }}>
+          <div style={{
+            fontWeight: 700, fontSize: 12, letterSpacing: '0.18em',
+            textTransform: 'uppercase', color: '#C9302A', marginBottom: 16,
+          }}>
+            Mode chercheur
+          </div>
+          <h1 className="font-newsreader text-[clamp(30px,4vw,44px)]" style={{
+            fontWeight: 600, lineHeight: 1.05, letterSpacing: '-0.015em', color: NAVY, margin: 0,
+          }}>
+            Tous les bilans de vote, <span style={{ color: '#C9302A' }}>en un tableau</span>.
+          </h1>
+          <p style={{ margin: '14px 0 0', fontSize: 16, lineHeight: 1.6, color: '#4B5563', maxWidth: 620 }}>
+            Les {initial.total} scorecards des députés sur un seul écran. Cliquez sur une colonne
+            pour trier, filtrez par nom, groupe ou département — ou emportez tout en CSV.
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-3 mt-6 sm:items-center">
+            <label htmlFor="tableau-filter" className="sr-only">Filtrer le tableau</label>
+            <input
+              id="tableau-filter"
+              type="search"
+              placeholder="Filtrer par nom, groupe ou département…"
+              value={filter}
+              onChange={e => setFilter(e.target.value)}
+              style={{
+                flex: 1, maxWidth: 420, height: 46, padding: '0 16px',
+                background: '#fff', border: '1px solid ' + LINE, borderRadius: 10,
+                fontSize: 15, color: '#1F2937', outline: 'none',
+                boxShadow: '0 1px 3px rgba(0,0,0,0.05)',
+              }}
+            />
+            <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+              <a
+                href={csvUrl.scorecard()}
+                download
+                style={{
+                  display: 'inline-flex', alignItems: 'center', gap: 8,
+                  background: NAVY, color: '#fff', height: 46, padding: '0 20px',
+                  borderRadius: 10, fontWeight: 600, fontSize: 14.5, textDecoration: 'none',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>
+                </svg>
+                Télécharger CSV
+              </a>
+              <Link
+                href="/donnees"
+                style={{
+                  display: 'inline-flex', alignItems: 'center',
+                  background: '#fff', color: NAVY, height: 46, padding: '0 18px',
+                  border: '1px solid ' + LINE, borderRadius: 10, fontWeight: 600,
+                  fontSize: 14.5, textDecoration: 'none', whiteSpace: 'nowrap',
+                  boxShadow: '0 1px 3px rgba(0,0,0,0.05)',
+                }}
+              >
+                Toutes les données →
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="px-3 sm:px-14 pt-7 pb-14 sm:pb-[72px]">
+        <div style={{ maxWidth: 1320, margin: '0 auto' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 4px 12px' }}>
+            <span className="font-mono" style={{ fontSize: 13, color: '#6B7280' }}>
+              {rows.length} député{rows.length !== 1 ? 's' : ''}
+            </span>
+            <Link href="/deputes" style={{ fontSize: 13.5, color: NAVY, fontWeight: 600, textDecoration: 'none' }}>
+              ← Vue annuaire
+            </Link>
+          </div>
+
+          <div style={{
+            background: '#fff', border: '1px solid ' + LINE, borderRadius: 12,
+            boxShadow: '0 1px 3px rgba(0,0,0,0.06)', overflowX: 'auto',
+          }}>
+            <table style={{ borderCollapse: 'collapse', width: '100%', minWidth: 980, fontSize: 13.5 }}>
+              <thead>
+                <tr style={{ background: '#FBFAF6', borderBottom: '1px solid ' + LINE }}>
+                  {COLUMNS.map(col => {
+                    const active = sortKey === col.key
+                    return (
+                      <th key={col.key} scope="col" style={{ padding: 0, textAlign: col.numeric ? 'right' : 'left' }}>
+                        <button
+                          onClick={() => toggleSort(col.key, col.numeric)}
+                          title={col.title}
+                          aria-sort={active ? (sortAsc ? 'ascending' : 'descending') : undefined}
+                          style={{
+                            width: '100%', display: 'flex', alignItems: 'center', gap: 5,
+                            justifyContent: col.numeric ? 'flex-end' : 'flex-start',
+                            padding: '12px 14px', background: 'none', border: 'none', cursor: 'pointer',
+                            font: '600 11.5px/1 var(--font-body)', letterSpacing: '0.07em',
+                            textTransform: 'uppercase', color: active ? NAVY : '#9CA3AF',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {col.label}
+                          <span aria-hidden="true" style={{ fontSize: 10, opacity: active ? 1 : 0.35 }}>
+                            {active ? (sortAsc ? '▲' : '▼') : '↕'}
+                          </span>
+                        </button>
+                      </th>
+                    )
+                  })}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map(r => (
+                  <tr
+                    key={r.deputy_id}
+                    style={{ borderBottom: '1px solid #F0F1F3' }}
+                    onMouseEnter={e => (e.currentTarget.style.background = '#FBFAF6')}
+                    onMouseLeave={e => (e.currentTarget.style.background = '')}
+                  >
+                    <td style={{ padding: '9px 14px', whiteSpace: 'nowrap' }}>
+                      <Link href={`/deputes/${r.deputy_id}`} style={{ color: NAVY, fontWeight: 600, textDecoration: 'none' }}>
+                        {r.full_name}
+                      </Link>
+                    </td>
+                    <td style={{ padding: '9px 14px', whiteSpace: 'nowrap' }} title={r.party ?? undefined}>
+                      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7 }}>
+                        <span style={{ width: 8, height: 8, borderRadius: 999, flexShrink: 0, background: partyHex(r.party) }} />
+                        <span style={{ color: '#374151' }}>{partyShort(r.party)}</span>
+                      </span>
+                    </td>
+                    <td style={{ padding: '9px 14px', color: '#6B7280', whiteSpace: 'nowrap' }}>
+                      {departmentLabel(r.department) ?? r.department ?? '—'}
+                    </td>
+                    <td className="font-mono" style={{ padding: '9px 14px', textAlign: 'right', color: '#374151' }}>{r.total_votes}</td>
+                    <td className="font-mono" style={{ padding: '9px 14px', textAlign: 'right', color: '#374151' }}>{formatPct(r.presence_rate)}</td>
+                    <td className="font-mono" style={{ padding: '9px 14px', textAlign: 'right', color: '#374151' }}>{r.votes_for}</td>
+                    <td className="font-mono" style={{ padding: '9px 14px', textAlign: 'right', color: '#374151' }}>{r.votes_against}</td>
+                    <td className="font-mono" style={{ padding: '9px 14px', textAlign: 'right', color: '#374151' }}>{r.abstentions}</td>
+                    <td className="font-mono" style={{ padding: '9px 14px', textAlign: 'right', color: '#374151' }}>{formatPct(r.votes_for_pct)}</td>
+                    <td className="font-mono" style={{ padding: '9px 14px', textAlign: 'right', color: '#374151' }}>{formatPct(r.solennel_participation_rate)}</td>
+                    <td className="font-mono" style={{ padding: '9px 14px', textAlign: 'right', color: '#374151' }}>{formatPct(r.voting_days_rate)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <p style={{ margin: '14px 4px 0', fontSize: 12.5, color: '#9CA3AF', lineHeight: 1.6 }}>
+            Données : Assemblée nationale (Licence Ouverte 2.0), via MonÉlu. La « présence » mesure
+            la participation aux scrutins publics, pas la présence physique en séance — voir la{' '}
+            <Link href="/methodologie" style={{ color: '#6B7280' }}>méthodologie</Link>.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/deputes/tableau/page.tsx
+++ b/frontend/src/app/deputes/tableau/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next'
+import { api } from '@/lib/api'
+import { TableauClient } from './TableauClient'
+
+export const metadata: Metadata = {
+  title: 'Tableau des députés - MonÉlu',
+  description:
+    "Tous les bilans de vote des députés de l'Assemblée nationale dans un tableau dense et triable : présence, positions, participation aux scrutins solennels. Export CSV.",
+}
+
+// Rendered at request time, like /deputes: prerendering at build time would
+// call the API's /deputies/scorecards during the deploy (and 404 until the
+// API side of MON-97 is live). The fetch itself is cached for 1h (lib/api.ts).
+export const dynamic = 'force-dynamic'
+
+export default async function TableauPage() {
+  const scorecards = await api.deputies.scorecards()
+  return <TableauClient initial={scorecards} />
+}

--- a/frontend/src/app/donnees/page.tsx
+++ b/frontend/src/app/donnees/page.tsx
@@ -1,0 +1,126 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { LegalPageLayout, LegalSection } from '@/components/LegalPageLayout'
+import { csvUrl } from '@/lib/api'
+
+export const metadata: Metadata = {
+  title: 'Données ouvertes - MonÉlu',
+  description:
+    'Téléchargez les données de vote des députés en CSV : positions par scrutin, historique par député, scorecards complètes. Format, fraîcheur et conditions de réutilisation.',
+}
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'https://monelu-production.up.railway.app'
+
+const EXPORTS: Array<{
+  name: string
+  href: string | null
+  pattern: string
+  what: string
+  columns: string
+}> = [
+  {
+    name: 'Scorecard de tous les députés',
+    href: csvUrl.scorecard(),
+    pattern: '/deputies/scorecard.csv',
+    what: "Une ligne par député : groupe, département, votes exprimés, taux de présence aux scrutins, participation aux scrutins solennels et aux jours de vote.",
+    columns:
+      'deputy_id, full_name, party, party_short, department, total_votes, present_votes, presence_rate, votes_for, votes_against, abstentions, votes_for_pct, abstention_pct, eligible_solennels, solennels_cast, solennel_participation_rate, eligible_voting_days, voting_days_present, voting_days_rate',
+  },
+  {
+    name: "Historique de vote d'un député",
+    href: null,
+    pattern: '/deputies/{deputy_id}/votes.csv',
+    what: "Tous les scrutins auxquels un député pouvait participer, avec sa position sur chacun. Le bouton « CSV » de chaque fiche député pointe vers cet export.",
+    columns: 'deputy_id, vote_id, voted_at, vote_title, theme, result, position',
+  },
+  {
+    name: "Positions complètes d'un scrutin",
+    href: null,
+    pattern: '/votes/{vote_id}/positions.csv',
+    what: "La position des 577 députés sur un scrutin donné. Le bouton « CSV » de chaque page de vote pointe vers cet export.",
+    columns: 'vote_id, deputy_id, full_name, party, party_short, department, position',
+  },
+]
+
+export default function DonneesPage() {
+  return (
+    <LegalPageLayout eyebrow="Open data" title="Données à emporter">
+
+      <LegalSection title="Exports CSV disponibles">
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: '0 0 18px' }}>
+          Trois exports couvrent l&apos;essentiel du besoin des journalistes et chercheurs. Ils sont
+          servis par la même API que le site — mêmes chiffres, aucun décalage. Pour explorer avant
+          de télécharger, la <Link href="/deputes/tableau" style={{ color: '#1B2B50' }}>vue tableau des députés</Link>{' '}
+          affiche toutes les scorecards triables sur un écran.
+        </p>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
+          {EXPORTS.map(e => (
+            <div key={e.pattern} style={{ background: '#F7F4ED', border: '1px solid #ECE7DC', borderRadius: '10px', padding: '16px 20px' }}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
+                <span style={{ fontWeight: 700, fontSize: '15px', color: '#1B2B50' }}>{e.name}</span>
+                {e.href && (
+                  <a
+                    href={e.href}
+                    download
+                    style={{ fontSize: '13.5px', fontWeight: 600, color: '#C9302A', textDecoration: 'none', whiteSpace: 'nowrap' }}
+                  >
+                    Télécharger ↓
+                  </a>
+                )}
+              </div>
+              <p style={{ fontSize: '14px', lineHeight: 1.65, color: '#4B5563', margin: '8px 0 10px' }}>{e.what}</p>
+              <div style={{ fontFamily: 'monospace', fontSize: '12.5px', color: '#1B2B50', marginBottom: 8 }}>
+                GET {API_BASE}{e.pattern}
+              </div>
+              <div style={{ fontSize: '12px', lineHeight: 1.6, color: '#9CA3AF' }}>
+                Colonnes : {e.columns}
+              </div>
+            </div>
+          ))}
+        </div>
+      </LegalSection>
+
+      <LegalSection title="Format des fichiers">
+        <ul style={{ fontSize: '15px', lineHeight: 1.85, color: '#4B5563', margin: 0, paddingLeft: '20px' }}>
+          <li>Encodage UTF-8 avec BOM — les accents s&apos;affichent correctement dans Excel et LibreOffice.</li>
+          <li>Séparateur virgule, fins de ligne CRLF (RFC 4180). Si votre Excel (réglé en français) place tout dans une colonne, passez par « Données → À partir d&apos;un fichier texte/CSV ».</li>
+          <li>Les taux (<code style={{ fontSize: '13px' }}>*_rate</code>, <code style={{ fontSize: '13px' }}>*_pct</code>) sont des ratios entre 0 et 1 ; les dates sont au format ISO 8601.</li>
+          <li><code style={{ fontSize: '13px' }}>position</code> vaut <code style={{ fontSize: '13px' }}>pour</code>, <code style={{ fontSize: '13px' }}>contre</code>, <code style={{ fontSize: '13px' }}>abstention</code> ou <code style={{ fontSize: '13px' }}>nonVotant</code> — l&apos;abstention est un acte exprimé, le non-votant était présent sans voter. Détails dans la <Link href="/methodologie" style={{ color: '#1B2B50' }}>méthodologie</Link>.</li>
+        </ul>
+      </LegalSection>
+
+      <LegalSection title="Fraîcheur des données">
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }}>
+          La base est mise à jour automatiquement chaque jour ouvré (ingestion à 06h00 UTC depuis
+          l&apos;open data de l&apos;Assemblée nationale). Les exports reflètent l&apos;état de la base au moment du
+          téléchargement. La base de production couvre les scrutins depuis le 1er juillet 2025 ;
+          l&apos;historique complet de la XVIIe législature (depuis juillet 2024) est en cours d&apos;extension.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Licence et attribution">
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: '0 0 10px' }}>
+          Les données sont réutilisables librement, y compris commercialement, sous Licence Ouverte
+          2.0 (Etalab) — la même licence que les sources officielles. La seule obligation est de
+          mentionner la source et la date. Attribution suggérée :
+        </p>
+        <div style={{ background: '#F7F4ED', border: '1px solid #ECE7DC', borderRadius: '8px', padding: '14px 18px', fontSize: '14px', color: '#1B2B50', fontFamily: 'monospace' }}>
+          Données : Assemblée nationale, via monelu.fr - Licence Ouverte 2.0
+        </div>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: '10px 0 0' }}>
+          Conditions détaillées sur la page <Link href="/licence-donnees" style={{ color: '#1B2B50' }}>Licence des données</Link>.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Besoin de plus que du CSV ?">
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }}>
+          L&apos;API REST expose les mêmes données en JSON, avec filtres et pagination — documentation
+          sur la page <Link href="/developpeurs" style={{ color: '#1B2B50' }}>développeurs</Link>. Les exports CSV sont soumis
+          au même rate-limiting que le reste de l&apos;API ; pour un usage intensif, écrivez à{' '}
+          <a href="mailto:walidelkhoukh99@gmail.com" style={{ color: '#1B2B50' }}>walidelkhoukh99@gmail.com</a>.
+        </p>
+      </LegalSection>
+
+    </LegalPageLayout>
+  )
+}

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -78,6 +78,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const staticUrls: MetadataRoute.Sitemap = [
     { url: SITE_URL, changeFrequency: 'daily', priority: 1.0 },
     { url: `${SITE_URL}/deputes`, changeFrequency: 'daily', priority: 0.9 },
+    { url: `${SITE_URL}/deputes/tableau`, changeFrequency: 'daily', priority: 0.6 },
+    { url: `${SITE_URL}/donnees`, changeFrequency: 'monthly', priority: 0.5 },
     { url: `${SITE_URL}/votes`, changeFrequency: 'daily', priority: 0.9 },
     { url: `${SITE_URL}/chat`, changeFrequency: 'monthly', priority: 0.5 },
     { url: `${SITE_URL}/a-propos`, changeFrequency: 'monthly', priority: 0.4 },

--- a/frontend/src/app/votes/[id]/VoteDetailClient.tsx
+++ b/frontend/src/app/votes/[id]/VoteDetailClient.tsx
@@ -5,6 +5,7 @@ import { ShareButton } from '@/components/ShareButton'
 import { InfoTooltip } from '@/components/InfoTooltip'
 import { getInitials, partyHex } from '@/lib/utils'
 import { resolvePostalCode } from '@/lib/postal'
+import { csvUrl } from '@/lib/api'
 
 interface DeputyLookupEntry {
   deputy_id: string
@@ -280,7 +281,7 @@ export function VoteDetailClient(props: Props) {
                   <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/></svg>
                 </a>
                 <a
-                  href={`${apiUrl}/votes/${voteId}/positions.csv`}
+                  href={csvUrl.votePositions(voteId)}
                   download
                   title="Télécharger les positions de tous les députés (CSV)"
                   aria-label="Télécharger les positions en CSV"

--- a/frontend/src/app/votes/[id]/VoteDetailClient.tsx
+++ b/frontend/src/app/votes/[id]/VoteDetailClient.tsx
@@ -279,6 +279,15 @@ export function VoteDetailClient(props: Props) {
                   style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', border: '1px solid #E4E6EA', color: '#4B5563', padding: '11px 16px', borderRadius: 8, fontWeight: 600, fontSize: 14, cursor: 'pointer', textDecoration: 'none' }}>
                   <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/></svg>
                 </a>
+                <a
+                  href={`${apiUrl}/votes/${voteId}/positions.csv`}
+                  download
+                  title="Télécharger les positions de tous les députés (CSV)"
+                  aria-label="Télécharger les positions en CSV"
+                  style={{ display: 'flex', alignItems: 'center', gap: 7, border: '1px solid #E4E6EA', color: '#4B5563', padding: '11px 16px', borderRadius: 8, fontWeight: 600, fontSize: 14, cursor: 'pointer', textDecoration: 'none' }}>
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                  CSV
+                </a>
                 <ShareButton
                   url={`/votes/${voteId}`}
                   title={`${adopted ? 'Adopté' : 'Rejeté'} - ${headline}`}

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -48,6 +48,7 @@ export function Footer() {
       <div style={{ display: 'flex', gap: '28px', fontSize: '13.5px', flexWrap: 'wrap' }}>
         <Link href="/deputes" style={{ color: '#6B7280', textDecoration: 'none' }}>Députés</Link>
         <Link href="/votes" style={{ color: '#6B7280', textDecoration: 'none' }}>Votes</Link>
+        <Link href="/donnees" style={{ color: '#6B7280', textDecoration: 'none' }}>Données</Link>
         <Link href="/developpeurs" style={{ color: '#6B7280', textDecoration: 'none' }}>Développeurs</Link>
         <Link href="/methodologie" style={{ color: '#6B7280', textDecoration: 'none' }}>Méthodologie</Link>
         <a href="https://github.com/Walid-peach" target="_blank" rel="noopener noreferrer" style={{ color: '#6B7280', textDecoration: 'none' }}>GitHub</a>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -32,6 +32,12 @@ export type Scorecard = {
   voting_days_rate: number
 }
 
+export type ScorecardRow = Scorecard & {
+  party: string | null
+  party_short: string | null
+  department: string | null
+}
+
 export type Vote = {
   vote_id: string
   vote_title: string
@@ -249,6 +255,8 @@ export const api = {
     },
     get: (id: string) => apiFetch<Deputy>(`/deputies/${id}/`, { revalidate: 86400 }),
     scorecard: (id: string) => apiFetch<Scorecard>(`/deputies/${id}/scorecard/`, { revalidate: 86400 }),
+    scorecards: () =>
+      apiFetch<{ total: number; items: ScorecardRow[] }>('/deputies/scorecards', { revalidate: 3600 }),
     stats: (party?: string) => {
       const q = new URLSearchParams()
       if (party) q.set('party', party)
@@ -300,4 +308,12 @@ export const api = {
       apiPost<{ status: string }>('/feedback/chat', { vote, question, answer, sources }),
   },
   health: () => apiFetch<Record<string, unknown>>('/health/', { revalidate: 300 }),
+}
+
+// CSV export download URLs (MON-97) — plain hrefs, the browser downloads
+// straight from the API (Content-Disposition: attachment).
+export const csvUrl = {
+  scorecard: () => `${API_BASE}/deputies/scorecard.csv`,
+  deputyVotes: (id: string) => `${API_BASE}/deputies/${encodeURIComponent(id)}/votes.csv`,
+  votePositions: (id: string) => `${API_BASE}/votes/${encodeURIComponent(id)}/positions.csv`,
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -762,3 +762,115 @@ def test_get_department_marts_missing(client, mock_cursor):
     assert data["avg_presence_rate"] is None
     assert data["most_dissident"] is None
     assert data["split_votes"][0]["vote_id"] == "VTANR5L17V1"
+
+
+# ---------------------------------------------------------------------------
+# CSV exports (MON-97)
+# ---------------------------------------------------------------------------
+
+_SCORECARD_ROW = {
+    "deputy_id": "PA1",
+    "full_name": "Jean Martin",
+    "party": "Rassemblement National",
+    "party_short": "RN",
+    "department": "Paris",
+    "total_votes": 100,
+    "present_votes": 90,
+    "presence_rate": 0.9,
+    "votes_for": 60,
+    "votes_against": 20,
+    "abstentions": 10,
+    "votes_for_pct": 0.667,
+    "abstention_pct": 0.111,
+    "eligible_solennels": 35,
+    "solennels_cast": 32,
+    "solennel_participation_rate": 0.914,
+    "eligible_voting_days": 126,
+    "voting_days_present": 77,
+    "voting_days_rate": 0.611,
+}
+
+
+def test_export_scorecards_csv(client, mock_cursor):
+    mock_cursor.fetchall.return_value = [_SCORECARD_ROW]
+    resp = client.get("/deputies/scorecard.csv")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/csv")
+    assert 'filename="monelu_scorecard_deputes.csv"' in resp.headers["content-disposition"]
+    # UTF-8 BOM so Excel detects the encoding
+    assert resp.content.startswith(b"\xef\xbb\xbf")
+    lines = resp.text.lstrip("\ufeff").splitlines()
+    assert lines[0].startswith("deputy_id,full_name,party,")
+    assert lines[1].startswith("PA1,Jean Martin,Rassemblement National,RN,Paris,100,90,0.9,")
+
+
+def test_list_scorecards_json(client, mock_cursor):
+    mock_cursor.fetchall.return_value = [_SCORECARD_ROW]
+    resp = client.get("/deputies/scorecards")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["items"][0]["deputy_id"] == "PA1"
+    assert data["items"][0]["party_short"] == "RN"
+    assert data["items"][0]["presence_rate"] == 0.9
+
+
+def test_export_deputy_votes_csv(client, mock_cursor):
+    mock_cursor.fetchone.return_value = {"full_name": "Jean Martin"}
+    mock_cursor.fetchall.return_value = [
+        {
+            "deputy_id": "PA1",
+            "vote_id": "VTANR5L17V1",
+            "voted_at": "2024-07-16T15:00:00",
+            "vote_title": "Vote sur le projet de loi de finances",
+            "theme": "budget",
+            "result": "adopté",
+            "position": "pour",
+        }
+    ]
+    resp = client.get("/deputies/PA1/votes.csv")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/csv")
+    assert 'filename="monelu_depute_PA1_votes.csv"' in resp.headers["content-disposition"]
+    assert resp.content.startswith(b"\xef\xbb\xbf")
+    lines = resp.text.lstrip("\ufeff").splitlines()
+    assert lines[0] == "deputy_id,vote_id,voted_at,vote_title,theme,result,position"
+    assert lines[1].endswith(",adopté,pour")
+
+
+def test_export_deputy_votes_csv_not_found(client, mock_cursor):
+    mock_cursor.fetchone.return_value = None
+    resp = client.get("/deputies/NONEXISTENT/votes.csv")
+    assert resp.status_code == 404
+
+
+def test_export_vote_positions_csv(client, mock_cursor):
+    mock_cursor.fetchone.return_value = {"vote_id": "VTANR5L17V1"}
+    mock_cursor.fetchall.return_value = [
+        {
+            "vote_id": "VTANR5L17V1",
+            "deputy_id": "PA1",
+            "full_name": "Jean Martin",
+            "party": "Rassemblement National",
+            "party_short": "RN",
+            "department": "Paris",
+            "position": "pour",
+        }
+    ]
+    resp = client.get("/votes/VTANR5L17V1/positions.csv")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/csv")
+    assert (
+        'filename="monelu_scrutin_VTANR5L17V1_positions.csv"'
+        in (resp.headers["content-disposition"])
+    )
+    assert resp.content.startswith(b"\xef\xbb\xbf")
+    lines = resp.text.lstrip("\ufeff").splitlines()
+    assert lines[0] == "vote_id,deputy_id,full_name,party,party_short,department,position"
+    assert lines[1] == "VTANR5L17V1,PA1,Jean Martin,Rassemblement National,RN,Paris,pour"
+
+
+def test_export_vote_positions_csv_not_found(client, mock_cursor):
+    mock_cursor.fetchone.return_value = None
+    resp = client.get("/votes/NOPE/positions.csv")
+    assert resp.status_code == 404

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -874,3 +874,28 @@ def test_export_vote_positions_csv_not_found(client, mock_cursor):
     mock_cursor.fetchone.return_value = None
     resp = client.get("/votes/NOPE/positions.csv")
     assert resp.status_code == 404
+
+
+def test_list_scorecards_marts_missing(client, mock_cursor):
+    import psycopg2.errors
+
+    mock_cursor.fetchall.side_effect = psycopg2.errors.UndefinedTable("mart missing")
+    resp = client.get("/deputies/scorecards")
+    assert resp.status_code == 503
+
+
+def test_export_scorecards_csv_marts_missing(client, mock_cursor):
+    import psycopg2.errors
+
+    mock_cursor.fetchall.side_effect = psycopg2.errors.UndefinedTable("mart missing")
+    resp = client.get("/deputies/scorecard.csv")
+    assert resp.status_code == 503
+
+
+def test_export_deputy_votes_csv_marts_missing(client, mock_cursor):
+    import psycopg2.errors
+
+    mock_cursor.fetchone.return_value = {"full_name": "Jean Martin"}
+    mock_cursor.fetchall.side_effect = psycopg2.errors.UndefinedTable("mart missing")
+    resp = client.get("/deputies/PA1/votes.csv")
+    assert resp.status_code == 503


### PR DESCRIPTION
## What

Adds three CSV export endpoints, a dense sortable scorecard table for the full deputy dataset, and a `/donnees` page documenting the exports and their licence.

## Why

Journalists and researchers are MonÉlu's second customer segment and the multiplier audience — their coverage brings citizens to the site. Today they have to scrape the site or use the raw AN open-data portal directly. Letting them download structured data reinforces the open-data positioning already stated on `/a-propos` and `/licence-donnees`, and is the on-ramp to a future paid API tier.

## Changes

**API (`api/`)**
- `api/csv_export.py`: shared `csv_response()` helper — `StreamingResponse` with `text/csv`, UTF-8 BOM (Excel encoding detection), `Content-Disposition: attachment`.
- `api/routers/votes.py`: `GET /votes/{vote_id}/positions.csv` — every deputy's position on one scrutin.
- `api/routers/deputies.py`:
  - `GET /deputies/scorecard.csv` — every deputy's scorecard (party, department, presence/participation rates).
  - `GET /deputies/scorecards` (JSON) — same rows, feeds the frontend table.
  - `GET /deputies/{deputy_id}/votes.csv` — one deputy's full voting record.
  - Registered before `/{deputy_id}` so the literal paths don't get swallowed by the path parameter.
- `api/schemas.py`: `DeputyScorecardRow` (scorecard + party/department context) and `DeputyScorecardListResponse`.
- All three CSV endpoints share the same rate-limit tier as the existing scorecard/alignment endpoints (`tiered_limit(10)`) and 404 on an unknown deputy/vote before touching the CSV writer.

**Frontend (`frontend/`)**
- `frontend/src/app/deputes/tableau/`: new dense table view — all deputies' scorecards on one screen, sortable by any column (click a header to sort, click again to flip direction), filterable by name/group/department, linked from `/deputes` via a "Vue tableau" button and reachable at `/deputes/tableau`.
- `frontend/src/app/donnees/page.tsx`: new data page listing the three exports (endpoint, columns, what each row means), CSV format conventions (UTF-8 BOM, CRLF, ISO 8601 dates, 0–1 ratios), data freshness, and Etalab 2.0 attribution — cross-linked from `/licence-donnees`.
- "Télécharger CSV" buttons added to the deputy detail page (full voting record) and the vote detail page (all positions on that scrutin).
- `frontend/src/lib/api.ts`: `api.deputies.scorecards()` (JSON, revalidate 1h) and `csvUrl.*` helpers building plain download hrefs — the browser downloads straight from the API via `Content-Disposition`, no client-side fetch/blob handling needed.
- `frontend/src/app/sitemap.ts`: added `/deputes/tableau` and `/donnees`.
- `Footer.tsx`: added a "Données" link.

## Testing

- `tests/test_api.py`: 7 new tests covering all three CSV endpoints (headers, BOM byte prefix, filename, column order, row content) plus the new JSON `scorecards` list endpoint and the 404 paths for both `votes.csv` and `positions.csv` on an unknown id.
- `venv/bin/python -m pytest tests/ -m "not integration" -q` — 219 passed (the CI-blocking selection).
- `venv/bin/ruff check .` and `venv/bin/ruff format --check .` — clean.
- `cd frontend && npm run lint && npm test && npm run build` — lint clean, 94 Jest tests passed, production build succeeds (`/deputes/tableau` is server-rendered on demand like `/deputes`, since prerendering it at build time would call the still-unreleased `/deputies/scorecards` endpoint).
- Manual live-server exercise of the CSV endpoints (curl against a running `uvicorn` with the local Docker Postgres) was not possible in this sandbox — outbound socket binding is blocked here. Coverage instead comes from the mocked-DB unit tests above, which assert on the actual response bytes (BOM, headers, CSV body), not just status codes.

## Risks / Notes

- No schema/migration changes — the new endpoints read from existing tables (`deputies`, `votes`, `vote_positions`, `analytics_marts.mart_deputy_scorecard`).
- `/deputies/scorecards` and `/deputies/scorecard.csv` return all ~577 deputies in one response; no pagination, matching the issue's "all deputies' scorecards on one screen" acceptance criterion. If the deputy count grows meaningfully this may need paging, but it's a non-issue at current scale.
- CSV filenames (`monelu_scorecard_deputes.csv`, `monelu_depute_{id}_votes.csv`, `monelu_scrutin_{id}_positions.csv`) are new public surface — not currently referenced anywhere else, safe to rename later if needed.
- The manual "open in Excel/LibreOffice" acceptance criterion could not be exercised end-to-end in this sandboxed session; recommend a quick manual check before merge.

## Breaking Changes

None.
