### PR TITLE
feat: build /groupes/[slug] group profile page (MON-151)

### DIFF
--- a/frontend/__tests__/lib/groups.test.ts
+++ b/frontend/__tests__/lib/groups.test.ts
@@ -1,0 +1,33 @@
+import { groupName, groupSlug } from '@/lib/groups'
+
+describe('groupName', () => {
+  it('maps a canonical slug to its full label', () => {
+    expect(groupName('rassemblement-national')).toBe('Rassemblement National')
+    expect(groupName('lfi-nfp')).toBe('La France insoumise - Nouveau Front Populaire')
+    expect(groupName('liot')).toBe('Libertés, Indépendants, Outre-mer et Territoires')
+    expect(groupName('non-inscrits')).toBe('Non inscrit')
+  })
+
+  it('normalizes case and surrounding whitespace', () => {
+    expect(groupName('Rassemblement-National')).toBe('Rassemblement National')
+    expect(groupName('  liot  ')).toBe('Libertés, Indépendants, Outre-mer et Territoires')
+  })
+
+  it('returns null for unknown slugs', () => {
+    expect(groupName('does-not-exist')).toBeNull()
+    expect(groupName('renaissance')).toBeNull()
+  })
+})
+
+describe('groupSlug', () => {
+  it('maps a canonical label to its slug', () => {
+    expect(groupSlug('Rassemblement National')).toBe('rassemblement-national')
+    expect(groupSlug('Non inscrit')).toBe('non-inscrits')
+  })
+
+  it('returns null for null, undefined, and unknown values', () => {
+    expect(groupSlug(null)).toBeNull()
+    expect(groupSlug(undefined)).toBeNull()
+    expect(groupSlug('Not A Real Group')).toBeNull()
+  })
+})

