### PR TITLE
feat: add data-page error report channel + feedback triage (MON-101)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "CLAUDE.md",
         "hashed_secret": "ffddd4c9867f24ed207b1da5b50693e6d85a7889",
         "is_verified": false,
-        "line_number": 171
+        "line_number": 172
       }
     ],
     "README.md": [
@@ -252,5 +252,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-14T21:55:39Z"
+  "generated_at": "2026-07-16T21:32:20Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,7 @@ Assemblée Nationale Open Data (ZIPs)
 | `api_keys` | Manually-issued public API keys (sha256 hash, label, rate_limit_multiplier) |
 | `api_key_usage` | Per-key, per-endpoint, per-day request counters for usage accounting |
 | `verifications` | Stored fact-check verdicts (ADR-022): immutable snapshots behind `/verifier/v/<id>` share URLs |
+| `feedback` | Generic user-feedback sink (MON-70, MON-101): `type`-discriminated rows (`chat` thumbs / `report` data-page error reports) with a JSONB `payload`; weekly manual triage query in `docs/monitoring.md` |
 
 Important data quirks:
 - `nonVotant` ≠ `abstention`: present in chamber but did not vote vs. formally abstained

--- a/api/routers/feedback.py
+++ b/api/routers/feedback.py
@@ -19,6 +19,15 @@ class ChatFeedbackRequest(BaseModel):
     sources: list[dict] = Field(default_factory=list, max_length=10)
 
 
+class ErrorReportRequest(BaseModel):
+    entity_type: str = Field(..., pattern="^(deputy|vote|page)$")
+    entity_id: str | None = Field(None, max_length=60)
+    entity_label: str | None = Field(None, max_length=300)
+    page_url: str | None = Field(None, max_length=300)
+    message: str = Field(..., min_length=1, max_length=2000)
+    email: str | None = Field(None, max_length=200)
+
+
 class FeedbackResponse(BaseModel):
     status: str = "ok"
 
@@ -46,6 +55,38 @@ def submit_chat_feedback(request: Request, body: ChatFeedbackRequest):
             conn.commit()
     except Exception:
         logger.exception("Failed to persist chat feedback")
+        raise HTTPException(
+            status_code=500,
+            detail="Service temporairement indisponible. Réessayez dans quelques secondes.",
+        ) from None
+    return FeedbackResponse()
+
+
+@router.post(
+    "/report",
+    response_model=FeedbackResponse,
+    summary="Signaler une erreur sur une page de données (MON-101)",
+)
+@limiter.limit(tiered_limit(10))
+def submit_error_report(request: Request, body: ErrorReportRequest):
+    payload = {
+        "entity_type": body.entity_type,
+        "entity_id": body.entity_id,
+        "entity_label": body.entity_label,
+        "page_url": body.page_url,
+        "message": body.message,
+        "email": body.email,
+    }
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO feedback (type, payload) VALUES (%s, %s)",
+                    ("report", Json(payload)),
+                )
+            conn.commit()
+    except Exception:
+        logger.exception("Failed to persist error report")
         raise HTTPException(
             status_code=500,
             detail="Service temporairement indisponible. Réessayez dans quelques secondes.",

--- a/data/migrations/005_feedback.sql
+++ b/data/migrations/005_feedback.sql
@@ -1,9 +1,10 @@
 -- MonÉlu — user feedback loop (MON-70)
 -- Idempotent: CREATE TABLE IF NOT EXISTS — safe to re-run.
 
--- Generic feedback sink: `type` distinguishes sources (e.g. 'chat'), `payload`
--- carries the type-specific context as JSONB so new feedback sources (e.g. the
--- data-page report channel in MON-101) don't need a schema migration.
+-- Generic feedback sink: `type` distinguishes sources ('chat' for MON-70 chat
+-- thumbs, 'report' for MON-101 data-page error reports), `payload` carries the
+-- type-specific context as JSONB so new feedback sources don't need a schema
+-- migration.
 CREATE TABLE IF NOT EXISTS feedback (
     id SERIAL PRIMARY KEY,
     type TEXT NOT NULL,

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -68,3 +68,34 @@ Set the alert contact to email for both monitors.
 Both UptimeRobot and Better Stack offer a free public status page backed by
 these same monitors — worth turning on for customer-facing trust once the
 above two monitors are live and stable.
+
+## 4. User feedback triage (MON-101)
+
+Every user signal lands in one generic `feedback` table (see
+`data/migrations/005_feedback.sql`), discriminated by a `type` column:
+
+- `type = 'chat'` — thumbs up/down on a RAG chat answer (MON-70). Payload:
+  `{vote, question, answer, sources}`.
+- `type = 'report'` — a "Signaler une erreur" report from a data page (MON-101).
+  Payload: `{entity_type, entity_id, entity_label, page_url, message, email}`.
+
+There is no dashboard yet — review is a weekly manual query. Run this against
+prod Supabase to list the last week's feedback, newest first:
+
+```sql
+SELECT
+  created_at,
+  type,
+  payload ->> 'entity_type' AS entity_type,
+  payload ->> 'entity_label' AS entity_label,
+  payload ->> 'vote'         AS chat_vote,
+  left(coalesce(payload ->> 'message', payload ->> 'question'), 200) AS text,
+  payload ->> 'email'        AS reply_to
+FROM feedback
+WHERE created_at >= now() - interval '7 days'
+ORDER BY created_at DESC;
+```
+
+Error reports (`type = 'report'`) that carry a `reply_to` e-mail are the ones a
+user expects a response to. Build a dashboard only once weekly volume makes the
+manual query impractical.

--- a/frontend/__tests__/components/ReportErrorButton.test.tsx
+++ b/frontend/__tests__/components/ReportErrorButton.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { ReportErrorButton } from '@/components/ReportErrorButton'
+import { api } from '@/lib/api'
+
+jest.mock('@/lib/api', () => ({
+  api: { feedback: { report: jest.fn() } },
+}))
+
+const reportMock = api.feedback.report as jest.Mock
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('ReportErrorButton', () => {
+  it('opens the form on click and shows the entity label', () => {
+    render(
+      <ReportErrorButton entityType="deputy" entityId="PA1" entityLabel="Jean Dupont" pageUrl="/deputes/PA1" />
+    )
+    expect(screen.queryByLabelText(/description de l'erreur/i)).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /signaler une erreur/i }))
+    expect(screen.getByLabelText(/description de l'erreur/i)).toBeInTheDocument()
+    expect(screen.getByText('Jean Dupont')).toBeInTheDocument()
+  })
+
+  it('submits the report with entity context and confirms success', async () => {
+    reportMock.mockResolvedValue({ status: 'ok' })
+    render(
+      <ReportErrorButton entityType="vote" entityId="V1" entityLabel="Un scrutin" pageUrl="/votes/V1" />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /signaler une erreur/i }))
+    fireEvent.change(screen.getByLabelText(/description de l'erreur/i), {
+      target: { value: 'Le résultat est faux.' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /envoyer le signalement/i }))
+
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent(/signalement envoyé/i))
+    expect(reportMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_type: 'vote',
+        entity_id: 'V1',
+        entity_label: 'Un scrutin',
+        page_url: '/votes/V1',
+        message: 'Le résultat est faux.',
+        email: null,
+      })
+    )
+  })
+
+  it('does not submit when the message is empty', () => {
+    render(
+      <ReportErrorButton entityType="page" entityLabel="Une page" pageUrl="/x" />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /signaler une erreur/i }))
+    fireEvent.click(screen.getByRole('button', { name: /envoyer le signalement/i }))
+    expect(reportMock).not.toHaveBeenCalled()
+  })
+
+  it('shows an error message when the request fails', async () => {
+    reportMock.mockRejectedValue(new Error('API error: 500'))
+    render(
+      <ReportErrorButton entityType="deputy" entityId="PA1" entityLabel="Jean Dupont" pageUrl="/deputes/PA1" />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /signaler une erreur/i }))
+    fireEvent.change(screen.getByLabelText(/description de l'erreur/i), {
+      target: { value: 'Erreur.' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /envoyer le signalement/i }))
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/échoué/i))
+  })
+})

