### PR TITLE
feat: dark mode for the vote detail page (MON-166)

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -58,6 +58,16 @@
      here. */
   --dp-badge-pos-bg: #EAF5EF;
   --dp-badge-neg-bg: #FBE9E7;
+  /* MON-166: two more badge states the vote detail page needs beyond
+     pos/neg - a neutral/amber "Partage" state (group split evenly) and an
+     info/blue theme tag. Same reasoning as --dp-badge-pos-bg/-neg-bg. */
+  --dp-badge-neutral-bg: #FEF3C7;
+  --dp-badge-neutral-text: #B45309;
+  --dp-badge-info-bg: #E8EFFE;
+  --dp-badge-info-text: #2A5DB0;
+  /* MON-166: translucent sticky-header backdrop (backdrop-filter: blur).
+     Needs its own token since it is not opaque like --dp-card-bg. */
+  --dp-sticky-bg: rgba(255,255,255,0.94);
 }
 
 /* MON-154: dark-mode theme tokens. The `dark` class is toggled on <html> by
@@ -88,6 +98,11 @@
   --dp-header-bg: #182338;
   --dp-badge-pos-bg: rgba(52,194,131,0.16);
   --dp-badge-neg-bg: rgba(255,107,96,0.16);
+  --dp-badge-neutral-bg: rgba(217,164,6,0.18);
+  --dp-badge-neutral-text: #E0B84D;
+  --dp-badge-info-bg: rgba(74,144,226,0.18);
+  --dp-badge-info-text: #7EB0F0;
+  --dp-sticky-bg: rgba(18,29,48,0.92);
 }
 
 @layer base {
@@ -139,5 +154,10 @@
     --dp-cta-bg: #E0786E;
     --dp-badge-pos-bg: #EAF5EF;
     --dp-badge-neg-bg: #FBE9E7;
+    --dp-badge-neutral-bg: #FEF3C7;
+    --dp-badge-neutral-text: #B45309;
+    --dp-badge-info-bg: #E8EFFE;
+    --dp-badge-info-text: #2A5DB0;
+    --dp-sticky-bg: rgba(255,255,255,0.94);
   }
 }

--- a/frontend/src/app/votes/[id]/VoteDetailClient.tsx
+++ b/frontend/src/app/votes/[id]/VoteDetailClient.tsx
@@ -146,7 +146,7 @@ export function VoteDetailClient(props: Props) {
     : null
 
   return (
-    <div style={{ background: '#F7F4ED', minHeight: '100vh' }}>
+    <div style={{ background: 'var(--dp-page-bg)', minHeight: '100vh' }}>
 
       {/* ── Sticky scroll bar ── */}
       <div style={{
@@ -156,19 +156,19 @@ export function VoteDetailClient(props: Props) {
         pointerEvents: showBar ? 'auto' : 'none',
         transition: 'opacity 0.3s ease, transform 0.45s cubic-bezier(0.22,1,0.36,1)',
       }}>
-        <div style={{ background: 'rgba(255,255,255,0.94)', backdropFilter: 'blur(14px)', borderBottom: '1px solid #E4E6EA', boxShadow: '0 8px 24px rgba(27,43,80,0.08)' }}>
+        <div style={{ background: 'var(--dp-sticky-bg)', backdropFilter: 'blur(14px)', borderBottom: '1px solid var(--dp-border)', boxShadow: '0 8px 24px var(--dp-avatar-shadow)' }}>
           <div className="px-5 sm:px-14" style={{ maxWidth: 1180, margin: '0 auto', display: 'flex', alignItems: 'center', gap: 16, padding: '10px 0' }}>
-            <span className="hidden sm:inline" style={{ fontSize: 12, fontWeight: 600, letterSpacing: '0.1em', textTransform: 'uppercase', color: '#9CA3AF', flexShrink: 0 }}>
+            <span className="hidden sm:inline" style={{ fontSize: 12, fontWeight: 600, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--dp-text-muted)', flexShrink: 0 }}>
               Scrutin n°{voteId}
             </span>
-            <span className="hidden sm:inline" style={{ fontSize: 12, color: '#D1D5DB' }}>·</span>
-            <span style={{ fontWeight: 600, fontSize: 15, color: '#1B2B50', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            <span className="hidden sm:inline" style={{ fontSize: 12, color: 'var(--dp-abstention)' }}>·</span>
+            <span style={{ fontWeight: 600, fontSize: 15, color: 'var(--dp-text)', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
               {headline}
             </span>
-            <span style={{ display: 'inline-flex', alignItems: 'center', fontSize: 12, fontWeight: 700, padding: '5px 14px', borderRadius: 999, background: adopted ? '#EAF5EF' : '#FBE9E7', color: adopted ? '#1F8A5B' : '#C9302A', flexShrink: 0 }}>
+            <span style={{ display: 'inline-flex', alignItems: 'center', fontSize: 12, fontWeight: 700, padding: '5px 14px', borderRadius: 999, background: adopted ? 'var(--dp-badge-pos-bg)' : 'var(--dp-badge-neg-bg)', color: adopted ? 'var(--dp-green)' : 'var(--dp-red)', flexShrink: 0 }}>
               {adopted ? 'Adopté' : 'Rejeté'}
             </span>
-            <span className="font-mono hidden sm:inline" style={{ fontSize: 12.5, color: '#6B7280', flexShrink: 0 }}>
+            <span className="font-mono hidden sm:inline" style={{ fontSize: 12.5, color: 'var(--dp-text-secondary)', flexShrink: 0 }}>
               {votesFor} pour · {votesAgainst} contre
             </span>
           </div>
@@ -176,12 +176,12 @@ export function VoteDetailClient(props: Props) {
       </div>
 
       {/* ── Hero ── */}
-      <div ref={heroRef} style={{ padding: '38px 56px 48px', background: 'linear-gradient(180deg,#ffffff 0%,#F7F4ED 100%)', borderBottom: '1px solid #ECE7DC' }}>
+      <div ref={heroRef} style={{ padding: '38px 56px 48px', background: 'linear-gradient(180deg,var(--dp-card-bg) 0%,var(--dp-page-bg) 100%)', borderBottom: '1px solid var(--dp-border-subtle)' }}>
         <div style={{ maxWidth: 1180, margin: '0 auto' }}>
 
           {/* Breadcrumb */}
-          <div style={{ fontSize: 13.5, color: '#9CA3AF', display: 'flex', alignItems: 'center', gap: 8 }}>
-            <Link href="/votes" style={{ color: '#C9302A', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5, textDecoration: 'none', fontWeight: 500 }}>
+          <div style={{ fontSize: 13.5, color: 'var(--dp-text-muted)', display: 'flex', alignItems: 'center', gap: 8 }}>
+            <Link href="/votes" style={{ color: 'var(--dp-red)', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5, textDecoration: 'none', fontWeight: 500 }}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round"><path d="m15 18-6-6 6-6"/></svg>
               Retour aux scrutins
             </Link>
@@ -194,80 +194,80 @@ export function VoteDetailClient(props: Props) {
             {/* Left: identity */}
             <div>
               <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 18, flexWrap: 'wrap' }}>
-                <span style={{ font: '700 11.5px/1 var(--font-sans)', letterSpacing: '0.16em', textTransform: 'uppercase', color: '#9CA3AF' }}>
+                <span style={{ font: '700 11.5px/1 var(--font-sans)', letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--dp-text-muted)' }}>
                   Scrutin public · n°{voteId}
                 </span>
-                <span className="font-mono" style={{ fontSize: 11.5, color: '#9CA3AF' }}>·</span>
-                <span suppressHydrationWarning className="font-mono" style={{ fontSize: 12, color: '#9CA3AF' }}>{shortDate(votedAt)}</span>
+                <span className="font-mono" style={{ fontSize: 11.5, color: 'var(--dp-text-muted)' }}>·</span>
+                <span suppressHydrationWarning className="font-mono" style={{ fontSize: 12, color: 'var(--dp-text-muted)' }}>{shortDate(votedAt)}</span>
               </div>
 
-              <h1 className="font-newsreader text-title" style={{ fontWeight: 600, lineHeight: 1.05, letterSpacing: '-0.015em', color: '#1B2B50', margin: 0, maxWidth: 620 }}>
+              <h1 className="font-newsreader text-title" style={{ fontWeight: 600, lineHeight: 1.05, letterSpacing: '-0.015em', color: 'var(--dp-text)', margin: 0, maxWidth: 620 }}>
                 {headline}
               </h1>
 
               <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: 20, flexWrap: 'wrap' }}>
-                <span style={{ display: 'inline-flex', alignItems: 'center', fontSize: 13, fontWeight: 600, padding: '6px 14px', borderRadius: 999, background: adopted ? '#EAF5EF' : '#FBE9E7', color: adopted ? '#1F8A5B' : '#C9302A' }}>
+                <span style={{ display: 'inline-flex', alignItems: 'center', fontSize: 13, fontWeight: 600, padding: '6px 14px', borderRadius: 999, background: adopted ? 'var(--dp-badge-pos-bg)' : 'var(--dp-badge-neg-bg)', color: adopted ? 'var(--dp-green)' : 'var(--dp-red)' }}>
                   {adopted ? 'Adopté' : 'Rejeté'}
                 </span>
                 {theme && (
-                  <span style={{ display: 'inline-flex', alignItems: 'center', fontSize: 13, fontWeight: 600, padding: '6px 14px', borderRadius: 999, background: '#E8EFFE', color: '#2A5DB0' }}>
+                  <span style={{ display: 'inline-flex', alignItems: 'center', fontSize: 13, fontWeight: 600, padding: '6px 14px', borderRadius: 999, background: 'var(--dp-badge-info-bg)', color: 'var(--dp-badge-info-text)' }}>
                     {theme}
                   </span>
                 )}
-                <span style={{ display: 'inline-flex', alignItems: 'center', fontSize: 13, fontWeight: 600, padding: '6px 14px', borderRadius: 999, background: '#F2F3F5', color: '#4B5563' }}>
+                <span style={{ display: 'inline-flex', alignItems: 'center', fontSize: 13, fontWeight: 600, padding: '6px 14px', borderRadius: 999, background: 'var(--dp-track-bg)', color: 'var(--dp-text-secondary)' }}>
                   XVII&#7497; législature
                 </span>
               </div>
 
               {summary && (
-                <p style={{ margin: '22px 0 0', fontSize: 15, lineHeight: 1.6, color: '#9CA3AF', maxWidth: 600 }}>
+                <p style={{ margin: '22px 0 0', fontSize: 15, lineHeight: 1.6, color: 'var(--dp-text-muted)', maxWidth: 600 }}>
                   <span style={{ fontWeight: 600 }}>Titre officiel :</span> {voteTitle}
                 </p>
               )}
 
               {dossierUrl && (
                 <a href={dossierUrl} target="_blank" rel="noopener noreferrer"
-                  style={{ display: 'inline-flex', alignItems: 'center', marginTop: 14, fontSize: 14, fontWeight: 600, color: '#C9302A', textDecoration: 'none' }}>
+                  style={{ display: 'inline-flex', alignItems: 'center', marginTop: 14, fontSize: 14, fontWeight: 600, color: 'var(--dp-red)', textDecoration: 'none' }}>
                   Voir le dossier officiel →
                 </a>
               )}
             </div>
 
             {/* Right: result card */}
-            <div className="mt-8 xl:mt-0" style={{ background: '#fff', border: '1px solid #E4E6EA', borderRadius: 14, padding: 28, boxShadow: '0 4px 12px rgba(0,0,0,0.08)' }}>
-              <div style={{ font: '700 11px/1 var(--font-sans)', letterSpacing: '0.14em', textTransform: 'uppercase', color: '#9CA3AF', marginBottom: 18 }}>
+            <div className="mt-8 xl:mt-0" style={{ background: 'var(--dp-card-bg)', border: '1px solid var(--dp-border)', borderRadius: 14, padding: 28, boxShadow: '0 4px 12px var(--dp-shadow-sm)' }}>
+              <div style={{ font: '700 11px/1 var(--font-sans)', letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--dp-text-muted)', marginBottom: 18 }}>
                 Résultat du scrutin
               </div>
 
               {/* Big numbers */}
               <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 0, textAlign: 'center', marginBottom: 22 }}>
-                <div style={{ borderRight: '1px solid #F0F1F3', padding: '0 12px' }}>
-                  <div className="font-newsreader text-section-lg" style={{ fontWeight: 600, color: '#1F8A5B', letterSpacing: '-0.02em' }}>{votesFor.toLocaleString('fr-FR')}</div>
-                  <div style={{ fontSize: 12, fontWeight: 600, color: '#1F8A5B', marginTop: 3, letterSpacing: '0.04em' }}>POUR</div>
+                <div style={{ borderRight: '1px solid var(--dp-track-bg)', padding: '0 12px' }}>
+                  <div className="font-newsreader text-section-lg" style={{ fontWeight: 600, color: 'var(--dp-green)', letterSpacing: '-0.02em' }}>{votesFor.toLocaleString('fr-FR')}</div>
+                  <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--dp-green)', marginTop: 3, letterSpacing: '0.04em' }}>POUR</div>
                 </div>
-                <div style={{ borderRight: '1px solid #F0F1F3', padding: '0 12px' }}>
-                  <div className="font-newsreader text-section-lg" style={{ fontWeight: 600, color: '#C9302A', letterSpacing: '-0.02em' }}>{votesAgainst.toLocaleString('fr-FR')}</div>
-                  <div style={{ fontSize: 12, fontWeight: 600, color: '#C9302A', marginTop: 3, letterSpacing: '0.04em' }}>CONTRE</div>
+                <div style={{ borderRight: '1px solid var(--dp-track-bg)', padding: '0 12px' }}>
+                  <div className="font-newsreader text-section-lg" style={{ fontWeight: 600, color: 'var(--dp-red)', letterSpacing: '-0.02em' }}>{votesAgainst.toLocaleString('fr-FR')}</div>
+                  <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--dp-red)', marginTop: 3, letterSpacing: '0.04em' }}>CONTRE</div>
                 </div>
                 <div style={{ padding: '0 12px' }}>
-                  <div className="font-newsreader text-section-lg" style={{ fontWeight: 600, color: '#9CA3AF', letterSpacing: '-0.02em' }}>{abstentions.toLocaleString('fr-FR')}</div>
-                  <div style={{ fontSize: 12, fontWeight: 600, color: '#9CA3AF', marginTop: 3, letterSpacing: '0.04em' }}>ABST.</div>
+                  <div className="font-newsreader text-section-lg" style={{ fontWeight: 600, color: 'var(--dp-text-muted)', letterSpacing: '-0.02em' }}>{abstentions.toLocaleString('fr-FR')}</div>
+                  <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--dp-text-muted)', marginTop: 3, letterSpacing: '0.04em' }}>ABST.</div>
                 </div>
               </div>
 
               {/* Stacked bar */}
               <div style={{ display: 'flex', height: 10, borderRadius: 999, overflow: 'hidden', marginBottom: 10 }}>
-                <div style={{ width: `${pourPct}%`, background: '#1F8A5B' }} />
-                <div style={{ width: `${contrePct}%`, background: '#D9685E' }} />
-                <div style={{ flex: 1, background: '#E4E6EA' }} />
+                <div style={{ width: `${pourPct}%`, background: 'var(--dp-green)' }} />
+                <div style={{ width: `${contrePct}%`, background: 'var(--dp-red)' }} />
+                <div style={{ flex: 1, background: 'var(--dp-border)' }} />
               </div>
-              <div className="font-mono" style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11, color: '#9CA3AF', marginBottom: 22 }}>
+              <div className="font-mono" style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11, color: 'var(--dp-text-muted)', marginBottom: 22 }}>
                 <span>{pourPct}%</span><span>{contrePct}%</span><span>{abstPct}%</span>
               </div>
 
               {/* Quorum note */}