--- a/frontend/src/app/groupes/[slug]/page.tsx
+++ b/frontend/src/app/groupes/[slug]/page.tsx
@@ -1,0 +1,326 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { api } from '@/lib/api'
+import type { GroupMember, GroupVoteBreakdown } from '@/lib/api'
+import { partyHex, formatDate } from '@/lib/utils'
+import { groupName } from '@/lib/groups'
+import { DeputyAvatar } from '@/components/DeputyAvatar'
+import { JsonLd } from '@/components/JsonLd'
+import { SITE_URL, buildBreadcrumbJsonLd } from '@/lib/seo'
+
+export const dynamicParams = true
+export const revalidate = 3600
+
+const NAVY  = '#1B2B50'
+const CREAM = '#F7F4ED'
+const LINE  = '#E4E6EA'
+const RED   = '#C9302A'
+
+export async function generateMetadata(
+  { params }: { params: Promise<{ slug: string }> }
+): Promise<Metadata> {
+  const { slug } = await params
+  const canonicalSlug = decodeURIComponent(slug).trim().toLowerCase()
+  if (!groupName(canonicalSlug)) return {}
+  const data = await api.groups.get(canonicalSlug).catch(() => null)
+  if (!data) return {}
+  const title = `${data.name} - MonÉlu`
+  const description =
+    `Les ${data.member_count} député${data.member_count !== 1 ? 's' : ''} du groupe ${data.name} ` +
+    'à l\'Assemblée nationale : cohésion, dissidents et votes qui les divisent.'
+  return {
+    title,
+    description,
+    openGraph: { title, description },
+    twitter: { card: 'summary_large_image', title, description },
+  }
+}
+
+function pct(rate: number | null | undefined): number | null {
+  return rate == null ? null : Math.round(rate * 100)
+}
+
+const MAJORITY_LABEL: Record<string, string> = {
+  pour: 'Pour',
+  contre: 'Contre',
+  abstention: 'Abstention',
+}
+
+const MAJORITY_COLOR: Record<string, string> = {
+  pour: '#15803D',
+  contre: RED,
+  abstention: '#9CA3AF',
+}
+
+export default async function GroupPage(
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params
+  const canonicalSlug = decodeURIComponent(slug).trim().toLowerCase()
+  const name = groupName(canonicalSlug)
+  if (!name) notFound()
+
+  const [data, nationalStats] = await Promise.all([
+    api.groups.get(canonicalSlug).catch(() => null),
+    api.deputies.stats().catch(() => null),
+  ])
+  if (!data) notFound()
+
+  const hex = partyHex(data.name)
+  const avgPresencePct = pct(data.avg_presence_rate)
+  const nationalPresencePct = pct(nationalStats?.avg_presence_rate)
+  const avgDissidentPct = pct(data.avg_dissident_rate)
+  const cohesionPct = avgDissidentPct === null ? null : 100 - avgDissidentPct
+  const topDissident = data.most_dissident_members[0]
+
+  const breadcrumb = buildBreadcrumbJsonLd([
+    { name: 'Accueil', url: SITE_URL },
+    { name: data.name, url: `${SITE_URL}/groupes/${data.slug}` },
+  ])
+
+  return (
+    <div style={{ background: CREAM, minHeight: '100vh' }}>
+      <JsonLd data={breadcrumb} />
+
+      {/* Hero */}
+      <div
+        className="px-5 sm:px-14 pt-8 sm:pt-[50px] pb-8 sm:pb-10"
+        style={{
+          background: `linear-gradient(180deg,#fff 0%,${CREAM} 100%)`,
+          borderBottom: '1px solid #ECE7DC',
+        }}
+      >
+        <div style={{ maxWidth: 1180, margin: '0 auto' }}>
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: 8,
+            fontWeight: 700, fontSize: 12, letterSpacing: '0.18em',
+            textTransform: 'uppercase', color: RED, marginBottom: 16,
+          }}>
+            <span style={{ width: 9, height: 9, borderRadius: 999, background: hex }} />
+            Groupe parlementaire
+          </div>
+          <h1 className="font-newsreader text-[clamp(32px,4vw,48px)]" style={{
+            fontWeight: 600, lineHeight: 1.05, letterSpacing: '-0.015em',
+            color: NAVY, margin: 0, maxWidth: 760,
+          }}>
+            {data.name}
+          </h1>
+          <p style={{ margin: '16px 0 0', fontSize: 17, lineHeight: 1.6, color: '#4B5563', maxWidth: 560 }}>
+            Les {data.member_count} député{data.member_count !== 1 ? 's' : ''} de ce
+            groupe à l&apos;Assemblée nationale : présence, cohésion et votes qui les divisent.
+          </p>
+
+          {/* Aggregate cards */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4" style={{ marginTop: 30, maxWidth: 900 }}>
+            {avgPresencePct !== null && (
+              <div style={{ background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12, padding: '20px 22px' }}>
+                <div style={{ fontSize: 13, color: '#6B7280', fontWeight: 500, marginBottom: 8 }}>
+                  Présence moyenne
+                </div>
+                <div className="font-mono" style={{ fontWeight: 700, fontSize: 26, color: NAVY }}>
+                  {avgPresencePct}%
+                </div>
+                {nationalPresencePct !== null && (
+                  <div style={{ fontSize: 12.5, color: '#9CA3AF', marginTop: 6 }}>
+                    Moyenne nationale : {nationalPresencePct}%
+                  </div>
+                )}
+              </div>
+            )}
+            {cohesionPct !== null && (
+              <div style={{ background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12, padding: '20px 22px' }}>
+                <div style={{ fontSize: 13, color: '#6B7280', fontWeight: 500, marginBottom: 8 }}>
+                  Cohésion du groupe
+                </div>
+                <div className="font-mono" style={{ fontWeight: 700, fontSize: 26, color: NAVY }}>
+                  {cohesionPct}%
+                </div>
+                <div style={{ fontSize: 12.5, color: '#9CA3AF', marginTop: 6 }}>
+                  Vote avec la majorité du groupe en moyenne
+                </div>
+              </div>
+            )}
+            {topDissident && (
+              <div style={{ background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12, padding: '20px 22px' }}>
+                <div style={{ fontSize: 13, color: '#6B7280', fontWeight: 500, marginBottom: 8 }}>
+                  Le plus dissident
+                </div>
+                <Link href={`/deputes/${topDissident.deputy_id}`} style={{ fontWeight: 600, fontSize: 16, color: NAVY, textDecoration: 'none' }}>
+                  {topDissident.full_name}
+                </Link>
+                <div style={{ fontSize: 12.5, color: '#9CA3AF', marginTop: 6 }}>
+                  Vote contre le groupe dans {pct(topDissident.dissident_rate)}% des scrutins
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="px-5 sm:px-14 pt-10 pb-14 sm:pb-[72px]">
+        <div style={{ maxWidth: 1180, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 48 }}>
+
+          {/* Members */}
+          <section>
+            <div style={{ fontWeight: 700, fontSize: 12, letterSpacing: '0.18em', textTransform: 'uppercase', color: RED }}>
+              Membres
+            </div>
+            <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: NAVY, margin: '12px 0 22px', letterSpacing: '-0.01em' }}>
+              Député{data.member_count !== 1 ? 's' : ''} du groupe
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+              {data.members.map((m: GroupMember) => {
+                const presence = pct(m.presence_rate)
+                const dissident = pct(m.dissident_rate)
+                return (
+                  <Link
+                    key={m.deputy_id}
+                    href={`/deputes/${m.deputy_id}`}
+                    style={{
+                      display: 'block', background: '#fff', border: `1px solid ${LINE}`,
+                      borderRadius: 12, padding: '20px 22px', textDecoration: 'none',
+                      boxShadow: '0 1px 3px rgba(0,0,0,0.05)',
+                    }}
+                  >
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 14, minWidth: 0 }}>
+                      <DeputyAvatar name={m.full_name} photoUrl={m.photo_url} size="sm" />
+                      <div style={{ minWidth: 0 }}>
+                        <div style={{ fontWeight: 600, fontSize: 15.5, color: NAVY, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                          {m.full_name}
+                        </div>
+                        <div style={{ fontSize: 13, color: '#9CA3AF', marginTop: 3 }}>
+                          {m.department ?? '—'}
+                        </div>
+                      </div>
+                    </div>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginTop: 14, flexWrap: 'wrap' }}>
+                      {presence !== null && (
+                        <span className="font-mono" style={{ fontSize: 12, color: '#6B7280' }}>
+                          Présence {presence}%
+                        </span>
+                      )}
+                      {dissident !== null && (
+                        <span className="font-mono" style={{ fontSize: 12, color: '#6B7280' }}>
+                          Dissidence {dissident}%
+                        </span>
+                      )}
+                    </div>
+                  </Link>
+                )
+              })}
+            </div>
+          </section>
+
+          {/* Most dissident */}
+          {data.most_dissident_members.length > 0 && (
+            <section>
+              <div style={{ fontWeight: 700, fontSize: 12, letterSpacing: '0.18em', textTransform: 'uppercase', color: RED }}>
+                Les frondeurs
+              </div>
+              <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: NAVY, margin: '12px 0 22px', letterSpacing: '-0.01em' }}>
+                Les députés qui s&apos;écartent le plus du groupe
+              </h2>
+              <div style={{
+                background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12,
+                overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
+              }}>
+                {data.most_dissident_members.map((m, i) => (
+                  <Link
+                    key={m.deputy_id}
+                    href={`/deputes/${m.deputy_id}`}
+                    style={{
+                      display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                      padding: '14px 22px', textDecoration: 'none', gap: 16,
+                      borderBottom: i < data.most_dissident_members.length - 1 ? '1px solid #F0F1F3' : 'none',
+                    }}
+                  >
+                    <span style={{ fontWeight: 600, fontSize: 14.5, color: NAVY }}>{m.full_name}</span>
+                    <span className="font-mono" style={{ fontSize: 13, color: RED }}>{pct(m.dissident_rate)}%</span>
+                  </Link>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Divided votes */}
+          {data.divided_votes.length > 0 && (
+            <section>
+              <div style={{ fontWeight: 700, fontSize: 12, letterSpacing: '0.18em', textTransform: 'uppercase', color: RED }}>
+                Là où ils se divisent
+              </div>
+              <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: NAVY, margin: '12px 0 8px', letterSpacing: '-0.01em' }}>
+                Les votes les plus disputés au sein du groupe
+              </h2>
+              <p style={{ margin: '0 0 22px', fontSize: 14.5, color: '#6B7280', maxWidth: 640 }}>
+                Scrutins où le groupe s&apos;est le plus partagé entre pour et contre.
+              </p>
+              <VoteBreakdownList votes={data.divided_votes} />
+            </section>
+          )}
+
+          {/* Recent scrutins */}
+          {data.recent_scrutins.length > 0 && (
+            <section>
+              <div style={{ fontWeight: 700, fontSize: 12, letterSpacing: '0.18em', textTransform: 'uppercase', color: RED }}>
+                Votes récents
+              </div>
+              <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: NAVY, margin: '12px 0 22px', letterSpacing: '-0.01em' }}>
+                Comment le groupe a voté récemment
+              </h2>
+              <VoteBreakdownList votes={data.recent_scrutins} />
+            </section>
+          )}
+
+          {/* Cross-link */}
+          <div>
+            <Link href="/deputes" style={{ fontSize: 14, color: NAVY, textDecoration: 'underline' }}>
+              ← Tous les députés de l&apos;Assemblée nationale
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function VoteBreakdownList({ votes }: { votes: GroupVoteBreakdown[] }) {
+  return (
+    <div style={{
+      background: '#fff', border: `1px solid ${LINE}`, borderRadius: 12,
+      overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
+    }}>
+      {votes.map((v, i) => (
+        <Link
+          key={v.vote_id}
+          href={`/votes/${v.vote_id}`}
+          style={{
+            display: 'block', padding: '16px 22px', textDecoration: 'none',
+            borderBottom: i < votes.length - 1 ? '1px solid #F0F1F3' : 'none',
+          }}
+        >
+          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 16, alignItems: 'baseline', flexWrap: 'wrap' }}>
+            <span style={{ fontWeight: 600, fontSize: 14.5, color: NAVY, flex: '1 1 380px', minWidth: 0 }}>
+              {v.vote_title}
+            </span>
+            <span style={{ display: 'flex', gap: 12, alignItems: 'baseline', whiteSpace: 'nowrap' }}>
+              <span className="font-mono" style={{ fontSize: 12.5, color: '#15803D' }}>{v.pour} pour</span>
+              <span className="font-mono" style={{ fontSize: 12.5, color: RED }}>{v.contre} contre</span>
+              {v.abstention > 0 && (
+                <span className="font-mono" style={{ fontSize: 12.5, color: '#9CA3AF' }}>{v.abstention} abst.</span>
+              )}
+            </span>
+          </div>
+          <div style={{ fontSize: 12.5, color: '#9CA3AF', marginTop: 5 }}>
+            {v.voted_at ? formatDate(v.voted_at) : ''}
+            {v.result ? ` · ${v.result === 'adopté' ? 'Adopté' : 'Rejeté'}` : ''}
+            {' · '}
+            <span style={{ color: MAJORITY_COLOR[v.majority_position] ?? '#9CA3AF' }}>
+              Groupe majoritairement {MAJORITY_LABEL[v.majority_position] ?? v.majority_position}
+            </span>
+          </div>
+        </Link>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -163,6 +163,41 @@ export type DepartmentDetail = {
   split_votes: DepartmentSplitVote[]
 }
 
+export type GroupMember = {
+  deputy_id: string
+  full_name: string
+  party: string | null
+  party_short: string | null
+  department: string | null
+  circonscription: string | null
+  photo_url: string | null
+  presence_rate: number | null
+  dissident_rate: number | null
+}
+
+export type GroupVoteBreakdown = {
+  vote_id: string
+  voted_at: string | null
+  vote_title: string
+  result: string | null
+  pour: number
+  contre: number
+  abstention: number
+  majority_position: string
+}
+
+export type GroupDetail = {
+  slug: string
+  name: string
+  member_count: number
+  members: GroupMember[]
+  avg_presence_rate: number | null
+  avg_dissident_rate: number | null
+  most_dissident_members: GroupMember[]
+  divided_votes: GroupVoteBreakdown[]
+  recent_scrutins: GroupVoteBreakdown[]
+}
+
 export type ThemeVoteItem = {
   vote_id: string
   voted_at: string | null
@@ -392,6 +427,10 @@ export const api = {
   departments: {
     get: (code: string) =>
       apiFetch<DepartmentDetail>(`/departments/${encodeURIComponent(code)}`, { revalidate: 3600 }),
+  },
+  groups: {
+    get: (slug: string) =>
+      apiFetch<GroupDetail>(`/groups/${encodeURIComponent(slug)}`, { revalidate: 3600 }),
   },
   themes: {
     get: (slug: string, params?: { limit?: number; offset?: number }) => {

--- a/frontend/src/lib/groups.ts
+++ b/frontend/src/lib/groups.ts
@@ -1,0 +1,33 @@
+// Slug <-> canonical party label map for /groupes/[slug], mirroring
+// api/groups_data.py (ADR-026, MON-150). The 12 labels are the same set
+// partyShort() in lib/utils.ts already keys off — this file only adds the
+// slug, which has no backend column and is derived from the label alone.
+const GROUP_SLUGS: Record<string, string> = {
+  'rassemblement-national': 'Rassemblement National',
+  'ensemble-pour-la-republique': 'Ensemble pour la République',
+  'lfi-nfp': 'La France insoumise - Nouveau Front Populaire',
+  'socialistes-et-apparentes': 'Socialistes et apparentés',
+  'droite-republicaine': 'Droite Républicaine',
+  'ecologiste-et-social': 'Écologiste et Social',
+  'les-democrates': 'Les Démocrates',
+  'horizons-independants': 'Horizons & Indépendants',
+  liot: 'Libertés, Indépendants, Outre-mer et Territoires',
+  'union-des-droites': 'Union des droites pour la République',
+  'gauche-democrate-republicaine': 'Gauche Démocrate et Républicaine',
+  'non-inscrits': 'Non inscrit',
+}
+
+const NAME_TO_SLUG = new Map(
+  Object.entries(GROUP_SLUGS).map(([slug, name]) => [name, slug])
+)
+
+/** Canonical slug for a group name, or null when the party isn't one of the 12 groups (e.g. NULL). */
+export function groupSlug(party: string | null | undefined): string | null {
+  if (!party) return null
+  return NAME_TO_SLUG.get(party.trim()) ?? null
+}
+
+/** Canonical party label for a slug (any casing/whitespace), or null if unknown. */
+export function groupName(slug: string): string | null {
+  return GROUP_SLUGS[slug.trim().toLowerCase()] ?? null
+}


### PR DESCRIPTION
## What
Adds `/groupes/[slug]`, the frontend page for parliamentary group profiles: member roster, participation/cohesion, most dissident members, and votes ranked by division and recency, sourced from `GET /groups/{slug}` (MON-150, merged in #239).

## Why
Completes the third step of MON-108 (parliamentary group profile pages). MON-149 (ADR-026) decided the slug scheme and aggregation approach; MON-150 built the API; this PR builds the page itself, following the `/departements/[code]` template named in the issue's scope.

## Changes
- `frontend/src/app/groupes/[slug]/page.tsx`: new page mirroring `/departements/[code]/page.tsx` — ISR (`revalidate = 3600`), `generateMetadata` for OG/title, breadcrumb `JsonLd`.
  - Hero: average presence vs. national average, a "cohésion du groupe" card (100 - avg dissident rate), and the most dissident member linking to their profile.
  - Member grid (`DeputyAvatar`, presence/dissidence per member, linking to `/deputes/{id}`).
  - "Les frondeurs" — full most-dissident-members ranking.
  - "Là où ils se divisent" — divided votes, and a "Votes récents" section — both rendered by a shared `VoteBreakdownList` component showing pour/contre/abstention and the group's majority position, linking to `/votes/{id}`.
  - `notFound()` for an unrecognized slug.
- `frontend/src/lib/groups.ts`: `groupSlug()` / `groupName()` — the same 12-entry slug<->canonical-label map as `api/groups_data.py` (ADR-026), mirroring `lib/departments.ts`.
- `frontend/src/lib/api.ts`: `GroupMember`, `GroupVoteBreakdown`, `GroupDetail` types and `api.groups.get(slug)`.
- `frontend/__tests__/lib/groups.test.ts`: normalization, case-insensitivity, and unknown-slug coverage for the new lib helpers (mirrors `departments.test.ts`).

## Testing
- `npm run lint` — clean.
- `npm test` — 149 passed (8 new).
- `npm run build` — succeeds; `/groupes/[slug]` registers as a dynamic route alongside `/departements/[code]`. One unrelated `/votes/[id]` static-generation retry warning during prerender is pre-existing flake (network timeout against the live API during the build), not caused by this change.
- Manual verification: ran `next dev` against the live production API (`https://monelu-production.up.railway.app`, the frontend's default `NEXT_PUBLIC_API_URL`) and loaded `/groupes/rassemblement-national` — confirmed real member data (122 deputies, e.g. Franck Allisio), presence/dissidence figures, cohesion score, and the divided-votes/recent-scrutins sections all render correctly.
- Confirmed `/groupes/not-a-real-group` triggers `notFound()` — the dev server reports it as HTTP 200 with 404 page content, which is a known `next dev` characteristic also reproduced by the existing `/departements/xx` and `/themes/not-a-real-theme` routes (verified side by side); a production build serves the correct status.

## Risks / Notes
- No backend or schema changes — purely additive frontend code.
- The issue's example slug ("renaissance") is stale — the actual canonical group for that party is "Ensemble pour la République" (`ensemble-pour-la-republique`) per ADR-026; verified against `rassemblement-national` instead.
- Unblocks MON-152 (cross-links from deputy/vote pages) and MON-153 (SEO polish), which can now run in parallel once this merges.

## Breaking Changes
None.