--- a/frontend/__tests__/lib/api.test.ts
+++ b/frontend/__tests__/lib/api.test.ts
@@ -69,6 +69,36 @@ describe('api.feedback.chat', () => {
   })
 })
 
+describe('api.feedback.report', () => {
+  it('posts the error report and returns the response', async () => {
+    mockFetch(200, { status: 'ok' })
+    const report = {
+      entity_type: 'deputy' as const,
+      entity_id: 'PA722990',
+      entity_label: 'Jean Dupont',
+      page_url: '/deputes/PA722990',
+      message: 'Le taux de présence semble erroné.',
+      email: null,
+    }
+    const result = await api.feedback.report(report)
+    expect(result.status).toBe('ok')
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${API_BASE}/feedback/report`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(report),
+      })
+    )
+  })
+
+  it('throws on a non-ok HTTP response', async () => {
+    mockFetch(500, { detail: 'Internal Server Error' })
+    await expect(
+      api.feedback.report({ entity_type: 'page', message: 'Erreur.' })
+    ).rejects.toThrow('API error: 500')
+  })
+})
+
 describe('api.deputies.votes', () => {
   it('omits since from the query string when not provided', async () => {
     mockFetch(200, { deputy_id: 'PA1', total: 0, items: [] })

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -8,6 +8,7 @@ import { departmentCode, departmentLabel } from '@/lib/departments'
 import { positionStyle } from '@/lib/vote-position'
 import { DeputyAvatar } from '@/components/DeputyAvatar'
 import { ShareButton } from '@/components/ShareButton'
+import { ReportErrorButton } from '@/components/ReportErrorButton'
 import { InfoTooltip } from '@/components/InfoTooltip'
 import { FollowDeputyButton } from '@/components/FollowDeputyButton'
 import { VoteTimelineItem } from '@/components/VoteTimelineItem'
@@ -218,6 +219,12 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                 >
                   Comparer
                 </Link>
+                <ReportErrorButton
+                  entityType="deputy"
+                  entityId={id}
+                  entityLabel={deputy.full_name}
+                  pageUrl={`/deputes/${id}`}
+                />
               </div>
             </div>
           </div>

--- a/frontend/src/app/votes/[id]/VoteDetailClient.tsx
+++ b/frontend/src/app/votes/[id]/VoteDetailClient.tsx
@@ -2,6 +2,7 @@
 import { useState, useRef, useCallback, useMemo, useEffect } from 'react'
 import Link from 'next/link'
 import { ShareButton } from '@/components/ShareButton'
+import { ReportErrorButton } from '@/components/ReportErrorButton'
 import { InfoTooltip } from '@/components/InfoTooltip'
 import { getInitials, partyHex } from '@/lib/utils'
 import { resolvePostalCode } from '@/lib/postal'
@@ -284,6 +285,14 @@ export function VoteDetailClient(props: Props) {
                   title={`${adopted ? 'Adopté' : 'Rejeté'} - ${headline}`}
                   text="Suivez ce scrutin sur MonÉlu"
                   ariaLabel="Partager ce vote"
+                />
+              </div>
+              <div style={{ marginTop: 12, display: 'flex', justifyContent: 'center' }}>
+                <ReportErrorButton
+                  entityType="vote"
+                  entityId={voteId}
+                  entityLabel={voteTitle}
+                  pageUrl={`/votes/${voteId}`}
                 />
               </div>
             </div>

--- a/frontend/src/components/ReportErrorButton.tsx
+++ b/frontend/src/components/ReportErrorButton.tsx
@@ -1,0 +1,135 @@
+'use client'
+import { useState } from 'react'
+import { api } from '@/lib/api'
+
+interface ReportErrorButtonProps {
+  entityType: 'deputy' | 'vote' | 'page'
+  entityId?: string | null
+  entityLabel: string
+  pageUrl: string
+}
+
+type Status = 'idle' | 'open' | 'sending' | 'sent' | 'error'
+
+export function ReportErrorButton({ entityType, entityId, entityLabel, pageUrl }: ReportErrorButtonProps) {
+  const [status, setStatus] = useState<Status>('idle')
+  const [message, setMessage] = useState('')
+  const [email, setEmail] = useState('')
+
+  async function handleSubmit() {
+    if (!message.trim()) return
+    setStatus('sending')
+    try {
+      await api.feedback.report({
+        entity_type: entityType,
+        entity_id: entityId ?? null,
+        entity_label: entityLabel,
+        page_url: pageUrl,
+        message: message.trim(),
+        email: email.trim() || null,
+      })
+      setStatus('sent')
+    } catch {
+      setStatus('error')
+    }
+  }
+
+  if (status === 'sent') {
+    return (
+      <span
+        role="status"
+        className="inline-flex items-center gap-1.5 text-sm text-emerald-700 font-medium px-2.5 py-1.5"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" aria-hidden="true">
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+        Merci, signalement envoyé !
+      </span>
+    )
+  }
+
+  return (
+    <div style={{ position: 'relative', display: 'inline-flex' }}>
+      <button
+        onClick={() => setStatus(s => (s === 'idle' ? 'open' : 'idle'))}
+        aria-expanded={status !== 'idle'}
+        className="inline-flex items-center gap-1.5 text-sm text-gray-mid hover:text-navy transition-colors px-4 py-3 rounded-lg border border-gray-border bg-white font-semibold"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z" />
+          <line x1="4" y1="22" x2="4" y2="15" />
+        </svg>
+        Signaler une erreur
+      </button>
+
+      {status !== 'idle' && (
+        <div
+          style={{
+            position: 'absolute', top: 'calc(100% + 8px)', left: 0, zIndex: 40,
+            width: 320, background: '#fff', border: '1px solid #E4E6EA',
+            borderRadius: 12, padding: 18, boxShadow: '0 8px 24px rgba(27,43,80,0.16)',
+            textAlign: 'left',
+          }}
+        >
+          <div style={{ fontSize: 12, color: '#9CA3AF', marginBottom: 10, lineHeight: 1.4 }}>
+            Concerne : <span style={{ color: '#1B2B50', fontWeight: 600 }}>{entityLabel}</span>
+          </div>
+          <textarea
+            value={message}
+            onChange={e => setMessage(e.target.value)}
+            maxLength={2000}
+            rows={3}
+            placeholder="Décrivez l'erreur constatée…"
+            aria-label="Description de l'erreur"
+            style={{
+              width: '100%', border: '1px solid #E4E6EA', borderRadius: 8,
+              padding: '9px 11px', fontSize: 13.5, color: '#1B2B50',
+              resize: 'vertical', outline: 'none', fontFamily: 'inherit',
+            }}
+          />
+          <input
+            type="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            maxLength={200}
+            placeholder="Votre e-mail (facultatif, pour vous répondre)"
+            aria-label="Adresse e-mail (facultatif)"
+            style={{
+              width: '100%', border: '1px solid #E4E6EA', borderRadius: 8,
+              padding: '8px 11px', fontSize: 13, color: '#1B2B50',
+              marginTop: 8, outline: 'none', fontFamily: 'inherit',
+            }}
+          />
+          {status === 'error' && (
+            <div role="alert" style={{ fontSize: 12.5, color: '#C9302A', marginTop: 8 }}>
+              L&apos;envoi a échoué. Réessayez dans quelques secondes.
+            </div>
+          )}
+          <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+            <button
+              onClick={handleSubmit}
+              disabled={status === 'sending' || !message.trim()}
+              style={{
+                flex: 1, background: '#1B2B50', color: '#fff', border: 'none',
+                padding: '9px 14px', borderRadius: 8, fontWeight: 600, fontSize: 13.5,
+                cursor: status === 'sending' || !message.trim() ? 'default' : 'pointer',
+                opacity: status === 'sending' || !message.trim() ? 0.6 : 1,
+              }}
+            >
+              {status === 'sending' ? 'Envoi…' : 'Envoyer le signalement'}
+            </button>
+            <button
+              onClick={() => setStatus('idle')}
+              style={{
+                background: '#fff', color: '#6B7280', border: '1px solid #E4E6EA',
+                padding: '9px 14px', borderRadius: 8, fontWeight: 600, fontSize: 13.5, cursor: 'pointer',
+              }}
+            >
+              Annuler
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -298,6 +298,14 @@ export const api = {
   feedback: {
     chat: (vote: 'up' | 'down', question: string, answer: string, sources: SearchResult['sources']) =>
       apiPost<{ status: string }>('/feedback/chat', { vote, question, answer, sources }),
+    report: (report: {
+      entity_type: 'deputy' | 'vote' | 'page'
+      entity_id?: string | null
+      entity_label?: string | null
+      page_url?: string | null
+      message: string
+      email?: string | null
+    }) => apiPost<{ status: string }>('/feedback/report', report),
   },
   health: () => apiFetch<Record<string, unknown>>('/health/', { revalidate: 300 }),
 }

--- a/tests/unit/test_feedback.py
+++ b/tests/unit/test_feedback.py
@@ -1,8 +1,8 @@
-"""Unit tests for the chat feedback endpoint (MON-70)."""
+"""Unit tests for the feedback endpoints (MON-70 chat, MON-101 error reports)."""
 
 from unittest.mock import patch
 
-from api.routers.feedback import ChatFeedbackRequest
+from api.routers.feedback import ChatFeedbackRequest, ErrorReportRequest
 
 
 def test_chat_feedback_request_valid():
@@ -44,5 +44,60 @@ def test_submit_chat_feedback_db_error_returns_500(client):
         resp = client.post(
             "/feedback/chat",
             json={"vote": "down", "question": "Q", "answer": "A", "sources": []},
+        )
+    assert resp.status_code == 500
+
+
+def test_error_report_request_valid():
+    req = ErrorReportRequest(
+        entity_type="deputy",
+        entity_id="PA722990",
+        entity_label="Jean Dupont",
+        page_url="/deputes/PA722990",
+        message="Le taux de présence semble erroné.",
+    )
+    assert req.entity_type == "deputy"
+    assert req.email is None
+
+
+def test_error_report_request_rejects_bad_entity_type():
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        ErrorReportRequest(entity_type="party", message="M")
+
+
+def test_error_report_request_rejects_empty_message():
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        ErrorReportRequest(entity_type="vote", message="")
+
+
+def test_submit_error_report_inserts_row(client, mock_cursor):
+    resp = client.post(
+        "/feedback/report",
+        json={
+            "entity_type": "vote",
+            "entity_id": "VTANR5L17V100",
+            "entity_label": "Projet de loi de finances",
+            "page_url": "/votes/VTANR5L17V100",
+            "message": "Le résultat affiché ne correspond pas au scrutin officiel.",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+    args, _ = mock_cursor.execute.call_args
+    assert "INSERT INTO feedback" in args[0]
+    assert args[1][0] == "report"
+
+
+def test_submit_error_report_db_error_returns_500(client):
+    with patch("api.routers.feedback.get_conn", side_effect=RuntimeError("db down")):
+        resp = client.post(
+            "/feedback/report",
+            json={"entity_type": "page", "message": "Erreur sur cette page."},
         )
     assert resp.status_code == 500


### PR DESCRIPTION
## What

Closes the user feedback loop from **MON-101** by adding its remaining half: a lightweight **"Signaler une erreur"** channel on data pages, plus a documented weekly triage query. The chat thumbs-up/down half was delivered earlier in **MON-70 / PR #199**, which also created the generic `feedback` table this builds on.

## Why

A transparency product invites "this number is wrong" reports - that is a feature, users auditing the data. MON-101 asks that *every* user signal have a destination. Chat feedback already lands in the `feedback` table; this gives data-page error reports the same home, so nothing evaporates.

## Changes

- **`api/routers/feedback.py`** - new `POST /feedback/report` endpoint. Writes `type='report'` rows into the existing `feedback` table with a JSONB payload `{entity_type, entity_id, entity_label, page_url, message, email}`. Mirrors the chat endpoint exactly: same `tiered_limit(10)` rate tier, same insert path, same graceful 500. Request model validates `entity_type` (`deputy`/`vote`/`page`) and a non-empty, length-capped `message`; `email` is optional.
- **`frontend/src/components/ReportErrorButton.tsx`** - new client component. A single "Signaler une erreur" button opens an inline popover pre-filled with the entity context; the user types a description (optional reply e-mail) and submits. Shows sending / success / error states and confirms with "Merci, signalement envoyé !".
- **`frontend/src/lib/api.ts`** - adds `api.feedback.report(...)` following the existing `apiPost` pattern.
- **Wiring** - the button is added to the deputy profile (`deputes/[id]`) action row and the vote detail card (`votes/[id]`), each auto-referencing its entity.
- **`docs/monitoring.md`** - documents the weekly manual triage SQL over the `feedback` table (covers both `chat` and `report` types); `CLAUDE.md` DB table list gains the `feedback` row.
- **No new migration** - reuses `data/migrations/005_feedback.sql`, whose generic `type`/`payload` shape explicitly anticipated this channel.
- **Tests** - backend request-model + endpoint tests (insert path + DB-error path) in `tests/unit/test_feedback.py`; frontend `api.feedback.report` client tests and a `ReportErrorButton` component test (open, submit-with-context, empty-guard, error state).

## Acceptance criteria

| Criterion | How it's met |
|-----------|--------------|
| Chat thumbs up/down persists with full context | Already shipped in MON-70 / PR #199 (`POST /feedback/chat`, `type='chat'`). |
| Any data page lets a user report an error in <=2 clicks, with the entity auto-referenced | Deputy and vote pages: click "Signaler une erreur" (1) -> type -> "Envoyer" (2). `entity_type`/`entity_id`/`entity_label`/`page_url` are pre-filled from the page. |
| You can list last week's feedback with one query | `docs/monitoring.md` section 4 - a single `SELECT ... WHERE created_at >= now() - interval '7 days'` over `feedback`, spanning both types. |

## Test plan

- Frontend: `npm run lint`, `npx tsc --noEmit`, and the new Jest suites all pass (17 tests across `api.test` + `ReportErrorButton`). `next build` compiles and type-checks cleanly; the only failure is the known `/sitemap.xml` prerender flake (`API error: 500` from the production-API fetch, reproduces on master, unrelated to this diff).
- Backend: `ruff check .` / `ruff format --check .` clean repo-wide. The Python test env could not run locally in this sandbox (`import slowapi` hangs here - environment issue, not code); the endpoint and models mirror the CI-green MON-70 code line-for-line, and CI (`pytest -m "not integration"`) is the blocking gate.

## Deploy / migration risks

None. No new migration - reuses the existing idempotent `feedback` table via a new `type` value. The new endpoint is additive and rate-limited at the same tier as `/search`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7aXqjqQ2eH4XGwjU68GQ1
