### PR TITLE
feat: printable deputy dossier PDF export (MON-114)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
 
       - name: Comment PR with dbt data-health results
         if: always() && github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@vercel/speed-insights": "^2.0.0",
         "framer-motion": "^12.41.0",
         "next": "^15.5.19",
+        "qrcode": "^1.5.4",
         "react": "^18",
         "react-dom": "^18",
         "swr": "^2.4.1"
@@ -25,6 +26,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^30.0.0",
         "@types/node": "^20",
+        "@types/qrcode": "^1.5.6",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "eslint": "^10.5.0",
@@ -5750,6 +5752,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/react": {
       "version": "18.3.31",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
@@ -6863,7 +6875,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7455,7 +7466,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7905,6 +7915,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -8023,6 +8042,12 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -8122,7 +8147,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
@@ -9279,7 +9303,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -9483,7 +9506,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -10192,7 +10214,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12038,7 +12059,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -12688,7 +12708,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -12704,7 +12723,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -12717,7 +12735,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -12911,6 +12928,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -13236,6 +13262,89 @@
       ],
       "license": "MIT"
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -13449,7 +13558,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13477,6 +13585,12 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -13725,6 +13839,12 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -14077,7 +14197,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -14232,7 +14351,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -15445,6 +15563,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/which-typed-array": {
       "version": "1.1.22",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@vercel/speed-insights": "^2.0.0",
     "framer-motion": "^12.41.0",
     "next": "^15.5.19",
+    "qrcode": "^1.5.4",
     "react": "^18",
     "react-dom": "^18",
     "swr": "^2.4.1"
@@ -28,6 +29,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^20",
+    "@types/qrcode": "^1.5.6",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "eslint": "^10.5.0",

