### PR TITLE
docs: curate quiz question set and finalize version (MON-136)

### DIFF
--- a/api/quiz_data.py
+++ b/api/quiz_data.py
@@ -8,17 +8,12 @@ editorial artifact updated quarterly by PR — never a DB table, never fetched f
 the AN portal at runtime. The frontend reads it through GET /quiz/questions.
 
 Every vote_id must exist in the production votes table (prod holds scrutins from
-2025-07-01 onward). Selection criteria (MON-136): whole-text scrutins
-("l'ensemble ..."), high participation (>= 400 voters out of 577), and divisive
-(the losing side of pour/contre holds >= 35% of the expressed pour+contre).
-
-VERSION note: "-draft" marks this as the provisional MON-137 set, picked from
-live prod data by the above criteria but pending the MON-136 editorial pass
-(phrasing review, final selection). MON-136 replaces the content of this list
-and drops the suffix; no code changes.
+2025-07-01 onward). Full selection criteria, phrasing rules, and the quarterly
+refresh process are documented in docs/quiz-curation.md (MON-136) — read that
+before touching this list.
 """
 
-QUIZ_VERSION = "2026-Q3-draft"
+QUIZ_VERSION = "2026-Q3"
 
 # Each entry: the scrutin, a neutral plain-French question, a one-line context
 # sentence, and a short theme tag for the UI. Question phrasing must stay

--- a/docs/quiz-curation.md
+++ b/docs/quiz-curation.md
@@ -1,0 +1,93 @@
+# Quiz question set curation (MON-109 / MON-136)
+
+This document describes how the vote-matching quiz's question set (`api/quiz_data.py`) is
+selected, so a future quarterly refresh can be done without re-reading the original issue.
+
+Per ADR-025, the question set is a versioned repo file, not a database table.
+It is curated by hand, quarterly, and shipped by PR.
+
+## Selection criteria
+
+A scrutin qualifies for the quiz if it meets all four criteria:
+
+1. **Whole-text vote.** The scrutin title starts with `l'ensemble de ...` (or the
+   organic-law/constitutional equivalent) — a vote on the full text, not an amendment
+   or a single article. Amendment votes are procedurally noisy and less recognizable
+   to a general audience.
+2. **In production.** The `vote_id` must exist in the production `votes` table.
+   Prod (Supabase free tier) only holds scrutins from 2025-07-01 onward (decision 7
+   in `CLAUDE.md`) — a scrutin that only exists in local dev cannot be used.
+   Verify with `GET /votes/{vote_id}` against the production API
+   (`https://monelu-production.up.railway.app`), not against local Docker data.
+3. **High participation.** `total_voters >= 400` (out of 577 seats). Below this,
+   the result reflects who showed up more than what the Assembly actually decided.
+4. **Divisive.** Of the *expressed* votes (`votes_for + votes_against`, abstentions
+   excluded), the losing side holds `>= 35%`. This is what makes agreement/disagreement
+   with a deputy actually discriminate between users — a 90/10 vote agrees with
+   almost everyone and adds no signal to the match.
+
+Within the votes that pass all four filters, prefer:
+
+- **Topic diversity.** No two questions share a `theme` tag — the quiz should span
+  civic ground (institutions, justice, economy, social policy, etc.), not cluster
+  on one axis.
+- **Recognizability.** Prefer scrutins that received general-audience press coverage
+  (aide à mourir, Corse, Nouvelle-Calédonie, fraudes fiscales, etc.) over technical
+  or procedural texts a non-specialist wouldn't have an intuition about.
+
+Target set size: ~10 questions (`MIN_ANSWERS = 3` is enforced server-side in
+`api/routers/quiz.py`, but the full set should stay close to 10 for quiz-completion time).
+
+## Phrasing rules
+
+Each entry has:
+
+- `question`: `"Auriez-vous voté pour ou contre <description of what the text does> ?"`
+  The description must stay **descriptive of the text's actual effect** — no
+  evaluative or leading language ("scandaleux", "enfin", "malgré l'opposition...").
+  Where possible, phrase it close to the official scrutin title, simplified into
+  plain French a non-specialist can parse in one read.
+- `context`: one sentence — the official/simplified bill title, the parliamentary
+  stage (première lecture / lecture définitive / commission mixte paritaire), and
+  the vote date. No commentary on the outcome or on who voted which way.
+
+Before shipping a refresh, re-read every `question`/`context` pair together and ask:
+does this text tip the reader toward "pour" or "contre" before they've formed their
+own opinion? If yes, rewrite it.
+
+## Process for a quarterly refresh
+
+1. Query recent whole-text scrutins from the production `votes` table (via
+   `GET /votes` listing endpoints, or direct SQL against prod if you have the
+   `DBT_*`/Supabase credentials) and compute participation and minority-share
+   for each candidate using the same formula as above.
+2. Shortlist candidates passing all four criteria, then pick ~10 that maximize
+   theme diversity and recognizability.
+3. Write `question`/`context` for each, review for neutrality per the rules above.
+4. Update `api/quiz_data.py`: replace `QUIZ_QUESTIONS`, bump `QUIZ_VERSION` to the
+   new quarter (e.g. `2026-Q4`). Old `QUIZ_VERSION` strings remain attached to
+   already-stored `quiz_shares` snapshots (ADR-025) — they are never rewritten,
+   so a version bump never invalidates a previously shared result card.
+5. Ship as a PR; `tests/unit/test_quiz.py` asserts every `vote_id` round-trips
+   through the API and that the response `version` matches `QUIZ_VERSION` —
+   no other test needs updating for a content-only refresh.
+
+## Current set (2026-Q3)
+
+Verified against production (`https://monelu-production.up.railway.app`) on 2026-07-19:
+
+| vote_id | theme | for | against | abst. | total | minority % |
+|---|---|---|---|---|---|---|
+| VTANR5L17V8280 | Fin de vie | 291 | 241 | 29 | 561 | 45.3 |
+| VTANR5L17V4758 | Protection sociale | 247 | 232 | 90 | 569 | 48.4 |
+| VTANR5L17V2957 | Agriculture | 316 | 223 | 25 | 564 | 41.4 |
+| VTANR5L17V7454 | Institutions | 271 | 202 | 64 | 537 | 42.7 |
+| VTANR5L17V6184 | Économie | 275 | 225 | 30 | 530 | 45.0 |
+| VTANR5L17V6319 | Finances publiques | 335 | 182 | 5 | 522 | 35.2 |
+| VTANR5L17V7987 | Sécurité | 313 | 199 | 5 | 517 | 38.9 |
+| VTANR5L17V3182 | Outre-mer | 279 | 247 | 9 | 535 | 47.0 |
+| VTANR5L17V2958 | Justice | 303 | 168 | 1 | 472 | 35.7 |
+| VTANR5L17V7408 | Logement | 292 | 160 | 14 | 466 | 35.4 |
+
+All ten pass the >=400-voter participation floor and the >=35% minority-share
+divisiveness floor, and cover ten distinct themes.


### PR DESCRIPTION
## What
Finalizes the vote-matching quiz's curated question set: verifies all 10 draft scrutins against production, drops the provisional `-draft` `QUIZ_VERSION` suffix, and documents the curation criteria so future quarterly refreshes are repeatable.

## Why
MON-137 shipped `api/quiz_data.py` with a provisional `2026-Q3-draft` set, explicitly pending this issue's editorial pass (MON-136): verify against prod, check phrasing neutrality, and write down the selection criteria for the quarterly refresh MON-135's ADR-025 calls for.

## Changes
- `api/quiz_data.py`: verified all 10 `vote_id`s against the production API (`GET /votes/{id}`) — each is a whole-text scrutin with ≥400 voters and a ≥35% minority share on the expressed pour/contre. Reviewed each `question`/`context` pair for neutral, descriptive phrasing (no leading/evaluative language). Content was already sound from the MON-137 draft, so this is a verification + finalization pass, not a rewrite: version bumped from `2026-Q3-draft` to `2026-Q3`, and the stale "pending MON-136" docstring note replaced with a pointer to the new doc.
- `docs/quiz-curation.md` (new): the four selection criteria (whole-text vote, in-prod, ≥400 voters, ≥35% minority share), phrasing rules, the quarterly-refresh process, and a verification table for the current 2026-Q3 set.

## Testing
- `venv/bin/python -m pytest tests/unit/test_quiz.py -q` — 19 passed (assertions are `QUIZ_VERSION`-relative, so the version bump needed no test changes).
- `venv/bin/python -m pytest tests/ -m "not integration" -q` — 254 passed (CI's blocking gate), no regressions.
- `venv/bin/ruff check .` and `venv/bin/ruff format --check .` — clean.
- Verified all 10 `vote_id`s live against `https://monelu-production.up.railway.app/votes/{id}` (see table in `docs/quiz-curation.md`).

## Risks / Notes
- Content-only change to an already-shipped, already-tested router (`api/routers/quiz.py`, from MON-137) — no schema or API contract change.
- `QUIZ_VERSION` bump does not invalidate any stored `quiz_shares` snapshots (ADR-025): old snapshots keep the version string that produced them.

## Breaking Changes
None.