-              <div style={{ background: '#F2F3F5', borderRadius: 8, padding: '12px 14px', fontSize: 13, color: '#4B5563', lineHeight: 1.5, marginBottom: 20 }}>
-                <span style={{ fontWeight: 600, color: '#1B2B50' }}>Majorité absolue requise : </span>289 voix.<br />
+              <div style={{ background: 'var(--dp-track-bg)', borderRadius: 8, padding: '12px 14px', fontSize: 13, color: 'var(--dp-text-secondary)', lineHeight: 1.5, marginBottom: 20 }}>
+                <span style={{ fontWeight: 600, color: 'var(--dp-text)' }}>Majorité absolue requise : </span>289 voix.<br />
                 Votants : {totalVoters.toLocaleString('fr-FR')} sur 577 députés inscrits.
               </div>
 
@@ -276,13 +276,13 @@ export function VoteDetailClient(props: Props) {
                 <a
                   href={`https://www.assemblee-nationale.fr/dyn/scrutins/${voteId}`}
                   target="_blank" rel="noopener noreferrer"
-                  style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', background: '#1B2B50', color: '#fff', padding: '11px 18px', borderRadius: 8, fontWeight: 600, fontSize: 14, cursor: 'pointer', textDecoration: 'none' }}>
+                  style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--dp-active-bg)', color: '#fff', padding: '11px 18px', borderRadius: 8, fontWeight: 600, fontSize: 14, cursor: 'pointer', textDecoration: 'none' }}>
                   Voir le texte officiel
                 </a>
                 <a
                   href={`${apiUrl}/votes/${voteId}`}
                   target="_blank" rel="noopener noreferrer"
