### PR TITLE
feat: shareable and embeddable vote/deputy cards (MON-96)

### DIFF
--- a/frontend/__tests__/components/EmbedButton.test.tsx
+++ b/frontend/__tests__/components/EmbedButton.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { EmbedButton } from '@/components/EmbedButton'
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('EmbedButton', () => {
+  it('shows an iframe snippet pointing at the given path when opened', () => {
+    render(<EmbedButton path="/embed/votes/V1" />)
+    expect(screen.queryByText(/<iframe/)).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /intégrer/i }))
+    expect(screen.getByText(/<iframe/)).toHaveTextContent('/embed/votes/V1')
+  })
+
+  it('copies the snippet to the clipboard and shows confirmation', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+
+    render(<EmbedButton path="/embed/votes/V1" />)
+    fireEvent.click(screen.getByRole('button', { name: /intégrer/i }))
+    fireEvent.click(screen.getByRole('button', { name: /copier le code/i }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(expect.stringContaining('/embed/votes/V1')))
+    await waitFor(() => expect(screen.getByRole('button', { name: /copié/i })).toBeInTheDocument())
+  })
+})

--- a/frontend/__tests__/components/ShareButton.test.tsx
+++ b/frontend/__tests__/components/ShareButton.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { ShareButton } from '@/components/ShareButton'
+
+const props = { url: '/votes/V1', title: 'Adopté - Un scrutin', text: 'Suivez ce scrutin sur MonÉlu' }
+
+afterEach(() => {
+  jest.restoreAllMocks()
+  // @ts-expect-error test-only cleanup of a property we add per test
+  delete navigator.share
+})
+
+describe('ShareButton', () => {
+  it('uses native share when available and does not open the menu', async () => {
+    const share = jest.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'share', { value: share, configurable: true })
+
+    render(<ShareButton {...props} />)
+    fireEvent.click(screen.getByRole('button', { name: /partager/i }))
+
+    await waitFor(() => expect(share).toHaveBeenCalledWith(
+      expect.objectContaining({ title: props.title, text: props.text })
+    ))
+    expect(screen.queryByRole('menuitem', { name: /copier le lien/i })).not.toBeInTheDocument()
+  })
+
+  it('falls back to a menu with copy-link and social links when native share is unavailable', () => {
+    render(<ShareButton {...props} />)
+    fireEvent.click(screen.getByRole('button', { name: /partager/i }))
+
+    expect(screen.getByRole('menuitem', { name: /copier le lien/i })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /partager sur x/i })).toHaveAttribute(
+      'href', expect.stringContaining('twitter.com/intent/tweet')
+    )
+    expect(screen.getByRole('menuitem', { name: /partager sur bluesky/i })).toHaveAttribute(
+      'href', expect.stringContaining('bsky.app/intent/compose')
+    )
+    expect(screen.getByRole('menuitem', { name: /partager sur facebook/i })).toHaveAttribute(
+      'href', expect.stringContaining('facebook.com/sharer')
+    )
+  })
+
+  it('copies the link to the clipboard and shows confirmation', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+
+    render(<ShareButton {...props} />)
+    fireEvent.click(screen.getByRole('button', { name: /partager/i }))
+    fireEvent.click(screen.getByRole('menuitem', { name: /copier le lien/i }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(expect.stringContaining(props.url)))
+    await waitFor(() => expect(screen.getByText(/copié/i)).toBeInTheDocument())
+  })
+})

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -45,7 +45,10 @@ const nextConfig = {
   async headers() {
     return [
       {
-        source: '/((?!embed).*)',
+        // Segment-anchored (`embed/`, not `embed`) so a future route that merely
+        // starts with the string "embed" (e.g. /embeddings) still falls under
+        // this deny-by-default rule instead of matching neither rule below.
+        source: '/((?!embed/).*)',
         headers: [
           { key: 'X-Frame-Options', value: 'DENY' },
           { key: 'Content-Security-Policy', value: "frame-ancestors 'self'" },
@@ -54,6 +57,9 @@ const nextConfig = {
       {
         source: '/embed/:path*',
         headers: [
+          // Deliberately permissive: /embed/* is the iframe surface external
+          // sites paste MonÉlu cards into (MON-96) — do not tighten this back
+          // to 'self' without breaking that feature.
           { key: 'Content-Security-Policy', value: 'frame-ancestors *' },
         ],
       },

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -40,6 +40,25 @@ const nextConfig = {
   async rewrites() {
     return []
   },
+  // /embed/* pages (MON-96) are meant to be iframed on external sites; every
+  // other route stays framing-denied by default.
+  async headers() {
+    return [
+      {
+        source: '/((?!embed).*)',
+        headers: [
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'Content-Security-Policy', value: "frame-ancestors 'self'" },
+        ],
+      },
+      {
+        source: '/embed/:path*',
+        headers: [
+          { key: 'Content-Security-Policy', value: 'frame-ancestors *' },
+        ],
+      },
+    ]
+  },
 }
 
 export default withSentryConfig(withPWA(nextConfig), {

--- a/frontend/src/app/deputes/[id]/opengraph-image.tsx
+++ b/frontend/src/app/deputes/[id]/opengraph-image.tsx
@@ -1,0 +1,125 @@
+import { ImageResponse } from 'next/og'
+import { api } from '@/lib/api'
+import { partyHex } from '@/lib/utils'
+
+export const runtime = 'edge'
+export const alt = 'Bilan de mandat — MonÉlu'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export const revalidate = 86400
+
+export default async function OGImage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const [deputy, scorecard] = await Promise.all([
+    api.deputies.get(id).catch(() => null),
+    api.deputies.scorecard(id).catch(() => null),
+  ])
+
+  const presencePct = scorecard ? Math.round((scorecard.presence_rate ?? 0) * 100) : null
+  const hex = deputy ? partyHex(deputy.party) : '#9CA3AF'
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: '#0D1F3C',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          padding: '80px',
+        }}
+      >
+        {deputy?.photo_url && (
+          <img
+            src={deputy.photo_url}
+            width={280}
+            height={280}
+            style={{ borderRadius: 20, objectFit: 'cover', marginRight: 56, border: '2px solid rgba(255,255,255,0.15)' }}
+          />
+        )}
+
+        <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+          <div
+            style={{
+              display: 'flex',
+              color: '#C9302C',
+              fontSize: 18,
+              letterSpacing: '0.15em',
+              textTransform: 'uppercase',
+              marginBottom: 22,
+              fontFamily: 'sans-serif',
+            }}
+          >
+            Député·e · MonÉlu
+          </div>
+
+          <div
+            style={{
+              display: 'flex',
+              color: '#ffffff',
+              fontSize: 54,
+              lineHeight: 1.15,
+              fontFamily: 'serif',
+              maxWidth: 780,
+              marginBottom: 20,
+            }}
+          >
+            {deputy?.full_name ?? 'Député introuvable'}
+          </div>
+
+          {deputy?.party && (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 10,
+                marginBottom: 32,
+              }}
+            >
+              <span style={{ width: 14, height: 14, borderRadius: 999, background: hex }} />
+              <span style={{ color: 'rgba(255,255,255,0.75)', fontSize: 24, fontFamily: 'sans-serif' }}>
+                {deputy.party}
+              </span>
+            </div>
+          )}
+
+          {presencePct !== null && (
+            <div style={{ display: 'flex', gap: 48 }}>
+              <div style={{ display: 'flex', flexDirection: 'column' }}>
+                <span style={{ color: '#ffffff', fontSize: 40, fontFamily: 'serif', fontWeight: 700 }}>{presencePct}%</span>
+                <span style={{ color: 'rgba(255,255,255,0.4)', fontSize: 14, fontFamily: 'sans-serif', textTransform: 'uppercase', letterSpacing: '0.1em', marginTop: 6 }}>
+                  Taux de présence
+                </span>
+              </div>
+              {scorecard && (
+                <div style={{ display: 'flex', flexDirection: 'column' }}>
+                  <span style={{ color: '#ffffff', fontSize: 40, fontFamily: 'serif', fontWeight: 700 }}>
+                    {scorecard.total_votes.toLocaleString('fr-FR')}
+                  </span>
+                  <span style={{ color: 'rgba(255,255,255,0.4)', fontSize: 14, fontFamily: 'sans-serif', textTransform: 'uppercase', letterSpacing: '0.1em', marginTop: 6 }}>
+                    Scrutins votés
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 60,
+            right: 80,
+            width: 8,
+            height: 200,
+            background: '#C9302C',
+            borderRadius: 4,
+          }}
+        />
+      </div>
+    ),
+    { ...size }
+  )
+}

--- a/frontend/src/app/embed/votes/[id]/page.tsx
+++ b/frontend/src/app/embed/votes/[id]/page.tsx
@@ -1,0 +1,80 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import { api } from '@/lib/api'
+import { SITE_URL } from '@/lib/seo'
+
+export const dynamicParams = true
+export const revalidate = 86400
+
+const NAVY = '#1B2B50'
+const LINE = '#E4E6EA'
+const RED = '#C9302A'
+
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
+  const { id } = await params
+  const vote = await api.votes.get(id).catch(() => null)
+  if (!vote) return {}
+  return { title: `${vote.vote_title} - MonÉlu`, robots: { index: false, follow: true } }
+}
+
+export default async function EmbedVotePage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const vote = await api.votes.get(id).catch(() => null)
+  if (!vote) notFound()
+
+  const denom = vote.total_voters || 1
+  const pourPct = Math.round(vote.votes_for / denom * 100)
+  const contrePct = Math.round(vote.votes_against / denom * 100)
+  const abstPct = Math.round(vote.abstentions / denom * 100)
+  const adopted = vote.result === 'adopté'
+  const voteUrl = `${SITE_URL}/votes/${id}`
+
+  return (
+    <div style={{ background: '#fff', fontFamily: 'sans-serif', padding: 20, maxWidth: 560 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
+        <span
+          style={{
+            display: 'inline-flex', padding: '3px 12px', borderRadius: 999, fontSize: 12, fontWeight: 700,
+            textTransform: 'uppercase', letterSpacing: '0.06em',
+            color: adopted ? '#1F8A5B' : RED,
+            background: adopted ? 'rgba(31,138,91,0.1)' : 'rgba(201,48,42,0.1)',
+          }}
+        >
+          {adopted ? 'Adopté' : 'Rejeté'}
+        </span>
+        <span style={{ fontSize: 12, color: '#9CA3AF' }}>
+          {new Date(vote.voted_at).toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' })}
+        </span>
+      </div>
+
+      <a
+        href={voteUrl}
+        target="_top"
+        rel="noopener noreferrer"
+        style={{ display: 'block', fontSize: 17, lineHeight: 1.35, color: NAVY, fontWeight: 600, textDecoration: 'none', marginBottom: 16 }}
+      >
+        {vote.vote_title}
+      </a>
+
+      <div style={{ display: 'flex', height: 12, borderRadius: 999, overflow: 'hidden', marginBottom: 10 }}>
+        <div style={{ width: `${pourPct}%`, background: '#1F8A5B' }} />
+        <div style={{ width: `${contrePct}%`, background: RED }} />
+        <div style={{ width: `${abstPct}%`, background: '#D1D5DB' }} />
+      </div>
+      <div style={{ display: 'flex', gap: 16, fontSize: 13, color: '#374151', marginBottom: 18 }}>
+        <span>Pour <strong>{pourPct}%</strong> ({vote.votes_for})</span>
+        <span>Contre <strong>{contrePct}%</strong> ({vote.votes_against})</span>
+        <span>Abst. <strong>{abstPct}%</strong> ({vote.abstentions})</span>
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', paddingTop: 14, borderTop: `1px solid ${LINE}` }}>
+        <span style={{ fontSize: 11.5, color: '#9CA3AF' }}>
+          Données Assemblée nationale · <strong style={{ color: NAVY }}>MonÉlu</strong>
+        </span>
+        <a href={voteUrl} target="_top" rel="noopener noreferrer" style={{ fontSize: 12, fontWeight: 600, color: RED, textDecoration: 'none' }}>
+          Voir la fiche complète →
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -9,6 +9,8 @@ import { BottomNav } from '@/components/BottomNav'
 import { PageTransition } from '@/components/PageTransition'
 import { FreshnessBadge } from '@/components/FreshnessBadge'
 import { Footer } from '@/components/Footer'
+import { HideOnEmbed } from '@/components/HideOnEmbed'
+import { MainFrame } from '@/components/MainFrame'
 import { JsonLd } from '@/components/JsonLd'
 import { buildWebsiteJsonLd } from '@/lib/seo'
 
@@ -71,8 +73,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <Suspense fallback={null}>
           <Nav />
         </Suspense>
-        <FreshnessBadge />
-        <main className="pb-[calc(5rem+env(safe-area-inset-bottom))] md:pb-0"><PageTransition>{children}</PageTransition></main>
+        <HideOnEmbed><FreshnessBadge /></HideOnEmbed>
+        <MainFrame><PageTransition>{children}</PageTransition></MainFrame>
         <Footer />
         <Suspense fallback={null}>
           <BottomNav />

--- a/frontend/src/app/votes/[id]/VoteDetailClient.tsx
+++ b/frontend/src/app/votes/[id]/VoteDetailClient.tsx
@@ -2,6 +2,7 @@
 import { useState, useRef, useCallback, useMemo, useEffect } from 'react'
 import Link from 'next/link'
 import { ShareButton } from '@/components/ShareButton'
+import { EmbedButton } from '@/components/EmbedButton'
 import { ReportErrorButton } from '@/components/ReportErrorButton'
 import { InfoTooltip } from '@/components/InfoTooltip'
 import { getInitials, partyHex } from '@/lib/utils'
@@ -299,6 +300,7 @@ export function VoteDetailClient(props: Props) {
                   text="Suivez ce scrutin sur MonÉlu"
                   ariaLabel="Partager ce vote"
                 />
+                <EmbedButton path={`/embed/votes/${voteId}`} />
               </div>
               <div style={{ marginTop: 12, display: 'flex', justifyContent: 'center' }}>
                 <ReportErrorButton

--- a/frontend/src/app/votes/[id]/opengraph-image.tsx
+++ b/frontend/src/app/votes/[id]/opengraph-image.tsx
@@ -1,0 +1,109 @@
+import { ImageResponse } from 'next/og'
+import { api } from '@/lib/api'
+
+export const runtime = 'edge'
+export const alt = 'Résultat du scrutin — MonÉlu'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export const revalidate = 86400
+
+export default async function OGImage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const vote = await api.votes.get(id).catch(() => null)
+
+  const adopted = vote?.result === 'adopté'
+  const denom = vote?.total_voters || 1
+  const pourPct = vote ? Math.round(vote.votes_for / denom * 100) : 0
+  const contrePct = vote ? Math.round(vote.votes_against / denom * 100) : 0
+  const abstPct = vote ? Math.round(vote.abstentions / denom * 100) : 0
+  const title = vote ? (vote.vote_title.length > 90 ? vote.vote_title.slice(0, 90) + '…' : vote.vote_title) : 'Scrutin introuvable'
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: '#0D1F3C',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          padding: '80px',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 28 }}>
+          <div
+            style={{
+              display: 'flex',
+              padding: '8px 20px',
+              borderRadius: 999,
+              background: adopted ? 'rgba(31,138,91,0.18)' : 'rgba(201,48,42,0.18)',
+              color: adopted ? '#3FCB8D' : '#F0837C',
+              fontSize: 22,
+              fontWeight: 700,
+              fontFamily: 'sans-serif',
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+            }}
+          >
+            {vote ? (adopted ? 'Adopté' : 'Rejeté') : 'Scrutin'}
+          </div>
+          {vote?.voted_at && (
+            <span style={{ color: 'rgba(255,255,255,0.45)', fontSize: 18, fontFamily: 'sans-serif' }}>
+              {new Date(vote.voted_at).toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' })}
+            </span>
+          )}
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            color: '#ffffff',
+            fontSize: 46,
+            lineHeight: 1.25,
+            fontFamily: 'serif',
+            maxWidth: 1020,
+            marginBottom: 44,
+          }}
+        >
+          {title}
+        </div>
+
+        {vote && (
+          <div style={{ display: 'flex', flexDirection: 'column', width: '100%', maxWidth: 1020 }}>
+            <div style={{ display: 'flex', height: 22, borderRadius: 999, overflow: 'hidden', width: '100%' }}>
+              <div style={{ width: `${pourPct}%`, background: '#1F8A5B', height: '100%' }} />
+              <div style={{ width: `${contrePct}%`, background: '#C9302C', height: '100%' }} />
+              <div style={{ width: `${abstPct}%`, background: 'rgba(255,255,255,0.3)', height: '100%' }} />
+            </div>
+            <div style={{ display: 'flex', gap: 40, marginTop: 20 }}>
+              <span style={{ color: 'rgba(255,255,255,0.85)', fontSize: 22, fontFamily: 'sans-serif' }}>
+                Pour <span style={{ color: '#3FCB8D', fontWeight: 700 }}>{pourPct}%</span>
+              </span>
+              <span style={{ color: 'rgba(255,255,255,0.85)', fontSize: 22, fontFamily: 'sans-serif' }}>
+                Contre <span style={{ color: '#F0837C', fontWeight: 700 }}>{contrePct}%</span>
+              </span>
+              <span style={{ color: 'rgba(255,255,255,0.85)', fontSize: 22, fontFamily: 'sans-serif' }}>
+                Abstention <span style={{ color: 'rgba(255,255,255,0.9)', fontWeight: 700 }}>{abstPct}%</span>
+              </span>
+            </div>
+          </div>
+        )}
+
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 60,
+            right: 80,
+            width: 8,
+            height: 200,
+            background: '#C9302C',
+            borderRadius: 4,
+          }}
+        />
+      </div>
+    ),
+    { ...size }
+  )
+}

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -12,6 +12,7 @@ const items = [
 
 export function BottomNav() {
   const path = usePathname()
+  if (path.startsWith('/embed')) return null
   return (
     <nav data-print-hide className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-gray-border z-50 pb-[env(safe-area-inset-bottom)]">
       <div className="grid grid-cols-5">

--- a/frontend/src/components/EmbedButton.tsx
+++ b/frontend/src/components/EmbedButton.tsx
@@ -1,0 +1,78 @@
+'use client'
+import { useEffect, useRef, useState } from 'react'
+
+interface EmbedButtonProps {
+  path: string
+  width?: number
+  height?: number
+}
+
+export function EmbedButton({ path, width = 560, height = 220 }: EmbedButtonProps) {
+  const [open, setOpen] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function onClickOutside(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', onClickOutside)
+    return () => document.removeEventListener('mousedown', onClickOutside)
+  }, [open])
+
+  const embedUrl = typeof window !== 'undefined' ? `${window.location.origin}${path}` : path
+  const snippet = `<iframe src="${embedUrl}" width="${width}" height="${height}" style="border:1px solid #E4E6EA;border-radius:12px" loading="lazy" title="MonÉlu"></iframe>`
+
+  async function copySnippet() {
+    try {
+      await navigator.clipboard.writeText(snippet)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // clipboard unavailable — silent fail
+    }
+  }
+
+  return (
+    <div ref={rootRef} style={{ position: 'relative' }}>
+      <button
+        onClick={e => { e.preventDefault(); e.stopPropagation(); setOpen(o => !o) }}
+        className="flex items-center gap-1.5 text-xs text-gray-mid hover:text-navy transition-colors px-2.5 py-1.5 rounded border border-gray-border bg-white shrink-0"
+        aria-label="Intégrer ce vote sur un autre site"
+        aria-expanded={open}
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="16 18 22 12 16 6" /><polyline points="8 6 2 12 8 18" />
+        </svg>
+        <span>Intégrer</span>
+      </button>
+
+      {open && (
+        <div
+          style={{
+            position: 'absolute', top: 'calc(100% + 6px)', right: 0, zIndex: 40,
+            background: '#fff', border: '1px solid #E4E6EA', borderRadius: 10,
+            boxShadow: '0 8px 24px rgba(0,0,0,0.12)', padding: 14, width: 320,
+          }}
+        >
+          <p style={{ fontSize: 12.5, color: '#4B5563', marginBottom: 8 }}>
+            Collez ce code dans votre page pour afficher ce vote en direct.
+          </p>
+          <code style={{ display: 'block', fontSize: 11, color: '#1B2B50', background: '#F7F4ED', borderRadius: 6, padding: 8, wordBreak: 'break-all', marginBottom: 10 }}>
+            {snippet}
+          </code>
+          <button
+            onClick={e => { e.preventDefault(); e.stopPropagation(); copySnippet() }}
+            style={{
+              width: '100%', padding: '8px 10px', borderRadius: 6, fontSize: 13, fontWeight: 600,
+              color: '#fff', background: '#1B2B50', border: 'none', cursor: 'pointer',
+            }}
+          >
+            {copied ? 'Copié !' : 'Copier le code'}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -14,7 +14,8 @@ export function Footer() {
 
   // /chat is a fixed-viewport app shell (height: calc(100dvh - 4rem), internal
   // scrolling only) — appending footer content below it would break that layout.
-  if (pathname.startsWith('/chat')) return null
+  // /embed/* pages are iframed into third-party sites — no site chrome there.
+  if (pathname.startsWith('/chat') || pathname.startsWith('/embed')) return null
 
   return (
     <footer

--- a/frontend/src/components/HideOnEmbed.tsx
+++ b/frontend/src/components/HideOnEmbed.tsx
@@ -1,0 +1,11 @@
+'use client'
+import { usePathname } from 'next/navigation'
+
+// /embed/* pages are iframed into third-party sites — wraps chrome that has
+// no per-route pathname check of its own (e.g. server components) so it can
+// still be omitted there.
+export function HideOnEmbed({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  if (pathname.startsWith('/embed')) return null
+  return <>{children}</>
+}

--- a/frontend/src/components/MainFrame.tsx
+++ b/frontend/src/components/MainFrame.tsx
@@ -1,0 +1,14 @@
+'use client'
+import { usePathname } from 'next/navigation'
+
+// /embed/* pages are iframed into third-party sites — they have no bottom
+// nav, so the space normally reserved for it would just be blank padding.
+export function MainFrame({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const isEmbed = pathname.startsWith('/embed')
+  return (
+    <main className={isEmbed ? '' : 'pb-[calc(5rem+env(safe-area-inset-bottom))] md:pb-0'}>
+      {children}
+    </main>
+  )
+}

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -19,6 +19,9 @@ const navLinks = [
 export function Nav() {
   const pathname = usePathname()
 
+  // /embed/* pages are iframed into third-party sites — no site chrome there.
+  if (pathname.startsWith('/embed')) return null
+
   return (
     <nav
       data-print-hide

--- a/frontend/src/components/ShareButton.tsx
+++ b/frontend/src/components/ShareButton.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 interface ShareButtonProps {
   url: string
@@ -10,49 +10,117 @@ interface ShareButtonProps {
 
 export function ShareButton({ url, title, text, ariaLabel }: ShareButtonProps) {
   const [copied, setCopied] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
 
-  async function handleShare() {
-    const fullUrl = typeof window !== 'undefined'
-      ? `${window.location.origin}${url}`
-      : url
-
-    if (typeof navigator !== 'undefined' && navigator.share) {
-      try {
-        await navigator.share({ url: fullUrl, title, text })
-        return
-      } catch (err) {
-        // User cancelled the share sheet: respect that, don't copy instead.
-        if (err instanceof Error && err.name === 'AbortError') return
-        // API genuinely unavailable - fall through to clipboard.
-      }
+  useEffect(() => {
+    if (!menuOpen) return
+    function onClickOutside(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setMenuOpen(false)
     }
+    document.addEventListener('mousedown', onClickOutside)
+    return () => document.removeEventListener('mousedown', onClickOutside)
+  }, [menuOpen])
+
+  function fullUrl() {
+    return typeof window !== 'undefined' ? `${window.location.origin}${url}` : url
+  }
+
+  async function copyLink() {
     try {
-      await navigator.clipboard.writeText(fullUrl)
+      await navigator.clipboard.writeText(fullUrl())
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     } catch {
-      // clipboard also unavailable — silent fail
+      // clipboard unavailable — silent fail
     }
   }
 
+  async function handleShare() {
+    if (typeof navigator !== 'undefined' && navigator.share) {
+      try {
+        await navigator.share({ url: fullUrl(), title, text })
+        return
+      } catch (err) {
+        // User cancelled the share sheet: respect that, don't fall back.
+        if (err instanceof Error && err.name === 'AbortError') return
+        // API genuinely unavailable — fall through to the desktop menu.
+      }
+    }
+    setMenuOpen(open => !open)
+  }
+
+  const shareUrl = fullUrl()
+  const shareText = text ?? title
+  const socialLinks = [
+    {
+      label: 'X',
+      href: `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(shareUrl)}`,
+    },
+    {
+      label: 'Bluesky',
+      href: `https://bsky.app/intent/compose?text=${encodeURIComponent(`${shareText} ${shareUrl}`)}`,
+    },
+    {
+      label: 'Facebook',
+      href: `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`,
+    },
+  ]
+
   return (
-    <button
-      onClick={e => { e.preventDefault(); e.stopPropagation(); handleShare() }}
-      className="flex items-center gap-1.5 text-xs text-gray-mid hover:text-navy transition-colors px-2.5 py-1.5 rounded border border-gray-border bg-white shrink-0"
-      aria-label={ariaLabel ?? 'Partager ce vote'}
-    >
-      {copied ? (
-        <span className="text-emerald-700 font-medium">Copié !</span>
-      ) : (
-        <>
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
-            <polyline points="16 6 12 2 8 6" />
-            <line x1="12" y1="2" x2="12" y2="15" />
-          </svg>
-          <span>Partager</span>
-        </>
+    <div ref={rootRef} style={{ position: 'relative' }}>
+      <button
+        onClick={e => { e.preventDefault(); e.stopPropagation(); handleShare() }}
+        className="flex items-center gap-1.5 text-xs text-gray-mid hover:text-navy transition-colors px-2.5 py-1.5 rounded border border-gray-border bg-white shrink-0"
+        aria-label={ariaLabel ?? 'Partager'}
+        aria-expanded={menuOpen}
+      >
+        {copied ? (
+          <span className="text-emerald-700 font-medium">Copié !</span>
+        ) : (
+          <>
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
+              <polyline points="16 6 12 2 8 6" />
+              <line x1="12" y1="2" x2="12" y2="15" />
+            </svg>
+            <span>Partager</span>
+          </>
+        )}
+      </button>
+
+      {menuOpen && (
+        <div
+          role="menu"
+          style={{
+            position: 'absolute', top: 'calc(100% + 6px)', left: 0, zIndex: 40,
+            background: '#fff', border: '1px solid #E4E6EA', borderRadius: 10,
+            boxShadow: '0 8px 24px rgba(0,0,0,0.12)', padding: 6, minWidth: 160,
+            display: 'flex', flexDirection: 'column',
+          }}
+        >
+          <button
+            role="menuitem"
+            onClick={e => { e.preventDefault(); e.stopPropagation(); copyLink(); setMenuOpen(false) }}
+            style={{ textAlign: 'left', padding: '8px 10px', borderRadius: 6, fontSize: 13, color: '#1B2B50', background: 'transparent', border: 'none', cursor: 'pointer' }}
+          >
+            Copier le lien
+          </button>
+          {socialLinks.map(social => (
+            <a
+              key={social.label}
+              role="menuitem"
+              href={social.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setMenuOpen(false)}
+              style={{ textAlign: 'left', padding: '8px 10px', borderRadius: 6, fontSize: 13, color: '#1B2B50', textDecoration: 'none' }}
+            >
+              Partager sur {social.label}
+            </a>
+          ))}
+        </div>
       )}
-    </button>
+    </div>
   )
 }


### PR DESCRIPTION
## What

Makes MonÉlu content portable off-platform: entity-specific OG cards for deputy and vote detail pages, an iframe-able `/embed/votes/[id]` vote card with a documented embed snippet, and richer share options (X, Bluesky, Facebook) alongside the existing native-share/copy-link button.

## Why

Vote results and deputy scorecards are exactly the kind of content that gets screenshot-shared today - MonÉlu should own that surface with real cards and embeds instead of a generic banner. Every embedded card in a news article is a durable backlink and brand impression (MON-96).

## Changes

**Per-entity OG images**
- `frontend/src/app/deputes/[id]/opengraph-image.tsx`: deputy photo, party, presence rate, and total scrutins voted, matching the existing navy/red visual style used by the root and quiz/chat/verifier share OG images.
- `frontend/src/app/votes/[id]/opengraph-image.tsx`: result badge (adopté/rejeté), vote title, and a pour/contre/abstention percentage bar.

**Embed surface**
- `frontend/src/app/embed/votes/[id]/page.tsx`: a minimal, stripped card (result, title linking back to the full page, vote breakdown, attribution) meant to be iframed on external sites.
- `frontend/src/components/EmbedButton.tsx`: a new "Intégrer" button on the vote detail page that shows a copyable `<iframe>` snippet pointing at the embed route.
- `frontend/next.config.mjs`: added `headers()` - every route now sends `X-Frame-Options: DENY` + `Content-Security-Policy: frame-ancestors 'self'` by default; `/embed/*` is carved out to allow framing (`frame-ancestors *`, no `X-Frame-Options`).
- Site chrome (`Nav`, `BottomNav`, `Footer`, `FreshnessBadge` via the new `HideOnEmbed` wrapper, and bottom-nav padding via the new `MainFrame` wrapper) is hidden on `/embed/*`, following the same self-hiding pattern `Footer` already used for `/chat`.

**Share buttons**
- `frontend/src/components/ShareButton.tsx`: still tries `navigator.share()` first (mobile), but now falls back to a small dropdown menu with copy-link, X, Bluesky, and Facebook share links instead of only copying to the clipboard. No prop changes, so both existing call sites (`deputes/[id]/page.tsx`, `votes/[id]/VoteDetailClient.tsx`) pick this up for free.

## Testing

- `npm run lint` - clean.
- `npm test` - 15 suites / 133 tests passing.
- `npm run build` - succeeds; confirms `/deputes/[id]/opengraph-image`, `/votes/[id]/opengraph-image`, and `/embed/votes/[id]` routes compile and type-check.
- Manual: ran `next dev`, confirmed via `curl -D -` that `/` sends `X-Frame-Options: DENY` + `frame-ancestors 'self'` while `/embed/votes/[id]` sends only `frame-ancestors *`; confirmed the embed page renders without Nav/Footer; confirmed the vote page shows the new "Intégrer" button.

## Risks / Notes

- The `next.config.mjs` `headers()` change is the first repo-wide CSP/X-Frame-Options policy - verified it doesn't break normal page loads (`npm run build` + manual curl check), but flagging it explicitly since it's a security-header change touching every route.
- OG image cards fetch `deputy`/`vote` data at request time (`revalidate: 86400`, matching the existing pattern in `chat/s/[id]` and `quiz/s/[id]` OG images) - no new endpoints required.
- Twitter/X, Bluesky, and Facebook share links use their public web share-intent URLs; no API keys or app registration needed.

## Breaking Changes

None.
