### PR TITLE
feat: vote-matching quiz backend - questions + agreement matching (MON-137)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -184,12 +184,13 @@ app.add_middleware(
 # ---------------------------------------------------------------------------
 # Routers
 # ---------------------------------------------------------------------------
-from api.routers import departments, deputies, feedback, keys, votes  # noqa: E402
+from api.routers import departments, deputies, feedback, keys, quiz, votes  # noqa: E402
 from api.routers.search import router as search_router  # noqa: E402
 from api.routers.verify import router as verify_router  # noqa: E402
 
 app.include_router(deputies.router, prefix="/deputies", tags=["Deputies"])
 app.include_router(departments.router, prefix="/departments", tags=["Departments"])
+app.include_router(quiz.router, prefix="/quiz", tags=["Quiz"])
 app.include_router(votes.router, prefix="/votes", tags=["Votes"])
 app.include_router(search_router, prefix="/search", tags=["Search"])
 app.include_router(verify_router, prefix="/verify", tags=["Verify"])

--- a/api/quiz_data.py
+++ b/api/quiz_data.py
@@ -1,0 +1,145 @@
+"""
+api/quiz_data.py
+
+Curated question set for the vote-matching quiz (MON-109, ADR-025).
+
+This file is the single source of truth for the quiz: a versioned, repo-committed
+editorial artifact updated quarterly by PR — never a DB table, never fetched from
+the AN portal at runtime. The frontend reads it through GET /quiz/questions.
+
+Every vote_id must exist in the production votes table (prod holds scrutins from
+2025-07-01 onward). Selection criteria (MON-136): whole-text scrutins
+("l'ensemble ..."), high participation (>= 400 voters out of 577), and divisive
+(the losing side of pour/contre holds >= 35% of the expressed pour+contre).
+
+VERSION note: "-draft" marks this as the provisional MON-137 set, picked from
+live prod data by the above criteria but pending the MON-136 editorial pass
+(phrasing review, final selection). MON-136 replaces the content of this list
+and drops the suffix; no code changes.
+"""
+
+QUIZ_VERSION = "2026-Q3-draft"
+
+# Each entry: the scrutin, a neutral plain-French question, a one-line context
+# sentence, and a short theme tag for the UI. Question phrasing must stay
+# descriptive of what the text does — no leading or evaluative wording.
+QUIZ_QUESTIONS: list[dict] = [
+    {
+        "vote_id": "VTANR5L17V8280",
+        "theme": "Fin de vie",
+        "question": "Auriez-vous voté pour ou contre la création d'un droit à l'aide à mourir ?",
+        "context": (
+            "Proposition de loi relative au droit à l'aide à mourir, "
+            "adoptée en lecture définitive le 15 juillet 2026."
+        ),
+    },
+    {
+        "vote_id": "VTANR5L17V4758",
+        "theme": "Protection sociale",
+        "question": ("Auriez-vous voté pour ou contre le budget 2026 de la Sécurité sociale ?"),
+        "context": (
+            "Projet de loi de financement de la sécurité sociale pour 2026, "
+            "adopté en lecture définitive le 16 décembre 2025."
+        ),
+    },
+    {
+        "vote_id": "VTANR5L17V2957",
+        "theme": "Agriculture",
+        "question": (
+            "Auriez-vous voté pour ou contre la loi levant certaines contraintes "
+            "à l'exercice du métier d'agriculteur ?"
+        ),
+        "context": (
+            "Proposition de loi visant à lever les contraintes à l'exercice du métier "
+            "d'agriculteur, adoptée le 8 juillet 2025 (texte de la commission mixte paritaire)."
+        ),
+    },
+    {
+        "vote_id": "VTANR5L17V7454",
+        "theme": "Institutions",
+        "question": (
+            "Auriez-vous voté pour ou contre l'autonomie de la Corse au sein de la République ?"
+        ),
+        "context": (
+            "Projet de loi constitutionnelle pour une Corse autonome au sein de la "
+            "République, adopté en première lecture le 23 juin 2026."
+        ),
+    },
+    {
+        "vote_id": "VTANR5L17V6184",
+        "theme": "Économie",
+        "question": (
+            "Auriez-vous voté pour ou contre la loi de simplification de la vie économique ?"
+        ),
+        "context": (
+            "Projet de loi de simplification de la vie économique, adopté le 14 avril 2026 "
+            "(texte de la commission mixte paritaire)."
+        ),
+    },
+    {
+        "vote_id": "VTANR5L17V6319",
+        "theme": "Finances publiques",
+        "question": (
+            "Auriez-vous voté pour ou contre le renforcement de la lutte contre "
+            "les fraudes sociales et fiscales ?"
+        ),
+        "context": (
+            "Projet de loi relatif à la lutte contre les fraudes sociales et fiscales, "
+            "adopté le 5 mai 2026 (texte de la commission mixte paritaire)."
+        ),
+    },
+    {
+        "vote_id": "VTANR5L17V7987",
+        "theme": "Sécurité",
+        "question": (
+            "Auriez-vous voté pour ou contre une présomption de légitime défense "
+            "pour les forces de l'ordre ?"
+        ),
+        "context": (
+            "Proposition de loi reconnaissant une présomption de légitime défense aux "
+            "forces de l'ordre dans l'exercice de leurs fonctions, adoptée en première "
+            "lecture le 7 juillet 2026."
+        ),
+    },
+    {
+        "vote_id": "VTANR5L17V3182",
+        "theme": "Outre-mer",
+        "question": (
+            "Auriez-vous voté pour ou contre le report des élections provinciales "
+            "en Nouvelle-Calédonie ?"
+        ),
+        "context": (
+            "Loi organique reportant le renouvellement du congrès et des assemblées de "
+            "province de la Nouvelle-Calédonie pour poursuivre les discussions sur son "
+            "avenir institutionnel, adoptée le 28 octobre 2025."
+        ),
+    },
+    {
+        "vote_id": "VTANR5L17V2958",
+        "theme": "Justice",
+        "question": (
+            "Auriez-vous voté pour ou contre l'extension du maintien en rétention des "
+            "personnes condamnées pour des faits graves ?"
+        ),
+        "context": (
+            "Proposition de loi facilitant le maintien en rétention des personnes condamnées "
+            "pour des faits d'une particulière gravité et présentant de forts risques de "
+            "récidive, adoptée en première lecture le 8 juillet 2025."
+        ),
+    },
+    {
+        "vote_id": "VTANR5L17V7408",
+        "theme": "Logement",
+        "question": (
+            "Auriez-vous voté pour ou contre la loi facilitant l'accès au logement "
+            "des travailleurs des services publics ?"
+        ),
+        "context": (
+            "Proposition de loi visant à améliorer l'accès au logement des travailleurs "
+            "des services publics, adoptée le 17 juin 2026 (texte de la commission "
+            "mixte paritaire)."
+        ),
+    },
+]
+
+QUIZ_VOTE_IDS: frozenset[str] = frozenset(q["vote_id"] for q in QUIZ_QUESTIONS)

--- a/api/routers/quiz.py
+++ b/api/routers/quiz.py
@@ -1,0 +1,310 @@
+"""
+api/routers/quiz.py
+
+"Quel député vote comme vous ?" — vote-matching quiz (MON-109, MON-137, ADR-025).
+
+Two endpoints:
+- GET  /quiz/questions : the curated question set (repo file, api/quiz_data.py).
+- POST /quiz/match     : stateless agreement computation over vote_positions.
+
+ADR-025 constraints: /match persists and logs nothing about the request —
+answers in, results out. The question set is never read from the DB.
+
+Denominator rules (consistent with ADR-019's presence framing):
+- Only expressed positions compare: pour / contre / abstention. `nonVotant`
+  (present but not voting) and absence never count as agreement or disagreement;
+  they simply shrink a deputy's comparable-vote count.
+- A deputy (or group) ranks only with at least half of the answered questions
+  comparable, floor 2 — one shared scrutin is not a political profile.
+"""
+
+from collections import Counter, defaultdict
+from math import ceil
+from typing import Literal, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field, field_validator
+from starlette.requests import Request
+
+from api.db import get_conn
+from api.departments_data import DEPT_NAMES, db_department_values, normalize_code
+from api.limiter import limiter, tiered_limit
+from api.quiz_data import QUIZ_QUESTIONS, QUIZ_VERSION, QUIZ_VOTE_IDS
+
+router = APIRouter()
+
+EXPRESSED_POSITIONS = ("pour", "contre", "abstention")
+MIN_ANSWERS = 3
+TOP_MATCHES_LIMIT = 10
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+class QuizQuestion(BaseModel):
+    vote_id: str
+    theme: str
+    question: str
+    context: str
+
+
+class QuizQuestionsResponse(BaseModel):
+    version: str
+    count: int
+    questions: list[QuizQuestion]
+
+
+class QuizAnswer(BaseModel):
+    vote_id: str
+    position: Literal["pour", "contre", "abstention"]
+
+
+class QuizMatchRequest(BaseModel):
+    answers: list[QuizAnswer] = Field(
+        ...,
+        min_length=MIN_ANSWERS,
+        max_length=len(QUIZ_QUESTIONS),
+        description="Réponses au quiz — au moins 3 pour un résultat significatif",
+    )
+    department: Optional[str] = Field(
+        None, description="Code de département pour la comparaison « vos députés » (optionnel)"
+    )
+
+    @field_validator("answers")
+    @classmethod
+    def _answers_known_and_unique(cls, answers: list[QuizAnswer]) -> list[QuizAnswer]:
+        seen: set[str] = set()
+        for a in answers:
+            if a.vote_id not in QUIZ_VOTE_IDS:
+                raise ValueError(f"vote_id inconnu du questionnaire: {a.vote_id}")
+            if a.vote_id in seen:
+                raise ValueError(f"vote_id en double: {a.vote_id}")
+            seen.add(a.vote_id)
+        return answers
+
+
+class QuizDeputyMatch(BaseModel):
+    deputy_id: str
+    full_name: Optional[str] = None
+    party: Optional[str] = None
+    party_short: Optional[str] = None
+    department: Optional[str] = None
+    photo_url: Optional[str] = None
+    # None when the deputy has no comparable expressed position at all.
+    agreement_pct: Optional[float] = None
+    matches: int
+    compared: int
+
+
+class QuizGroupAlignment(BaseModel):
+    party: str
+    party_short: Optional[str] = None
+    agreement_pct: float
+    matches: int
+    compared: int
+    deputy_count: int
+
+
+class QuizDepartmentResult(BaseModel):
+    code: str
+    name: str
+    deputies: list[QuizDeputyMatch]
+
+
+class QuizMatchResponse(BaseModel):
+    version: str
+    answered: int
+    eligible_deputies: int
+    top_matches: list[QuizDeputyMatch]
+    # The eligible deputy who agrees with you the least — same threshold as
+    # the ranking, so a 0% on two shared votes never headlines the card.
+    opposite: Optional[QuizDeputyMatch] = None
+    groups: list[QuizGroupAlignment]
+    my_department: Optional[QuizDepartmentResult] = None
+
+
+# ---------------------------------------------------------------------------
+# Pure computation helpers — no DB, unit-testable in isolation
+# ---------------------------------------------------------------------------
+def eligibility_threshold(answered: int) -> int:
+    return max(2, ceil(answered / 2))
+
+
+def compute_deputy_stats(rows: list[dict], answers: dict[str, str]) -> dict[str, dict]:
+    """Per-deputy agreement over expressed positions.
+
+    `rows` carry one expressed position per (deputy, vote); `answers` maps
+    vote_id -> user position. Returns {deputy_id: {profile fields, matches,
+    compared}}.
+    """
+    stats: dict[str, dict] = {}
+    for row in rows:
+        entry = stats.setdefault(
+            row["deputy_id"],
+            {
+                "deputy_id": row["deputy_id"],
+                "full_name": row["full_name"],
+                "party": row["party"],
+                "party_short": row["party_short"],
+                "department": row["department"],
+                "photo_url": row["photo_url"],
+                "matches": 0,
+                "compared": 0,
+            },
+        )
+        entry["compared"] += 1
+        if row["position"] == answers[row["vote_id"]]:
+            entry["matches"] += 1
+    return stats
+
+
+def to_match(entry: dict) -> QuizDeputyMatch:
+    pct = round(100 * entry["matches"] / entry["compared"], 1) if entry["compared"] else None
+    return QuizDeputyMatch(**entry, agreement_pct=pct)
+
+
+def compute_group_alignment(
+    rows: list[dict], answers: dict[str, str], threshold: int
+) -> list[QuizGroupAlignment]:
+    """Agreement with each group's majority line, vote by vote.
+
+    A group's position on a scrutin is the strict plurality of its members'
+    expressed positions; scrutins where the group's top two positions tie are
+    skipped for that group (no majority line to compare against).
+    """
+    # (party, vote_id) -> Counter of expressed positions
+    votes_by_group: dict[tuple[str, str], Counter] = defaultdict(Counter)
+    members_by_group: dict[str, set[str]] = defaultdict(set)
+    short_by_party: dict[str, Optional[str]] = {}
+    for row in rows:
+        party = row["party"]
+        if not party:
+            continue
+        votes_by_group[(party, row["vote_id"])][row["position"]] += 1
+        members_by_group[party].add(row["deputy_id"])
+        short_by_party.setdefault(party, row["party_short"])
+
+    tallies: dict[str, dict] = defaultdict(lambda: {"matches": 0, "compared": 0})
+    for (party, vote_id), counter in votes_by_group.items():
+        ranked = counter.most_common(2)
+        if len(ranked) > 1 and ranked[0][1] == ranked[1][1]:
+            continue  # tied plurality — the group has no line on this scrutin
+        majority_position = ranked[0][0]
+        tallies[party]["compared"] += 1
+        if majority_position == answers[vote_id]:
+            tallies[party]["matches"] += 1
+
+    groups = [
+        QuizGroupAlignment(
+            party=party,
+            party_short=short_by_party.get(party),
+            agreement_pct=round(100 * t["matches"] / t["compared"], 1),
+            matches=t["matches"],
+            compared=t["compared"],
+            deputy_count=len(members_by_group[party]),
+        )
+        for party, t in tallies.items()
+        if t["compared"] >= threshold
+    ]
+    groups.sort(key=lambda g: (-g.agreement_pct, -g.compared, g.party))
+    return groups
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+@router.get(
+    "/questions",
+    response_model=QuizQuestionsResponse,
+    summary="Le questionnaire du quiz « Quel député vote comme vous ? »",
+)
+@limiter.limit(tiered_limit(30))
+def get_questions(request: Request) -> QuizQuestionsResponse:
+    return QuizQuestionsResponse(
+        version=QUIZ_VERSION,
+        count=len(QUIZ_QUESTIONS),
+        questions=[QuizQuestion(**q) for q in QUIZ_QUESTIONS],
+    )
+
+
+@router.post(
+    "/match",
+    response_model=QuizMatchResponse,
+    summary="Calcule votre accord avec chaque député et chaque groupe",
+)
+@limiter.limit(tiered_limit(10))
+def match(request: Request, body: QuizMatchRequest) -> QuizMatchResponse:
+    dept_code: Optional[str] = None
+    if body.department is not None:
+        dept_code = normalize_code(body.department)
+        if dept_code is None:
+            raise HTTPException(status_code=422, detail="Code de département inconnu")
+
+    answers = {a.vote_id: a.position for a in body.answers}
+    threshold = eligibility_threshold(len(answers))
+
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT vp.deputy_id, vp.vote_id, vp.position,
+                       d.full_name, d.party, d.party_short, d.department, d.photo_url
+                FROM vote_positions vp
+                JOIN deputies d ON d.deputy_id = vp.deputy_id
+                WHERE vp.vote_id = ANY(%s)
+                  AND vp.position IN ('pour', 'contre', 'abstention')
+                  AND d.mandate_end IS NULL
+                """,
+                (list(answers),),
+            )
+            rows = cur.fetchall()
+
+            # A department's deputies can be absent from every quiz scrutin;
+            # fetch the roster separately so they still appear (compared=0).
+            dept_rows: list[dict] = []
+            if dept_code is not None:
+                cur.execute(
+                    """
+                    SELECT deputy_id, full_name, party, party_short,
+                           department, photo_url
+                    FROM deputies
+                    WHERE department = ANY(%s) AND mandate_end IS NULL
+                    ORDER BY last_name, first_name
+                    """,
+                    (db_department_values(dept_code),),
+                )
+                dept_rows = cur.fetchall()
+
+    stats = compute_deputy_stats(rows, answers)
+
+    eligible = [e for e in stats.values() if e["compared"] >= threshold]
+    eligible.sort(
+        key=lambda e: (-e["matches"] / e["compared"], -e["compared"], e["full_name"] or "")
+    )
+
+    opposite = None
+    if eligible:
+        opposite = to_match(
+            min(eligible, key=lambda e: (e["matches"] / e["compared"], -e["compared"]))
+        )
+
+    my_department = None
+    if dept_code is not None:
+        my_department = QuizDepartmentResult(
+            code=dept_code,
+            name=DEPT_NAMES[dept_code],
+            deputies=[
+                to_match(stats.get(r["deputy_id"], {**r, "matches": 0, "compared": 0}))
+                for r in dept_rows
+            ],
+        )
+
+    return QuizMatchResponse(
+        version=QUIZ_VERSION,
+        answered=len(answers),
+        eligible_deputies=len(eligible),
+        top_matches=[to_match(e) for e in eligible[:TOP_MATCHES_LIMIT]],
+        opposite=opposite,
+        groups=compute_group_alignment(rows, answers, threshold),
+        my_department=my_department,
+    )

--- a/api/routers/quiz.py
+++ b/api/routers/quiz.py
@@ -252,10 +252,10 @@ def match(request: Request, body: QuizMatchRequest) -> QuizMatchResponse:
                 FROM vote_positions vp
                 JOIN deputies d ON d.deputy_id = vp.deputy_id
                 WHERE vp.vote_id = ANY(%s)
-                  AND vp.position IN ('pour', 'contre', 'abstention')
+                  AND vp.position = ANY(%s)
                   AND d.mandate_end IS NULL
                 """,
-                (list(answers),),
+                (list(answers), list(EXPRESSED_POSITIONS)),
             )
             rows = cur.fetchall()
 