-                  style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', border: '1px solid #E4E6EA', color: '#4B5563', padding: '11px 16px', borderRadius: 8, fontWeight: 600, fontSize: 14, cursor: 'pointer', textDecoration: 'none' }}>
+                  style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', border: '1px solid var(--dp-border)', color: 'var(--dp-text-secondary)', padding: '11px 16px', borderRadius: 8, fontWeight: 600, fontSize: 14, cursor: 'pointer', textDecoration: 'none' }}>
                   <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/></svg>
                 </a>
                 <a
@@ -290,7 +290,7 @@ export function VoteDetailClient(props: Props) {
                   download
                   title="Télécharger les positions de tous les députés (CSV)"
                   aria-label="Télécharger les positions en CSV"
-                  style={{ display: 'flex', alignItems: 'center', gap: 7, border: '1px solid #E4E6EA', color: '#4B5563', padding: '11px 16px', borderRadius: 8, fontWeight: 600, fontSize: 14, cursor: 'pointer', textDecoration: 'none' }}>
+                  style={{ display: 'flex', alignItems: 'center', gap: 7, border: '1px solid var(--dp-border)', color: 'var(--dp-text-secondary)', padding: '11px 16px', borderRadius: 8, fontWeight: 600, fontSize: 14, cursor: 'pointer', textDecoration: 'none' }}>
                   <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
                   CSV
                 </a>
@@ -325,12 +325,12 @@ export function VoteDetailClient(props: Props) {
             {/* Hémicycle */}
             {hemicycleDeputies.length > 0 && (
               <section>
-                <div style={{ font: '700 12px/1 var(--font-sans)', letterSpacing: '0.18em', textTransform: 'uppercase', color: '#C9302A' }}>Hémicycle</div>
-                <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: '#1B2B50', margin: '12px 0 4px', letterSpacing: '-0.01em' }}>Le vote, siège par siège</h2>
-                <p style={{ fontSize: 15, color: '#6B7280', margin: '0 0 20px', maxWidth: 560 }}>
+                <div style={{ font: '700 12px/1 var(--font-sans)', letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--dp-red)' }}>Hémicycle</div>
+                <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: 'var(--dp-text)', margin: '12px 0 4px', letterSpacing: '-0.01em' }}>Le vote, siège par siège</h2>
+                <p style={{ fontSize: 15, color: 'var(--dp-text-secondary)', margin: '0 0 20px', maxWidth: 560 }}>
                   Un point par député ayant pris part au scrutin, placé selon son groupe parlementaire. Survolez ou touchez un siège pour voir le détail.
                 </p>
-                <div style={{ background: '#fff', border: '1px solid #E4E6EA', borderRadius: 12, padding: '24px 28px', boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
+                <div style={{ background: 'var(--dp-card-bg)', border: '1px solid var(--dp-border)', borderRadius: 12, padding: '24px 28px', boxShadow: '0 1px 3px var(--dp-shadow-sm)' }}>
                   <HemicycleChart deputies={hemicycleDeputies} />
                 </div>
               </section>
@@ -338,63 +338,63 @@ export function VoteDetailClient(props: Props) {
 
             {/* Comment a voté votre député ? */}
             <section>
-              <div style={{ font: '700 12px/1 var(--font-sans)', letterSpacing: '0.18em', textTransform: 'uppercase', color: '#C9302A' }}>Votre député</div>
-              <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: '#1B2B50', margin: '12px 0 4px', letterSpacing: '-0.01em' }}>Comment a voté votre député&nbsp;?</h2>
-              <p style={{ fontSize: 15, color: '#6B7280', margin: '0 0 18px', maxWidth: 560 }}>Tapez un nom ou un code postal pour retrouver sa position sur ce scrutin.</p>
+              <div style={{ font: '700 12px/1 var(--font-sans)', letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--dp-red)' }}>Votre député</div>
+              <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: 'var(--dp-text)', margin: '12px 0 4px', letterSpacing: '-0.01em' }}>Comment a voté votre député&nbsp;?</h2>
+              <p style={{ fontSize: 15, color: 'var(--dp-text-secondary)', margin: '0 0 18px', maxWidth: 560 }}>Tapez un nom ou un code postal pour retrouver sa position sur ce scrutin.</p>
 
               <div style={{ position: 'relative', maxWidth: 440 }}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 10, background: '#fff', border: '1px solid #E4E6EA', borderRadius: 10, padding: '0 16px', height: 48 }}>
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#9CA3AF" strokeWidth="2" strokeLinecap="round"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.2-3.2"/></svg>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10, background: 'var(--dp-card-bg)', border: '1px solid var(--dp-border)', borderRadius: 10, padding: '0 16px', height: 48 }}>
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--dp-text-muted)" strokeWidth="2" strokeLinecap="round"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.2-3.2"/></svg>
                   <input
                     type="text"
                     value={lookupQuery}
                     onChange={e => { setLookupQuery(e.target.value); setSelected(null) }}
                     placeholder="Nom du député ou code postal…"
