### PR TITLE
fix: stack vote-detail results card on mobile (MON-144)

### DIFF
--- a/frontend/src/app/votes/[id]/VoteDetailClient.tsx
+++ b/frontend/src/app/votes/[id]/VoteDetailClient.tsx
@@ -156,18 +156,18 @@ export function VoteDetailClient(props: Props) {
         transition: 'opacity 0.3s ease, transform 0.45s cubic-bezier(0.22,1,0.36,1)',
       }}>
         <div style={{ background: 'rgba(255,255,255,0.94)', backdropFilter: 'blur(14px)', borderBottom: '1px solid #E4E6EA', boxShadow: '0 8px 24px rgba(27,43,80,0.08)' }}>
-          <div style={{ maxWidth: 1180, margin: '0 auto', display: 'flex', alignItems: 'center', gap: 16, padding: '10px 56px' }}>
-            <span style={{ fontSize: 12, fontWeight: 600, letterSpacing: '0.1em', textTransform: 'uppercase', color: '#9CA3AF', flexShrink: 0 }}>
+          <div className="px-5 sm:px-14" style={{ maxWidth: 1180, margin: '0 auto', display: 'flex', alignItems: 'center', gap: 16, padding: '10px 0' }}>
+            <span className="hidden sm:inline" style={{ fontSize: 12, fontWeight: 600, letterSpacing: '0.1em', textTransform: 'uppercase', color: '#9CA3AF', flexShrink: 0 }}>
               Scrutin n°{voteId}
             </span>
-            <span style={{ fontSize: 12, color: '#D1D5DB' }}>·</span>
+            <span className="hidden sm:inline" style={{ fontSize: 12, color: '#D1D5DB' }}>·</span>
             <span style={{ fontWeight: 600, fontSize: 15, color: '#1B2B50', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
               {headline}
             </span>
             <span style={{ display: 'inline-flex', alignItems: 'center', fontSize: 12, fontWeight: 700, padding: '5px 14px', borderRadius: 999, background: adopted ? '#EAF5EF' : '#FBE9E7', color: adopted ? '#1F8A5B' : '#C9302A', flexShrink: 0 }}>
               {adopted ? 'Adopté' : 'Rejeté'}
             </span>
-            <span className="font-mono" style={{ fontSize: 12.5, color: '#6B7280', flexShrink: 0 }}>
+            <span className="font-mono hidden sm:inline" style={{ fontSize: 12.5, color: '#6B7280', flexShrink: 0 }}>
               {votesFor} pour · {votesAgainst} contre
             </span>
           </div>
@@ -188,7 +188,7 @@ export function VoteDetailClient(props: Props) {
             <span>Scrutin n°{voteId}</span>
           </div>
 
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 380px', gap: 64, alignItems: 'start', marginTop: 30 }}>
+          <div className="xl:grid xl:grid-cols-[1fr_380px] xl:gap-16 xl:items-start" style={{ marginTop: 30 }}>
 
             {/* Left: identity */}
             <div>
@@ -233,7 +233,7 @@ export function VoteDetailClient(props: Props) {
             </div>
 
             {/* Right: result card */}
-            <div style={{ background: '#fff', border: '1px solid #E4E6EA', borderRadius: 14, padding: 28, boxShadow: '0 4px 12px rgba(0,0,0,0.08)' }}>
+            <div className="mt-8 xl:mt-0" style={{ background: '#fff', border: '1px solid #E4E6EA', borderRadius: 14, padding: 28, boxShadow: '0 4px 12px rgba(0,0,0,0.08)' }}>
               <div style={{ font: '700 11px/1 var(--font-sans)', letterSpacing: '0.14em', textTransform: 'uppercase', color: '#9CA3AF', marginBottom: 18 }}>
                 Résultat du scrutin
               </div>
@@ -271,7 +271,7 @@ export function VoteDetailClient(props: Props) {
               </div>
 
               {/* Actions */}
-              <div style={{ display: 'flex', gap: 10 }}>
+              <div className="flex-wrap" style={{ display: 'flex', gap: 10 }}>
                 <a
                   href={`https://www.assemblee-nationale.fr/dyn/scrutins/${voteId}`}
                   target="_blank" rel="noopener noreferrer"


### PR DESCRIPTION
## What
Fixes the vote detail page (`/votes/[id]`) on mobile, where the "Résultat du scrutin" results card overflowed the viewport instead of stacking below the title.

## Why
The hero row used a fixed `display: 'grid', gridTemplateColumns: '1fr 380px'` that never wraps. On a 390px viewport the results card extended to x=769 (`scrollWidth - clientWidth = 379`), so the card appeared as a sliver at the right edge and the whole page panned horizontally.

While fixing the primary grid, two smaller non-wrapping-flex-row bugs in the same hero region turned out to contribute to the same symptom and were fixed alongside it:
- The sticky scroll bar (label + separator + headline + badge + vote tally, all `flexShrink: 0` except the headline) didn't fit in the mobile width either.
- The results card's actions row (official text / PDF / CSV / Partager) is four fixed-width buttons in one non-wrapping flex row, which no longer fit once the card became full-width on mobile.

## Changes
- `frontend/src/app/votes/[id]/VoteDetailClient.tsx`:
  - Hero grid: two-column `1fr 380px` layout now only applies at the `xl` breakpoint (`xl:grid xl:grid-cols-[1fr_380px] xl:gap-16 xl:items-start`), matching the existing hero pattern already used in `VotesClient.tsx` / `DeputiesClient.tsx` (MON-121 era). Below `xl` it's a normal block, so the results card stacks full-width under the title with a `mt-8` gap.
  - Sticky scroll bar: padding is now responsive (`px-5 sm:px-14`) and the redundant scrutin-number label and vote tally are hidden below `sm` (already shown in the card itself), leaving only the headline and Adopté/Rejeté badge, which fit.
  - Results card actions row: added `flex-wrap` so the four action buttons wrap onto a second line on narrow screens instead of overflowing.

## Testing
- `npm run lint` - no errors
- `npm run build` - succeeds
- `npm test -- --watchAll=false` - 15 suites / 131 tests passed
- Manual verification: local production build + Playwright at 390x844 on `/votes/VTANR5L17V8359`. `scrollWidth - clientWidth` dropped from 379px (before) to 22px (after) - the results card itself no longer overflows or produces a sliver; the residual 22px comes from unrelated components further down the same page (the hemicycle chart's group-ventilation table and a "Sources officielles" tooltip box), which this issue doesn't describe. Screenshot confirms the card now stacks cleanly below the title with wrapped action buttons.
- `ruff check .` / `ruff format --check .` at repo root - all pass (no Python changes in this PR).

## Risks / Notes
- Pure frontend CSS fix, no schema/API/deploy-config changes.
- Follow-up worth filing: the hemicycle legend / group-ventilation table and the "Sources officielles" tooltip box on the same page have their own smaller mobile overflow (~22px), unrelated to the card this issue targets - left out of scope here per MON-144's stated root cause and fix.

## Breaking Changes
None.
