### PR TITLE
feat: dark-mode theme infrastructure and toggle (MON-154)

### DIFF
--- a/frontend/__tests__/components/ThemeToggle.landing.test.tsx
+++ b/frontend/__tests__/components/ThemeToggle.landing.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react'
+
+import { ThemeProvider } from '@/components/ThemeProvider'
+import { ThemeToggle } from '@/components/ThemeToggle'
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}))
+
+beforeEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: jest.fn().mockImplementation(() => ({
+      matches: false,
+      media: '(prefers-color-scheme: dark)',
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    })),
+  })
+})
+
+afterEach(() => {
+  window.localStorage.clear()
+  document.documentElement.classList.remove('dark')
+})
+
+describe('ThemeToggle on the landing page', () => {
+  it('renders nothing, since the landing page is always light', () => {
+    render(
+      <ThemeProvider>
+        <ThemeToggle />
+      </ThemeProvider>
+    )
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('never applies the dark class even when the stored preference is dark', () => {
+    window.localStorage.setItem('monelu-theme', 'dark')
+
+    render(
+      <ThemeProvider>
+        <ThemeToggle />
+      </ThemeProvider>
+    )
+
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+})

--- a/frontend/__tests__/components/ThemeToggle.test.tsx
+++ b/frontend/__tests__/components/ThemeToggle.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { ThemeProvider } from '@/components/ThemeProvider'
+import { ThemeToggle } from '@/components/ThemeToggle'
+import { THEME_STORAGE_KEY } from '@/lib/theme'
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/votes',
+}))
+
+function renderToggle() {
+  return render(
+    <ThemeProvider>
+      <ThemeToggle />
+    </ThemeProvider>
+  )
+}
+
+function mockMatchMedia(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: jest.fn().mockImplementation(() => ({
+      matches,
+      media: '(prefers-color-scheme: dark)',
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    })),
+  })
+}
+
+beforeEach(() => {
+  mockMatchMedia(false)
+})
+
+afterEach(() => {
+  window.localStorage.clear()
+  document.documentElement.classList.remove('dark')
+  jest.restoreAllMocks()
+})
+
+describe('ThemeToggle', () => {
+  it('defaults to light and switches to dark on click, persisting the choice', () => {
+    renderToggle()
+    const button = screen.getByRole('button', { name: /passer en mode sombre/i })
+
+    fireEvent.click(button)
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark')
+    expect(screen.getByRole('button', { name: /passer en mode clair/i })).toBeInTheDocument()
+  })
+
+  it('toggles back to light and updates storage', () => {
+    renderToggle()
+    const button = screen.getByRole('button', { name: /passer en mode sombre/i })
+
+    fireEvent.click(button)
+    fireEvent.click(screen.getByRole('button', { name: /passer en mode clair/i }))
+
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('light')
+  })
+
+  it('respects prefers-color-scheme on first render when nothing is stored', () => {
+    mockMatchMedia(true)
+
+    renderToggle()
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('prefers a stored choice over the system preference', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'light')
+    mockMatchMedia(true)
+
+    renderToggle()
+
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+})

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -12,8 +12,22 @@
 @keyframes nudge { 0%,100% { transform: translate(-50%,0); } 50% { transform: translate(-50%,5px); } }
 [data-hint] { animation: nudge 2s ease-in-out infinite; }
 
+:root {
+  --color-bg: theme('colors.gray.off');
+  --color-fg: theme('colors.navy.DEFAULT');
+}
+
+/* MON-154: dark-mode theme tokens. The `dark` class is toggled on <html> by
+   ThemeProvider and never applied on the landing page (ADR-027). Page- and
+   component-level dark: variants land in follow-up MON-103 sub-issues — this
+   only wires the mechanism through the shared body background/foreground. */
+.dark {
+  --color-bg: #0B1424;
+  --color-fg: #F1F0EC;
+}
+
 @layer base {
-  body { @apply font-sans bg-white text-navy; }
+  body { @apply font-sans; background-color: var(--color-bg); color: var(--color-fg); }
   h1, h2, h3 { @apply font-newsreader; }
 }
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from 'next'
 import { Suspense } from 'react'
+import Script from 'next/script'
 import { DM_Serif_Display, DM_Sans, Newsreader } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/react'
 import { SpeedInsights } from '@vercel/speed-insights/next'
@@ -12,7 +13,9 @@ import { Footer } from '@/components/Footer'
 import { HideOnEmbed } from '@/components/HideOnEmbed'
 import { MainFrame } from '@/components/MainFrame'
 import { JsonLd } from '@/components/JsonLd'
+import { ThemeProvider } from '@/components/ThemeProvider'
 import { buildWebsiteJsonLd } from '@/lib/seo'
+import { THEME_STORAGE_KEY } from '@/lib/theme'
 
 const serif = DM_Serif_Display({
   subsets: ['latin'],
@@ -68,17 +71,22 @@ export const viewport: Viewport = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="fr" className={`${serif.variable} ${sans.variable} ${newsreader.variable}`}>
-      <body className="bg-gray-off min-h-screen">
-        <JsonLd data={buildWebsiteJsonLd()} />
-        <Suspense fallback={null}>
-          <Nav />
-        </Suspense>
-        <HideOnEmbed><FreshnessBadge /></HideOnEmbed>
-        <MainFrame><PageTransition>{children}</PageTransition></MainFrame>
-        <Footer />
-        <Suspense fallback={null}>
-          <BottomNav />
-        </Suspense>
+      <body className="min-h-screen">
+        <Script id="theme-no-flash" strategy="beforeInteractive">
+          {`(function(){try{if(window.location.pathname==='/')return;var s=localStorage.getItem('${THEME_STORAGE_KEY}');var d=s==='dark'||(s!=='light'&&window.matchMedia('(prefers-color-scheme: dark)').matches);if(d)document.documentElement.classList.add('dark');}catch(e){}})();`}
+        </Script>
+        <ThemeProvider>
+          <JsonLd data={buildWebsiteJsonLd()} />
+          <Suspense fallback={null}>
+            <Nav />
+          </Suspense>
+          <HideOnEmbed><FreshnessBadge /></HideOnEmbed>
+          <MainFrame><PageTransition>{children}</PageTransition></MainFrame>
+          <Footer />
+          <Suspense fallback={null}>
+            <BottomNav />
+          </Suspense>
+        </ThemeProvider>
         <Analytics />
         <SpeedInsights />
       </body>

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,6 +1,7 @@
 'use client'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+import { ThemeToggle } from './ThemeToggle'
 
 const items = [
   { href: '/', label: 'Accueil', icon: '⌂' },
@@ -15,20 +16,23 @@ export function BottomNav() {
   if (path.startsWith('/embed')) return null
   return (
     <nav data-print-hide className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-gray-border z-50 pb-[env(safe-area-inset-bottom)]">
-      <div className="grid grid-cols-5">
-        {items.map(item => {
-          const active =
-            path === item.href || (item.href !== '/' && path.startsWith(item.href))
-          return (
-            <Link key={item.href} href={item.href}
-              className={`flex flex-col items-center justify-center py-3 gap-0.5 text-xs font-medium transition-colors
-                ${active
-                  ? 'text-navy' : 'text-gray-mid'}`}>
-              <span className="text-lg leading-none">{item.icon}</span>
-              <span>{item.label}</span>
-            </Link>
-          )
-        })}
+      <div className="flex items-center">
+        <div className="grid grid-cols-5 flex-1">
+          {items.map(item => {
+            const active =
+              path === item.href || (item.href !== '/' && path.startsWith(item.href))
+            return (
+              <Link key={item.href} href={item.href}
+                className={`flex flex-col items-center justify-center py-3 gap-0.5 text-xs font-medium transition-colors
+                  ${active
+                    ? 'text-navy' : 'text-gray-mid'}`}>
+                <span className="text-lg leading-none">{item.icon}</span>
+                <span>{item.label}</span>
+              </Link>
+            )
+          })}
+        </div>
+        <ThemeToggle className="mr-2 shrink-0" />
       </div>
     </nav>
   )

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation'
 import { MonEluLogo } from './MonEluLogo'
 import { GlobalSearch } from './GlobalSearch'
 import { FollowedDeputyChip } from './FollowedDeputyChip'
+import { ThemeToggle } from './ThemeToggle'
 
 export const NAV_HEIGHT_PX = 64
 
@@ -46,6 +47,7 @@ export function Nav() {
         })}
       </div>
       <div className="flex items-center gap-4">
+        <ThemeToggle />
         <FollowedDeputyChip />
         <GlobalSearch />
         <a href="https://monelu-production.up.railway.app/docs"

--- a/frontend/src/components/ThemeProvider.tsx
+++ b/frontend/src/components/ThemeProvider.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { createContext, useCallback, useContext, useEffect, useState } from 'react'
+import { usePathname } from 'next/navigation'
+import { THEME_STORAGE_KEY, isLightOnlyPath, type Theme } from '@/lib/theme'
+
+type ThemeContextValue = {
+  theme: Theme
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+function getStoredOrPreferredTheme(): Theme {
+  const stored = window.localStorage.getItem(THEME_STORAGE_KEY)
+  if (stored === 'light' || stored === 'dark') return stored
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const [theme, setTheme] = useState<Theme>('light')
+
+  useEffect(() => {
+    // Reading localStorage/matchMedia during render would mismatch the
+    // server-rendered 'light' default and break hydration — this effect is
+    // the one-time sync from those browser-only APIs into React state.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setTheme(getStoredOrPreferredTheme())
+  }, [])
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark' && !isLightOnlyPath(pathname))
+  }, [theme, pathname])
+
+  const toggleTheme = useCallback(() => {
+    setTheme(prev => {
+      const next: Theme = prev === 'dark' ? 'light' : 'dark'
+      window.localStorage.setItem(THEME_STORAGE_KEY, next)
+      return next
+    })
+  }, [])
+
+  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider')
+  return ctx
+}

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { isLightOnlyPath } from '@/lib/theme'
+import { useTheme } from './ThemeProvider'
+
+export function ThemeToggle({ className = '' }: { className?: string }) {
+  const pathname = usePathname()
+  const { theme, toggleTheme } = useTheme()
+
+  if (isLightOnlyPath(pathname)) return null
+
+  const isDark = theme === 'dark'
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-label={isDark ? 'Passer en mode clair' : 'Passer en mode sombre'}
+      title={isDark ? 'Passer en mode clair' : 'Passer en mode sombre'}
+      className={`flex items-center justify-center w-8 h-8 rounded-full text-gray-mid hover:text-navy hover:bg-gray-light transition-colors ${className}`}
+    >
+      <span aria-hidden="true" className="text-base leading-none">{isDark ? '☀' : '☾'}</span>
+    </button>
+  )
+}

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -1,0 +1,9 @@
+export type Theme = 'light' | 'dark'
+
+export const THEME_STORAGE_KEY = 'monelu-theme'
+
+// The cinematic landing page keeps its fixed navy/red visual treatment
+// (ADR-027) — it never renders dark, regardless of the stored preference.
+export function isLightOnlyPath(pathname: string): boolean {
+  return pathname === '/'
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -8,6 +8,7 @@ import type { Config } from 'tailwindcss'
  *   font-mono       (system monospace)  — numbers, dates, metadata, code blocks
  */
 const config: Config = {
+  darkMode: 'class',
   content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
   theme: {
     extend: {


### PR DESCRIPTION
## What
Adds the dark-mode mechanism for MonÉlu's frontend: a class-based Tailwind dark mode, a `ThemeProvider` that syncs `localStorage` and `prefers-color-scheme`, a no-flash inline script, and a toggle wired into `Nav` and `BottomNav`.

## Why
MON-103 (dark mode across the app, landing page excluded) was decomposed into a theme-infra sub-issue plus per-surface sub-issues. Per ADR-027 (`docs/decisions.md`), which reverses ADR-018's original dark-mode deferral, this PR (MON-154) builds only the mechanism the later sub-issues restyle pages against — it does not add `dark:` variants across the app yet.

## Changes
- `frontend/tailwind.config.ts`: `darkMode: 'class'`.
- `frontend/src/lib/theme.ts`: `Theme` type, `THEME_STORAGE_KEY`, and `isLightOnlyPath()` — the landing page (`/`) is always light since it keeps its fixed cinematic treatment and shares `Nav`/`Footer` chrome with the rest of the app.
- `frontend/src/components/ThemeProvider.tsx`: context provider — reads the stored theme or `prefers-color-scheme` on mount, toggles the `dark` class on `<html>`, and forces light whenever `pathname === '/'`, even if dark is the active stored preference.
- `frontend/src/components/ThemeToggle.tsx`: toggle button (renders `null` on the landing page).
- `frontend/src/app/layout.tsx`: adds a `beforeInteractive` inline script that applies the `dark` class before hydration (avoids a flash of the wrong theme), and wraps the app body in `ThemeProvider`.
- `frontend/src/app/globals.css`: `--color-bg`/`--color-fg` CSS variables for light/dark, driving the shared `body` background/foreground only — page- and component-level `dark:` variants are out of scope here and land in the follow-up MON-103 sub-issues (MON-155 through MON-159).
- `frontend/src/components/Nav.tsx`, `BottomNav.tsx`: wire in `ThemeToggle`. `BottomNav`'s single `grid-cols-5` row is now wrapped in a flex row with the toggle as a fixed-width sibling, so the toggle doesn't overlap the "Chat IA" label.

## Testing
- `npm run lint` — clean.
- `npm test` — 19 suites / 144 tests pass, including two new suites (`ThemeToggle.test.tsx`, `ThemeToggle.landing.test.tsx`) covering: default-to-light, toggle + persistence, `prefers-color-scheme` fallback, stored choice taking precedence over system preference, and the landing page never rendering the toggle or applying `dark`.
- `npm run build` — succeeds (type-check passes as part of `next build`); the `/sitemap.xml` prerender retry is known noise unrelated to this change (reproduces on master).
- Manual: ran `next dev`, curled `/` and `/votes` — toggle markup and its aria-label are absent on `/` and present on `/votes`, confirming the light-only-on-landing behavior server-side.

## Risks / Notes
- This PR intentionally does not restyle any page — only the shared `body` background/foreground responds to the toggle today. Visual dark-mode coverage for deputies/departments, votes/scorecards, chat/verifier/quiz, and static pages/chrome lands in MON-155 through MON-158; MON-159 does the final contrast audit.
- The mount-time `setTheme` call in `ThemeProvider` is flagged by `react-hooks/set-state-in-effect` and explicitly suppressed with a comment — it's the standard one-time sync from `localStorage`/`matchMedia` (browser-only APIs unavailable during SSR), the same pattern used by libraries like `next-themes`.

## Breaking Changes
None.

https://claude.ai/code/session_01HVxc7TTP3xnsgNC3mtzxEb