### PR TITLE
feat: dark mode for the votes list page (MON-156)

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -50,6 +50,14 @@
      it must NOT be reused for a solid background under white text, since
      its dark-mode value is too light for that contrast to hold. */
   --dp-cta-bg: #E0786E;
+  /* MON-156: the vote list's own adopte/rejete result badge (distinct from
+     vote-position.ts's pour/contre/abstention badges, which stay a deferred
+     gap for MON-159). Text reuses --dp-green/--dp-red; only the pale
+     background tint needs its own token since it must stay legible in
+     dark mode, unlike vote-position.ts's badges which are out of scope
+     here. */
+  --dp-badge-pos-bg: #EAF5EF;
+  --dp-badge-neg-bg: #FBE9E7;
 }
 
 /* MON-154: dark-mode theme tokens. The `dark` class is toggled on <html> by
@@ -78,6 +86,8 @@
   --dp-avatar-shadow: rgba(0,0,0,0.45);
   --dp-cta-shadow: rgba(232,142,133,0.25);
   --dp-header-bg: #182338;
+  --dp-badge-pos-bg: rgba(52,194,131,0.16);
+  --dp-badge-neg-bg: rgba(255,107,96,0.16);
 }
 
 @layer base {
@@ -86,9 +96,9 @@
 }
 
 @layer utilities {
-  .badge-adopte { @apply bg-emerald-50 text-emerald-800 border border-emerald-200 text-xs font-medium px-2 py-0.5 rounded; }
-  .badge-rejete { @apply bg-red-50 text-red-civic border border-red-200 text-xs font-medium px-2 py-0.5 rounded; }
-  .badge-party { @apply bg-navy-muted text-navy text-xs font-medium px-2 py-0.5 rounded; }
+  .badge-adopte { @apply bg-emerald-50 text-emerald-800 border border-emerald-200 text-xs font-medium px-2 py-0.5 rounded dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-800; }
+  .badge-rejete { @apply bg-red-50 text-red-civic border border-red-200 text-xs font-medium px-2 py-0.5 rounded dark:bg-red-950/40 dark:text-red-300 dark:border-red-800; }
+  .badge-party { @apply bg-navy-muted text-navy text-xs font-medium px-2 py-0.5 rounded dark:bg-white/10 dark:text-gray-100; }
 }
 
 /* MON-114: printable deputy dossier — hide app chrome and force a clean
@@ -127,5 +137,7 @@
     --dp-header-bg: #FBFAF6;
     --dp-active-bg: #1B2B50;
     --dp-cta-bg: #E0786E;
+    --dp-badge-pos-bg: #EAF5EF;
+    --dp-badge-neg-bg: #FBE9E7;
   }
 }

--- a/frontend/src/app/votes/VotesClient.tsx
+++ b/frontend/src/app/votes/VotesClient.tsx
@@ -87,30 +87,30 @@ export function VotesClient({ initial, heroStats }: { initial: VoteList; heroSta
   }
 
   return (
-    <div style={{ background: '#F7F4ED', minHeight: '100vh' }}>
+    <div style={{ background: 'var(--dp-page-bg)', minHeight: '100vh' }}>
 
       {/* ── Hero ── */}
-      <div className="px-5 sm:px-14 pt-8 sm:pt-[50px] pb-8 sm:pb-10" style={{ background: 'linear-gradient(180deg,#fff 0%,#F7F4ED 100%)', borderBottom: '1px solid #ECE7DC' }}>
+      <div className="px-5 sm:px-14 pt-8 sm:pt-[50px] pb-8 sm:pb-10" style={{ background: 'linear-gradient(180deg,var(--dp-card-bg) 0%,var(--dp-page-bg) 100%)', borderBottom: '1px solid var(--dp-border-subtle)' }}>
         <div className="xl:grid xl:grid-cols-[1fr_340px] xl:gap-16 xl:items-start" style={{ maxWidth: 1180, margin: '0 auto' }}>
 
