### PR TITLE
feat: dark mode for the printable deputy dossier (MON-163)

### DIFF
--- a/frontend/src/app/deputes/DeputiesClient.tsx
+++ b/frontend/src/app/deputes/DeputiesClient.tsx
@@ -206,7 +206,7 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
               onClick={() => setDebouncedSearch(search)}
               className="w-full sm:w-auto justify-center"
               style={{
-                display: 'flex', alignItems: 'center', background: ACCENT, color: '#fff',
+                display: 'flex', alignItems: 'center', background: 'var(--dp-cta-bg)', color: '#fff',
                 height: 54, padding: '0 30px', borderRadius: 10, fontWeight: 600,
                 fontSize: 16, cursor: 'pointer', whiteSpace: 'nowrap',
                 boxShadow: '0 2px 8px var(--dp-cta-shadow)', border: 'none',

--- a/frontend/src/app/deputes/[id]/dossier/page.tsx
+++ b/frontend/src/app/deputes/[id]/dossier/page.tsx
@@ -12,9 +12,9 @@ import { PrintButton } from '@/components/PrintButton'
 export const dynamicParams = true
 export const revalidate = 86400
 
-const NAVY = '#1B2B50'
-const LINE = '#E4E6EA'
-const RED  = '#C9302A'
+const NAVY = 'var(--dp-text)'
+const LINE = 'var(--dp-border)'
+const RED  = 'var(--dp-red)'
 
 export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
   const { id } = await params
@@ -49,9 +49,9 @@ export default async function DeputyDossierPage({ params }: { params: Promise<{ 
   const generatedOn = new Date().toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' })
 
   return (
-    <div style={{ background: '#fff', minHeight: '100vh' }}>
+    <div style={{ background: 'var(--dp-card-bg)', minHeight: '100vh' }}>
       <div data-print-hide style={{ padding: '20px 32px', borderBottom: `1px solid ${LINE}`, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <span style={{ fontSize: 14, color: '#6B7280' }}>
+        <span style={{ fontSize: 14, color: 'var(--dp-text-secondary)' }}>
           Aperçu du dossier imprimable — utilisez « Imprimer » et choisissez « Enregistrer en PDF » comme destination.
         </span>
         <PrintButton />
@@ -65,11 +65,11 @@ export default async function DeputyDossierPage({ params }: { params: Promise<{ 
             <div style={{ fontWeight: 800, fontSize: 20, color: NAVY, letterSpacing: '-0.01em' }}>
               Mon<span style={{ color: RED }}>É</span>lu
             </div>
-            <div style={{ fontSize: 11.5, color: '#6B7280', marginTop: 2 }}>
+            <div style={{ fontSize: 11.5, color: 'var(--dp-text-secondary)', marginTop: 2 }}>
               Chaque vote. Chaque député. En clair.
             </div>
           </div>
-          <div style={{ textAlign: 'right', fontSize: 11, color: '#9CA3AF' }}>
+          <div style={{ textAlign: 'right', fontSize: 11, color: 'var(--dp-text-muted)' }}>
             Dossier généré le {generatedOn}
             <br />
             XVII<sup>e</sup> législature
@@ -87,7 +87,7 @@ export default async function DeputyDossierPage({ params }: { params: Promise<{ 
             <h1 style={{ fontSize: 26, fontWeight: 700, color: NAVY, margin: 0, letterSpacing: '-0.01em' }}>
               {deputy.full_name}
             </h1>
-            <div style={{ fontSize: 13.5, color: '#4B5563', marginTop: 6 }}>
+            <div style={{ fontSize: 13.5, color: 'var(--dp-text-secondary)', marginTop: 6 }}>
               {deptLabel && <span>{deptLabel}</span>}
               {deputy.mandate_start && (
                 <span> · Mandat depuis le {formatDate(deputy.mandate_start)}</span>
@@ -106,7 +106,7 @@ export default async function DeputyDossierPage({ params }: { params: Promise<{ 
           </div>
           <div style={{ textAlign: 'center', flexShrink: 0 }}>
             <div dangerouslySetInnerHTML={{ __html: qrSvg }} />
-            <div style={{ fontSize: 9.5, color: '#9CA3AF', marginTop: 4, maxWidth: 96 }}>
+            <div style={{ fontSize: 9.5, color: 'var(--dp-text-muted)', marginTop: 4, maxWidth: 96 }}>
               Profil complet en ligne
             </div>
           </div>
@@ -121,9 +121,9 @@ export default async function DeputyDossierPage({ params }: { params: Promise<{ 
               { value: alignmentPct !== null ? `${alignmentPct}%` : '—', label: 'loyauté au groupe' },
               { value: scorecard.total_votes.toLocaleString('fr-FR'), label: 'scrutins votés' },
             ].map((s, i) => (
-              <div key={i} style={{ padding: '14px 10px', textAlign: 'center', borderRight: i < 3 ? `1px solid ${LINE}` : undefined, background: '#FAFAF8' }}>
+              <div key={i} style={{ padding: '14px 10px', textAlign: 'center', borderRight: i < 3 ? `1px solid ${LINE}` : undefined, background: 'var(--dp-header-bg)' }}>
                 <div style={{ fontSize: 22, fontWeight: 700, color: NAVY }}>{s.value}</div>
-                <div style={{ fontSize: 10.5, color: '#6B7280', marginTop: 3, lineHeight: 1.3 }}>{s.label}</div>
+                <div style={{ fontSize: 10.5, color: 'var(--dp-text-secondary)', marginTop: 3, lineHeight: 1.3 }}>{s.label}</div>
               </div>
             ))}
           </div>
@@ -136,11 +136,11 @@ export default async function DeputyDossierPage({ params }: { params: Promise<{ 
               Répartition des votes exprimés
             </div>
             <div style={{ height: 10, borderRadius: 999, overflow: 'hidden', display: 'flex', marginBottom: 8 }}>
-              <div style={{ width: `${pourPct}%`,   background: '#1F8A5B' }} />
+              <div style={{ width: `${pourPct}%`,   background: 'var(--dp-green)' }} />
               <div style={{ width: `${contrePct}%`, background: RED }} />
-              <div style={{ width: `${abstPct}%`,   background: '#D1D5DB' }} />
+              <div style={{ width: `${abstPct}%`,   background: 'var(--dp-abstention)' }} />
             </div>
-            <div style={{ display: 'flex', gap: 18, fontSize: 12, color: '#374151' }}>
+            <div style={{ display: 'flex', gap: 18, fontSize: 12, color: 'var(--dp-text-secondary)' }}>
               <span>Pour {pourPct}%</span>
               <span>Contre {contrePct}%</span>
               <span>Abstention {abstPct}%</span>
@@ -158,11 +158,11 @@ export default async function DeputyDossierPage({ params }: { params: Promise<{ 
               {dissidentVotes.items.map(v => (
                 <div key={v.vote_id} style={{ border: `1px solid ${LINE}`, borderRadius: 6, padding: '10px 12px' }}>
                   <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
-                    {v.voted_at && <span style={{ fontSize: 10.5, color: '#9CA3AF' }}>{formatDate(v.voted_at)}</span>}
+                    {v.voted_at && <span style={{ fontSize: 10.5, color: 'var(--dp-text-muted)' }}>{formatDate(v.voted_at)}</span>}
                     <span style={{ fontSize: 10.5, fontWeight: 700, color: positionStyle(v.position).color }}>
                       A voté {positionStyle(v.position).label}
                     </span>
-                    <span style={{ fontSize: 10.5, color: '#9CA3AF' }}>
+                    <span style={{ fontSize: 10.5, color: 'var(--dp-text-muted)' }}>
                       groupe : {positionStyle(v.majority_position).label}
                     </span>
                   </div>
@@ -174,7 +174,7 @@ export default async function DeputyDossierPage({ params }: { params: Promise<{ 
         )}
 
         {/* Methodology footnote */}
-        <div style={{ borderTop: `1px solid ${LINE}`, paddingTop: 14, fontSize: 10, color: '#9CA3AF', lineHeight: 1.5 }}>
+        <div style={{ borderTop: `1px solid ${LINE}`, paddingTop: 14, fontSize: 10, color: 'var(--dp-text-muted)', lineHeight: 1.5 }}>
           Méthodologie : le taux de présence compte toute position enregistrée (y compris non-votant) sur les
           scrutins tenus pendant le mandat. Le taux de loyauté compare, vote par vote, la position du député à
           la position majoritaire de son groupe parlementaire actuel. Source : données officielles ouvertes de

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -179,7 +179,7 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
                   href={`/chat?q=${encodeURIComponent(`Quel est le bilan de ${deputy.full_name} ?`)}`}
                   style={{
                     display: 'inline-flex', alignItems: 'center', gap: 8,
-                    background: ACCENT, color: '#fff', padding: '12px 24px',
+                    background: 'var(--dp-cta-bg)', color: '#fff', padding: '12px 24px',
                     borderRadius: 9, fontWeight: 600, fontSize: 15,
                     boxShadow: '0 2px 8px var(--dp-cta-shadow)', textDecoration: 'none',
                   }}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -39,10 +39,17 @@
   --dp-cta-shadow: rgba(224,120,110,0.35);
   --dp-header-bg: #FBFAF6;
   /* MON-160: a fixed navy "selected/active" surface (pagination current
-     page, etc.) — intentionally NOT overridden in .dark below. It pairs
+     page, etc.) - intentionally NOT overridden in .dark below. It pairs
      with hardcoded white text, so it must stay dark-enough-for-white-text
      in both themes rather than inverting like --dp-text does. */
   --dp-active-bg: #1B2B50;
+  /* MON-163: same reasoning as --dp-active-bg, for solid accent-colored CTA
+     buttons paired with hardcoded white text (e.g. "Poser une question",
+     "Rechercher", the print button). --dp-accent itself is allowed to
+     invert/lighten for decorative or text use (party-color dots, etc.) -
+     it must NOT be reused for a solid background under white text, since
+     its dark-mode value is too light for that contrast to hold. */
+  --dp-cta-bg: #E0786E;
 }
 
 /* MON-154: dark-mode theme tokens. The `dark` class is toggled on <html> by
@@ -85,9 +92,40 @@
 }
 
 /* MON-114: printable deputy dossier — hide app chrome and force a clean
-   single page when the dossier route is sent to the browser's print dialog. */
+   single page when the dossier route is sent to the browser's print dialog.
+   MON-163: printed output must always be light, even if the page was
+   viewed in dark mode - reset every dp-/color- token back to its
+   light value here. This rule targets :root (same specificity as .dark,
+   which also targets :root/<html>) and is placed after .dark in the file,
+   so it wins the cascade tie whenever printing, regardless of which class
+   is present on <html>. */
 @media print {
   [data-print-hide] { display: none !important; }
   body { background: #fff !important; }
   @page { size: A4; margin: 14mm; }
+
+  :root {
+    --color-bg: theme('colors.gray.off');
+    --color-fg: theme('colors.navy.DEFAULT');
+    --dp-page-bg: #F7F4ED;
+    --dp-card-bg: #FFFFFF;
+    --dp-border: #E4E6EA;
+    --dp-border-subtle: #ECE7DC;
+    --dp-text: theme('colors.navy.DEFAULT');
+    --dp-text-secondary: #6B7280;
+    --dp-text-muted: #9CA3AF;
+    --dp-green: #1F8A5B;
+    --dp-red: #C9302A;
+    --dp-accent: #E0786E;
+    --dp-abstention: #D1D5DB;
+    --dp-track-bg: #EEF0F2;
+    --dp-underline: #C4C9D2;
+    --dp-avg-marker: rgba(0,0,0,0.25);
+    --dp-shadow-sm: rgba(0,0,0,0.05);
+    --dp-avatar-shadow: rgba(27,43,80,0.12);
+    --dp-cta-shadow: rgba(224,120,110,0.35);
+    --dp-header-bg: #FBFAF6;
+    --dp-active-bg: #1B2B50;
+    --dp-cta-bg: #E0786E;
+  }
 }

--- a/frontend/src/components/PrintButton.tsx
+++ b/frontend/src/components/PrintButton.tsx
@@ -12,9 +12,9 @@ export function PrintButton({ label = 'Imprimer / Enregistrer en PDF' }: Props) 
       data-print-hide
       style={{
         display: 'inline-flex', alignItems: 'center', gap: 8,
-        background: '#E0786E', color: '#fff', padding: '12px 24px',
+        background: 'var(--dp-cta-bg)', color: '#fff', padding: '12px 24px',
         borderRadius: 9, fontWeight: 600, fontSize: 15, border: 'none',
-        cursor: 'pointer', boxShadow: '0 2px 8px rgba(224,120,110,0.35)',
+        cursor: 'pointer', boxShadow: '0 2px 8px var(--dp-cta-shadow)',
       }}
     >
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">


### PR DESCRIPTION
## What
Adds dark mode to the on-screen preview of the printable deputy dossier (`/deputes/[id]/dossier`), while guaranteeing the printed/PDF output always stays light regardless of the active screen theme. Also fixes a real contrast bug in two already-merged pages, discovered while implementing this one.

## Why
Follow-up to MON-155/MON-160/MON-161/MON-162, converting `dossier/page.tsx`'s ~17 inline hex literals. This page carries a specific risk the issue called out up front: it's meant to be printed to paper/PDF, and dark-mode CSS variables must not leak into that output.

## Changes
- `frontend/src/app/deputes/[id]/dossier/page.tsx`: local `NAVY`/`LINE`/`RED` consts and all other inline hex literals now reference `--dp-*` variables, including the root wrapper's background (`'#fff'` → `var(--dp-card-bg)`).
- `frontend/src/app/globals.css`: the existing `@media print` block (MON-114) now also resets every `--color-*`/`--dp-*` custom property back to its light value. This rule targets `:root`, the same specificity as `.dark` (both effectively target `<html>`), and is placed after `.dark` in the file, so it wins the cascade tie whenever printing — regardless of whether the page was viewed in dark mode. Verified in the compiled CSS output that the reset block is present and correct.
- **Bug fix, not just this page's scope:** while converting `PrintButton.tsx` (rendered on this page), found that `--dp-accent`'s dark-mode value (`#E88E85`, a light peach) is too light for the hardcoded white text used on solid CTA buttons (`background: ACCENT, color: '#fff'`) — a real contrast failure in dark mode. Introduced `--dp-cta-bg` (constant across themes, same pattern as MON-160's `--dp-active-bg`) and fixed all three affected call sites:
  - `PrintButton.tsx` (this PR)
  - `frontend/src/app/deputes/[id]/page.tsx`'s "Poser une question sur ce député" button (already merged in MON-155)
  - `frontend/src/app/deputes/DeputiesClient.tsx`'s "Rechercher" button (already merged in MON-160)

## Testing
- `npm run lint` — clean.
- `npm test` — 149 tests / 20 suites pass.
- `npm run build` — succeeds (after fixing a CSS syntax error I introduced: a code comment containing the literal substring `--dp-*/--color-*` prematurely closed the enclosing `/* */` comment at the `*/` inside it — caught by the build failing loudly, fixed by rewording the comment).
- Manual: ran `next dev`, curled a deputy's `/dossier` page, confirmed all expected `--dp-*` variables (including the new `--dp-cta-bg`) render correctly. Inspected the compiled `.next/static/css/app/layout.css` output directly to confirm the `@media print { :root { ... } }` reset block compiled with literal hex values (Tailwind's `theme()` calls resolved correctly inside the nested media query).

## Risks / Notes
- Print output correctness (the main risk this issue called out) could not be verified with an actual print preview/PDF export in this environment — verification rests on the CSS cascade reasoning above plus inspecting the compiled CSS. Worth a real print-to-PDF check once a browser is available, toggling dark mode on first.
- Same known, deliberate gap as prior PRs: `vote-position.ts` badge colors (used in the dossier's dissident-votes section) remain out of scope.

## Breaking Changes
None.

https://claude.ai/code/session_01HVxc7TTP3xnsgNC3mtzxEb