### PR TITLE
fix: mobile chat sidebar defeats hidden md:flex (MON-141)

### DIFF
--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -456,7 +456,7 @@ function ChatInner() {
     <div style={{ display: 'flex', height: 'calc(100dvh - 4rem)', overflow: 'hidden', fontFamily: 'var(--font-sans)', background: bg0 }}>
 
       {/* ══════════ SIDEBAR ══════════ */}
-      <div style={{ width: 260, flexShrink: 0, background: '#111C35', display: 'flex', flexDirection: 'column', overflow: 'hidden' }} className="hidden md:flex">
+      <div style={{ width: 260, flexShrink: 0, background: '#111C35', flexDirection: 'column', overflow: 'hidden' }} className="hidden md:flex">
 
         {/* New chat button */}
         <div style={{ padding: '16px 16px 12px', flexShrink: 0 }}>


### PR DESCRIPTION
## What
Fixes the chat sidebar rendering on mobile by removing an inline `display: 'flex'` style that was overriding Tailwind's `hidden md:flex` classes on `frontend/src/app/chat/page.tsx`.

## Why
The sidebar div carried both `className="hidden md:flex"` and an inline style object containing `display: 'flex'`.
Inline styles always win over class-based styles in CSS specificity, so Tailwind's `hidden` never applied at any viewport width.
On phones the desktop conversation sidebar rendered anyway and squeezed the chat thread to ~260px: verify-mode copy wrapped one word per line, the Question/Vérifier toggle was clipped mid-pill, and the send button overlapped the character counter.

This is critical because `/partager` (the PWA Web Share Target, MON-115) 303-redirects to `/chat?mode=verify&claim=...`, and OS share sheets only exist on phones - so the headline PWA share flow landed end-to-end on a broken surface.

## Changes
- `frontend/src/app/chat/page.tsx`: removed `display: 'flex'` from the sidebar's inline style object, letting the `hidden md:flex` Tailwind classes control visibility as originally intended (sidebar hidden below the `md` breakpoint, flex column at `md` and up).
- No drawer or alternate mobile history affordance was added - mobile chat is sidebar-less, matching the pre-existing `hidden md:flex` design intent. Conversation history remains available on desktop only; a mobile history drawer can be filed as a follow-up if wanted.

## Testing
- `npm run lint` - no errors
- `npm run build` - succeeds (production build)
- `npm test -- --watchAll=false` - 14 suites / 122 tests passed
- Manual verification: production build served locally, screenshotted at 390x844 with Playwright at `/chat?mode=verify&claim=test` - sidebar is hidden, verify-mode copy wraps normally, Question/Vérifier toggle renders fully, send button and character counter no longer overlap.
- `ruff check .` / `ruff format --check .` at repo root - all pass (no Python changes in this PR).

## Risks / Notes
- Pure CSS fix, no schema, API, or deploy-config changes.
- Deliberately did not build a mobile conversation-history drawer - kept the fix minimal per the bug's root cause; flagging this as a possible follow-up (MON-141 description itself calls it out as an open decision).

## Breaking Changes
None.