-          <div className="xl:col-start-1 xl:row-start-1" style={{ font: '700 12px/1 var(--font-sans)', letterSpacing: '0.18em', textTransform: 'uppercase', color: '#C9302A' }}>
+          <div className="xl:col-start-1 xl:row-start-1" style={{ font: '700 12px/1 var(--font-sans)', letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--dp-red)' }}>
             Scrutins publics
           </div>
 
-          <h1 className="font-newsreader text-display xl:col-start-1 xl:row-start-2" style={{ fontWeight: 600, lineHeight: 1.05, letterSpacing: '-0.015em', color: '#1B2B50', margin: '16px 0 0', maxWidth: 760 }}>
-            Les votes de l&apos;Assemblée nationale, <span style={{ color: '#C9302A' }}>en clair</span>.
+          <h1 className="font-newsreader text-display xl:col-start-1 xl:row-start-2" style={{ fontWeight: 600, lineHeight: 1.05, letterSpacing: '-0.015em', color: 'var(--dp-text)', margin: '16px 0 0', maxWidth: 760 }}>
+            Les votes de l&apos;Assemblée nationale, <span style={{ color: 'var(--dp-red)' }}>en clair</span>.
           </h1>
 
-          <p className="xl:col-start-1 xl:row-start-3" style={{ margin: '16px 0 0', fontSize: 17, lineHeight: 1.6, color: '#4B5563', maxWidth: 540 }}>
+          <p className="xl:col-start-1 xl:row-start-3" style={{ margin: '16px 0 0', fontSize: 17, lineHeight: 1.6, color: 'var(--dp-text-secondary)', maxWidth: 540 }}>
             Retrouvez chaque scrutin public de la XVII&#7497; législature — texte voté, résultat, et ventilation par groupe.
           </p>
 
           {/* Stats strip (below xl) */}
           <div className="xl:hidden grid grid-cols-2 sm:flex gap-3" style={{ marginTop: 32, maxWidth: 700 }}>
             {heroStats.map((hs, i) => (
-              <div key={i} style={{ padding: '18px 22px', border: '1px solid #ECE7DC', borderRadius: 12, background: '#fff', boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
-                <div className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: '#1B2B50', letterSpacing: '-0.01em' }}>{hs.value}</div>
-                <div style={{ fontSize: 12, color: '#9CA3AF', marginTop: 4, lineHeight: 1.35 }}>{hs.label}</div>
+              <div key={i} style={{ padding: '18px 22px', border: '1px solid var(--dp-border-subtle)', borderRadius: 12, background: 'var(--dp-card-bg)', boxShadow: '0 1px 3px var(--dp-shadow-sm)' }}>
+                <div className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: 'var(--dp-text)', letterSpacing: '-0.01em' }}>{hs.value}</div>
+                <div style={{ fontSize: 12, color: 'var(--dp-text-muted)', marginTop: 4, lineHeight: 1.35 }}>{hs.label}</div>
               </div>
             ))}
           </div>
@@ -118,30 +118,30 @@ export function VotesClient({ initial, heroStats }: { initial: VoteList; heroSta
           {/* Stats column (xl and up) */}
           <div className="hidden xl:flex xl:flex-col xl:gap-3 xl:col-start-2 xl:row-start-1 xl:row-span-5 xl:self-start">
             {heroStats.map((hs, i) => (
-              <div key={i} style={{ padding: '18px 22px', border: '1px solid #ECE7DC', borderRadius: 12, background: '#fff', boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
-                <div className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: '#1B2B50', letterSpacing: '-0.01em' }}>{hs.value}</div>
-                <div style={{ fontSize: 12, color: '#9CA3AF', marginTop: 4, lineHeight: 1.35 }}>{hs.label}</div>
+              <div key={i} style={{ padding: '18px 22px', border: '1px solid var(--dp-border-subtle)', borderRadius: 12, background: 'var(--dp-card-bg)', boxShadow: '0 1px 3px var(--dp-shadow-sm)' }}>
+                <div className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: 'var(--dp-text)', letterSpacing: '-0.01em' }}>{hs.value}</div>
+                <div style={{ fontSize: 12, color: 'var(--dp-text-muted)', marginTop: 4, lineHeight: 1.35 }}>{hs.label}</div>
               </div>
             ))}
           </div>
 
           {/* Search bar */}
           <div className="xl:col-start-1 xl:row-start-4 flex flex-col sm:flex-row gap-3" style={{ marginTop: 28, maxWidth: 720 }}>