-                    style={{ flex: 1, border: 'none', outline: 'none', fontSize: 14.5, color: '#1B2B50', background: 'transparent' }}
+                    style={{ flex: 1, border: 'none', outline: 'none', fontSize: 14.5, color: 'var(--dp-text)', background: 'transparent' }}
                   />
                 </div>
 
                 {suggestions.length > 0 && !selected && (
-                  <div style={{ position: 'absolute', top: '100%', left: 0, right: 0, marginTop: 6, background: '#fff', border: '1px solid #E4E6EA', borderRadius: 10, boxShadow: '0 8px 24px rgba(0,0,0,0.1)', zIndex: 10, overflow: 'hidden' }}>
+                  <div style={{ position: 'absolute', top: '100%', left: 0, right: 0, marginTop: 6, background: 'var(--dp-card-bg)', border: '1px solid var(--dp-border)', borderRadius: 10, boxShadow: '0 8px 24px var(--dp-shadow-sm)', zIndex: 10, overflow: 'hidden' }}>
                     {suggestions.map(d => (
                       <button
                         key={d.deputy_id}
                         onClick={() => { setSelected(d); setLookupQuery(d.full_name) }}
-                        style={{ display: 'flex', width: '100%', alignItems: 'center', gap: 10, padding: '10px 16px', background: 'none', border: 'none', borderBottom: '1px solid #F0F1F3', cursor: 'pointer', textAlign: 'left' }}
+                        style={{ display: 'flex', width: '100%', alignItems: 'center', gap: 10, padding: '10px 16px', background: 'none', border: 'none', borderBottom: '1px solid var(--dp-track-bg)', cursor: 'pointer', textAlign: 'left' }}
                       >
                         <span style={{ width: 28, height: 28, flexShrink: 0, borderRadius: 999, display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 700, fontSize: 11, color: '#fff', background: partyHex(d.party) }}>
                           {getInitials(d.full_name)}
                         </span>
-                        <span style={{ fontSize: 13.5, color: '#1B2B50', fontWeight: 500 }}>{d.full_name}</span>
+                        <span style={{ fontSize: 13.5, color: 'var(--dp-text)', fontWeight: 500 }}>{d.full_name}</span>
                       </button>
                     ))}
                   </div>
                 )}
 
                 {lookupQuery.trim().length >= 2 && suggestions.length === 0 && !selected && !/^\d{1,4}$/.test(lookupQuery.trim()) && (
-                  <div style={{ marginTop: 8, fontSize: 13, color: '#9CA3AF' }}>Aucun député trouvé pour « {lookupQuery} ».</div>
+                  <div style={{ marginTop: 8, fontSize: 13, color: 'var(--dp-text-muted)' }}>Aucun député trouvé pour « {lookupQuery} ».</div>
                 )}
               </div>
 
               {selected && (
-                <Link href={`/deputes/${selected.deputy_id}`} style={{ display: 'flex', alignItems: 'center', gap: 16, marginTop: 16, maxWidth: 440, background: '#fff', border: '1px solid #E4E6EA', borderRadius: 12, padding: '16px 20px', boxShadow: '0 1px 3px rgba(0,0,0,0.05)', textDecoration: 'none' }}>
+                <Link href={`/deputes/${selected.deputy_id}`} style={{ display: 'flex', alignItems: 'center', gap: 16, marginTop: 16, maxWidth: 440, background: 'var(--dp-card-bg)', border: '1px solid var(--dp-border)', borderRadius: 12, padding: '16px 20px', boxShadow: '0 1px 3px var(--dp-shadow-sm)', textDecoration: 'none' }}>
                   <span style={{ width: 44, height: 44, flexShrink: 0, borderRadius: 999, display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 700, fontSize: 14, color: '#fff', background: partyHex(selected.party) }}>
                     {getInitials(selected.full_name)}
                   </span>
                   <div style={{ flex: 1, minWidth: 0 }}>
-                    <div style={{ fontWeight: 600, fontSize: 15, color: '#1B2B50' }}>{selected.full_name}</div>
-                    <div style={{ fontSize: 13, color: '#9CA3AF', marginTop: 2 }}>{selected.party ?? 'Parti inconnu'}</div>
+                    <div style={{ fontWeight: 600, fontSize: 15, color: 'var(--dp-text)' }}>{selected.full_name}</div>
+                    <div style={{ fontSize: 13, color: 'var(--dp-text-muted)', marginTop: 2 }}>{selected.party ?? 'Parti inconnu'}</div>
                   </div>
                   {selected.position ? (
                     <span style={{
                       fontSize: 13, fontWeight: 700, padding: '6px 14px', borderRadius: 999,
-                      color: selected.position === 'pour' ? '#1F8A5B' : selected.position === 'contre' ? '#C9302A' : '#6B7280',
-                      background: selected.position === 'pour' ? '#EAF5EF' : selected.position === 'contre' ? '#FBE9E7' : '#F0F1F3',
+                      color: selected.position === 'pour' ? 'var(--dp-green)' : selected.position === 'contre' ? 'var(--dp-red)' : 'var(--dp-text-secondary)',
+                      background: selected.position === 'pour' ? 'var(--dp-badge-pos-bg)' : selected.position === 'contre' ? 'var(--dp-badge-neg-bg)' : 'var(--dp-track-bg)',
                     }}>
                       {POSITION_LABELS[selected.position] ?? selected.position}
                     </span>
                   ) : (
-                    <span style={{ fontSize: 13, fontWeight: 700, padding: '6px 14px', borderRadius: 999, color: '#9CA3AF', background: '#F2F3F5' }}>
+                    <span style={{ fontSize: 13, fontWeight: 700, padding: '6px 14px', borderRadius: 999, color: 'var(--dp-text-muted)', background: 'var(--dp-track-bg)' }}>
                       Absent · non enregistré
                     </span>
                   )}
@@ -405,12 +405,12 @@ export function VoteDetailClient(props: Props) {
             {/* Ventilation par groupe */}
             {groups.length > 0 && (
               <section>
-                <div style={{ font: '700 12px/1 var(--font-sans)', letterSpacing: '0.18em', textTransform: 'uppercase', color: '#C9302A' }}>Ventilation par groupe</div>
-                <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: '#1B2B50', margin: '12px 0 4px', letterSpacing: '-0.01em' }}>Comment chaque groupe a voté</h2>
-                <p style={{ fontSize: 15, color: '#6B7280', margin: '0 0 22px', maxWidth: 560 }}>Position majoritaire exprimée par les membres de chaque groupe parlementaire.</p>
+                <div style={{ font: '700 12px/1 var(--font-sans)', letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--dp-red)' }}>Ventilation par groupe</div>
+                <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: 'var(--dp-text)', margin: '12px 0 4px', letterSpacing: '-0.01em' }}>Comment chaque groupe a voté</h2>
+                <p style={{ fontSize: 15, color: 'var(--dp-text-secondary)', margin: '0 0 22px', maxWidth: 560 }}>Position majoritaire exprimée par les membres de chaque groupe parlementaire.</p>
 
-                <div style={{ background: '#fff', border: '1px solid #E4E6EA', borderRadius: 12, overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
-                  <div style={{ display: 'grid', gridTemplateColumns: '200px 1fr 80px 80px 80px 90px', gap: 14, padding: '12px 24px', borderBottom: '1px solid #E4E6EA', background: '#FBFAF6', font: '600 11px/1 var(--font-sans)', letterSpacing: '0.08em', textTransform: 'uppercase', color: '#9CA3AF' }}>
+                <div style={{ background: 'var(--dp-card-bg)', border: '1px solid var(--dp-border)', borderRadius: 12, overflow: 'hidden', boxShadow: '0 1px 3px var(--dp-shadow-sm)' }}>
+                  <div style={{ display: 'grid', gridTemplateColumns: '200px 1fr 80px 80px 80px 90px', gap: 14, padding: '12px 24px', borderBottom: '1px solid var(--dp-border)', background: 'var(--dp-header-bg)', font: '600 11px/1 var(--font-sans)', letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--dp-text-muted)' }}>
                     <span>Groupe</span><span>Position</span><span style={{ textAlign: 'right' }}>Pour</span><span style={{ textAlign: 'right' }}>Contre</span>
                     <span style={{ textAlign: 'right' }}>Abst.</span>
                     <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 5 }}>
@@ -424,25 +424,25 @@ export function VoteDetailClient(props: Props) {
                     </span>
                   </div>
                   {groups.map((g) => {
-                    const posColor = g.position === 'Pour' ? '#1F8A5B' : g.position === 'Contre' ? '#C9302A' : '#B45309'
-                    const posBg   = g.position === 'Pour' ? '#EAF5EF' : g.position === 'Contre' ? '#FBE9E7' : '#FEF3C7'
+                    const posColor = g.position === 'Pour' ? 'var(--dp-green)' : g.position === 'Contre' ? 'var(--dp-red)' : 'var(--dp-badge-neutral-text)'
+                    const posBg   = g.position === 'Pour' ? 'var(--dp-badge-pos-bg)' : g.position === 'Contre' ? 'var(--dp-badge-neg-bg)' : 'var(--dp-badge-neutral-bg)'
                     return (
-                      <div key={g.name} style={{ display: 'grid', gridTemplateColumns: '200px 1fr 80px 80px 80px 90px', gap: 14, padding: '16px 24px', borderBottom: '1px solid #F0F1F3', alignItems: 'center', background: '#fff' }}>
+                      <div key={g.name} style={{ display: 'grid', gridTemplateColumns: '200px 1fr 80px 80px 80px 90px', gap: 14, padding: '16px 24px', borderBottom: '1px solid var(--dp-track-bg)', alignItems: 'center', background: 'var(--dp-card-bg)' }}>
                         <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
                           <span style={{ width: 9, height: 9, borderRadius: 999, flexShrink: 0, background: g.color, display: 'inline-block' }} />
-                          <span style={{ fontSize: 13.5, color: '#374151', fontWeight: 500 }}>{g.name}</span>
+                          <span style={{ fontSize: 13.5, color: 'var(--dp-text-secondary)', fontWeight: 500 }}>{g.name}</span>
                         </div>
                         <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                          <div style={{ flex: 1, height: 7, borderRadius: 999, background: '#F0F1F3', overflow: 'hidden', display: 'flex' }}>
-                            <div style={{ height: '100%', background: '#1F8A5B', width: `${g.forPct}%` }} />
-                            <div style={{ height: '100%', background: '#D9685E', width: `${g.agtPct}%` }} />
+                          <div style={{ flex: 1, height: 7, borderRadius: 999, background: 'var(--dp-track-bg)', overflow: 'hidden', display: 'flex' }}>
+                            <div style={{ height: '100%', background: 'var(--dp-green)', width: `${g.forPct}%` }} />
+                            <div style={{ height: '100%', background: 'var(--dp-red)', width: `${g.agtPct}%` }} />
                           </div>
                           <span style={{ fontSize: 12, fontWeight: 700, padding: '4px 11px', borderRadius: 999, color: posColor, background: posBg, flexShrink: 0 }}>{g.position}</span>
                         </div>
-                        <div className="font-mono" style={{ fontSize: 13, color: '#1F8A5B', textAlign: 'right', fontWeight: 600 }}>{g.pour}</div>
-                        <div className="font-mono" style={{ fontSize: 13, color: '#C9302A', textAlign: 'right', fontWeight: 600 }}>{g.contre}</div>
-                        <div className="font-mono" style={{ fontSize: 13, color: '#9CA3AF', textAlign: 'right' }}>{g.abst}</div>
-                        <div className="font-mono" style={{ fontSize: 13, color: '#9CA3AF', textAlign: 'right' }}>{g.nonVotant}</div>
+                        <div className="font-mono" style={{ fontSize: 13, color: 'var(--dp-green)', textAlign: 'right', fontWeight: 600 }}>{g.pour}</div>
+                        <div className="font-mono" style={{ fontSize: 13, color: 'var(--dp-red)', textAlign: 'right', fontWeight: 600 }}>{g.contre}</div>
+                        <div className="font-mono" style={{ fontSize: 13, color: 'var(--dp-text-muted)', textAlign: 'right' }}>{g.abst}</div>
+                        <div className="font-mono" style={{ fontSize: 13, color: 'var(--dp-text-muted)', textAlign: 'right' }}>{g.nonVotant}</div>
                       </div>
                     )
                   })}
@@ -453,25 +453,25 @@ export function VoteDetailClient(props: Props) {
             {/* Dissidences */}
             {dissidents.length > 0 && (
               <section>
-                <div style={{ font: '700 12px/1 var(--font-sans)', letterSpacing: '0.18em', textTransform: 'uppercase', color: '#C9302A' }}>Votes notables</div>
-                <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: '#1B2B50', margin: '12px 0 22px', letterSpacing: '-0.01em' }}>Dissidences &amp; surprises</h2>
+                <div style={{ font: '700 12px/1 var(--font-sans)', letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--dp-red)' }}>Votes notables</div>
+                <h2 className="font-newsreader text-section-sm" style={{ fontWeight: 600, color: 'var(--dp-text)', margin: '12px 0 22px', letterSpacing: '-0.01em' }}>Dissidences &amp; surprises</h2>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
                   {dissidents.map((d) => {
-                    const voteColor = d.vote === 'pour' ? '#1F8A5B' : d.vote === 'contre' ? '#C9302A' : '#6B7280'
-                    const voteBg   = d.vote === 'pour' ? '#EAF5EF' : d.vote === 'contre' ? '#FBE9E7' : '#F0F1F3'
+                    const voteColor = d.vote === 'pour' ? 'var(--dp-green)' : d.vote === 'contre' ? 'var(--dp-red)' : 'var(--dp-text-secondary)'
+                    const voteBg   = d.vote === 'pour' ? 'var(--dp-badge-pos-bg)' : d.vote === 'contre' ? 'var(--dp-badge-neg-bg)' : 'var(--dp-track-bg)'
                     const voteLabel = d.vote === 'pour' ? 'Pour' : d.vote === 'contre' ? 'Contre' : 'Abstention'
                     return (
-                      <Link key={d.deputy_id} href={`/deputes/${d.deputy_id}`} style={{ background: '#fff', border: '1px solid #E4E6EA', borderRadius: 10, padding: '18px 22px', display: 'flex', alignItems: 'center', gap: 18, boxShadow: '0 1px 3px rgba(0,0,0,0.05)', textDecoration: 'none', cursor: 'pointer' }}>
+                      <Link key={d.deputy_id} href={`/deputes/${d.deputy_id}`} style={{ background: 'var(--dp-card-bg)', border: '1px solid var(--dp-border)', borderRadius: 10, padding: '18px 22px', display: 'flex', alignItems: 'center', gap: 18, boxShadow: '0 1px 3px var(--dp-shadow-sm)', textDecoration: 'none', cursor: 'pointer' }}>
                         <span style={{ width: 40, height: 40, flexShrink: 0, borderRadius: 999, display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 700, fontSize: 13, color: '#fff', background: d.avatarColor }}>
                           {d.initials}
                         </span>
                         <div style={{ flex: 1, minWidth: 0 }}>
-                          <div style={{ fontWeight: 600, fontSize: 15, color: '#1B2B50' }}>{d.full_name}</div>
-                          <div style={{ fontSize: 13, color: '#9CA3AF', marginTop: 2 }}>{d.party}</div>
+                          <div style={{ fontWeight: 600, fontSize: 15, color: 'var(--dp-text)' }}>{d.full_name}</div>
+                          <div style={{ fontSize: 13, color: 'var(--dp-text-muted)', marginTop: 2 }}>{d.party}</div>
                         </div>
                         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 5 }}>
                           <span style={{ fontSize: 12.5, fontWeight: 700, padding: '4px 12px', borderRadius: 999, color: voteColor, background: voteBg }}>{voteLabel}</span>
-                          <span style={{ fontSize: 12, color: '#6B7280' }}>{d.note}</span>
+                          <span style={{ fontSize: 12, color: 'var(--dp-text-secondary)' }}>{d.note}</span>
                         </div>
                       </Link>
                     )
@@ -486,22 +486,22 @@ export function VoteDetailClient(props: Props) {
 
             {/* Related votes */}
             {related.length > 0 && (
-              <div style={{ background: '#fff', border: '1px solid #E4E6EA', borderRadius: 12, padding: 20, boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
-                <div style={{ font: '700 11px/1 var(--font-sans)', letterSpacing: '0.14em', textTransform: 'uppercase', color: '#9CA3AF', marginBottom: 16 }}>Scrutins liés</div>
+              <div style={{ background: 'var(--dp-card-bg)', border: '1px solid var(--dp-border)', borderRadius: 12, padding: 20, boxShadow: '0 1px 3px var(--dp-shadow-sm)' }}>
+                <div style={{ font: '700 11px/1 var(--font-sans)', letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--dp-text-muted)', marginBottom: 16 }}>Scrutins liés</div>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
                   {related.map((r) => {
                     const rAdopted = r.result === 'adopté'
                     return (
-                      <Link key={r.vote_id} href={`/votes/${r.vote_id}`} style={{ padding: '12px 0', borderBottom: '1px solid #F0F1F3', textDecoration: 'none' }}>
-                        <div style={{ fontSize: 13.5, fontWeight: 500, color: '#1B2B50', lineHeight: 1.35 }}
+                      <Link key={r.vote_id} href={`/votes/${r.vote_id}`} style={{ padding: '12px 0', borderBottom: '1px solid var(--dp-track-bg)', textDecoration: 'none' }}>
+                        <div style={{ fontSize: 13.5, fontWeight: 500, color: 'var(--dp-text)', lineHeight: 1.35 }}
                           className="line-clamp-2">
                           {r.vote_title}
                         </div>
                         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 7 }}>
-                          <span suppressHydrationWarning className="font-mono" style={{ fontSize: 11, color: '#9CA3AF' }}>
+                          <span suppressHydrationWarning className="font-mono" style={{ fontSize: 11, color: 'var(--dp-text-muted)' }}>
                             {new Date(r.voted_at).toLocaleDateString('fr-FR', { day: 'numeric', month: 'short', year: 'numeric' })}
                           </span>
-                          <span style={{ fontSize: 11.5, fontWeight: 600, padding: '3px 9px', borderRadius: 999, color: rAdopted ? '#1F8A5B' : '#C9302A', background: rAdopted ? '#EAF5EF' : '#FBE9E7' }}>
+                          <span style={{ fontSize: 11.5, fontWeight: 600, padding: '3px 9px', borderRadius: 999, color: rAdopted ? 'var(--dp-green)' : 'var(--dp-red)', background: rAdopted ? 'var(--dp-badge-pos-bg)' : 'var(--dp-badge-neg-bg)' }}>
                             {rAdopted ? 'Adopté' : 'Rejeté'}
                           </span>
                         </div>
@@ -513,16 +513,16 @@ export function VoteDetailClient(props: Props) {
             )}
 
             {/* Sources */}
-            <div style={{ background: '#fff', border: '1px solid #E4E6EA', borderRadius: 12, padding: 20, boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
-              <div style={{ font: '700 11px/1 var(--font-sans)', letterSpacing: '0.14em', textTransform: 'uppercase', color: '#9CA3AF', marginBottom: 14 }}>Sources officielles</div>
+            <div style={{ background: 'var(--dp-card-bg)', border: '1px solid var(--dp-border)', borderRadius: 12, padding: 20, boxShadow: '0 1px 3px var(--dp-shadow-sm)' }}>
+              <div style={{ font: '700 11px/1 var(--font-sans)', letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--dp-text-muted)', marginBottom: 14 }}>Sources officielles</div>
               <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
                 {[
                   { label: 'Assemblée nationale', href: `https://www.assemblee-nationale.fr/dyn/scrutins/${voteId}` },
                   { label: 'API MonÉlu — données brutes', href: `${apiUrl}/votes/${voteId}` },
                 ].map(({ label, href }) => (
                   <a key={href} href={href} target="_blank" rel="noopener noreferrer"
-                    style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 13.5, color: '#1B2B50', textDecoration: 'none', fontWeight: 500 }}>
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#9CA3AF" strokeWidth="2" strokeLinecap="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                    style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 13.5, color: 'var(--dp-text)', textDecoration: 'none', fontWeight: 500 }}>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--dp-text-muted)" strokeWidth="2" strokeLinecap="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
                     {label}
                   </a>
                 ))}
@@ -530,9 +530,9 @@ export function VoteDetailClient(props: Props) {
             </div>
 
             {/* Freshness */}
-            <div style={{ fontSize: 12, color: '#9CA3AF', lineHeight: 1.6, padding: '0 2px' }}>
+            <div style={{ fontSize: 12, color: 'var(--dp-text-muted)', lineHeight: 1.6, padding: '0 2px' }}>
               Données issues du flux officiel de l&apos;Assemblée nationale.<br />
-              Dernière mise à jour : <span suppressHydrationWarning style={{ color: '#6B7280', fontWeight: 600 }}>{shortDate(votedAt)}</span>
+              Dernière mise à jour : <span suppressHydrationWarning style={{ color: 'var(--dp-text-secondary)', fontWeight: 600 }}>{shortDate(votedAt)}</span>
             </div>
           </div>
         </div>

--- a/frontend/src/app/votes/[id]/page.tsx
+++ b/frontend/src/app/votes/[id]/page.tsx
@@ -145,7 +145,7 @@ export default async function VoteDetailPage({ params }: { params: Promise<{ id:
         { name: 'Votes', url: `${SITE_URL}/votes` },
         { name: vote.vote_title, url: `${SITE_URL}/votes/${vote.vote_id}` },
       ])} />
-      <Suspense fallback={<div style={{ padding: '48px 32px', color: '#9CA3AF', fontSize: 14 }}>Chargement…</div>}>
+      <Suspense fallback={<div style={{ padding: '48px 32px', color: 'var(--dp-text-muted)', fontSize: 14 }}>Chargement…</div>}>
         <VoteDetailClient
           voteId={vote.vote_id}
           voteTitle={vote.vote_title}


### PR DESCRIPTION
## What
Adds dark mode to `/votes/[id]` by converting `VoteDetailClient.tsx`'s inline hex-literal styling (the largest single-file conversion in this series so far, ~140 literals across 542 lines) to the shared `--dp-*` CSS variable palette.

## Why
Split off from MON-156 after that page's list-view PR discovered `VoteDetailClient.tsx` was too large to include in the same PR. This page repeats several badge/pill states (adopte/rejete, group-split "Partagé", theme tag) throughout its hero, sticky header, group breakdown, dissidents list, and related-votes sidebar — enough distinct visual states to need two new CSS variable pairs beyond what MON-155/MON-156 already established.

## Changes
- `frontend/src/app/votes/[id]/VoteDetailClient.tsx` and `page.tsx`: all inline hex/`rgba()` literals now reference `--dp-*` variables.
- Reuses `--dp-badge-pos-bg`/`--dp-badge-neg-bg` (added in MON-156) for the adopte/rejete badge, which appears four times on this page (sticky header, hero, group rows via a different color pairing, related-votes sidebar).
- `frontend/src/app/globals.css`: adds two more badge-state variable pairs this page needs and MON-156 didn't: `--dp-badge-neutral-bg`/`-text` (the amber "Partagé" state when a group splits evenly) and `--dp-badge-info-bg`/`-text` (the blue theme tag pill). Also adds `--dp-sticky-bg` for the translucent `backdrop-filter: blur` sticky header background, which needs a semi-transparent value rather than the opaque `--dp-card-bg`.
- Applies the established `--dp-active-bg` fix (MON-160/161/163/165) to the "Voir le texte officiel" link, styled as a solid navy CTA button with hardcoded white text.
- Left the three `partyHex()`-colored avatar circles (deputy lookup results, dissidents list) as-is — per-party brand colors with white text, the same deferred category as prior PRs, not a `--dp-*` token.

## Testing
- `npm run lint` — clean.
- `npm test` — 149 tests / 20 suites pass.
- `npm run build` — succeeds.
- Manual: ran `next dev`, curled a real vote page (`/votes/VTANR5L17V8427`) — unlike the client/localStorage-only pages earlier in this series, this page is server-rendered (SSG via `generateStaticParams`), so curl exercised the full converted markup directly. Confirmed 18 of the 22 `--dp-*` variables used by this file render in that specific vote's HTML; the remaining four (`--dp-badge-neutral-*`, `--dp-badge-info-*`) only render conditionally (a split-group vote, or a vote with a theme) — confirmed those four are present with no typos in the compiled `.next/static/chunks/app/votes/[id]/page.js` bundle instead.

## Risks / Notes
- Same known, deliberate gap as prior PRs: `partyHex()`'s per-party brand colors remain out of scope.
- No visual/screenshot verification was possible in this environment, though this is the first page in the series where the actual converted markup (not just a loading skeleton) was confirmed rendering via curl.

## Breaking Changes
None.

https://claude.ai/code/session_01HVxc7TTP3xnsgNC3mtzxEb