### PR TITLE
feat: quiz entry points, SEO, and docs (MON-140)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -158,7 +158,7 @@
         "filename": "README.md",
         "hashed_secret": "09b30f6138f119acf5e4d3d7ad571e8c0b9f2059",
         "is_verified": false,
-        "line_number": 181
+        "line_number": 186
       }
     ],
     "frontend/public/sw.js": [
@@ -252,5 +252,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-18T22:02:56Z"
+  "generated_at": "2026-07-19T19:38:30Z"
 }

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ The API tier is fully stateless. All state lives in Supabase (managed Postgres w
 | POST | `/search` | Natural language query over the legislative corpus *(Phase 2)* |
 | POST | `/verify` | Fact-check a claim about a deputy's votes — structured verdict + citations |
 | GET | `/verify/{id}` | Stored verdict snapshot (no LLM call) — backs the share URL |
+| GET | `/quiz/questions` | Curated quiz question set (versioned repo file, ADR-025) |
+| POST | `/quiz/match` | Stateless vote-matching quiz computation — nothing persisted or logged |
+| POST | `/quiz/share` | Store an immutable quiz result snapshot (recomputed server-side) |
+| GET | `/quiz/share/{id}` | Stored quiz result snapshot — backs the `/quiz/s/<id>` share URL |
 
 ---
 
@@ -69,6 +73,7 @@ Implemented with [slowapi](https://github.com/laurentS/slowapi), keyed by remote
 | `GET /deputies/{id}/scorecard` | 10 req / min |
 | `POST /search` | 10 req / min |
 | `POST /verify` | 10 req / min |
+| `POST /quiz/match`, `POST /quiz/share` | 10 req / min |
 
 On limit exceeded: HTTP 429 · `{"error": "Too Many Requests", "detail": "..."}` · `Retry-After` + `X-RateLimit-*` headers.
 
@@ -282,6 +287,8 @@ design.
 | `routers/votes.py` | Vote list, latest, and detail endpoints |
 | `routers/search.py` | `POST /search` — RAG query endpoint |
 | `routers/verify.py` | `POST /verify` + `GET /verify/{id}` — fact-check verdicts (ADR-022) |
+| `routers/quiz.py` | `/quiz/*` — vote-matching quiz: questions, stateless matching, share snapshots (ADR-025) |
+| `quiz_data.py` | Curated, versioned quiz question set — updated quarterly by PR (ADR-025) |
 | `schemas.py` | Pydantic response models (all fields `Optional` to match DB NULLs) |
 
 ### Frontend (`frontend/`)

--- a/frontend/src/app/methodologie/page.tsx
+++ b/frontend/src/app/methodologie/page.tsx
@@ -97,6 +97,60 @@ export default function MethodologiePage() {
         </p>
       </LegalSection>
 
+      <LegalSection id="quiz" title="Le quiz « Quel député vote comme vous ? »">
+        <p style={{ ...textStyle, marginBottom: '10px' }}>
+          Le quiz compare vos réponses aux positions <strong>réellement enregistrées</strong> de chaque
+          député sur les mêmes scrutins. Votre pourcentage d&apos;accord avec un député est simplement&nbsp;:
+          nombre de scrutins où vous avez voté pareil, divisé par le nombre de scrutins comparables.
+          Seules les positions <strong>exprimées</strong> comptent (pour, contre, abstention)&nbsp;: un député
+          non-votant ou absent sur un scrutin n&apos;est ni d&apos;accord ni en désaccord avec vous - ce
+          scrutin est simplement retiré du dénominateur pour ce député.
+        </p>
+        <p style={{ ...textStyle, marginBottom: '10px' }}>
+          <strong>Seuil de comparabilité&nbsp;:</strong> un député (ou un groupe) n&apos;apparaît dans le
+          classement que s&apos;il a une position exprimée sur au moins la moitié de vos réponses, avec un
+          minimum de deux scrutins - un seul scrutin partagé ne fait pas un profil politique. Même règle
+          pour le &laquo;&nbsp;député le plus éloigné&nbsp;&raquo;&nbsp;: un 0&nbsp;% calculé sur deux votes
+          ne peut pas faire la une du résultat.
+        </p>
+        <p style={{ ...textStyle, marginBottom: '10px' }}>
+          L&apos;accord avec un <strong>groupe parlementaire</strong> se calcule contre sa ligne majoritaire,
+          scrutin par scrutin&nbsp;: la position exprimée la plus fréquente parmi ses membres. Si deux
+          positions sont à égalité stricte au sein du groupe, le groupe n&apos;a pas de ligne sur ce scrutin
+          et il est ignoré pour ce calcul.
+        </p>
+        <p style={{ ...textStyle, marginBottom: '10px' }}>
+          <strong>Le questionnaire</strong> est un ensemble d&apos;une dizaine de scrutins réels, choisi selon
+          trois critères&nbsp;: des votes sur l&apos;ensemble d&apos;un texte (pas des amendements), une forte
+          participation (au moins 400 votants sur 577), et un vrai clivage (le camp minoritaire pèse au moins
+          35&nbsp;% des pour+contre exprimés). La sélection est versionnée (par exemple
+          &laquo;&nbsp;2026-Q3&nbsp;&raquo;), revue trimestriellement, et chaque résultat partagé garde la
+          version du questionnaire qui l&apos;a produit. La formulation des questions reste descriptive du
+          texte voté, jamais orientée.
+        </p>
+        <p style={textStyle}>
+          <strong>Vie privée&nbsp;:</strong> le calcul se fait côté serveur mais rien n&apos;est
+          enregistré - ni vos réponses, ni votre code postal. Seul un résultat que vous choisissez
+          explicitement de partager est stocké, et il est alors <strong>recalculé par le serveur</strong> à
+          partir de vos réponses&nbsp;: une carte de résultat MonÉlu ne peut pas contenir de pourcentages
+          fabriqués.
+        </p>
+        <p style={sourceLineStyle}>
+          Source :{' '}
+          <a href={`${REPO_BASE}/api/routers/quiz.py`} target="_blank" rel="noopener noreferrer" style={linkStyle}>
+            quiz.py
+          </a>{' '}
+          ·{' '}
+          <a href={`${REPO_BASE}/api/quiz_data.py`} target="_blank" rel="noopener noreferrer" style={linkStyle}>
+            quiz_data.py (questionnaire versionné)
+          </a>{' '}
+          ·{' '}
+          <a href={`${REPO_BASE}/docs/decisions.md`} target="_blank" rel="noopener noreferrer" style={linkStyle}>
+            ADR-025, décision architecturale
+          </a>
+        </p>
+      </LegalSection>
+
       <LegalSection id="adopte-rejete" title="Vote adopté ou rejeté">
         <p style={textStyle}>
           Le résultat d&apos;un scrutin (adopté ou rejeté) n&apos;est jamais recalculé par MonÉlu : il est repris

--- a/frontend/src/app/mon-depute/page.tsx
+++ b/frontend/src/app/mon-depute/page.tsx
@@ -123,6 +123,12 @@ export default function MonDeputePage() {
           >
             Trouver mon député
           </Link>
+          <p style={{ margin: '20px 0 0', fontSize: 14, color: '#6B7280' }}>
+            Vous ne savez pas qui suivre ?{' '}
+            <Link href="/quiz" style={{ color: NAVY, fontWeight: 600 }}>
+              Découvrez quel député vote comme vous →
+            </Link>
+          </p>
         </div>
       </div>
     )
@@ -242,6 +248,33 @@ export default function MonDeputePage() {
                 </div>
               </div>
             )}
+          </section>
+
+          {/* Quiz cross-link (MON-140) */}
+          <section style={{
+            background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12,
+            padding: '20px 24px', display: 'flex', alignItems: 'center',
+            justifyContent: 'space-between', gap: 16, flexWrap: 'wrap',
+          }}>
+            <div>
+              <div style={{ fontWeight: 600, fontSize: 15, color: NAVY }}>
+                Votez-vous comme {deputy.full_name} ?
+              </div>
+              <div style={{ fontSize: 13.5, color: '#6B7280', marginTop: 4 }}>
+                Répondez à une dizaine de vrais scrutins et comparez vos positions aux siennes.
+              </div>
+            </div>
+            <Link
+              href="/quiz"
+              style={{
+                display: 'inline-flex', alignItems: 'center', gap: 8,
+                background: ACCENT, color: '#fff', padding: '10px 20px',
+                borderRadius: 9, fontWeight: 600, fontSize: 14, textDecoration: 'none',
+                boxShadow: '0 2px 8px rgba(224,120,110,0.35)', whiteSpace: 'nowrap',
+              }}
+            >
+              Faire le test →
+            </Link>
           </section>
 
           {/* Recent votes */}

--- a/frontend/src/app/quiz/page.tsx
+++ b/frontend/src/app/quiz/page.tsx
@@ -1,13 +1,36 @@
 import type { Metadata } from 'next'
+import { JsonLd } from '@/components/JsonLd'
+import { SITE_URL, buildBreadcrumbJsonLd } from '@/lib/seo'
 import { QuizClient } from './QuizClient'
 
+const TITLE = 'Quel député vote comme vous ? — MonÉlu'
+const DESCRIPTION =
+  'Répondez à une dizaine de vrais scrutins de l’Assemblée nationale et découvrez ' +
+  'quel député vote comme vous. Sans compte, rien n’est enregistré.'
+
 export const metadata: Metadata = {
-  title: 'Quel député vote comme vous ? — MonÉlu',
-  description:
-    'Répondez à une dizaine de vrais scrutins de l’Assemblée nationale et découvrez ' +
-    'quel député vote comme vous. Sans compte, rien n’est enregistré.',
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: `${SITE_URL}/quiz` },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: `${SITE_URL}/quiz`,
+    type: 'website',
+  },
+  twitter: { card: 'summary_large_image', title: TITLE, description: DESCRIPTION },
 }
 
 export default function QuizPage() {
-  return <QuizClient />
+  return (
+    <>
+      <JsonLd
+        data={buildBreadcrumbJsonLd([
+          { name: 'Accueil', url: SITE_URL },
+          { name: 'Quel député vote comme vous ?', url: `${SITE_URL}/quiz` },
+        ])}
+      />
+      <QuizClient />
+    </>
+  )
 }

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -82,6 +82,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${SITE_URL}/donnees`, changeFrequency: 'monthly', priority: 0.5 },
     { url: `${SITE_URL}/votes`, changeFrequency: 'daily', priority: 0.9 },
     { url: `${SITE_URL}/chat`, changeFrequency: 'monthly', priority: 0.5 },
+    // /quiz only — /quiz/s/* share snapshots stay out of the sitemap, like
+    // the /chat/s/* and /verifier/v/* snapshot URLs.
+    { url: `${SITE_URL}/quiz`, changeFrequency: 'monthly', priority: 0.7 },
     { url: `${SITE_URL}/a-propos`, changeFrequency: 'monthly', priority: 0.4 },
     { url: `${SITE_URL}/developpeurs`, changeFrequency: 'monthly', priority: 0.4 },
     { url: `${SITE_URL}/methodologie`, changeFrequency: 'monthly', priority: 0.5 },

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -6,6 +6,7 @@ const items = [
   { href: '/', label: 'Accueil', icon: '⌂' },
   { href: '/deputes', label: 'Députés', icon: '◉' },
   { href: '/votes', label: 'Votes', icon: '◈' },
+  { href: '/quiz', label: 'Quiz', icon: '✦' },
   { href: '/chat', label: 'Chat IA', icon: '◎' },
 ]
 
@@ -13,7 +14,7 @@ export function BottomNav() {
   const path = usePathname()
   return (
     <nav data-print-hide className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-gray-border z-50">
-      <div className="grid grid-cols-4">
+      <div className="grid grid-cols-5">
         {items.map(item => {
           const active =
             path === item.href || (item.href !== '/' && path.startsWith(item.href))

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -49,6 +49,7 @@ export function Footer() {
       <div style={{ display: 'flex', gap: '28px', fontSize: '13.5px', flexWrap: 'wrap' }}>
         <Link href="/deputes" style={{ color: '#6B7280', textDecoration: 'none' }}>Députés</Link>
         <Link href="/votes" style={{ color: '#6B7280', textDecoration: 'none' }}>Votes</Link>
+        <Link href="/quiz" style={{ color: '#6B7280', textDecoration: 'none' }}>Quiz</Link>
         <Link href="/donnees" style={{ color: '#6B7280', textDecoration: 'none' }}>Données</Link>
         <Link href="/developpeurs" style={{ color: '#6B7280', textDecoration: 'none' }}>Développeurs</Link>
         <Link href="/methodologie" style={{ color: '#6B7280', textDecoration: 'none' }}>Méthodologie</Link>

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -11,6 +11,7 @@ export const NAV_HEIGHT_PX = 64
 const navLinks = [
   { href: '/deputes', label: 'Députés' },
   { href: '/votes', label: 'Votes' },
+  { href: '/quiz', label: 'Quiz' },
   { href: '/chat', label: 'Chat IA' },
   { href: '/a-propos', label: 'À propos' },
 ]

--- a/frontend/src/components/home/AssemblyScrollExperience.tsx
+++ b/frontend/src/components/home/AssemblyScrollExperience.tsx
@@ -52,6 +52,12 @@ function StaticExperience({ stats, leadVote }: Props) {
                 buttonLabel="Comprendre mon député"
               />
             </div>
+            <Link
+              href="/quiz"
+              className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-red-light underline underline-offset-4"
+            >
+              Quel député vote comme vous ? Faites le test →
+            </Link>
             <div className="mt-8 hidden md:block">
               <TrustRow lastUpdated={stats.lastUpdated} />
             </div>
@@ -121,6 +127,21 @@ function MobileExperience({ stats, leadVote }: Props) {
               Chaque scrutin: {stats.deputies} positions individuelles.
             </h2>
           </div>
+        </article>
+        <article className="border border-navy/10 bg-white p-5 shadow-xl shadow-navy/6">
+          <p className="text-xs font-semibold uppercase text-red-civic">Le quiz</p>
+          <h2 className="mt-3 font-serif text-2xl leading-tight text-navy">
+            Quel député vote comme vous&nbsp;?
+          </h2>
+          <p className="mt-3 text-sm leading-6 text-gray-mid">
+            Une dizaine de vrais scrutins, comparés aux votes réels des députés.
+          </p>
+          <Link
+            href="/quiz"
+            className="mt-4 inline-flex items-center gap-2 rounded-lg bg-red-civic px-5 py-2.5 text-sm font-semibold text-white"
+          >
+            Faire le test →
+          </Link>
         </article>
       </div>
     </section>
@@ -903,13 +924,20 @@ function CinematicExperience({ stats, leadVote, deputyInfo }: Props) {
                   ))}
                 </div>
 
-                <div data-s6item style={{ marginTop: 28, opacity: 0, pointerEvents: 'auto' }}>
+                <div data-s6item style={{ marginTop: 28, opacity: 0, pointerEvents: 'auto', display: 'flex', gap: 16, flexWrap: 'wrap', justifyContent: 'center' }}>
                   <Link
                     href="/chat"
                     style={{ display: 'inline-flex', alignItems: 'center', gap: 10, background: 'linear-gradient(160deg,rgba(39,224,173,0.18),rgba(39,224,173,0.08))', border: '1px solid rgba(39,224,173,0.45)', padding: '14px 32px', borderRadius: 12, fontSize: 16, fontWeight: 600, color: '#27e0ad', textDecoration: 'none', backdropFilter: 'blur(8px)', WebkitBackdropFilter: 'blur(8px)', pointerEvents: 'auto' }}
                   >
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="none"><path d="M12 2.5 L13.7 9.6 L21 11 L13.7 12.4 L12 19.5 L10.3 12.4 L3 11 L10.3 9.6 Z" fill="#27e0ad" /></svg>
                     Poser une question à MonÉlu →
+                  </Link>
+                  <Link
+                    href="/quiz"
+                    style={{ display: 'inline-flex', alignItems: 'center', gap: 10, background: 'linear-gradient(160deg,rgba(240,88,76,0.2),rgba(240,88,76,0.08))', border: '1px solid rgba(240,88,76,0.5)', padding: '14px 32px', borderRadius: 12, fontSize: 16, fontWeight: 600, color: '#f3b6b1', textDecoration: 'none', backdropFilter: 'blur(8px)', WebkitBackdropFilter: 'blur(8px)', pointerEvents: 'auto' }}
+                  >
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#f3b6b1" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><rect x="4" y="4" width="16" height="16" rx="3" /><path d="M8 12.2l2.6 2.6L16 9" /></svg>
+                    Quel député vote comme vous ? →
                   </Link>
                 </div>
 


### PR DESCRIPTION
## What
Discoverability, SEO, and documentation pass for the vote-matching quiz (MON-140, closing out the MON-109 epic polish).
The quiz UI (MON-138) and share surface (MON-139) already shipped; this PR makes the quiz reachable, indexable, and documented.

## Why
`/quiz` existed but nothing linked to it: no nav entry, no homepage CTA, no sitemap entry, and the methodologie page did not explain how agreement is computed.
A feature nobody can find or audit does not serve the product's civic-credibility goal.

## Changes

### Entry points
- `Nav.tsx`: "Quiz" link in the desktop nav (between Votes and Chat IA).
- `BottomNav.tsx`: quiz item added; grid goes from 4 to 5 columns.
- `Footer.tsx`: quiz link in the footer row.
- Homepage (`AssemblyScrollExperience.tsx`), all three experiences:
  - cinematic desktop: a second CTA "Quel député vote comme vous ? →" beside the chat CTA in scene 6;
  - mobile card stack: a quiz card with a "Faire le test →" button;
  - reduced-motion static hero: a text link under the hero search.
- `/mon-depute`: quiz link in the empty "pick a deputy" state, plus a cross-link banner in the dashboard ("Votez-vous comme {deputy} ?").

### SEO
- `sitemap.ts`: `/quiz` added to the static URLs (monthly, 0.7). `/quiz/s/*` share snapshots stay out of the sitemap, consistent with `/chat/s/*` and `/verifier/v/*`.
- `quiz/page.tsx`: canonical URL, OpenGraph, and Twitter card metadata built from the `seo.ts` `SITE_URL` constant, plus breadcrumb JsonLd via `buildBreadcrumbJsonLd`. Title and description unchanged.

### Methodologie
- New "Le quiz « Quel député vote comme vous ? »" section on `/methodologie`, in plain French and consistent with `api/routers/quiz.py` and ADR-025:
  - agreement = matching scrutins / comparable scrutins, expressed positions only (pour/contre/abstention);
  - nonVotant and absent shrink the denominator, never count as agreement or disagreement;
  - eligibility threshold: at least half of the answered questions comparable, floor 2 (applies to the "opposite" deputy too);
  - group line = strict plurality of expressed positions, tied scrutins skipped;
  - question-set curation criteria (whole-text scrutins, ≥ 400 voters, losing side ≥ 35% of pour+contre), versioned, quarterly refresh by PR;
  - privacy: nothing persisted on `/quiz/match`; shares are recomputed server-side so branded cards cannot carry fabricated numbers.
  - Source links to `quiz.py`, `quiz_data.py`, and the ADR.

### Docs
- `README.md`: quiz endpoints in the API table, `/quiz/match` + `/quiz/share` in the rate-limiting table, `routers/quiz.py` and `quiz_data.py` rows in Code Structure.
- `CLAUDE.md` already documents the quiz router, `quiz_shares` table, and ADR-025 (added by MON-137/139) — no changes needed.
- `.secrets.baseline`: line-number refresh by the pre-commit hook, no content change.

## Acceptance criteria mapping
- **Quiz reachable from homepage and main navigation** — Nav, BottomNav, Footer, and all three homepage experiences link to `/quiz`.
- **`/quiz` in the generated sitemap with correct metadata; build passes** — sitemap entry added; canonical/OG/Twitter/JsonLd added; `next build` green with `/quiz` prerendered static.
- **Methodologie documents the matching math** — new section mirrors the denominator, threshold, and group-line rules implemented in `quiz.py`.
- **CLAUDE.md/docs accurate (docs-sync clean)** — README updated; CLAUDE.md already current.

## Testing
- `npm run lint` — clean.
- `npm test` — 133 tests, 15 suites, all passing.
- `npm run build` — green; `/quiz` static, sitemap and all routes prerender.
- `ruff check .` and `ruff format --check .` — clean (no Python changes).
- `venv/bin/python -m pytest tests/ -m "not integration" -q` — 254 passed.

## Risks / Notes
- Frontend-only + README; no API, schema, or deploy config changes.
- BottomNav labels get slightly tighter at 5 columns on narrow phones; labels are all short (max 7 chars).
- The methodologie text describes the `2026-Q3` question-set versioning generically; the pending MON-136 editorial pass (currently `2026-Q3-draft`) requires no text change here.

## Breaking Changes
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MECuemDq5Qf5pVqZpLKxEU