-            <div style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 12, background: '#fff', border: '1px solid #E4E6EA', borderRadius: 10, padding: '0 18px', height: 54, boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#9CA3AF" strokeWidth="2" strokeLinecap="round"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.2-3.2"/></svg>
+            <div style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 12, background: 'var(--dp-card-bg)', border: '1px solid var(--dp-border)', borderRadius: 10, padding: '0 18px', height: 54, boxShadow: '0 1px 3px var(--dp-shadow-sm)' }}>
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--dp-text-muted)" strokeWidth="2" strokeLinecap="round"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.2-3.2"/></svg>
               <input
                 type="text"
                 value={inputVal}
                 onChange={e => setInputVal(e.target.value)}
                 onKeyDown={e => e.key === 'Enter' && handleSearch()}
                 placeholder="Titre du scrutin, numéro, mot-clé…"
-                style={{ flex: 1, border: 'none', outline: 'none', fontSize: 16, color: '#1B2B50', background: 'transparent' }}
+                style={{ flex: 1, border: 'none', outline: 'none', fontSize: 16, color: 'var(--dp-text)', background: 'transparent' }}
               />
             </div>
             <button
               onClick={handleSearch}
               className="w-full sm:w-auto justify-center"
-              style={{ display: 'flex', alignItems: 'center', background: '#E0786E', color: '#fff', height: 54, padding: '0 28px', borderRadius: 10, fontWeight: 600, fontSize: 16, cursor: 'pointer', whiteSpace: 'nowrap', border: 'none', boxShadow: '0 2px 8px rgba(224,120,110,0.4)' }}>
+              style={{ display: 'flex', alignItems: 'center', background: 'var(--dp-cta-bg)', color: '#fff', height: 54, padding: '0 28px', borderRadius: 10, fontWeight: 600, fontSize: 16, cursor: 'pointer', whiteSpace: 'nowrap', border: 'none', boxShadow: '0 2px 8px var(--dp-cta-shadow)' }}>
               Rechercher
             </button>
           </div>
