### PR TITLE
feat: add share option to chat/RAG answers (MON-66)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "CLAUDE.md",
         "hashed_secret": "ffddd4c9867f24ed207b1da5b50693e6d85a7889",
         "is_verified": false,
-        "line_number": 172
+        "line_number": 173
       }
     ],
     "README.md": [
@@ -252,5 +252,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-16T21:32:20Z"
+  "generated_at": "2026-07-16T22:46:21Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Assemblée Nationale Open Data (ZIPs)
 
 **`api/`** — FastAPI application
 - `main.py`: App factory, CORS (GET + POST — POST is needed for `/search`; an empty `CORS_ORIGINS` blocks all cross-origin requests and logs a startup warning), slowapi rate limiting (30 req/min global, 10 req/min on scorecard and search), global exception handler. `/health` returns DB status, record counts, last ingestion timestamp, and dbt mart row counts. The landing page is now the Next.js frontend (`frontend/`), not a FastAPI-served HTML page.
-- `routers/deputies.py`, `routers/votes.py`, `routers/search.py`, `routers/verify.py`, `routers/departments.py`: All DB queries — direct SQL, no ORM. `verify.py` is the fact-check surface (MON-126, ADR-022): `POST /verify/` runs the verification chain and stores an immutable verdict snapshot; `GET /verify/{id}` serves stored verdicts with no LLM call. `departments.py` (MON-107) serves `GET /departments/{code}` — current deputies of a department with scorecard highlights, aggregates, and recent split votes; the code↔name map lives in `api/departments_data.py` (mirrors `scripts/update_party.py` DEPT_NAMES plus overseas collectivities; frontend copy in `frontend/src/lib/departments.ts`).
+- `routers/deputies.py`, `routers/votes.py`, `routers/search.py`, `routers/verify.py`, `routers/departments.py`: All DB queries — direct SQL, no ORM. `verify.py` is the fact-check surface (MON-126, ADR-022): `POST /verify/` runs the verification chain and stores an immutable verdict snapshot; `GET /verify/{id}` serves stored verdicts with no LLM call. `search.py` also carries the chat share surface (MON-66, ADR-024): `POST /search/share` persists a chat answer already returned by `POST /search/` (question, answer, sources, confidence) as an immutable snapshot; `GET /search/share/{id}` serves it with no LLM call, at share URL `/chat/s/<id>`. `departments.py` (MON-107) serves `GET /departments/{code}` — current deputies of a department with scorecard highlights, aggregates, and recent split votes; the code↔name map lives in `api/departments_data.py` (mirrors `scripts/update_party.py` DEPT_NAMES plus overseas collectivities; frontend copy in `frontend/src/lib/departments.ts`).
 - `schemas.py`: Pydantic response models; all fields `Optional` to match DB NULLs
 - `limiter.py`: Shared slowapi `Limiter` instance imported by routers
 
@@ -155,6 +155,7 @@ Assemblée Nationale Open Data (ZIPs)
 | `api_keys` | Manually-issued public API keys (sha256 hash, label, rate_limit_multiplier) |
 | `api_key_usage` | Per-key, per-endpoint, per-day request counters for usage accounting |
 | `verifications` | Stored fact-check verdicts (ADR-022): immutable snapshots behind `/verifier/v/<id>` share URLs |
+| `chat_shares` | Stored chat/RAG answer snapshots (MON-66, ADR-024): immutable snapshots behind `/chat/s/<id>` share URLs |
 | `feedback` | Generic user-feedback sink (MON-70, MON-101): `type`-discriminated rows (`chat` thumbs / `report` data-page error reports) with a JSONB `payload`; weekly manual triage query in `docs/monitoring.md` |
 
 Important data quirks:

--- a/api/routers/search.py
+++ b/api/routers/search.py
@@ -1,16 +1,22 @@
 import logging
+import os
+import uuid
 from typing import Literal
 
 import groq
 from fastapi import APIRouter, HTTPException, Request
+from psycopg2.extras import Json
 from pydantic import BaseModel, Field
 
+from api.db import get_conn
 from api.limiter import limiter, tiered_limit
 from rag.chain.rag_chain import ask
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+FRONTEND_BASE_URL = os.getenv("FRONTEND_BASE_URL", "https://mon-elu.vercel.app").rstrip("/")
 
 
 class SearchRequest(BaseModel):
@@ -86,3 +92,101 @@ def search(request: Request, body: SearchRequest):
             status_code=500,
             detail="Service temporairement indisponible. Réessayez dans quelques secondes.",
         ) from None