--- a/tests/unit/test_quiz.py
+++ b/tests/unit/test_quiz.py
@@ -1,0 +1,211 @@
+"""Unit tests for the vote-matching quiz endpoints (MON-137, ADR-025)."""
+
+import pytest
+from pydantic import ValidationError
+
+from api.quiz_data import QUIZ_QUESTIONS, QUIZ_VERSION
+from api.routers.quiz import (
+    QuizMatchRequest,
+    compute_group_alignment,
+    eligibility_threshold,
+)
+
+V1, V2, V3 = (q["vote_id"] for q in QUIZ_QUESTIONS[:3])
+
+ANSWERS_3 = [
+    {"vote_id": V1, "position": "pour"},
+    {"vote_id": V2, "position": "contre"},
+    {"vote_id": V3, "position": "abstention"},
+]
+
+
+def _row(deputy_id, vote_id, position, party="Groupe X", name=None):
+    return {
+        "deputy_id": deputy_id,
+        "vote_id": vote_id,
+        "position": position,
+        "full_name": name or f"Député {deputy_id}",
+        "party": party,
+        "party_short": party.split()[-1] if party else None,
+        "department": "Gironde",
+        "photo_url": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Question set + GET /quiz/questions
+# ---------------------------------------------------------------------------
+def test_question_set_shape():
+    assert len(QUIZ_QUESTIONS) == 10
+    ids = [q["vote_id"] for q in QUIZ_QUESTIONS]
+    assert len(set(ids)) == len(ids)
+    for q in QUIZ_QUESTIONS:
+        assert q["question"].startswith("Auriez-vous voté")
+        assert q["context"] and q["theme"]
+
+
+def test_get_questions_returns_versioned_set(client):
+    resp = client.get("/quiz/questions")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["version"] == QUIZ_VERSION
+    assert body["count"] == 10
+    assert body["questions"][0]["vote_id"] == V1
+
+
+# ---------------------------------------------------------------------------
+# Request validation
+# ---------------------------------------------------------------------------
+def test_match_request_rejects_too_few_answers():
+    with pytest.raises(ValidationError):
+        QuizMatchRequest(answers=ANSWERS_3[:2])
+
+
+def test_match_request_rejects_unknown_vote_id():
+    with pytest.raises(ValidationError, match="inconnu"):
+        QuizMatchRequest(answers=ANSWERS_3[:2] + [{"vote_id": "VTFAKE", "position": "pour"}])
+
+
+def test_match_request_rejects_duplicate_vote_id():
+    with pytest.raises(ValidationError, match="double"):
+        QuizMatchRequest(answers=ANSWERS_3[:2] + [{"vote_id": V1, "position": "contre"}])
+
+
+def test_match_rejects_invalid_position(client):
+    resp = client.post(
+        "/quiz/match",
+        json={"answers": ANSWERS_3[:2] + [{"vote_id": V3, "position": "nonVotant"}]},
+    )
+    assert resp.status_code == 422
+
+
+def test_match_rejects_unknown_department(client, mock_cursor):
+    resp = client.post("/quiz/match", json={"answers": ANSWERS_3, "department": "9999"})
+    assert resp.status_code == 422
+    mock_cursor.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Matching math through the endpoint
+# ---------------------------------------------------------------------------
+def test_match_ranks_agreement_and_applies_threshold(client, mock_cursor):
+    mock_cursor.fetchall.return_value = [
+        # A agrees on all three answers
+        _row("A", V1, "pour"),
+        _row("A", V2, "contre"),
+        _row("A", V3, "abstention"),
+        # B agrees on two of three
+        _row("B", V1, "pour"),
+        _row("B", V2, "contre"),
+        _row("B", V3, "pour"),
+        # C has one comparable vote — below the threshold of 2, never ranked
+        _row("C", V1, "pour", party="Groupe Y"),
+        # D disagrees on both comparable votes
+        _row("D", V1, "contre", party="Groupe Y"),
+        _row("D", V2, "pour", party="Groupe Y"),
+    ]
+
+    resp = client.post("/quiz/match", json={"answers": ANSWERS_3})
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["version"] == QUIZ_VERSION
+    assert body["answered"] == 3
+    assert body["eligible_deputies"] == 3
+
+    top = body["top_matches"]
+    assert [m["deputy_id"] for m in top] == ["A", "B", "D"]
+    assert top[0]["agreement_pct"] == 100.0
+    assert top[1]["agreement_pct"] == 66.7
+    assert top[2]["agreement_pct"] == 0.0
+    assert top[0]["compared"] == 3
+
+    assert body["opposite"]["deputy_id"] == "D"
+
+    # Groupe X: majority pour+contre match on V1/V2, V3 is a 1-1 tie (skipped).
+    # Groupe Y: V1 ties, only V2 has a line — compared 1 < threshold, excluded.
+    assert [g["party"] for g in body["groups"]] == ["Groupe X"]
+    assert body["groups"][0]["agreement_pct"] == 100.0
+    assert body["groups"][0]["compared"] == 2
+    assert body["groups"][0]["deputy_count"] == 2
+
+
+def test_match_department_roster_includes_absent_deputy(client, mock_cursor):
+    positions = [
+        _row("A", V1, "pour"),
+        _row("A", V2, "contre"),
+    ]
+    roster = [
+        {
+            "deputy_id": "A",
+            "full_name": "Député A",
+            "party": "Groupe X",
+            "party_short": "X",
+            "department": "Gironde",
+            "photo_url": None,
+        },
+        # E never voted on any quiz scrutin — still listed, with no percentage
+        {
+            "deputy_id": "E",
+            "full_name": "Député E",
+            "party": "Groupe X",
+            "party_short": "X",
+            "department": "Gironde",
+            "photo_url": None,
+        },
+    ]
+    mock_cursor.fetchall.side_effect = [positions, roster]
+
+    resp = client.post("/quiz/match", json={"answers": ANSWERS_3, "department": "33"})
+    assert resp.status_code == 200
+    dept = resp.json()["my_department"]
+    assert dept["code"] == "33"
+    assert dept["name"] == "Gironde"
+    by_id = {d["deputy_id"]: d for d in dept["deputies"]}
+    assert by_id["A"]["agreement_pct"] == 100.0
+    assert by_id["E"]["agreement_pct"] is None
+    assert by_id["E"]["compared"] == 0
+
+
+def test_match_no_positions_returns_empty_results(client, mock_cursor):
+    mock_cursor.fetchall.return_value = []
+    resp = client.post("/quiz/match", json={"answers": ANSWERS_3})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["top_matches"] == []
+    assert body["opposite"] is None
+    assert body["groups"] == []
+    assert body["eligible_deputies"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+def test_eligibility_threshold_floor_and_half():
+    assert eligibility_threshold(3) == 2
+    assert eligibility_threshold(4) == 2
+    assert eligibility_threshold(7) == 4
+    assert eligibility_threshold(10) == 5
+
+
+def test_group_alignment_skips_tied_votes():
+    rows = [
+        _row("A", V1, "pour"),
+        _row("B", V1, "contre"),  # 1-1 tie on V1 — no group line
+        _row("A", V2, "contre"),
+        _row("B", V2, "contre"),
+        _row("A", V3, "abstention"),
+        _row("B", V3, "abstention"),
+    ]
+    answers = {V1: "pour", V2: "contre", V3: "pour"}
+    groups = compute_group_alignment(rows, answers, threshold=2)
+    assert len(groups) == 1
+    g = groups[0]
+    assert g.compared == 2  # V1 skipped
+    assert g.matches == 1  # V2 matches, V3 does not
+    assert g.agreement_pct == 50.0
+
+
+def test_group_alignment_ignores_deputies_without_party():
+    rows = [_row("A", V1, "pour", party=None), _row("A", V2, "pour", party=None)]
+    assert compute_group_alignment(rows, {V1: "pour", V2: "pour"}, threshold=2) == []


### PR DESCRIPTION
## What

Backend for the "Quel député vote comme vous ?" quiz (MON-109 epic, ADR-025):

- `api/quiz_data.py` - versioned curated question set (`2026-Q3-draft`), 10 whole-text scrutins picked from **live prod data** by the MON-136 criteria (>= 400 voters, losing side >= 35% of pour+contre, "l'ensemble ..." votes only), spanning 10 themes (fin de vie, PLFSS 2026, agriculture, Corse, économie, fraudes, sécurité, Nouvelle-Calédonie, rétention, logement). Every vote_id verified present in prod.
- `api/routers/quiz.py`:
  - `GET /quiz/questions` (30/min) - the question set with its version string; no DB.
  - `POST /quiz/match` (10/min) - stateless agreement computation: per-deputy ranking (top 10 + "opposite"), per-group majority-line alignment, optional department roster comparison. Nothing persisted or logged (ADR-025).
- Denominator rules documented in the module docstring: only expressed positions (pour/contre/abstention) compare; `nonVotant`/absence shrink the comparable count; ranking requires >= half the answered questions comparable (floor 2). Group line = strict plurality; tied scrutins are skipped for that group.

## Note on MON-136 (blocker handled pragmatically)

MON-137 is formally blocked by MON-136 (editorial curation). The question set here is a **provisional draft** grounded in real prod scrutins so the engine ships now; MON-136 becomes a content-only pass on `api/quiz_data.py` (phrasing review, final selection, drop the `-draft` suffix) with zero code changes.

## Acceptance criteria

- Deterministic agreement results for a fixed answer set → unit-tested (ranking, threshold, tie-breaks, group ties, empty results).
- `GET /quiz/questions` returns the versioned set → tested.
- Denominator rules documented in code, consistent with ADR-019 → module docstring + inline comments.
- Invalid vote_ids / malformed answers / unknown department → 422, not 500 → tested (validators run before any DB access).
- No new table, no writes → the router only SELECTs.

## Test plan

- `pytest tests/ -m "not integration"`: 248 passed (13 new in `tests/unit/test_quiz.py`).
- `ruff check .` + `ruff format --check .`: clean repo-wide.
- Exercised for real against the prod Supabase pooler: 571 eligible deputies ranked, LFI 80% group alignment for a test answer set, Gironde roster (12 deputies) returned, invalid department and unknown vote_id both 422.

## Deploy risk

None: no migration, no schema change, no config change. Two new read-only endpoints behind the existing shared limiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MECuemDq5Qf5pVqZpLKxEU