--- a/frontend/src/app/deputes/[id]/dossier/page.tsx
+++ b/frontend/src/app/deputes/[id]/dossier/page.tsx
@@ -1,0 +1,187 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import QRCode from 'qrcode'
+import { api } from '@/lib/api'
+import { partyHex, formatDate } from '@/lib/utils'
+import { departmentLabel } from '@/lib/departments'
+import { positionStyle } from '@/lib/vote-position'
+import { SITE_URL } from '@/lib/seo'
+import { DeputyAvatar } from '@/components/DeputyAvatar'
+import { PrintButton } from '@/components/PrintButton'
+
+export const dynamicParams = true
+export const revalidate = 86400
+
+const NAVY = '#1B2B50'
+const LINE = '#E4E6EA'
+const RED  = '#C9302A'
+
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
+  const { id } = await params
+  const deputy = await api.deputies.get(id).catch(() => null)
+  if (!deputy) return {}
+  return { title: `Dossier PDF — ${deputy.full_name} - MonÉlu` }
+}
+
+export default async function DeputyDossierPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const [deputy, scorecard, alignment, dissidentVotes] = await Promise.all([
+    api.deputies.get(id).catch(() => null),
+    api.deputies.scorecard(id).catch(() => null),
+    api.deputies.alignment(id).catch(() => null),
+    api.deputies.dissidentVotes(id, 3).catch(() => null),
+  ])
+  if (!deputy) notFound()
+
+  const profileUrl = `${SITE_URL}/deputes/${id}`
+  const qrSvg = await QRCode.toString(profileUrl, { type: 'svg', margin: 0, width: 96 })
+
+  const presencePct   = scorecard ? Math.round((scorecard.presence_rate ?? 0) * 100) : null
+  const solennelPct   = scorecard ? Math.round((scorecard.solennel_participation_rate ?? 0) * 100) : null
+  const alignmentPct  = alignment ? Math.round(alignment.party_alignment_rate * 100) : null
+  const denom         = scorecard ? (scorecard.present_votes || 1) : 1
+  const pourPct       = scorecard ? Math.round(scorecard.votes_for     / denom * 100) : 0
+  const contrePct     = scorecard ? Math.round(scorecard.votes_against / denom * 100) : 0
+  const abstPct       = scorecard ? Math.round(scorecard.abstentions   / denom * 100) : 0
+
+  const hex = partyHex(deputy.party)
+  const deptLabel = departmentLabel(deputy.department)
+  const generatedOn = new Date().toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' })
+
+  return (
+    <div style={{ background: '#fff', minHeight: '100vh' }}>
+      <div data-print-hide style={{ padding: '20px 32px', borderBottom: `1px solid ${LINE}`, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <span style={{ fontSize: 14, color: '#6B7280' }}>
+          Aperçu du dossier imprimable — utilisez « Imprimer » et choisissez « Enregistrer en PDF » comme destination.
+        </span>
+        <PrintButton />
+      </div>
+
+      <div style={{ maxWidth: 780, margin: '0 auto', padding: '36px 40px' }}>
+
+        {/* Header */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', borderBottom: `2px solid ${NAVY}`, paddingBottom: 18, marginBottom: 26 }}>
+          <div>
+            <div style={{ fontWeight: 800, fontSize: 20, color: NAVY, letterSpacing: '-0.01em' }}>
+              Mon<span style={{ color: RED }}>É</span>lu
+            </div>
+            <div style={{ fontSize: 11.5, color: '#6B7280', marginTop: 2 }}>
+              Chaque vote. Chaque député. En clair.
+            </div>
+          </div>
+          <div style={{ textAlign: 'right', fontSize: 11, color: '#9CA3AF' }}>
+            Dossier généré le {generatedOn}
+            <br />
+            XVII<sup>e</sup> législature
+          </div>
+        </div>
+
+        {/* Identity */}
+        <div style={{ display: 'flex', gap: 24, alignItems: 'flex-start', marginBottom: 26 }}>
+          <div style={{ width: 80, flexShrink: 0 }}>
+            <div style={{ borderRadius: 999, overflow: 'hidden', border: `1px solid ${LINE}` }}>
+              <DeputyAvatar name={deputy.full_name} photoUrl={deputy.photo_url} size="xl" />
+            </div>
+          </div>
+          <div style={{ flex: 1 }}>
+            <h1 style={{ fontSize: 26, fontWeight: 700, color: NAVY, margin: 0, letterSpacing: '-0.01em' }}>
+              {deputy.full_name}
+            </h1>
+            <div style={{ fontSize: 13.5, color: '#4B5563', marginTop: 6 }}>
+              {deptLabel && <span>{deptLabel}</span>}
+              {deputy.mandate_start && (
+                <span> · Mandat depuis le {formatDate(deputy.mandate_start)}</span>
+              )}
+            </div>
+            {deputy.party && (
+              <div style={{
+                display: 'inline-flex', alignItems: 'center', gap: 7, marginTop: 10,
+                padding: '5px 12px', borderRadius: 999, background: `${hex}14`,
+                border: `1px solid ${hex}40`, color: hex, fontWeight: 600, fontSize: 12.5,
+              }}>
+                <span style={{ width: 7, height: 7, borderRadius: 999, background: hex }} />
+                {deputy.party}
+              </div>
+            )}
+          </div>
+          <div style={{ textAlign: 'center', flexShrink: 0 }}>
+            <div dangerouslySetInnerHTML={{ __html: qrSvg }} />
+            <div style={{ fontSize: 9.5, color: '#9CA3AF', marginTop: 4, maxWidth: 96 }}>
+              Profil complet en ligne
+            </div>
+          </div>
+        </div>
+
+        {/* Stat grid */}
+        {scorecard && (
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 0, border: `1px solid ${LINE}`, borderRadius: 8, overflow: 'hidden', marginBottom: 24 }}>
+            {[
+              { value: `${presencePct ?? '—'}%`, label: 'présence aux votes' },
+              { value: `${solennelPct ?? '—'}%`, label: 'participation solennelle' },
+              { value: alignmentPct !== null ? `${alignmentPct}%` : '—', label: 'loyauté au groupe' },
+              { value: scorecard.total_votes.toLocaleString('fr-FR'), label: 'scrutins votés' },
+            ].map((s, i) => (
+              <div key={i} style={{ padding: '14px 10px', textAlign: 'center', borderRight: i < 3 ? `1px solid ${LINE}` : undefined, background: '#FAFAF8' }}>
+                <div style={{ fontSize: 22, fontWeight: 700, color: NAVY }}>{s.value}</div>
+                <div style={{ fontSize: 10.5, color: '#6B7280', marginTop: 3, lineHeight: 1.3 }}>{s.label}</div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Vote breakdown */}
+        {scorecard && (
+          <div style={{ marginBottom: 26 }}>
+            <div style={{ fontSize: 12, fontWeight: 700, color: NAVY, marginBottom: 8, textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+              Répartition des votes exprimés
+            </div>
+            <div style={{ height: 10, borderRadius: 999, overflow: 'hidden', display: 'flex', marginBottom: 8 }}>
+              <div style={{ width: `${pourPct}%`,   background: '#1F8A5B' }} />
+              <div style={{ width: `${contrePct}%`, background: RED }} />
+              <div style={{ width: `${abstPct}%`,   background: '#D1D5DB' }} />
+            </div>
+            <div style={{ display: 'flex', gap: 18, fontSize: 12, color: '#374151' }}>
+              <span>Pour {pourPct}%</span>
+              <span>Contre {contrePct}%</span>
+              <span>Abstention {abstPct}%</span>
+            </div>
+          </div>
+        )}
+
+        {/* Notable votes */}
+        {dissidentVotes && dissidentVotes.items.length > 0 && (
+          <div style={{ marginBottom: 26, breakInside: 'avoid' }}>
+            <div style={{ fontSize: 12, fontWeight: 700, color: NAVY, marginBottom: 10, textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+              Votes marquants — dissidences avec le groupe
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {dissidentVotes.items.map(v => (
+                <div key={v.vote_id} style={{ border: `1px solid ${LINE}`, borderRadius: 6, padding: '10px 12px' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+                    {v.voted_at && <span style={{ fontSize: 10.5, color: '#9CA3AF' }}>{formatDate(v.voted_at)}</span>}
+                    <span style={{ fontSize: 10.5, fontWeight: 700, color: positionStyle(v.position).color }}>
+                      A voté {positionStyle(v.position).label}
+                    </span>
+                    <span style={{ fontSize: 10.5, color: '#9CA3AF' }}>
+                      groupe : {positionStyle(v.majority_position).label}
+                    </span>
+                  </div>
+                  <div style={{ fontSize: 12.5, color: NAVY, lineHeight: 1.35 }}>{v.vote_title}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Methodology footnote */}
+        <div style={{ borderTop: `1px solid ${LINE}`, paddingTop: 14, fontSize: 10, color: '#9CA3AF', lineHeight: 1.5 }}>
+          Méthodologie : le taux de présence compte toute position enregistrée (y compris non-votant) sur les
+          scrutins tenus pendant le mandat. Le taux de loyauté compare, vote par vote, la position du député à
+          la position majoritaire de son groupe parlementaire actuel. Source : données officielles ouvertes de
+          l&apos;Assemblée nationale, XVII<sup>e</sup> législature. Détails complets : {SITE_URL}/methodologie —
+          profil vivant : {profileUrl}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -233,6 +233,20 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
                   CSV
                 </a>
+                <Link
+                  href={`/deputes/${id}/dossier`}
+                  target="_blank"
+                  title="Ouvrir le dossier imprimable (photo, bilan, votes marquants)"
+                  style={{
+                    display: 'inline-flex', alignItems: 'center', gap: 8,
+                    background: '#fff', border: `1px solid ${LINE}`, color: NAVY,
+                    padding: '12px 22px', borderRadius: 9, fontWeight: 600,
+                    fontSize: 15, textDecoration: 'none',
+                  }}
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="6 9 6 2 18 2 18 9" /><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" /><rect x="6" y="14" width="12" height="8" /></svg>
+                  Exporter en PDF
+                </Link>
                 <ReportErrorButton
                   entityType="deputy"
                   entityId={id}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -22,3 +22,11 @@
   .badge-rejete { @apply bg-red-50 text-red-civic border border-red-200 text-xs font-medium px-2 py-0.5 rounded; }
   .badge-party { @apply bg-navy-muted text-navy text-xs font-medium px-2 py-0.5 rounded; }
 }
+
+/* MON-114: printable deputy dossier — hide app chrome and force a clean
+   single page when the dossier route is sent to the browser's print dialog. */
+@media print {
+  [data-print-hide] { display: none !important; }
+  body { background: #fff !important; }
+  @page { size: A4; margin: 14mm; }
+}

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -12,7 +12,7 @@ const items = [
 export function BottomNav() {
   const path = usePathname()
   return (
-    <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-gray-border z-50">
+    <nav data-print-hide className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-gray-border z-50">
       <div className="grid grid-cols-4">
         {items.map(item => {
           const active =

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -18,6 +18,7 @@ export function Footer() {
 
   return (
     <footer
+      data-print-hide
       className="pb-20 md:pb-8"
       style={{
         paddingTop: '32px',

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -20,6 +20,7 @@ export function Nav() {
 
   return (
     <nav
+      data-print-hide
       className="hidden md:flex items-center justify-between px-8 bg-white border-b border-gray-border sticky top-0 z-50"
       style={{ height: NAV_HEIGHT_PX }}
     >

--- a/frontend/src/components/PrintButton.tsx
+++ b/frontend/src/components/PrintButton.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+type Props = {
+  label?: string
+}
+
+export function PrintButton({ label = 'Imprimer / Enregistrer en PDF' }: Props) {
+  return (
+    <button
+      type="button"
+      onClick={() => window.print()}
+      data-print-hide
+      style={{
+        display: 'inline-flex', alignItems: 'center', gap: 8,
+        background: '#E0786E', color: '#fff', padding: '12px 24px',
+        borderRadius: 9, fontWeight: 600, fontSize: 15, border: 'none',
+        cursor: 'pointer', boxShadow: '0 2px 8px rgba(224,120,110,0.35)',
+      }}
+    >
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <polyline points="6 9 6 2 18 2 18 9" /><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" /><rect x="6" y="14" width="12" height="8" />
+      </svg>
+      {label}
+    </button>
+  )
+}


### PR DESCRIPTION
## What
Adds a one-click "Exporter en PDF" export for deputy profiles: a new print-optimized dossier route plus a button that opens it.

## Why
Journalists and NGO researchers currently screenshot deputy profiles for interviews, portraits, and election dossiers. MON-114 asks for a branded, publication-ready one-pager instead - a print stylesheet is the cheap first version explicitly named in the issue (vs. a client-side PDF library or a server-side headless-Chromium pipeline, both larger-effort options also named there). Every dossier that lands in a newsroom carries the brand and a link back to the live profile.

## Changes
- **`frontend/src/app/deputes/[id]/dossier/page.tsx`** (new): server-rendered one-page dossier - photo, name, department, mandate start, party, a 4-up stat grid (presence, solennel participation, party loyalty, total scrutins), the Pour/Contre/Abstention breakdown bar, up to 3 notable dissident votes, a methodology footnote, and a QR code (generated server-side via `qrcode`, no client JS) linking back to the live profile. Reuses the same API calls (`deputies.get/scorecard/alignment/dissidentVotes`) as the main profile page.
- **`frontend/src/components/PrintButton.tsx`** (new): small client component, calls `window.print()`.
- **`frontend/src/app/deputes/[id]/page.tsx`**: adds an "Exporter en PDF" link in the existing CTA row (next to the CSV export link), opening the dossier route in a new tab.
- **`frontend/src/app/globals.css`**: adds a `@media print` block - hides any element with `data-print-hide` (site chrome) and sets an A4 page size/margin.
- **`frontend/src/components/Nav.tsx`, `BottomNav.tsx`, `Footer.tsx`**: tag their root element with `data-print-hide` so they disappear when the dossier is printed.
- **`frontend/package.json`**: adds `qrcode` (dependency, range-pinned) and `@types/qrcode` (devDependency) per the repo's pinning convention - no history of breaking changes for this package.

## Testing
- `npx tsc --noEmit` - clean.
- `npm run lint` - no warnings/errors.
- `npm test` - 12 suites / 100 tests passing, unchanged.
- `npm run build` - succeeds; `/deputes/[id]/dossier` registered as a dynamic route. The `/sitemap.xml` 60s prerender retry is known noise, reproduces on master.
- Manual: ran `npm run dev`, fetched `/deputes/PA841729` (confirmed the new "Exporter en PDF" link renders and points to `/deputes/PA841729/dossier` with `target="_blank"`) and `/deputes/PA841729/dossier` directly (confirmed real name/party/mandate/QR-code SVG render in the HTML, not just placeholders).
- Not tested: actual browser print-to-PDF output pixel fidelity (no headless browser in this environment) - the `@media print` rules and single-column, compact layout are the standard mechanism, but a human should do one real "Enregistrer en PDF" pass in Chrome/Firefox before considering this pixel-final.

## Risks / Notes
- This ships the print-stylesheet MVP only, per explicit product-owner decision (asked and confirmed before implementing) - not the react-pdf or headless-Chromium alternatives the issue also named. If a downloadable-without-print-dialog `.pdf` file becomes a hard requirement later, that's a follow-up issue, not a gap in this PR.
- No new backend endpoint, no schema change, no new ADR needed - this is presentation-only over already-exposed API data.
- Reviewer should sanity-check the print layout fits one page for deputies with more/fewer dissident votes than the sample tested.

## Breaking Changes
None.