+
+
+class ShareRequest(BaseModel):
+    question: str = Field(..., min_length=1, max_length=500)
+    answer: str = Field(..., min_length=1, max_length=8000)
+    sources: list[dict] = Field(default_factory=list, max_length=20)
+    confidence: str | None = Field(None, max_length=50)
+    data_source: str | None = Field(None, max_length=50)
+    caveat: str | None = Field(None, max_length=500)
+
+
+class ShareResponse(BaseModel):
+    id: str
+    question: str
+    answer: str
+    sources: list[dict]
+    confidence: str | None = None
+    data_source: str | None = None
+    caveat: str | None = None
+    shared_at: str
+    share_url: str
+
+
+def _to_share_response(row: dict) -> ShareResponse:
+    share_id = str(row["id"])
+    return ShareResponse(
+        id=share_id,
+        question=row["question"],
+        answer=row["answer"],
+        sources=row["sources"],
+        confidence=row["confidence"],
+        data_source=row["data_source"],
+        caveat=row["caveat"],
+        shared_at=row["created_at"].isoformat(),
+        share_url=f"{FRONTEND_BASE_URL}/chat/s/{share_id}",
+    )
+
+
+@router.post(
+    "/share",
+    response_model=ShareResponse,
+    summary="Partagez une réponse du chat (aucun appel IA - snapshot de la réponse déjà obtenue)",
+)
+@limiter.limit(tiered_limit(30))
+def share_answer(request: Request, body: ShareRequest):
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO chat_shares
+                        (question, answer, sources, confidence, data_source, caveat)
+                    VALUES (%s, %s, %s, %s, %s, %s)
+                    RETURNING id, question, answer, sources, confidence, data_source,
+                              caveat, created_at
+                    """,
+                    (
+                        body.question,
+                        body.answer,
+                        Json(body.sources),
+                        body.confidence,
+                        body.data_source,
+                        body.caveat,
+                    ),
+                )
+                row = cur.fetchone()
+            conn.commit()
+    except Exception:
+        logger.exception("Failed to persist chat share")
+        raise HTTPException(
+            status_code=500,
+            detail="Service temporairement indisponible. Réessayez dans quelques secondes.",
+        ) from None
+    return _to_share_response(row)
+
+
+@router.get(
+    "/share/{share_id}",
+    response_model=ShareResponse,
+    summary="Relisez une réponse partagée (aucun appel IA)",
+)
+@limiter.limit(tiered_limit(30))
+def get_share(request: Request, share_id: uuid.UUID):
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, question, answer, sources, confidence, data_source,
+                       caveat, created_at
+                FROM chat_shares
+                WHERE id = %s
+                """,
+                (str(share_id),),
+            )
+            row = cur.fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Réponse partagée introuvable.")
+    return _to_share_response(row)

