### PR TITLE
feat: build the vote-matching quiz UI (MON-138)

### DIFF
--- a/frontend/__tests__/components/QuizClient.test.tsx
+++ b/frontend/__tests__/components/QuizClient.test.tsx
@@ -199,6 +199,21 @@ describe('QuizClient', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('allows going back from the postal step to revise answers', async () => {
+    const user = userEvent.setup()
+    render(<QuizClient />)
+
+    await answerAllQuestions(user)
+    expect(screen.getByText('Et votre député à vous ?')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: '← Revenir aux questions' }))
+    // Lands on the last question with the previous selection still highlighted.
+    expect(screen.getByText('Question 3 / 3')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Pour' })).toHaveStyle({
+      border: '2px solid #1F8A5B',
+    })
+  })
+
   it('links results to the matched deputy profiles', async () => {
     const user = userEvent.setup()
     mockMatch.mockResolvedValue(MATCH)

--- a/frontend/__tests__/components/QuizClient.test.tsx
+++ b/frontend/__tests__/components/QuizClient.test.tsx
@@ -1,0 +1,256 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { QuizClient } from '@/app/quiz/QuizClient'
+import type { QuizMatchResponse, QuizQuestionsResponse } from '@/lib/api'
+
+jest.mock('@/lib/api', () => ({
+  api: {
+    quiz: {
+      questions: jest.fn(),
+      match: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('@/lib/postal', () => ({
+  resolvePostalCodeToDepartment: jest.fn(),
+}))
+
+import { api } from '@/lib/api'
+import { resolvePostalCodeToDepartment } from '@/lib/postal'
+
+const mockQuestions = api.quiz.questions as jest.Mock
+const mockMatch = api.quiz.match as jest.Mock
+const mockResolve = resolvePostalCodeToDepartment as jest.Mock
+
+const QUESTIONS: QuizQuestionsResponse = {
+  version: '2026-Q3-test',
+  count: 3,
+  questions: [
+    {
+      vote_id: 'V1',
+      theme: 'Fin de vie',
+      question: 'Auriez-vous voté pour ou contre la question 1 ?',
+      context: 'Contexte 1.',
+    },
+    {
+      vote_id: 'V2',
+      theme: 'Budget',
+      question: 'Auriez-vous voté pour ou contre la question 2 ?',
+      context: 'Contexte 2.',
+    },
+    {
+      vote_id: 'V3',
+      theme: 'Écologie',
+      question: 'Auriez-vous voté pour ou contre la question 3 ?',
+      context: 'Contexte 3.',
+    },
+  ],
+}
+
+const BEST = {
+  deputy_id: 'PA100',
+  full_name: 'Jeanne Martin',
+  party: 'Socialistes et apparentés',
+  party_short: 'SOC',
+  department: 'Gironde',
+  photo_url: null,
+  agreement_pct: 83.3,
+  matches: 5,
+  compared: 6,
+}
+
+const MATCH: QuizMatchResponse = {
+  version: '2026-Q3-test',
+  answered: 3,
+  eligible_deputies: 540,
+  top_matches: [
+    BEST,
+    { ...BEST, deputy_id: 'PA101', full_name: 'Paul Durand', agreement_pct: 80, matches: 4, compared: 5 },
+  ],
+  opposite: { ...BEST, deputy_id: 'PA200', full_name: 'Luc Petit', agreement_pct: 10, matches: 0, compared: 5 },
+  groups: [
+    {
+      party: 'Socialistes et apparentés',
+      party_short: 'SOC',
+      agreement_pct: 75,
+      matches: 3,
+      compared: 4,
+      deputy_count: 66,
+    },
+  ],
+  my_department: null,
+}
+
+const MATCH_WITH_DEPT: QuizMatchResponse = {
+  ...MATCH,
+  my_department: {
+    code: '33',
+    name: 'Gironde',
+    deputies: [
+      { ...BEST, deputy_id: 'PA300', full_name: 'Marie Bordeaux', agreement_pct: 66.7, matches: 2, compared: 3 },
+      { ...BEST, deputy_id: 'PA301', full_name: 'Jean Absent', agreement_pct: null, matches: 0, compared: 0 },
+    ],
+  },
+}
+
+async function answerAllQuestions(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(await screen.findByRole('button', { name: 'Commencer le quiz' }))
+  for (let i = 0; i < QUESTIONS.questions.length; i++) {
+    await user.click(screen.getByRole('button', { name: 'Pour' }))
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockQuestions.mockResolvedValue(QUESTIONS)
+})
+
+describe('QuizClient', () => {
+  it('walks intro → questions → postal skip → results with no persistence', async () => {
+    const user = userEvent.setup()
+    mockMatch.mockResolvedValue(MATCH)
+    render(<QuizClient />)
+
+    expect(screen.getByText('Quel député vote comme vous ?')).toBeInTheDocument()
+    await answerAllQuestions(user)
+
+    // Optional postal step reached after the last question.
+    expect(screen.getByText('Et votre député à vous ?')).toBeInTheDocument()
+    await user.click(
+      screen.getByRole('button', { name: 'Passer cette étape et voir mes résultats' })
+    )
+
+    await screen.findByText(/Vous votez à 83.3% comme Jeanne Martin/)
+    expect(mockMatch).toHaveBeenCalledWith(
+      [
+        { vote_id: 'V1', position: 'pour' },
+        { vote_id: 'V2', position: 'pour' },
+        { vote_id: 'V3', position: 'pour' },
+      ],
+      undefined
+    )
+    // Skipping the postal step yields full results minus the department section.
+    expect(screen.getByText('Votre alignement par groupe')).toBeInTheDocument()
+    expect(screen.queryByText('Les députés de votre département')).not.toBeInTheDocument()
+  })
+
+  it('shows a progress indicator and supports going back a question', async () => {
+    const user = userEvent.setup()
+    render(<QuizClient />)
+    await user.click(await screen.findByRole('button', { name: 'Commencer le quiz' }))
+
+    expect(screen.getByText('Question 1 / 3')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Contre' }))
+    expect(screen.getByText('Question 2 / 3')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: '← Retour' }))
+    expect(screen.getByText('Question 1 / 3')).toBeInTheDocument()
+    // The previously selected answer stays highlighted (selected state kept).
+    expect(screen.getByRole('button', { name: 'Contre' })).toHaveStyle({
+      border: '2px solid #C9302A',
+    })
+  })
+
+  it('resolves the postal code to a department and passes it to the match call', async () => {
+    const user = userEvent.setup()
+    mockResolve.mockResolvedValue({ code: '33', nom: 'Gironde' })
+    mockMatch.mockResolvedValue(MATCH_WITH_DEPT)
+    render(<QuizClient />)
+
+    await answerAllQuestions(user)
+    await user.type(screen.getByLabelText('Code postal'), '33000')
+    await user.click(screen.getByRole('button', { name: 'Voir mes résultats' }))
+
+    await screen.findByText('Les députés de votre département')
+    expect(mockResolve).toHaveBeenCalledWith('33000')
+    expect(mockMatch).toHaveBeenCalledWith(expect.any(Array), '33')
+    expect(screen.getByText('Marie Bordeaux')).toBeInTheDocument()
+    // A department deputy with no comparable vote renders gracefully.
+    expect(screen.getByText('aucun vote comparable')).toBeInTheDocument()
+  })
+
+  it('rejects an unknown postal code with a message and no match call', async () => {
+    const user = userEvent.setup()
+    mockResolve.mockResolvedValue(null)
+    render(<QuizClient />)
+
+    await answerAllQuestions(user)
+    await user.type(screen.getByLabelText('Code postal'), '99999')
+    await user.click(screen.getByRole('button', { name: 'Voir mes résultats' }))
+
+    await screen.findByText(/Code postal introuvable/)
+    expect(mockMatch).not.toHaveBeenCalled()
+  })
+
+  it('requires at least 3 expressed answers before computing', async () => {
+    const user = userEvent.setup()
+    render(<QuizClient />)
+    await user.click(await screen.findByRole('button', { name: 'Commencer le quiz' }))
+
+    await user.click(screen.getByRole('button', { name: 'Pour' }))
+    await user.click(screen.getByRole('button', { name: 'Passer cette question' }))
+    await user.click(screen.getByRole('button', { name: 'Abstention' }))
+
+    expect(screen.getByText('Encore quelques réponses')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Passer cette étape et voir mes résultats' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('links results to the matched deputy profiles', async () => {
+    const user = userEvent.setup()
+    mockMatch.mockResolvedValue(MATCH)
+    render(<QuizClient />)
+
+    await answerAllQuestions(user)
+    await user.click(
+      screen.getByRole('button', { name: 'Passer cette étape et voir mes résultats' })
+    )
+
+    await screen.findAllByText(/Jeanne Martin/)
+    expect(screen.getByRole('link', { name: /Jeanne Martin/ })).toHaveAttribute(
+      'href',
+      '/deputes/PA100'
+    )
+    expect(screen.getByRole('link', { name: /Paul Durand/ })).toHaveAttribute(
+      'href',
+      '/deputes/PA101'
+    )
+    expect(screen.getByRole('link', { name: /Luc Petit/ })).toHaveAttribute(
+      'href',
+      '/deputes/PA200'
+    )
+    expect(screen.getByRole('link', { name: 'Ouvrir Mon député' })).toHaveAttribute(
+      'href',
+      '/mon-depute'
+    )
+  })
+
+  it('surfaces a match-call failure with a retry path', async () => {
+    const user = userEvent.setup()
+    mockMatch.mockRejectedValueOnce(new Error('API error: 500')).mockResolvedValueOnce(MATCH)
+    render(<QuizClient />)
+
+    await answerAllQuestions(user)
+    await user.click(
+      screen.getByRole('button', { name: 'Passer cette étape et voir mes résultats' })
+    )
+    await screen.findByText(/Le calcul a échoué/)
+
+    await user.click(
+      screen.getByRole('button', { name: 'Passer cette étape et voir mes résultats' })
+    )
+    await screen.findByText(/Vous votez à 83.3% comme Jeanne Martin/)
+  })
+
+  it('shows an error state when the question set cannot load', async () => {
+    mockQuestions.mockRejectedValue(new Error('API error: 500'))
+    render(<QuizClient />)
+    await waitFor(() =>
+      expect(screen.getByText(/Impossible de charger le questionnaire/)).toBeInTheDocument()
+    )
+    expect(screen.queryByRole('button', { name: /Commencer le quiz/ })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/quiz/QuizClient.tsx
+++ b/frontend/src/app/quiz/QuizClient.tsx
@@ -431,13 +431,23 @@ export function QuizClient() {
                 Le calcul a échoué. Réessayez dans un instant.
               </p>
             )}
-            <div style={{ marginTop: 22 }}>
+            <div style={{ marginTop: 22, display: 'flex', gap: 20, flexWrap: 'wrap' }}>
               <button
                 onClick={() => submit(null)}
                 disabled={matching}
                 style={{ fontSize: 14.5, color: NAVY, background: 'none', border: 'none', cursor: 'pointer', textDecoration: 'underline', padding: 4 }}
               >
                 {matching ? 'Calcul…' : 'Passer cette étape et voir mes résultats'}
+              </button>
+              <button
+                onClick={() => {
+                  if (questions) setIndex(questions.length - 1)
+                  setPhase('questions')
+                }}
+                disabled={matching}
+                style={{ fontSize: 14.5, color: GRAY, background: 'none', border: 'none', cursor: 'pointer', textDecoration: 'underline', padding: 4 }}
+              >
+                ← Revenir aux questions
               </button>
             </div>
           </>

--- a/frontend/src/app/quiz/QuizClient.tsx
+++ b/frontend/src/app/quiz/QuizClient.tsx
@@ -1,0 +1,607 @@
+'use client'
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { api } from '@/lib/api'
+import type {
+  QuizAnswerPosition,
+  QuizDeputyMatch,
+  QuizMatchResponse,
+  QuizQuestion,
+} from '@/lib/api'
+import { partyHex } from '@/lib/utils'
+import { departmentLabel } from '@/lib/departments'
+import { resolvePostalCodeToDepartment } from '@/lib/postal'
+import type { ResolvedDepartment } from '@/lib/postal'
+import { DeputyAvatar } from '@/components/DeputyAvatar'
+import { POS } from '@/lib/vote-position'
+
+const NAVY = '#1B2B50'
+const CREAM = '#F7F4ED'
+const LINE = '#E4E6EA'
+const ACCENT = '#E0786E'
+const RED = '#C9302A'
+const GRAY = '#6B7280'
+
+// Mirrors MIN_ANSWERS in api/routers/quiz.py — the backend rejects fewer.
+const MIN_ANSWERS = 3
+
+type Phase = 'intro' | 'questions' | 'postal' | 'results'
+
+const kicker: React.CSSProperties = {
+  fontWeight: 700,
+  fontSize: 12,
+  letterSpacing: '0.18em',
+  textTransform: 'uppercase',
+  color: RED,
+}
+
+const card: React.CSSProperties = {
+  background: '#fff',
+  border: `1px solid ${LINE}`,
+  borderRadius: 12,
+  padding: '22px 24px',
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ background: CREAM, minHeight: '100vh' }}>
+      <div style={{ maxWidth: 760, margin: '0 auto', padding: '40px 20px 96px' }}>{children}</div>
+    </div>
+  )
+}
+
+function AgreementBar({ pct, color }: { pct: number; color: string }) {
+  return (
+    <div
+      style={{
+        position: 'relative',
+        height: 8,
+        background: '#EEF0F2',
+        borderRadius: 999,
+        overflow: 'hidden',
+      }}
+    >
+      <div style={{ height: '100%', background: color, borderRadius: 999, width: `${pct}%` }} />
+    </div>
+  )
+}
+
+function pctLabel(match: QuizDeputyMatch): string {
+  return match.agreement_pct !== null ? `${match.agreement_pct}%` : '—'
+}
+
+function comparedLabel(match: QuizDeputyMatch): string {
+  if (match.compared === 0) return 'aucun vote comparable'
+  return `${match.matches}/${match.compared} vote${match.compared > 1 ? 's' : ''} en accord`
+}
+
+function DeputyMatchRow({ match, rank }: { match: QuizDeputyMatch; rank?: number }) {
+  const hex = partyHex(match.party)
+  return (
+    <Link
+      href={`/deputes/${match.deputy_id}`}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 14,
+        padding: '12px 14px',
+        borderRadius: 10,
+        textDecoration: 'none',
+        background: '#fff',
+        border: `1px solid ${LINE}`,
+      }}
+    >
+      {rank !== undefined && (
+        <span className="font-mono" style={{ fontSize: 13, color: '#9CA3AF', width: 20 }}>
+          {rank}
+        </span>
+      )}
+      <DeputyAvatar name={match.full_name ?? '?'} photoUrl={match.photo_url} size="sm" />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontWeight: 600, fontSize: 15, color: NAVY }}>{match.full_name}</div>
+        <div style={{ fontSize: 12.5, color: GRAY, marginTop: 2 }}>
+          {[match.party_short ?? match.party, departmentLabel(match.department)]
+            .filter(Boolean)
+            .join(' · ')}
+        </div>
+      </div>
+      <div style={{ textAlign: 'right' }}>
+        <div className="font-mono" style={{ fontWeight: 700, fontSize: 18, color: hex }}>
+          {pctLabel(match)}
+        </div>
+        <div style={{ fontSize: 11.5, color: '#9CA3AF' }}>{comparedLabel(match)}</div>
+      </div>
+    </Link>
+  )
+}
+
+export function QuizClient() {
+  const [phase, setPhase] = useState<Phase>('intro')
+  const [questions, setQuestions] = useState<QuizQuestion[] | null>(null)
+  const [questionsError, setQuestionsError] = useState(false)
+  const [index, setIndex] = useState(0)
+  const [answers, setAnswers] = useState<Record<string, QuizAnswerPosition>>({})
+
+  const [postalInput, setPostalInput] = useState('')
+  const [resolving, setResolving] = useState(false)
+  const [postalError, setPostalError] = useState<string | null>(null)
+  const [resolved, setResolved] = useState<ResolvedDepartment | null>(null)
+
+  const [matching, setMatching] = useState(false)
+  const [matchError, setMatchError] = useState(false)
+  const [result, setResult] = useState<QuizMatchResponse | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    api.quiz
+      .questions()
+      .then(res => {
+        if (!cancelled) setQuestions(res.questions)
+      })
+      .catch(() => {
+        if (!cancelled) setQuestionsError(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const answeredCount = Object.keys(answers).length
+
+  function answer(voteId: string, position: QuizAnswerPosition) {
+    setAnswers(prev => ({ ...prev, [voteId]: position }))
+    advance()
+  }
+
+  function skip(voteId: string) {
+    setAnswers(prev => {
+      const next = { ...prev }
+      delete next[voteId]
+      return next
+    })
+    advance()
+  }
+
+  function advance() {
+    if (questions && index < questions.length - 1) setIndex(index + 1)
+    else setPhase('postal')
+  }
+
+  function back() {
+    if (index > 0) setIndex(index - 1)
+    else setPhase('intro')
+  }
+
+  async function submit(department: string | null) {
+    setMatching(true)
+    setMatchError(false)
+    try {
+      const payload = Object.entries(answers).map(([vote_id, position]) => ({
+        vote_id,
+        position,
+      }))
+      const res = await api.quiz.match(payload, department ?? undefined)
+      setResult(res)
+      setPhase('results')
+    } catch {
+      setMatchError(true)
+    } finally {
+      setMatching(false)
+    }
+  }
+
+  async function confirmPostal() {
+    setPostalError(null)
+    setResolving(true)
+    const dept = await resolvePostalCodeToDepartment(postalInput.trim())
+    setResolving(false)
+    if (!dept) {
+      setPostalError('Code postal introuvable — vérifiez les 5 chiffres, ou passez cette étape.')
+      return
+    }
+    setResolved(dept)
+    await submit(dept.code)
+  }
+
+  function restart() {
+    setPhase('intro')
+    setIndex(0)
+    setAnswers({})
+    setPostalInput('')
+    setPostalError(null)
+    setResolved(null)
+    setResult(null)
+    setMatchError(false)
+  }
+
+  // ------------------------------------------------------------------ intro
+  if (phase === 'intro') {
+    return (
+      <Shell>
+        <div style={{ textAlign: 'center', paddingTop: 40 }}>
+          <div style={{ ...kicker, marginBottom: 16 }}>Le quiz</div>
+          <h1
+            className="font-newsreader text-[clamp(30px,5vw,46px)]"
+            style={{ fontWeight: 600, color: NAVY, margin: 0, letterSpacing: '-0.015em' }}
+          >
+            Quel député vote comme vous ?
+          </h1>
+          <p style={{ margin: '18px auto 0', maxWidth: 520, fontSize: 16, lineHeight: 1.65, color: '#4B5563' }}>
+            Une dizaine de vrais scrutins de l’Assemblée nationale, posés en français courant.
+            Répondez pour, contre ou abstention — à la fin, on compare vos réponses aux votes
+            réels des 577 députés.
+          </p>
+          <p style={{ margin: '14px auto 0', maxWidth: 520, fontSize: 13.5, color: GRAY }}>
+            Sans compte. Vos réponses restent dans votre navigateur : rien n’est enregistré.
+          </p>
+          {questionsError ? (
+            <p style={{ marginTop: 28, fontSize: 15, color: RED }}>
+              Impossible de charger le questionnaire pour le moment. Réessayez dans un instant.
+            </p>
+          ) : (
+            <button
+              onClick={() => setPhase('questions')}
+              disabled={!questions}
+              style={{
+                marginTop: 32,
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 8,
+                background: ACCENT,
+                color: '#fff',
+                padding: '13px 30px',
+                borderRadius: 9,
+                fontWeight: 600,
+                fontSize: 15.5,
+                border: 'none',
+                cursor: questions ? 'pointer' : 'wait',
+                opacity: questions ? 1 : 0.6,
+                boxShadow: '0 2px 8px rgba(224,120,110,0.35)',
+              }}
+            >
+              {questions ? 'Commencer le quiz' : 'Chargement…'}
+            </button>
+          )}
+        </div>
+      </Shell>
+    )
+  }
+
+  // -------------------------------------------------------------- questions
+  if (phase === 'questions' && questions) {
+    const q = questions[index]
+    const selected = answers[q.vote_id]
+    return (
+      <Shell>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 }}>
+          <div style={kicker}>
+            Question {index + 1} / {questions.length}
+          </div>
+          <div style={{ fontSize: 12.5, color: GRAY }}>{q.theme}</div>
+        </div>
+        <div
+          role="progressbar"
+          aria-valuenow={index + 1}
+          aria-valuemin={1}
+          aria-valuemax={questions.length}
+          style={{ height: 6, background: '#E7E2D6', borderRadius: 999, overflow: 'hidden', marginBottom: 30 }}
+        >
+          <div
+            style={{
+              height: '100%',
+              background: NAVY,
+              borderRadius: 999,
+              width: `${((index + 1) / questions.length) * 100}%`,
+              transition: 'width 200ms ease',
+            }}
+          />
+        </div>
+
+        <h2
+          className="font-newsreader text-[clamp(22px,3.5vw,32px)]"
+          style={{ fontWeight: 600, color: NAVY, margin: 0, letterSpacing: '-0.01em', lineHeight: 1.3 }}
+        >
+          {q.question}
+        </h2>
+        <p style={{ margin: '14px 0 30px', fontSize: 14.5, lineHeight: 1.6, color: GRAY }}>{q.context}</p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          {(['pour', 'contre', 'abstention'] as const).map(pos => {
+            const { label, color, bg } = POS[pos]
+            const active = selected === pos
+            return (
+              <button
+                key={pos}
+                onClick={() => answer(q.vote_id, pos)}
+                style={{
+                  padding: '15px 20px',
+                  borderRadius: 10,
+                  fontWeight: 600,
+                  fontSize: 16,
+                  textAlign: 'left',
+                  cursor: 'pointer',
+                  color,
+                  background: bg,
+                  border: `2px solid ${active ? color : 'transparent'}`,
+                }}
+              >
+                {label}
+              </button>
+            )
+          })}
+        </div>
+
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 28 }}>
+          <button
+            onClick={back}
+            style={{ fontSize: 14, color: NAVY, background: 'none', border: 'none', cursor: 'pointer', textDecoration: 'underline', padding: 4 }}
+          >
+            ← Retour
+          </button>
+          <button
+            onClick={() => skip(q.vote_id)}
+            style={{ fontSize: 14, color: GRAY, background: 'none', border: 'none', cursor: 'pointer', textDecoration: 'underline', padding: 4 }}
+          >
+            Passer cette question
+          </button>
+        </div>
+      </Shell>
+    )
+  }
+
+  // ----------------------------------------------------------------- postal
+  if (phase === 'postal') {
+    const enough = answeredCount >= MIN_ANSWERS
+    return (
+      <Shell>
+        <div style={{ ...kicker, marginBottom: 16 }}>Dernière étape</div>
+        {!enough ? (
+          <>
+            <h2
+              className="font-newsreader text-[clamp(24px,3.5vw,34px)]"
+              style={{ fontWeight: 600, color: NAVY, margin: 0, letterSpacing: '-0.01em' }}
+            >
+              Encore quelques réponses
+            </h2>
+            <p style={{ margin: '16px 0 28px', fontSize: 15.5, lineHeight: 1.6, color: '#4B5563' }}>
+              Il faut au moins {MIN_ANSWERS} réponses exprimées pour un résultat significatif —
+              vous en avez donné {answeredCount}.
+            </p>
+            <button
+              onClick={() => {
+                setIndex(0)
+                setPhase('questions')
+              }}
+              style={{
+                background: ACCENT, color: '#fff', padding: '12px 26px', borderRadius: 9,
+                fontWeight: 600, fontSize: 15, border: 'none', cursor: 'pointer',
+              }}
+            >
+              Reprendre les questions
+            </button>
+          </>
+        ) : (
+          <>
+            <h2
+              className="font-newsreader text-[clamp(24px,3.5vw,34px)]"
+              style={{ fontWeight: 600, color: NAVY, margin: 0, letterSpacing: '-0.01em' }}
+            >
+              Et votre député à vous ?
+            </h2>
+            <p style={{ margin: '16px 0 24px', fontSize: 15.5, lineHeight: 1.6, color: '#4B5563' }}>
+              Donnez votre code postal pour comparer aussi vos réponses aux votes des députés de
+              votre département. Facultatif — il n’est ni envoyé à nos serveurs tel quel, ni conservé.
+            </p>
+            <form
+              onSubmit={e => {
+                e.preventDefault()
+                confirmPostal()
+              }}
+              style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}
+            >
+              <input
+                inputMode="numeric"
+                pattern="\d{5}"
+                maxLength={5}
+                placeholder="Code postal (ex. 33000)"
+                value={postalInput}
+                onChange={e => setPostalInput(e.target.value)}
+                aria-label="Code postal"
+                style={{
+                  flex: '1 1 200px', padding: '12px 16px', borderRadius: 9,
+                  border: `1px solid ${LINE}`, fontSize: 15.5, color: NAVY, background: '#fff',
+                }}
+              />
+              <button
+                type="submit"
+                disabled={resolving || matching || !/^\d{5}$/.test(postalInput.trim())}
+                style={{
+                  background: ACCENT, color: '#fff', padding: '12px 26px', borderRadius: 9,
+                  fontWeight: 600, fontSize: 15, border: 'none',
+                  cursor: resolving || matching ? 'wait' : 'pointer',
+                  opacity: resolving || matching || !/^\d{5}$/.test(postalInput.trim()) ? 0.6 : 1,
+                }}
+              >
+                {resolving || matching ? 'Calcul…' : 'Voir mes résultats'}
+              </button>
+            </form>
+            {postalError && <p style={{ marginTop: 12, fontSize: 14, color: RED }}>{postalError}</p>}
+            {matchError && (
+              <p style={{ marginTop: 12, fontSize: 14, color: RED }}>
+                Le calcul a échoué. Réessayez dans un instant.
+              </p>
+            )}
+            <div style={{ marginTop: 22 }}>
+              <button
+                onClick={() => submit(null)}
+                disabled={matching}
+                style={{ fontSize: 14.5, color: NAVY, background: 'none', border: 'none', cursor: 'pointer', textDecoration: 'underline', padding: 4 }}
+              >
+                {matching ? 'Calcul…' : 'Passer cette étape et voir mes résultats'}
+              </button>
+            </div>
+          </>
+        )}
+      </Shell>
+    )
+  }
+
+  // ---------------------------------------------------------------- results
+  if (phase === 'results' && result) {
+    const best = result.top_matches[0] ?? null
+    const others = result.top_matches.slice(1)
+    const bestHex = best ? partyHex(best.party) : NAVY
+    return (
+      <Shell>
+        <div style={{ ...kicker, marginBottom: 16 }}>Vos résultats</div>
+
+        {best ? (
+          <>
+            <h1
+              className="font-newsreader text-[clamp(26px,4vw,38px)]"
+              style={{ fontWeight: 600, color: NAVY, margin: 0, letterSpacing: '-0.015em' }}
+            >
+              Vous votez à {pctLabel(best)} comme {best.full_name}
+            </h1>
+            <p style={{ margin: '10px 0 26px', fontSize: 14, color: GRAY }}>
+              Sur {result.answered} scrutin{result.answered > 1 ? 's' : ''} répondu
+              {result.answered > 1 ? 's' : ''}, comparé aux positions exprimées de{' '}
+              {result.eligible_deputies} députés.
+            </p>
+
+            <Link
+              href={`/deputes/${best.deputy_id}`}
+              style={{ ...card, display: 'flex', alignItems: 'center', gap: 20, textDecoration: 'none', borderLeft: `4px solid ${bestHex}` }}
+            >
+              <DeputyAvatar name={best.full_name ?? '?'} photoUrl={best.photo_url} size="xl" priority />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontWeight: 700, fontSize: 20, color: NAVY }}>{best.full_name}</div>
+                <div style={{ fontSize: 14, color: GRAY, marginTop: 4 }}>
+                  {[best.party, departmentLabel(best.department)].filter(Boolean).join(' · ')}
+                </div>
+                <div style={{ fontSize: 13, color: '#9CA3AF', marginTop: 4 }}>{comparedLabel(best)}</div>
+              </div>
+              <div className="font-mono" style={{ fontWeight: 700, fontSize: 34, color: bestHex }}>
+                {pctLabel(best)}
+              </div>
+            </Link>
+          </>
+        ) : (
+          <>
+            <h1
+              className="font-newsreader text-[clamp(26px,4vw,38px)]"
+              style={{ fontWeight: 600, color: NAVY, margin: 0, letterSpacing: '-0.015em' }}
+            >
+              Pas assez de votes comparables
+            </h1>
+            <p style={{ margin: '14px 0 0', fontSize: 15.5, lineHeight: 1.6, color: '#4B5563' }}>
+              Aucun député n’a exprimé de position sur assez de scrutins de votre sélection pour
+              établir une comparaison fiable. Réessayez en répondant à davantage de questions.
+            </p>
+          </>
+        )}
+
+        {others.length > 0 && (
+          <section style={{ marginTop: 40 }}>
+            <h2 className="font-newsreader" style={{ fontWeight: 600, fontSize: 22, color: NAVY, margin: '0 0 16px' }}>
+              Vos autres meilleurs matchs
+            </h2>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {others.map((m, i) => (
+                <DeputyMatchRow key={m.deputy_id} match={m} rank={i + 2} />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {result.opposite && (
+          <section style={{ marginTop: 40 }}>
+            <h2 className="font-newsreader" style={{ fontWeight: 600, fontSize: 22, color: NAVY, margin: '0 0 6px' }}>
+              À l’opposé de vos votes
+            </h2>
+            <p style={{ margin: '0 0 16px', fontSize: 13.5, color: GRAY }}>
+              Le député qui vote le moins souvent comme vous.
+            </p>
+            <DeputyMatchRow match={result.opposite} />
+          </section>
+        )}
+
+        {result.groups.length > 0 && (
+          <section style={{ marginTop: 40 }}>
+            <h2 className="font-newsreader" style={{ fontWeight: 600, fontSize: 22, color: NAVY, margin: '0 0 6px' }}>
+              Votre alignement par groupe
+            </h2>
+            <p style={{ margin: '0 0 18px', fontSize: 13.5, color: GRAY }}>
+              Accord entre vos réponses et la position majoritaire de chaque groupe parlementaire,
+              scrutin par scrutin.
+            </p>
+            <div style={{ ...card, display: 'flex', flexDirection: 'column', gap: 16 }}>
+              {result.groups.map(g => {
+                const hex = partyHex(g.party)
+                return (
+                  <div key={g.party}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 6, gap: 12 }}>
+                      <span style={{ fontSize: 14, fontWeight: 600, color: NAVY, minWidth: 0 }}>
+                        {g.party}
+                      </span>
+                      <span className="font-mono" style={{ fontWeight: 700, fontSize: 15, color: hex }}>
+                        {g.agreement_pct}%
+                      </span>
+                    </div>
+                    <AgreementBar pct={g.agreement_pct} color={hex} />
+                  </div>
+                )
+              })}
+            </div>
+          </section>
+        )}
+
+        {result.my_department && (
+          <section style={{ marginTop: 40 }}>
+            <h2 className="font-newsreader" style={{ fontWeight: 600, fontSize: 22, color: NAVY, margin: '0 0 6px' }}>
+              Les députés de votre département
+            </h2>
+            <p style={{ margin: '0 0 16px', fontSize: 13.5, color: GRAY }}>
+              {result.my_department.name}
+              {resolved && resolved.nom !== result.my_department.name ? ` (${resolved.nom})` : ''} —
+              votre accord avec chacun de ses députés.
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {result.my_department.deputies.map(m => (
+                <DeputyMatchRow key={m.deputy_id} match={m} />
+              ))}
+            </div>
+          </section>
+        )}
+
+        <section style={{ marginTop: 48, ...card, textAlign: 'center' }}>
+          <p style={{ margin: '0 0 16px', fontSize: 15, lineHeight: 1.6, color: '#4B5563' }}>
+            Envie de suivre un de ces députés vote après vote ?
+          </p>
+          <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap' }}>
+            <Link
+              href="/mon-depute"
+              style={{
+                background: ACCENT, color: '#fff', padding: '11px 22px', borderRadius: 9,
+                fontWeight: 600, fontSize: 14.5, textDecoration: 'none',
+              }}
+            >
+              Ouvrir Mon député
+            </Link>
+            <button
+              onClick={restart}
+              style={{
+                fontSize: 14.5, color: NAVY, background: '#fff', border: `1px solid ${LINE}`,
+                padding: '11px 22px', borderRadius: 9, fontWeight: 600, cursor: 'pointer',
+              }}
+            >
+              Refaire le quiz
+            </button>
+          </div>
+        </section>
+      </Shell>
+    )
+  }
+
+  return <Shell>{null}</Shell>
+}

--- a/frontend/src/app/quiz/page.tsx
+++ b/frontend/src/app/quiz/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next'
+import { QuizClient } from './QuizClient'
+
+export const metadata: Metadata = {
+  title: 'Quel député vote comme vous ? — MonÉlu',
+  description:
+    'Répondez à une dizaine de vrais scrutins de l’Assemblée nationale et découvrez ' +
+    'quel député vote comme vous. Sans compte, rien n’est enregistré.',
+}
+
+export default function QuizPage() {
+  return <QuizClient />
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -209,6 +209,59 @@ export type ChatShareResult = {
   share_url: string
 }
 
+export type QuizQuestion = {
+  vote_id: string
+  theme: string
+  question: string
+  context: string
+}
+
+export type QuizQuestionsResponse = {
+  version: string
+  count: number
+  questions: QuizQuestion[]
+}
+
+export type QuizAnswerPosition = 'pour' | 'contre' | 'abstention'
+
+export type QuizDeputyMatch = {
+  deputy_id: string
+  full_name: string | null
+  party: string | null
+  party_short: string | null
+  department: string | null
+  photo_url: string | null
+  // null when the deputy has no comparable expressed position at all.
+  agreement_pct: number | null
+  matches: number
+  compared: number
+}
+
+export type QuizGroupAlignment = {
+  party: string
+  party_short: string | null
+  agreement_pct: number
+  matches: number
+  compared: number
+  deputy_count: number
+}
+
+export type QuizDepartmentResult = {
+  code: string
+  name: string
+  deputies: QuizDeputyMatch[]
+}
+
+export type QuizMatchResponse = {
+  version: string
+  answered: number
+  eligible_deputies: number
+  top_matches: QuizDeputyMatch[]
+  opposite: QuizDeputyMatch | null
+  groups: QuizGroupAlignment[]
+  my_department: QuizDepartmentResult | null
+}
+
 // 5xx: transient upstream hiccups, short retries.
 // 429: the API rate limiter (30 req/min per IP) — hit hard during `next build`,
 // where prerendering ~117 pages from one IP exceeds the budget and fails the
@@ -310,6 +363,16 @@ export const api = {
     },
     latest: () => apiFetch<Vote[]>('/votes/latest/', { revalidate: 300 }),
     get: (id: string) => apiFetch<VoteDetail>(`/votes/${id}/`, { revalidate: 86400 }),
+  },
+  quiz: {
+    // The question set is a versioned repo file server-side (ADR-025) — it only
+    // changes by deploy, so cache it as aggressively as immutable snapshots.
+    questions: () => apiFetch<QuizQuestionsResponse>('/quiz/questions', { revalidate: 86400 }),
+    match: (answers: Array<{ vote_id: string; position: QuizAnswerPosition }>, department?: string) =>
+      apiPost<QuizMatchResponse>('/quiz/match', {
+        answers,
+        ...(department ? { department } : {}),
+      }),
   },
   search: (question: string) => apiPost<SearchResult>('/search/', { question }),
   verify: (claim: string) => apiPost<VerifyResult>('/verify/', { claim }),


### PR DESCRIPTION
## What

New `/quiz` page implementing the user-facing flow of the "Quel député vote comme vous ?" quiz (MON-109), on top of the MON-137 backend (PR #221):

- **Intro screen** - explains the quiz, states the no-account / nothing-persisted promise, loads the question set from `GET /quiz/questions`.
- **Question flow** - one question at a time (pour/contre/abstention via the shared `POS` palette), progress bar, back navigation, per-question skip. Answers are held in client state only.
- **Optional postal-code step** - reuses `resolvePostalCodeToDepartment` (`lib/postal.ts`, MON-84) to turn a postal code into a department code for the "vos députés" comparison; fully skippable. If fewer than 3 questions were answered (backend `MIN_ANSWERS`), the step asks the visitor to answer more instead of submitting.
- **Results screen** - best-match deputy hero card, top-10 list, "à l'opposé" deputy, per-group alignment bars (`partyHex` colors), and the own-department section when a postal code was given. Funnels: every deputy row links to `/deputes/[id]`, plus a "Mon député" CTA and a restart button.
- `lib/api.ts` gains the quiz response types and `api.quiz.questions()` / `api.quiz.match()`.

Entry points, SEO beyond basic metadata, and the share card are out of scope (MON-139, MON-140).

## Acceptance criteria

| Criterion | How it is met |
|---|---|
| Complete the quiz and see best match, department comparison, group alignment; no account, nothing persisted | Full flow implemented; answers live in React state only, no storage or cookies; verified by the walk-through test |
| Skipping the postal step still yields full results minus the own-deputy section | "Passer cette étape" submits without `department`; test asserts the department section is absent |
| Result links land on correct deputy profile pages | All match rows are `Link`s to `/deputes/<deputy_id>`; asserted in tests |
| `npm run lint`, `npm test`, `npm run build` pass; responsive on mobile | All three green locally (130 tests, `/quiz` prerenders at 8.6 kB); single-column max-width layout, wrapping flex rows |

## Test plan

- 8 new Jest tests (`__tests__/components/QuizClient.test.tsx`): full happy path, progress/back navigation with kept selections, postal resolution passed to the match call, unknown postal code rejection, minimum-3-answers gate, profile links, match-failure retry, question-set load failure.
- Smoke-tested against production: `GET /quiz/questions` and `POST /quiz/match` (with `department=33`) return the expected shapes; dev-server render of `/quiz` shows the intro.

## Risks

Frontend-only; no schema, deploy-config, or API changes. The page calls the already-deployed MON-137 endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MECuemDq5Qf5pVqZpLKxEU