### PR TITLE
ci: run next build in frontend CI (MON-148)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
 
   frontend:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: frontend
@@ -91,6 +91,20 @@ jobs:
 
       - name: Run tests
         run: npm test -- --ci
+
+      - name: Cache Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: frontend/.next/cache
+          key: next-build-cache-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}-${{ hashFiles('frontend/src/**') }}
+          restore-keys: |
+            next-build-cache-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}-
+
+      - name: Build
+        # Prerenders all SSG pages against the production API; src/lib/api.ts
+        # already retries through the rate limiter, so this can take a few
+        # minutes on a cold cache.
+        run: npm run build
 
   dbt-data-health:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What
Adds a `next build` step to the frontend CI job so the PWA/service-worker webpack integration and all SSG pages are exercised on every PR, not only at Vercel deploy time.

## Why
The frontend CI job ran `lint`, `tsc --noEmit`, and `jest`, but never `next build`.
The entire PWA layer (next-pwa webpack integration, service-worker generation, manifest wiring) and all SSG pages were only exercised by the Vercel deploy, which is a known-flaky gate (429s on `/votes` prerender, see commit `00ccf8e`).
A `next.config.mjs` typo or an SSG data failure could pass CI green and fail only at deploy time.

## Changes
- `.github/workflows/ci.yml`: added a `Build` step (`npm run build`) to the `frontend` job, after lint/typecheck/test.
- Added an `actions/cache` step for `frontend/.next/cache` keyed on the lockfile and source tree, so repeat builds on the same branch are fast.
- Bumped the `frontend` job's `timeout-minutes` from 15 to 20 to leave headroom for the existing 429 rate-limit backoff in `frontend/src/lib/api.ts` (up to ~108s of backoff per throttled page on a cold cache).

## Testing
- Ran `npm run build` locally against the production API: all 124 pages generated successfully (0 errors), including the 100 `/votes/[id]` SSG pages.
- Validated the workflow YAML with `python3 -c "import yaml; yaml.safe_load(...)"`.
- No Python or frontend source changed, so `pytest`/`ruff`/`jest`/`tsc` are unaffected by this change; CI will run them as before.

## Risks / Notes
- The build step calls the real production Railway API for every PR (same behavior as today's Vercel deploys). No new cost - it hits the existing free-tier API, and `apiFetch`'s 429 backoff already handles the per-IP rate limit.
- Cold-cache builds may take a few minutes if the rate limiter throttles the CI runner's IP; the cache step should make repeat pushes to the same branch faster.
- Follow-up idea (not in scope here): a recorded/stubbed API fixture would make the build step fully deterministic and remove the dependency on prod API availability - left as a possible future issue if build flakiness shows up in practice.

## Breaking Changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)