@@ -153,7 +153,7 @@ export function VotesClient({ initial, heroStats }: { initial: VoteList; heroSta
               const active = result === r && theme === ''
               return (
                 <button key={r} onClick={() => changeFilter(r, '')}
-                  style={{ background: active ? '#1B2B50' : '#fff', color: active ? '#fff' : '#4B5563', border: `1px solid ${active ? '#1B2B50' : '#E4E6EA'}`, padding: '8px 16px', borderRadius: 999, fontSize: 13.5, fontWeight: active ? 600 : 400, cursor: 'pointer' }}>
+                  style={{ background: active ? 'var(--dp-active-bg)' : 'var(--dp-card-bg)', color: active ? '#fff' : 'var(--dp-text-secondary)', border: `1px solid ${active ? 'var(--dp-active-bg)' : 'var(--dp-border)'}`, padding: '8px 16px', borderRadius: 999, fontSize: 13.5, fontWeight: active ? 600 : 400, cursor: 'pointer' }}>
                   {label}
                 </button>
               )
@@ -162,7 +162,7 @@ export function VotesClient({ initial, heroStats }: { initial: VoteList; heroSta
               const active = theme === t
               return (
                 <button key={t} onClick={() => changeFilter(result, active ? '' : t)}
-                  style={{ background: active ? '#1B2B50' : '#fff', color: active ? '#fff' : '#4B5563', border: `1px solid ${active ? '#1B2B50' : '#E4E6EA'}`, padding: '8px 16px', borderRadius: 999, fontSize: 13.5, fontWeight: active ? 600 : 400, cursor: 'pointer' }}>
+                  style={{ background: active ? 'var(--dp-active-bg)' : 'var(--dp-card-bg)', color: active ? '#fff' : 'var(--dp-text-secondary)', border: `1px solid ${active ? 'var(--dp-active-bg)' : 'var(--dp-border)'}`, padding: '8px 16px', borderRadius: 999, fontSize: 13.5, fontWeight: active ? 600 : 400, cursor: 'pointer' }}>
                   {t.split(' & ')[0]}
                 </button>
               )
@@ -172,7 +172,7 @@ export function VotesClient({ initial, heroStats }: { initial: VoteList; heroSta
           {/* Theme hub pages (MON-106) — aggregate stats per theme, distinct
               from the in-page filter chips above. */}
           <div className="xl:col-start-1 xl:row-start-6" style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 14, alignItems: 'center' }}>
-            <span style={{ fontSize: 12.5, color: '#9CA3AF', marginRight: 4 }}>Voir le bilan par thème :</span>
+            <span style={{ fontSize: 12.5, color: 'var(--dp-text-muted)', marginRight: 4 }}>Voir le bilan par thème :</span>
             {THEMES.map((t) => {
               const slug = themeSlug(t)
               if (!slug) return null
@@ -193,29 +193,29 @@ export function VotesClient({ initial, heroStats }: { initial: VoteList; heroSta
         <div style={{ maxWidth: 1180, margin: '0 auto' }}>
 
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 4px 14px' }}>
-            <span className="font-mono" style={{ fontSize: 13, color: '#6B7280' }}>
+            <span className="font-mono" style={{ fontSize: 13, color: 'var(--dp-text-secondary)' }}>
               {total.toLocaleString('fr-FR')} scrutins
               {result && ` · ${result.charAt(0).toUpperCase() + result.slice(1)}s`}
               {theme && ` · ${theme}`}
               {' · triés par date'}
             </span>
             {(result || theme || search) && (
-              <button onClick={() => changeFilter('', '')} style={{ fontSize: 13, color: '#C9302A', background: 'none', border: 'none', cursor: 'pointer' }}>
+              <button onClick={() => changeFilter('', '')} style={{ fontSize: 13, color: 'var(--dp-red)', background: 'none', border: 'none', cursor: 'pointer' }}>
                 Effacer les filtres
               </button>
             )}
           </div>
 
-          <div style={{ background: '#fff', border: '1px solid #E4E6EA', borderRadius: 12, overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.06)' }}>
+          <div style={{ background: 'var(--dp-card-bg)', border: '1px solid var(--dp-border)', borderRadius: 12, overflow: 'hidden', boxShadow: '0 1px 3px var(--dp-shadow-sm)' }}>
             {/* Table header */}
-            <div className="hidden sm:grid" style={{ gridTemplateColumns: '100px 1fr 180px 260px 36px', gap: 16, padding: '13px 26px', borderBottom: '1px solid #E4E6EA', background: '#FBFAF6', font: '600 11.5px/1 var(--font-sans)', letterSpacing: '0.08em', textTransform: 'uppercase', color: '#9CA3AF' }}>
+            <div className="hidden sm:grid" style={{ gridTemplateColumns: '100px 1fr 180px 260px 36px', gap: 16, padding: '13px 26px', borderBottom: '1px solid var(--dp-border)', background: 'var(--dp-header-bg)', font: '600 11.5px/1 var(--font-sans)', letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--dp-text-muted)' }}>
               <span>Date</span><span>Scrutin</span><span>Thème</span><span>Résultat</span><span></span>
             </div>
 
             {isLoading ? (
-              <div style={{ padding: '32px 0', textAlign: 'center', color: '#9CA3AF', fontSize: 14 }}>Chargement…</div>
+              <div style={{ padding: '32px 0', textAlign: 'center', color: 'var(--dp-text-muted)', fontSize: 14 }}>Chargement…</div>
             ) : votes.length === 0 ? (
-              <div style={{ padding: '40px 26px', textAlign: 'center', color: '#9CA3AF', fontSize: 14 }}>Aucun scrutin trouvé.</div>
+              <div style={{ padding: '40px 26px', textAlign: 'center', color: 'var(--dp-text-muted)', fontSize: 14 }}>Aucun scrutin trouvé.</div>
             ) : (
               votes.map((vote) => {
                 const total_v = vote.total_voters || 1
@@ -226,22 +226,22 @@ export function VotesClient({ initial, heroStats }: { initial: VoteList; heroSta
                 return (
                   <Link key={vote.vote_id} href={`/votes/${vote.vote_id}`}
                     className="grid grid-cols-1 sm:grid-cols-[100px_1fr_180px_260px_36px] gap-1.5 sm:gap-4 px-4 sm:px-[26px] py-4 sm:py-[18px]"
-                    style={{ borderBottom: '1px solid #F0F1F3', alignItems: 'center', textDecoration: 'none', background: '#fff', transition: 'background 0.12s' }}
-                    onMouseEnter={e => (e.currentTarget.style.background = '#FBFAF6')}
-                    onMouseLeave={e => (e.currentTarget.style.background = '#fff')}>
+                    style={{ borderBottom: '1px solid var(--dp-track-bg)', alignItems: 'center', textDecoration: 'none', background: 'var(--dp-card-bg)', transition: 'background 0.12s' }}
+                    onMouseEnter={e => (e.currentTarget.style.background = 'var(--dp-header-bg)')}
+                    onMouseLeave={e => (e.currentTarget.style.background = 'var(--dp-card-bg)')}>
 
                     {/* Date */}
-                    <div suppressHydrationWarning className="font-mono order-1 sm:order-none" style={{ fontSize: 12, color: '#9CA3AF', lineHeight: 1.4 }}>
+                    <div suppressHydrationWarning className="font-mono order-1 sm:order-none" style={{ fontSize: 12, color: 'var(--dp-text-muted)', lineHeight: 1.4 }}>
                       {shortDate(vote.voted_at)}
                     </div>
 
                     {/* Title */}
                     <div className="order-2 sm:order-none" style={{ minWidth: 0 }}>
-                      <div style={{ fontWeight: 600, fontSize: 15, color: '#1B2B50', lineHeight: 1.3 }}
+                      <div style={{ fontWeight: 600, fontSize: 15, color: 'var(--dp-text)', lineHeight: 1.3 }}
                         className="line-clamp-2">
                         {vote.summary_plain || vote.vote_title}
                       </div>
-                      <div style={{ fontSize: 12.5, color: '#9CA3AF', marginTop: 4 }}
+                      <div style={{ fontSize: 12.5, color: 'var(--dp-text-muted)', marginTop: 4 }}
                         className="line-clamp-1">
                         Scrutin n°{vote.vote_id}
                         {vote.summary_plain && ` · ${vote.vote_title}`}
@@ -255,29 +255,29 @@ export function VotesClient({ initial, heroStats }: { initial: VoteList; heroSta
                           {vote.theme.split(' & ')[0]}
                         </span>
                       ) : (
-                        <span style={{ color: '#D1D5DB', fontSize: 12 }}>—</span>
+                        <span style={{ color: 'var(--dp-abstention)', fontSize: 12 }}>—</span>
                       )}
                     </div>
 
                     {/* Result */}
                     <div className="order-4 sm:order-none">
                       <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 7, flexWrap: 'wrap' }}>
-                        <span style={{ fontSize: 12, fontWeight: 700, letterSpacing: '0.05em', padding: '3px 10px', borderRadius: 999, background: adopted ? '#EAF5EF' : '#FBE9E7', color: adopted ? '#1F8A5B' : '#C9302A' }}>
+                        <span style={{ fontSize: 12, fontWeight: 700, letterSpacing: '0.05em', padding: '3px 10px', borderRadius: 999, background: adopted ? 'var(--dp-badge-pos-bg)' : 'var(--dp-badge-neg-bg)', color: adopted ? 'var(--dp-green)' : 'var(--dp-red)' }}>
                           {adopted ? 'Adopté' : 'Rejeté'}
                         </span>
-                        <span className="font-mono" style={{ fontSize: 11.5, color: '#6B7280' }}>
+                        <span className="font-mono" style={{ fontSize: 11.5, color: 'var(--dp-text-secondary)' }}>
                           {vote.votes_for} pour · {vote.votes_against} contre
                         </span>
                       </div>
-                      <div style={{ display: 'flex', height: 5, borderRadius: 999, overflow: 'hidden', background: '#F0F1F3' }}>
-                        <div style={{ height: '100%', background: '#1F8A5B', width: `${forPct}%` }} />
-                        <div style={{ height: '100%', background: '#D9685E', width: `${agtPct}%` }} />
-                        <div style={{ height: '100%', background: '#D1D5DB', flex: 1 }} />
+                      <div style={{ display: 'flex', height: 5, borderRadius: 999, overflow: 'hidden', background: 'var(--dp-track-bg)' }}>
+                        <div style={{ height: '100%', background: 'var(--dp-green)', width: `${forPct}%` }} />
+                        <div style={{ height: '100%', background: 'var(--dp-red)', width: `${agtPct}%` }} />
+                        <div style={{ height: '100%', background: 'var(--dp-abstention)', flex: 1 }} />
                       </div>
                     </div>
 
                     {/* Chevron */}
-                    <svg className="hidden sm:block" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#C4C9D2" strokeWidth="2.2" strokeLinecap="round"><path d="m9 6 6 6-6 6"/></svg>
+                    <svg className="hidden sm:block" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--dp-underline)" strokeWidth="2.2" strokeLinecap="round"><path d="m9 6 6 6-6 6"/></svg>
                   </Link>
                 )
               })
@@ -286,9 +286,9 @@ export function VotesClient({ initial, heroStats }: { initial: VoteList; heroSta
 
           {/* Pagination */}
           {totalPages > 1 && (
-            <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 6, marginTop: 26, fontSize: 14, color: '#6B7280' }}>
+            <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 6, marginTop: 26, fontSize: 14, color: 'var(--dp-text-secondary)' }}>
               <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}
-                style={{ width: 34, height: 34, display: 'flex', alignItems: 'center', justifyContent: 'center', border: '1px solid #E4E6EA', borderRadius: 8, background: '#fff', cursor: page === 1 ? 'default' : 'pointer', opacity: page === 1 ? 0.4 : 1 }}>
+                style={{ width: 34, height: 34, display: 'flex', alignItems: 'center', justifyContent: 'center', border: '1px solid var(--dp-border)', borderRadius: 8, background: 'var(--dp-card-bg)', cursor: page === 1 ? 'default' : 'pointer', opacity: page === 1 ? 0.4 : 1 }}>
                 ‹
               </button>
               {buildPageNumbers(page, totalPages).map((p, i) =>
@@ -296,13 +296,13 @@ export function VotesClient({ initial, heroStats }: { initial: VoteList; heroSta
                   <span key={`ellipsis-${i}`} style={{ padding: '0 6px' }}>…</span>
                 ) : (
                   <button key={p} onClick={() => setPage(p as number)}
-                    style={{ width: 34, height: 34, display: 'flex', alignItems: 'center', justifyContent: 'center', borderRadius: 8, background: page === p ? '#1B2B50' : '#fff', color: page === p ? '#fff' : '#6B7280', border: page === p ? 'none' : '1px solid #E4E6EA', fontWeight: page === p ? 600 : 400, cursor: 'pointer' }}>
+                    style={{ width: 34, height: 34, display: 'flex', alignItems: 'center', justifyContent: 'center', borderRadius: 8, background: page === p ? 'var(--dp-active-bg)' : 'var(--dp-card-bg)', color: page === p ? '#fff' : 'var(--dp-text-secondary)', border: page === p ? 'none' : '1px solid var(--dp-border)', fontWeight: page === p ? 600 : 400, cursor: 'pointer' }}>
                     {p}
                   </button>
                 )
               )}
               <button onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page === totalPages}
-                style={{ width: 34, height: 34, display: 'flex', alignItems: 'center', justifyContent: 'center', border: '1px solid #E4E6EA', borderRadius: 8, background: '#fff', cursor: page === totalPages ? 'default' : 'pointer', opacity: page === totalPages ? 0.4 : 1 }}>
+                style={{ width: 34, height: 34, display: 'flex', alignItems: 'center', justifyContent: 'center', border: '1px solid var(--dp-border)', borderRadius: 8, background: 'var(--dp-card-bg)', cursor: page === totalPages ? 'default' : 'pointer', opacity: page === totalPages ? 0.4 : 1 }}>
                 ›
               </button>
             </div>


### PR DESCRIPTION
## What
Adds dark mode to the `/votes` list page by converting `VotesClient.tsx`'s inline hex-literal styling to the shared `--dp-*` CSS variable palette, and gives the vote list's own adopte/rejete result badge dark-mode-appropriate colors.

## Why
Follow-up to MON-155/MON-160-165, applying the established conversion pattern to `VotesClient.tsx` (~73 inline hex literals). While implementing, found that `VoteDetailClient.tsx` (~140 literals, 542 lines) is too large to safely include alongside the list page, and that `themes/[slug]/page.tsx` (MON-106, merged after MON-103 was originally decomposed) was never assigned a sub-issue. Both split into follow-ups (MON-166, MON-167) rather than risking an unreviewable diff or silently expanding scope.

## Changes
- `frontend/src/app/votes/VotesClient.tsx`: all inline hex/`rgba()` literals now reference `--dp-*` variables, including the `onMouseLeave` row-hover handler that sets `.style.background` directly (not via React's `style` prop).
- Applies the established active-bg pattern (MON-160) to the result/theme filter chips and pagination's active-page button, and `--dp-cta-bg` (MON-163) to the "Rechercher" button — both pair a solid background with hardcoded white text.
- `frontend/src/app/globals.css`: adds `--dp-badge-pos-bg`/`--dp-badge-neg-bg` for the vote list's own "Adopté"/"Rejeté" result badge. This issue's acceptance criteria explicitly requires these badges stay distinguishable in dark mode (unlike other pages, where badge colors are a deferred MON-159 gap), so they're fixed here rather than deferred — the badge text reuses the already-correct `--dp-green`/`--dp-red`, only the pale background tint needed a new token.
- Also added `dark:` variants to the `badge-adopte`/`badge-rejete`/`badge-party` Tailwind utility classes in `globals.css`, named explicitly in this issue's scope. Turned out to be dead code — grepped the whole `src/` tree and found zero usages; `VotesClient.tsx` hand-rolls its own badge styling inline instead. Fixed anyway since it costs nothing and future-proofs them if ever used.

## Testing
- `npm run lint` — clean.
- `npm test` — 149 tests / 20 suites pass.
- `npm run build` — succeeds.
- Manual: ran `next dev`, curled `/votes`, confirmed most expected `--dp-*` variables render correctly. The adopte/rejete badge specifically couldn't be confirmed via curl (the page uses `useSWR`, whose `isLoading` state renders a loading placeholder before data resolves, even with `initial` fallback data present) — instead confirmed `--dp-badge-pos-bg`/`--dp-badge-neg-bg` are present with no typos in the compiled client bundle (`.next/static/chunks/app/votes/page.js`).

## Risks / Notes
- `themeColors()` (the per-topic pill colors like "Économie & Budget") is a shared `lib/utils.ts` function with its own hardcoded pastel colors, the same category of cross-cutting gap as `vote-position.ts` and `partyHex()` — left unconverted and deferred to MON-159, consistent with prior PRs.
- No visual/screenshot verification was possible in this environment, and the badge specifically could only be confirmed via the compiled bundle rather than a rendered page (see above).

## Breaking Changes
None.

https://claude.ai/code/session_01HVxc7TTP3xnsgNC3mtzxEb