--- a/data/migrations/007_chat_shares.sql
+++ b/data/migrations/007_chat_shares.sql
@@ -1,0 +1,19 @@
+-- MonÉlu — stored chat/RAG answer snapshots (MON-66, ADR-024)
+-- Idempotent: CREATE TABLE/INDEX IF NOT EXISTS — safe to re-run.
+
+-- A chat share is an immutable snapshot of an answer the user already saw in
+-- the chat UI: the question, the answer, and the sources rendered with it,
+-- frozen at share time. Rows are never updated; sharing the same answer twice
+-- creates a new row (mirrors ADR-022's verifications table). No user identity
+-- is stored; UUIDs keep stored shares non-enumerable.
+CREATE TABLE IF NOT EXISTS chat_shares (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    question TEXT NOT NULL,
+    answer TEXT NOT NULL,
+    -- [{"content", "metadata", "similarity"}] as rendered in the chat UI.
+    sources JSONB NOT NULL DEFAULT '[]'::jsonb,
+    confidence TEXT,
+    data_source TEXT,
+    caveat TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -530,6 +530,29 @@ Auto-detection is kept but demoted to a nudge: a `verify_claim` intent added to 
 
 ---
 
+## ADR-024 - Chat answers are shareable via a stored snapshot, mirroring ADR-022 (MON-66)
+
+**Date:** 2026-07-17
+**Status:** Final
+
+**Decision:** A chat assistant message gets a "Partager" action that persists the answer the user already saw - question, answer text, sources, confidence, data source, and caveat - into a new `chat_shares` table via `POST /search/share`, and returns a share URL `/chat/s/<id>`. `GET /search/share/<id>` serves the stored snapshot with no LLM call. The share page is a standalone read-only view (`ChatAnswerCard`), not a re-render of the interactive chat bubble.
+
+**Reason:** This is the same shape of decision as ADR-022, applied to `/search` instead of `/verify`: the share moment is unauthenticated, potentially high-traffic, and must not trigger a Groq call. Two design points specific to chat answers:
+
+- **Store the client-submitted answer, don't recompute it.** Unlike `/verify`, which computes its own verdict server-side from the claim, a chat share persists the *exact* answer text the user already received from an earlier `/search` call - the user is sharing what they saw, and the LLM is non-deterministic at temperature 0.2, so recomputing at share time could silently produce a different answer than what was shared. This mirrors the existing `POST /feedback/chat` endpoint (MON-70), which already accepts client-submitted `question`/`answer`/`sources` without recomputation - `chat_shares` uses the same trust boundary, not a new one.
+- **A dedicated table, not the generic `feedback` sink.** `feedback` is write-only (moderation triage, never served back to users per row). A share is read back publicly at a stable URL and needs OG metadata, so it gets its own table with the immutable-snapshot shape from `verifications` (UUID PK, no user identity, `created_at`), not a `type`-discriminated `payload` row.
+
+**Impact:**
+- MON-66 adds the `chat_shares` table (additive migration `007_chat_shares.sql`) and `POST /search/share` / `GET /search/share/<id>`.
+- The chat page's assistant message gains a "Partager" action next to "Copier", reusing the `ShareButton` component's native-share-or-clipboard behavior.
+- `mdToHtml`, `mapSource`, and the confidence badge metadata moved from `chat/page.tsx` into `frontend/src/lib/chatFormat.ts` so the share page renders an answer identically to the chat bubble.
+- Do NOT recompute the answer on `POST /search/share` or on `GET /search/share/<id>` - both are LLM-free by construction (share stores what was already computed; get is a plain SELECT).
+- Do NOT add listing/browsing of stored shares without a moderation decision first (same constraint as ADR-022's verifications).
+
+**Trigger to revisit:** if shared answers become a moderation or impersonation problem (fabricated MonÉlu-branded content circulating), add server-side validation against a real `/search` call or a moderation queue before serving new shares; if storage nears the Supabase free tier limit, `chat_shares` is a TTL candidate alongside `verifications`.
+
+---
+
 ## Rules for future development sessions
 
 1. Read this file before writing any code

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -9,6 +9,7 @@ import { api } from '@/lib/api'
 import type { SearchResult, VerifyResult } from '@/lib/api'
 import { InfoTooltip } from '@/components/InfoTooltip'
 import { VerdictCard } from '@/components/VerdictCard'
+import { mdToHtml, mapSource, CONFIDENCE_META, CONFIDENCE_EXPLANATION } from '@/lib/chatFormat'
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -86,80 +87,6 @@ function relativeTime(ts: number): string {
   return new Date(ts).toLocaleDateString('fr-FR', { day: 'numeric', month: 'short' })
 }
 
-// ── Markdown renderer ──────────────────────────────────────────────────────
-
-function mdToHtml(text: string): string {
-  let h = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-  h = h.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-  const blocks = h.split('\n\n')
-  return blocks.map(block => {
-    const lines = block.split('\n')
-    if (lines.length > 1 && lines.every(l => /^- /.test(l))) {
-      const items = lines.map(l => `<li style="margin:5px 0">${l.slice(2)}</li>`).join('')
-      return `<ul style="margin:6px 0 12px 0;padding-left:22px">${items}</ul>`
-    }
-    if (lines.length > 1 && lines.every(l => /^\d+\. /.test(l))) {
-      const items = lines.map(l => `<li style="margin:5px 0">${l.replace(/^\d+\.\s/, '')}</li>`).join('')
-      return `<ol style="margin:6px 0 12px 0;padding-left:22px">${items}</ol>`
-    }
-    return `<p style="margin:0 0 14px 0">${lines.join('<br>')}</p>`
-  }).join('')
-}
-
-// ── Source card helpers ────────────────────────────────────────────────────
-
-type SourceCard = { dot: string; label: string; sub: string; badge: string; badgeBg: string; badgeColor: string; href?: string }
-
-function mapSource(src: SearchResult['sources'][0]): SourceCard {
-  const meta = src.metadata || {}
-  const type = meta.chunk_type || 'stat'
-  if (type === 'deputy' || type === 'notable_deputy') {
-    return {
-      dot: meta.group_color || '#1B2B50',
-      label: meta.deputy_name || meta.full_name || meta.name || 'Député',
-      sub: [meta.department, meta.circonscription, meta.party].filter(Boolean).join(' · ') || '',
-      badge: meta.group_short || meta.group || meta.party || '',
-      badgeBg: '#F1F5F9', badgeColor: '#475569',
-      href: meta.deputy_id ? `/deputes/${meta.deputy_id}` : undefined,
-    }
-  }
-  if (type === 'vote' || type === 'law_summary') {
-    const adopted = (meta.result || '').toLowerCase().includes('adopt')
-    return {
-      dot: adopted ? '#15803D' : '#DC2626',
-      label: meta.title || meta.vote_title || src.content.slice(0, 60),
-      sub: meta.date || meta.voted_at || '',
-      badge: meta.result || '',
-      badgeBg: adopted ? '#DCFCE7' : '#FEE2E2',
-      badgeColor: adopted ? '#15803D' : '#DC2626',
-      href: meta.vote_id ? `/votes/${meta.vote_id}` : undefined,
-    }
-  }
-  return {
-    dot: '#1B2B50',
-    label: src.content.slice(0, 55) + (src.content.length > 55 ? '…' : ''),
-    sub: `Pertinence ${Math.round(src.similarity * 100)} %`,
-    badge: type, badgeBg: '#EFF3FB', badgeColor: '#1B2B50',
-  }
-}
-
-// ── Confidence badge helpers ────────────────────────────────────────────────
-// compute_confidence() in rag/chain/rag_chain.py derives this from retrieval
-// quality (top similarity + supporting chunk count), not LLM self-rating.
-
-const CONFIDENCE_META: Record<string, { label: string; bg: string; color: string; bgDark: string; colorDark: string }> = {
-  high:   { label: 'Haute confiance',   bg: '#DCFCE7', color: '#15803D', bgDark: 'rgba(21,128,61,0.20)', colorDark: '#4ADE80' },
-  medium: { label: 'Confiance moyenne', bg: '#FEF3C7', color: '#92400E', bgDark: 'rgba(180,83,9,0.20)',  colorDark: '#FBBF24' },
-  low:    { label: 'Basse confiance',   bg: '#FEE2E2', color: '#B91C1C', bgDark: 'rgba(185,28,28,0.20)', colorDark: '#F87171' },
-}
-
-const CONFIDENCE_EXPLANATION =
-  "La confiance reflète la qualité des sources retrouvées dans la base de données (similarité et nombre), " +
-  "pas l'auto-évaluation du modèle. " +
-  'Haute confiance : plusieurs sources très proches de la question. ' +
-  'Confiance moyenne : sources partiellement pertinentes. ' +
-  'Basse confiance : peu de sources vraiment pertinentes — vérifiez la réponse à la source.'
-
 // ── Verify mode helpers ─────────────────────────────────────────────────────
 
 const VERIFY_MIN_LENGTH = 10
@@ -217,6 +144,7 @@ function ChatInner() {
   const [activeConvId, setActiveConvId]   = useState<string | null>(null)
   const [copied, setCopied]       = useState(false)
   const [feedbackByMsg, setFeedbackByMsg] = useState<Record<number, 'pending' | 'up' | 'down' | 'error'>>({})
+  const [shareByMsg, setShareByMsg] = useState<Record<number, 'pending' | 'shared' | 'error'>>({})
 
   const scrollRef     = useRef<HTMLDivElement>(null)
   const textareaRef   = useRef<HTMLTextAreaElement>(null)
@@ -466,6 +394,30 @@ function ChatInner() {
     api.feedback.chat(vote, result.question, result.answer, result.sources)
       .then(() => setFeedbackByMsg(prev => ({ ...prev, [i]: vote })))
       .catch(() => setFeedbackByMsg(prev => ({ ...prev, [i]: 'error' })))
+  }, [])
+
+  const shareAnswer = useCallback(async (i: number, result: SearchResult) => {
+    setShareByMsg(prev => ({ ...prev, [i]: 'pending' }))
+    try {
+      const share = await api.shareAnswer(result)
+      if (typeof navigator !== 'undefined' && navigator.share) {
+        try {
+          await navigator.share({ url: share.share_url, title: 'Réponse MonÉlu', text: result.question })
+          setShareByMsg(prev => ({ ...prev, [i]: 'shared' }))
+          return
+        } catch (err) {
+          if (err instanceof Error && err.name === 'AbortError') {
+            setShareByMsg(prev => { const next = { ...prev }; delete next[i]; return next })
+            return
+          }
+        }
+      }
+      await navigator.clipboard.writeText(share.share_url)
+      setShareByMsg(prev => ({ ...prev, [i]: 'shared' }))
+      setTimeout(() => setShareByMsg(prev => { const next = { ...prev }; delete next[i]; return next }), 2000)
+    } catch {
+      setShareByMsg(prev => ({ ...prev, [i]: 'error' }))
+    }
   }, [])
 
   const hasMessages = messages.length > 0
@@ -805,6 +757,27 @@ function ChatInner() {
                               <rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
                             </svg>
                             {copied ? 'Copié !' : 'Copier'}
+                          </ActionBtn>
+                          <ActionBtn
+                            onClick={() => shareAnswer(i, msg.result)}
+                            dark={dk}
+                          >
+                            {shareByMsg[i] === 'pending' ? (
+                              'Partage…'
+                            ) : shareByMsg[i] === 'shared' ? (
+                              'Copié !'
+                            ) : shareByMsg[i] === 'error' ? (
+                              'Erreur, réessayez'
+                            ) : (
+                              <>
+                                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                  <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
+                                  <polyline points="16 6 12 2 8 6" />
+                                  <line x1="12" y1="2" x2="12" y2="15" />
+                                </svg>
+                                Partager
+                              </>
+                            )}
                           </ActionBtn>
                           {showVerifyAction && (
                             <ActionBtn onClick={() => prefillVerify(msg.result.question)} dark={dk}>

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -144,7 +144,7 @@ function ChatInner() {
   const [activeConvId, setActiveConvId]   = useState<string | null>(null)
   const [copied, setCopied]       = useState(false)
   const [feedbackByMsg, setFeedbackByMsg] = useState<Record<number, 'pending' | 'up' | 'down' | 'error'>>({})
-  const [shareByMsg, setShareByMsg] = useState<Record<number, 'pending' | 'shared' | 'error'>>({})
+  const [shareByMsg, setShareByMsg] = useState<Record<number, 'pending' | 'shared' | 'copied' | 'error'>>({})
 
   const scrollRef     = useRef<HTMLDivElement>(null)
   const textareaRef   = useRef<HTMLTextAreaElement>(null)
@@ -404,6 +404,7 @@ function ChatInner() {
         try {
           await navigator.share({ url: share.share_url, title: 'Réponse MonÉlu', text: result.question })
           setShareByMsg(prev => ({ ...prev, [i]: 'shared' }))
+          setTimeout(() => setShareByMsg(prev => { const next = { ...prev }; delete next[i]; return next }), 2000)
           return
         } catch (err) {
           if (err instanceof Error && err.name === 'AbortError') {
@@ -413,7 +414,7 @@ function ChatInner() {
         }
       }
       await navigator.clipboard.writeText(share.share_url)
-      setShareByMsg(prev => ({ ...prev, [i]: 'shared' }))
+      setShareByMsg(prev => ({ ...prev, [i]: 'copied' }))
       setTimeout(() => setShareByMsg(prev => { const next = { ...prev }; delete next[i]; return next }), 2000)
     } catch {
       setShareByMsg(prev => ({ ...prev, [i]: 'error' }))
@@ -765,6 +766,8 @@ function ChatInner() {
                             {shareByMsg[i] === 'pending' ? (
                               'Partage…'
                             ) : shareByMsg[i] === 'shared' ? (
+                              'Partagé !'
+                            ) : shareByMsg[i] === 'copied' ? (
                               'Copié !'
                             ) : shareByMsg[i] === 'error' ? (
                               'Erreur, réessayez'

--- a/frontend/src/app/chat/s/[id]/opengraph-image.tsx
+++ b/frontend/src/app/chat/s/[id]/opengraph-image.tsx
@@ -1,0 +1,96 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = 'Réponse MonÉlu — recherche sur les votes et les députés'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+// Chat shares are immutable snapshots (ADR-024): cache the card aggressively.
+export const revalidate = 86400
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? text.slice(0, max) + '…' : text
+}
+
+export default async function OGImage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const share = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL ?? 'https://monelu-production.up.railway.app'}/search/share/${id}`
+  )
+    .then(r => (r.ok ? r.json() : null))
+    .catch(() => null)
+
+  const question = share ? truncate(share.question, 120) : 'Réponse introuvable'
+  const answer = share ? truncate(share.answer.replace(/\*\*/g, ''), 220) : ''
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: '#0D1F3C',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          padding: '80px',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            color: 'rgba(255,255,255,0.55)',
+            fontSize: 18,
+            letterSpacing: '0.15em',
+            textTransform: 'uppercase',
+            marginBottom: 28,
+            fontFamily: 'sans-serif',
+          }}
+        >
+          MonÉlu — Recherche sur les votes et les députés
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            color: '#ffffff',
+            fontSize: 38,
+            fontStyle: 'italic',
+            lineHeight: 1.3,
+            fontFamily: 'serif',
+            maxWidth: 1000,
+            marginBottom: 32,
+          }}
+        >
+          « {question} »
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            color: 'rgba(255,255,255,0.75)',
+            fontSize: 24,
+            lineHeight: 1.5,
+            fontFamily: 'sans-serif',
+            maxWidth: 1000,
+          }}
+        >
+          {answer}
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            color: 'rgba(255,255,255,0.6)',
+            fontSize: 22,
+            fontFamily: 'sans-serif',
+            marginTop: 44,
+          }}
+        >
+          mon-elu.vercel.app/chat
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}

--- a/frontend/src/app/chat/s/[id]/page.tsx
+++ b/frontend/src/app/chat/s/[id]/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { api } from '@/lib/api'
+import { ChatAnswerCard } from '@/components/ChatAnswerCard'
+
+// Chat shares are immutable snapshots (ADR-024, mirrors ADR-022 for
+// verifications): this page reads the stored answer via GET /search/share/{id}
+// — it must never re-run the RAG chain.
+export const dynamicParams = true
+export const revalidate = 86400
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}): Promise<Metadata> {
+  const { id } = await params
+  const share = await api.chatShare(id).catch(() => null)
+  if (!share) return {}
+  const title = `« ${share.question} » - MonÉlu`
+  const description = share.answer.length > 160 ? share.answer.slice(0, 160) + '…' : share.answer
+  return {
+    title,
+    description,
+    openGraph: { title, description, url: `https://mon-elu.vercel.app/chat/s/${id}` },
+    twitter: { card: 'summary_large_image', title, description },
+  }
+}
+
+export default async function ChatSharePage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const result = await api.chatShare(id).catch(() => null)
+  if (!result) notFound()
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-10 md:py-14">
+      <p className="text-xs uppercase tracking-wide text-gray-mid mb-4">
+        MonÉlu — réponse partagée
+      </p>
+      <ChatAnswerCard result={result} />
+      <div className="mt-6 flex flex-wrap items-center gap-4 text-sm">
+        <Link
+          href={`/chat?q=${encodeURIComponent(result.question)}`}
+          className="border border-navy text-navy px-4 py-2 rounded-lg hover:bg-navy hover:text-white transition-colors"
+        >
+          Reposer cette question avec les données du jour
+        </Link>
+        <Link href="/chat" className="text-gray-mid underline hover:text-navy">
+          Poser une autre question
+        </Link>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/components/ChatAnswerCard.tsx
+++ b/frontend/src/components/ChatAnswerCard.tsx
@@ -1,0 +1,86 @@
+import Link from 'next/link'
+import { ShareButton } from './ShareButton'
+import { mdToHtml, mapSource, CONFIDENCE_META } from '@/lib/chatFormat'
+import type { ChatShareResult } from '@/lib/api'
+
+export function ChatAnswerCard({ result }: { result: ChatShareResult }) {
+  const conf = result.confidence ? CONFIDENCE_META[result.confidence] : undefined
+  const sources = (result.sources || []).slice(0, 3).map(mapSource)
+
+  return (
+    <div className="bg-white border border-gray-border rounded-xl p-6 shadow-sm">
+      <div className="flex items-start justify-between gap-3 mb-4">
+        {conf ? (
+          <span
+            className="inline-block text-xs font-bold uppercase tracking-wide px-3 py-1.5 rounded-full"
+            style={{ background: conf.bg, color: conf.color }}
+          >
+            {conf.label}
+          </span>
+        ) : (
+          <span />
+        )}
+        <ShareButton
+          url={`/chat/s/${result.id}`}
+          title="Réponse MonÉlu"
+          text={result.question}
+          ariaLabel="Partager cette réponse"
+        />
+      </div>
+
+      <blockquote className="border-l-4 border-gray-border pl-4 text-navy font-medium italic mb-4">
+        « {result.question} »
+      </blockquote>
+
+      <div
+        className="text-[15px] leading-relaxed text-navy mb-2"
+        dangerouslySetInnerHTML={{ __html: mdToHtml(result.answer) }}
+      />
+
+      {result.caveat && (
+        <div className="mt-3 mb-2 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2">
+          <span className="text-xs leading-relaxed text-amber-800">{result.caveat}</span>
+        </div>
+      )}
+
+      {sources.length > 0 && (
+        <div className="mt-5 mb-2">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-mid mb-2">Sources</h3>
+          <div className="flex flex-wrap gap-2">
+            {sources.map((src, si) => {
+              const inner = (
+                <>
+                  <div className="w-2.5 h-2.5 rounded-full shrink-0" style={{ background: src.dot }} />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-xs font-semibold text-navy truncate">{src.label}</div>
+                    {src.sub && <div className="text-[11px] text-gray-mid truncate">{src.sub}</div>}
+                  </div>
+                  {src.badge && (
+                    <div
+                      className="shrink-0 text-[10px] font-bold px-2 py-0.5 rounded-full whitespace-nowrap"
+                      style={{ background: src.badgeBg, color: src.badgeColor }}
+                    >
+                      {src.badge}
+                    </div>
+                  )}
+                </>
+              )
+              const className = 'flex items-center gap-2.5 bg-white border border-gray-border rounded-lg px-3 py-2 max-w-[280px]'
+              return src.href ? (
+                <Link key={si} href={src.href} className={className}>{inner}</Link>
+              ) : (
+                <div key={si} className={className}>{inner}</div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      <p className="text-xs text-gray-mid border-t border-gray-border pt-3 mt-4">
+        Réponse générée le{' '}
+        {new Date(result.shared_at).toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' })}
+        {' · '}Source : données ouvertes de l&apos;Assemblée Nationale.
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -197,6 +197,18 @@ export type VerifyResult = {
   share_url: string
 }
 
+export type ChatShareResult = {
+  id: string
+  question: string
+  answer: string
+  sources: SearchResult['sources']
+  confidence: string | null
+  data_source: string | null
+  caveat: string | null
+  shared_at: string
+  share_url: string
+}
+
 // 5xx: transient upstream hiccups, short retries.
 // 429: the API rate limiter (30 req/min per IP) — hit hard during `next build`,
 // where prerendering ~117 pages from one IP exceeds the budget and fails the
@@ -303,6 +315,17 @@ export const api = {
   verify: (claim: string) => apiPost<VerifyResult>('/verify/', { claim }),
   // Verdicts are immutable snapshots (ADR-022) — cache aggressively.
   verification: (id: string) => apiFetch<VerifyResult>(`/verify/${id}`, { revalidate: 86400 }),
+  // Chat shares are immutable snapshots too (ADR-024) — same caching approach.
+  shareAnswer: (result: SearchResult) =>
+    apiPost<ChatShareResult>('/search/share', {
+      question: result.question,
+      answer: result.answer,
+      sources: result.sources,
+      confidence: result.confidence,
+      data_source: result.data_source,
+      caveat: result.caveat,
+    }),
+  chatShare: (id: string) => apiFetch<ChatShareResult>(`/search/share/${id}`, { revalidate: 86400 }),
   feedback: {
     chat: (vote: 'up' | 'down', question: string, answer: string, sources: SearchResult['sources']) =>
       apiPost<{ status: string }>('/feedback/chat', { vote, question, answer, sources }),

--- a/frontend/src/lib/chatFormat.ts
+++ b/frontend/src/lib/chatFormat.ts
@@ -1,0 +1,72 @@
+import type { SearchResult } from '@/lib/api'
+
+// Shared between the chat page and the read-only share page (MON-66) so a
+// shared answer renders identically to how the user saw it in the chat.
+
+export function mdToHtml(text: string): string {
+  let h = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  h = h.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+  const blocks = h.split('\n\n')
+  return blocks.map(block => {
+    const lines = block.split('\n')
+    if (lines.length > 1 && lines.every(l => /^- /.test(l))) {
+      const items = lines.map(l => `<li style="margin:5px 0">${l.slice(2)}</li>`).join('')
+      return `<ul style="margin:6px 0 12px 0;padding-left:22px">${items}</ul>`
+    }
+    if (lines.length > 1 && lines.every(l => /^\d+\. /.test(l))) {
+      const items = lines.map(l => `<li style="margin:5px 0">${l.replace(/^\d+\.\s/, '')}</li>`).join('')
+      return `<ol style="margin:6px 0 12px 0;padding-left:22px">${items}</ol>`
+    }
+    return `<p style="margin:0 0 14px 0">${lines.join('<br>')}</p>`
+  }).join('')
+}
+
+export type SourceCard = { dot: string; label: string; sub: string; badge: string; badgeBg: string; badgeColor: string; href?: string }
+
+export function mapSource(src: SearchResult['sources'][0]): SourceCard {
+  const meta = src.metadata || {}
+  const type = meta.chunk_type || 'stat'
+  if (type === 'deputy' || type === 'notable_deputy') {
+    return {
+      dot: meta.group_color || '#1B2B50',
+      label: meta.deputy_name || meta.full_name || meta.name || 'Député',
+      sub: [meta.department, meta.circonscription, meta.party].filter(Boolean).join(' · ') || '',
+      badge: meta.group_short || meta.group || meta.party || '',
+      badgeBg: '#F1F5F9', badgeColor: '#475569',
+      href: meta.deputy_id ? `/deputes/${meta.deputy_id}` : undefined,
+    }
+  }
+  if (type === 'vote' || type === 'law_summary') {
+    const adopted = (meta.result || '').toLowerCase().includes('adopt')
+    return {
+      dot: adopted ? '#15803D' : '#DC2626',
+      label: meta.title || meta.vote_title || src.content.slice(0, 60),
+      sub: meta.date || meta.voted_at || '',
+      badge: meta.result || '',
+      badgeBg: adopted ? '#DCFCE7' : '#FEE2E2',
+      badgeColor: adopted ? '#15803D' : '#DC2626',
+      href: meta.vote_id ? `/votes/${meta.vote_id}` : undefined,
+    }
+  }
+  return {
+    dot: '#1B2B50',
+    label: src.content.slice(0, 55) + (src.content.length > 55 ? '…' : ''),
+    sub: `Pertinence ${Math.round(src.similarity * 100)} %`,
+    badge: type, badgeBg: '#EFF3FB', badgeColor: '#1B2B50',
+  }
+}
+
+// compute_confidence() in rag/chain/rag_chain.py derives this from retrieval
+// quality (top similarity + supporting chunk count), not LLM self-rating.
+export const CONFIDENCE_META: Record<string, { label: string; bg: string; color: string; bgDark: string; colorDark: string }> = {
+  high:   { label: 'Haute confiance',   bg: '#DCFCE7', color: '#15803D', bgDark: 'rgba(21,128,61,0.20)', colorDark: '#4ADE80' },
+  medium: { label: 'Confiance moyenne', bg: '#FEF3C7', color: '#92400E', bgDark: 'rgba(180,83,9,0.20)',  colorDark: '#FBBF24' },
+  low:    { label: 'Basse confiance',   bg: '#FEE2E2', color: '#B91C1C', bgDark: 'rgba(185,28,28,0.20)', colorDark: '#F87171' },
+}
+
+export const CONFIDENCE_EXPLANATION =
+  "La confiance reflète la qualité des sources retrouvées dans la base de données (similarité et nombre), " +
+  "pas l'auto-évaluation du modèle. " +
+  'Haute confiance : plusieurs sources très proches de la question. ' +
+  'Confiance moyenne : sources partiellement pertinentes. ' +
+  'Basse confiance : peu de sources vraiment pertinentes — vérifiez la réponse à la source.'

--- a/tests/unit/test_search_share.py
+++ b/tests/unit/test_search_share.py
@@ -1,0 +1,90 @@
+"""Unit tests for the chat share endpoints (MON-66, ADR-024)."""
+
+import datetime
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from api.routers.search import ShareRequest
+
+
+def test_share_request_valid():
+    req = ShareRequest(question="Qui a voté pour ?", answer="Réponse.", sources=[])
+    assert req.question == "Qui a voté pour ?"
+    assert req.confidence is None
+
+
+def test_share_request_rejects_too_many_sources():
+    with pytest.raises(ValidationError):
+        ShareRequest(question="Q", answer="A", sources=[{}] * 21)
+
+
+def test_share_request_rejects_empty_answer():
+    with pytest.raises(ValidationError):
+        ShareRequest(question="Q", answer="", sources=[])
+
+
+def test_share_answer_inserts_row_and_returns_share_url(client, mock_cursor):
+    mock_cursor.fetchone.return_value = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "question": "Q",
+        "answer": "A",
+        "sources": [{"content": "c", "metadata": {}, "similarity": 0.9}],
+        "confidence": "medium",
+        "data_source": "RAG",
+        "caveat": None,
+        "created_at": datetime.datetime(2026, 7, 17, tzinfo=datetime.timezone.utc),
+    }
+    resp = client.post(
+        "/search/share",
+        json={
+            "question": "Q",
+            "answer": "A",
+            "sources": [{"content": "c", "metadata": {}, "similarity": 0.9}],
+            "confidence": "medium",
+            "data_source": "RAG",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == "11111111-1111-1111-1111-111111111111"
+    assert body["share_url"].endswith("/chat/s/11111111-1111-1111-1111-111111111111")
+    args, _ = mock_cursor.execute.call_args
+    assert "INSERT INTO chat_shares" in args[0]
+
+
+def test_share_answer_db_error_returns_500(client):
+    with patch("api.routers.search.get_conn", side_effect=RuntimeError("db down")):
+        resp = client.post(
+            "/search/share",
+            json={"question": "Q", "answer": "A", "sources": []},
+        )
+    assert resp.status_code == 500
+
+
+def test_get_share_returns_stored_snapshot(client, mock_cursor):
+    mock_cursor.fetchone.return_value = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "question": "Q",
+        "answer": "A",
+        "sources": [],
+        "confidence": "medium",
+        "data_source": "RAG",
+        "caveat": None,
+        "created_at": datetime.datetime(2026, 7, 17, tzinfo=datetime.timezone.utc),
+    }
+    resp = client.get("/search/share/11111111-1111-1111-1111-111111111111")
+    assert resp.status_code == 200
+    assert resp.json()["question"] == "Q"
+
+
+def test_get_share_returns_404_when_missing(client, mock_cursor):
+    mock_cursor.fetchone.return_value = None
+    resp = client.get("/search/share/11111111-1111-1111-1111-111111111111")
+    assert resp.status_code == 404
+
+
+def test_get_share_rejects_invalid_uuid(client):
+    resp = client.get("/search/share/not-a-uuid")
+    assert resp.status_code == 422


### PR DESCRIPTION
## What
Adds a "Partager" (share) action to chat/RAG answers, letting users share a specific answer via a stable, read-only URL without needing an account (MON-66).

## Why
The chat page had no way to share a specific answer - only a plain-text "Copier" action. MON-66's acceptance criteria call for an unauthenticated share flow that renders a read-only view of the result. The fact-check verifier feature (ADR-022) already solved this exact problem for verdicts; this PR applies the same immutable-snapshot pattern to chat answers rather than inventing a new one.

## Changes
- **New `chat_shares` table** (`data/migrations/007_chat_shares.sql`): UUID-keyed immutable snapshot of a shared answer (question, answer, sources, confidence, data_source, caveat), no user identity stored - mirrors `verifications`.
- **`api/routers/search.py`**: adds `POST /search/share` (stores the answer the user already saw - does not recompute it, matching the existing `POST /feedback/chat` trust boundary) and `GET /search/share/{id}` (serves the stored snapshot, no LLM call).
- **`frontend/src/lib/api.ts`**: `ChatShareResult` type, `api.shareAnswer()` and `api.chatShare()` client methods.
- **`frontend/src/app/chat/page.tsx`**: assistant messages get a "Partager" button next to "Copier" that persists the answer and shares/copies the resulting URL (native share sheet with clipboard fallback, reusing the existing `ShareButton` behavior).
- **`frontend/src/lib/chatFormat.ts`** (new): `mdToHtml`, `mapSource`, and confidence-badge metadata extracted out of `chat/page.tsx` so the new share page renders an answer identically to the chat bubble.
- **`frontend/src/components/ChatAnswerCard.tsx`** (new) + **`frontend/src/app/chat/s/[id]/page.tsx`** (new): standalone read-only share page, modeled directly on `/verifier/v/[id]`, with `opengraph-image.tsx` for link previews.
- **`docs/decisions.md`**: new ADR-024 documenting the design (store-don't-recompute, dedicated table vs. the generic `feedback` sink).
- **`CLAUDE.md`**: documents the new `chat_shares` table and the `search.py` share endpoints.
- **`tests/unit/test_search_share.py`** (new): request validation + endpoint tests for `POST/GET /search/share`.

## Testing
- `pytest tests/ -m "not integration" -q` → 235 passed (includes 8 new tests in `test_search_share.py`).
- `ruff check .` / `ruff format --check .` → clean.
- Frontend: `npm run lint`, `npx tsc --noEmit`, `npm test` (100 passed), `npm run build` → all clean; `/chat/s/[id]` builds as a dynamic route alongside the existing `/verifier/v/[id]`.
- Manual: ran the migration against local Docker Postgres, started the API and a `next dev` server pointed at it, created a real share via `POST /search/share`, and loaded `/chat/s/<id>` - confirmed the answer, sources, caveat, and `<title>` metadata render correctly, and that a missing id 404s (dev-mode `notFound()` returns HTTP 200 with a not-found body, same pre-existing behavior as `/verifier/v/[id]`, not a regression).

## Risks / Notes
- `POST /search/share` trusts the client-submitted answer text rather than recomputing it server-side (same trust boundary as the existing `POST /feedback/chat`) - see ADR-024 for the reasoning and the moderation trigger-to-revisit if this becomes an abuse vector.
- Additive migration only (`CREATE TABLE IF NOT EXISTS`), safe to re-run, no impact on existing tables.
- Reviewers should double check the "Partager" button's placement/behavior in the chat UI reads naturally next to "Copier".

## Breaking Changes
None.
