### PR TITLE
feat: dark mode for chat/verify share pages and shared components (MON-157)

### DIFF
--- a/frontend/src/app/chat/s/[id]/page.tsx
+++ b/frontend/src/app/chat/s/[id]/page.tsx
@@ -35,18 +35,18 @@ export default async function ChatSharePage({ params }: { params: Promise<{ id: 
 
   return (
     <main className="max-w-3xl mx-auto px-4 py-10 md:py-14">
-      <p className="text-xs uppercase tracking-wide text-gray-mid mb-4">
+      <p className="text-xs uppercase tracking-wide text-gray-mid dark:text-[color:var(--dp-text-muted)] mb-4">
         MonÉlu — réponse partagée
       </p>
       <ChatAnswerCard result={result} />
       <div className="mt-6 flex flex-wrap items-center gap-4 text-sm">
         <Link
           href={`/chat?q=${encodeURIComponent(result.question)}`}
-          className="border border-navy text-navy px-4 py-2 rounded-lg hover:bg-navy hover:text-white transition-colors"
+          className="border border-navy text-navy dark:border-[color:var(--dp-text)] dark:text-[color:var(--dp-text)] px-4 py-2 rounded-lg hover:bg-navy hover:text-white transition-colors"
         >
           Reposer cette question avec les données du jour
         </Link>
-        <Link href="/chat" className="text-gray-mid underline hover:text-navy">
+        <Link href="/chat" className="text-gray-mid dark:text-[color:var(--dp-text-muted)] underline hover:text-navy dark:hover:text-[color:var(--dp-text)]">
           Poser une autre question
         </Link>
       </div>

--- a/frontend/src/app/quiz/s/[id]/page.tsx
+++ b/frontend/src/app/quiz/s/[id]/page.tsx
@@ -10,8 +10,8 @@ import { QuizResultSections } from '../../QuizResultSections'
 export const dynamicParams = true
 export const revalidate = 86400
 
-const CREAM = '#F7F4ED'
-const RED = '#C9302A'
+const CREAM = 'var(--dp-page-bg)'
+const RED = 'var(--dp-red)'
 
 function hookTitle(share: Awaited<ReturnType<typeof api.quiz.getShare>>): string {
   const best = share.result.top_matches[0]
@@ -68,14 +68,14 @@ export default async function QuizSharePage({ params }: { params: Promise<{ id: 
               display: 'inline-flex',
               alignItems: 'center',
               gap: 8,
-              background: '#E0786E',
+              background: 'var(--dp-cta-bg)',
               color: '#fff',
               padding: '13px 30px',
               borderRadius: 9,
               fontWeight: 600,
               fontSize: 15.5,
               textDecoration: 'none',
-              boxShadow: '0 2px 8px rgba(224,120,110,0.35)',
+              boxShadow: '0 2px 8px var(--dp-cta-shadow)',
             }}
           >
             Faites le test — quel député vote comme vous ?

--- a/frontend/src/app/verifier/v/[id]/page.tsx
+++ b/frontend/src/app/verifier/v/[id]/page.tsx
@@ -43,18 +43,18 @@ export default async function VerificationPage({ params }: { params: Promise<{ i
 
   return (
     <main className="max-w-3xl mx-auto px-4 py-10 md:py-14">
-      <p className="text-xs uppercase tracking-wide text-gray-mid mb-4">
+      <p className="text-xs uppercase tracking-wide text-gray-mid dark:text-[color:var(--dp-text-muted)] mb-4">
         Vérification MonÉlu — verdict enregistré
       </p>
       <VerdictCard result={result} />
       <div className="mt-6 flex flex-wrap items-center gap-4 text-sm">
         <Link
           href={`/chat?mode=verify&claim=${encodeURIComponent(result.claim)}`}
-          className="border border-navy text-navy px-4 py-2 rounded-lg hover:bg-navy hover:text-white transition-colors"
+          className="border border-navy text-navy dark:border-[color:var(--dp-text)] dark:text-[color:var(--dp-text)] px-4 py-2 rounded-lg hover:bg-navy hover:text-white transition-colors"
         >
           Re-vérifier avec les données du jour
         </Link>
-        <Link href="/chat?mode=verify" className="text-gray-mid underline hover:text-navy">
+        <Link href="/chat?mode=verify" className="text-gray-mid dark:text-[color:var(--dp-text-muted)] underline hover:text-navy dark:hover:text-[color:var(--dp-text)]">
           Vérifier une autre affirmation
         </Link>
       </div>

--- a/frontend/src/components/ChatAnswerCard.tsx
+++ b/frontend/src/components/ChatAnswerCard.tsx
@@ -8,7 +8,7 @@ export function ChatAnswerCard({ result }: { result: ChatShareResult }) {
   const sources = (result.sources || []).slice(0, 3).map(mapSource)
 
   return (
-    <div className="bg-white border border-gray-border rounded-xl p-6 shadow-sm">
+    <div className="bg-white border border-gray-border dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)] rounded-xl p-6 shadow-sm">
       <div className="flex items-start justify-between gap-3 mb-4">
         {conf ? (
           <span
@@ -28,32 +28,32 @@ export function ChatAnswerCard({ result }: { result: ChatShareResult }) {
         />
       </div>
 
-      <blockquote className="border-l-4 border-gray-border pl-4 text-navy font-medium italic mb-4">
+      <blockquote className="border-l-4 border-gray-border dark:border-[color:var(--dp-border)] pl-4 text-navy dark:text-[color:var(--dp-text)] font-medium italic mb-4">
         « {result.question} »
       </blockquote>
 
       <div
-        className="text-[15px] leading-relaxed text-navy mb-2"
+        className="text-[15px] leading-relaxed text-navy dark:text-[color:var(--dp-text)] mb-2"
         dangerouslySetInnerHTML={{ __html: mdToHtml(result.answer) }}
       />
 
       {result.caveat && (
-        <div className="mt-3 mb-2 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2">
-          <span className="text-xs leading-relaxed text-amber-800">{result.caveat}</span>
+        <div className="mt-3 mb-2 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/40 px-3 py-2">
+          <span className="text-xs leading-relaxed text-amber-800 dark:text-amber-300">{result.caveat}</span>
         </div>
       )}
 
       {sources.length > 0 && (
         <div className="mt-5 mb-2">
-          <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-mid mb-2">Sources</h3>
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-mid dark:text-[color:var(--dp-text-muted)] mb-2">Sources</h3>
           <div className="flex flex-wrap gap-2">
             {sources.map((src, si) => {
               const inner = (
                 <>
                   <div className="w-2.5 h-2.5 rounded-full shrink-0" style={{ background: src.dot }} />
                   <div className="min-w-0 flex-1">
-                    <div className="text-xs font-semibold text-navy truncate">{src.label}</div>
-                    {src.sub && <div className="text-[11px] text-gray-mid truncate">{src.sub}</div>}
+                    <div className="text-xs font-semibold text-navy dark:text-[color:var(--dp-text)] truncate">{src.label}</div>
+                    {src.sub && <div className="text-[11px] text-gray-mid dark:text-[color:var(--dp-text-muted)] truncate">{src.sub}</div>}
                   </div>
                   {src.badge && (
                     <div
@@ -65,7 +65,7 @@ export function ChatAnswerCard({ result }: { result: ChatShareResult }) {
                   )}
                 </>
               )
-              const className = 'flex items-center gap-2.5 bg-white border border-gray-border rounded-lg px-3 py-2 max-w-[280px]'
+              const className = 'flex items-center gap-2.5 bg-white border border-gray-border dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)] rounded-lg px-3 py-2 max-w-[280px]'
               return src.href ? (
                 <Link key={si} href={src.href} className={className}>{inner}</Link>
               ) : (
@@ -76,7 +76,7 @@ export function ChatAnswerCard({ result }: { result: ChatShareResult }) {
         </div>
       )}
 
-      <p className="text-xs text-gray-mid border-t border-gray-border pt-3 mt-4">
+      <p className="text-xs text-gray-mid dark:text-[color:var(--dp-text-muted)] border-t border-gray-border dark:border-[color:var(--dp-border)] pt-3 mt-4">
         Réponse générée le{' '}
         {new Date(result.shared_at).toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' })}
         {' · '}Source : données ouvertes de l&apos;Assemblée Nationale.

--- a/frontend/src/components/VerdictCard.tsx
+++ b/frontend/src/components/VerdictCard.tsx
@@ -3,12 +3,12 @@ import { ShareButton } from './ShareButton'
 import type { VerifyResult } from '@/lib/api'
 
 const VERDICT_STYLES: Record<VerifyResult['verdict'], { label: string; badge: string }> = {
-  vrai: { label: 'Vrai', badge: 'bg-emerald-100 text-emerald-800 border-emerald-300' },
-  faux: { label: 'Faux', badge: 'bg-red-100 text-red-800 border-red-300' },
-  trompeur: { label: 'Trompeur', badge: 'bg-amber-100 text-amber-800 border-amber-300' },
+  vrai: { label: 'Vrai', badge: 'bg-emerald-100 text-emerald-800 border-emerald-300 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-800' },
+  faux: { label: 'Faux', badge: 'bg-red-100 text-red-800 border-red-300 dark:bg-red-950/40 dark:text-red-300 dark:border-red-800' },
+  trompeur: { label: 'Trompeur', badge: 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-800' },
   inverifiable: {
     label: 'Invérifiable avec nos données',
-    badge: 'bg-gray-100 text-gray-700 border-gray-300',
+    badge: 'bg-gray-100 text-gray-700 border-gray-300 dark:bg-white/10 dark:text-gray-300 dark:border-gray-600',
   },
 }
 
@@ -33,7 +33,7 @@ export function VerdictCard({ result }: { result: VerifyResult }) {
   const horizon = formatDate(result.data_horizon)
 
   return (
-    <div className="bg-white border border-gray-border rounded-xl p-6 shadow-sm">
+    <div className="bg-white border border-gray-border dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)] rounded-xl p-6 shadow-sm">
       <div className="flex items-start justify-between gap-3 mb-4">
         <span
           className={`inline-block text-sm font-bold uppercase tracking-wide px-3 py-1.5 rounded-md border ${style.badge}`}
@@ -48,16 +48,16 @@ export function VerdictCard({ result }: { result: VerifyResult }) {
         />
       </div>
 
-      <blockquote className="border-l-4 border-gray-border pl-4 text-navy font-medium italic mb-4">
+      <blockquote className="border-l-4 border-gray-border dark:border-[color:var(--dp-border)] pl-4 text-navy dark:text-[color:var(--dp-text)] font-medium italic mb-4">
         « {result.claim} »
       </blockquote>
 
       {result.deputy && (
-        <p className="text-sm text-gray-mid mb-3">
+        <p className="text-sm text-gray-mid dark:text-[color:var(--dp-text-muted)] mb-3">
           Député concerné :{' '}
           <Link
             href={`/deputes/${result.deputy.deputy_id}`}
-            className="text-navy font-medium underline hover:text-red-civic"
+            className="text-navy dark:text-[color:var(--dp-text)] font-medium underline hover:text-red-civic"
           >
             {result.deputy.name}
           </Link>
@@ -65,11 +65,11 @@ export function VerdictCard({ result }: { result: VerifyResult }) {
         </p>
       )}
 
-      <p className="text-[15px] leading-relaxed text-navy mb-5">{result.explanation}</p>
+      <p className="text-[15px] leading-relaxed text-navy dark:text-[color:var(--dp-text)] mb-5">{result.explanation}</p>
 
       {result.citations.length > 0 && (
         <div className="mb-5">
-          <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-mid mb-2">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-mid dark:text-[color:var(--dp-text-muted)] mb-2">
             Scrutins cités
           </h3>
           <ul className="space-y-2">
@@ -77,10 +77,10 @@ export function VerdictCard({ result }: { result: VerifyResult }) {
               <li key={c.vote_id}>
                 <Link
                   href={`/votes/${c.vote_id}`}
-                  className="block border border-gray-border rounded-lg p-3 hover:border-navy transition-colors"
+                  className="block border border-gray-border dark:border-[color:var(--dp-border)] rounded-lg p-3 hover:border-navy transition-colors"
                 >
-                  <span className="block text-sm font-medium text-navy">{c.title}</span>
-                  <span className="block text-xs text-gray-mid mt-1">
+                  <span className="block text-sm font-medium text-navy dark:text-[color:var(--dp-text)]">{c.title}</span>
+                  <span className="block text-xs text-gray-mid dark:text-[color:var(--dp-text-muted)] mt-1">
                     {formatDate(c.voted_at)}
                     {c.result ? ` · ${c.result}` : ''}
                     {c.deputy_position && result.deputy
@@ -94,7 +94,7 @@ export function VerdictCard({ result }: { result: VerifyResult }) {
         </div>
       )}
 
-      <p className="text-xs text-gray-mid border-t border-gray-border pt-3">
+      <p className="text-xs text-gray-mid dark:text-[color:var(--dp-text-muted)] border-t border-gray-border dark:border-[color:var(--dp-border)] pt-3">
         {CONFIDENCE_LABELS[result.confidence]}
         {verifiedAt ? ` · Vérifié le ${verifiedAt}` : ''}
         {horizon ? ` · Sur la base des scrutins de l'Assemblée Nationale depuis le ${horizon}` : ''}

--- a/frontend/src/components/chat/Bubbles.tsx
+++ b/frontend/src/components/chat/Bubbles.tsx
@@ -9,9 +9,9 @@ const chunkTypeLabel: Record<string, string> = {
 }
 
 const confidenceColor: Record<string, string> = {
-  high: 'bg-emerald-100 text-emerald-800',
-  medium: 'bg-amber-100 text-amber-800',
-  low: 'bg-red-50 text-red-700',
+  high: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300',
+  medium: 'bg-amber-100 text-amber-800 dark:bg-amber-950/40 dark:text-amber-300',
+  low: 'bg-red-50 text-red-700 dark:bg-red-950/40 dark:text-red-300',
 }
 
 const confidenceLabel: Record<string, string> = {
@@ -33,25 +33,25 @@ export function UserBubble({ text }: { text: string }) {
 export function AssistantBubble({ result }: { result: SearchResult }) {
   return (
     <div className="flex justify-start">
-      <div className="bg-white border border-gray-border rounded-2xl rounded-tl-sm px-4 py-3 max-w-[90%] space-y-3">
-        <p className="text-sm text-navy leading-relaxed whitespace-pre-wrap">{result.answer}</p>
+      <div className="bg-white border border-gray-border dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)] rounded-2xl rounded-tl-sm px-4 py-3 max-w-[90%] space-y-3">
+        <p className="text-sm text-navy dark:text-[color:var(--dp-text)] leading-relaxed whitespace-pre-wrap">{result.answer}</p>
 
         {result.confidence && (
-          <span className={`inline-block text-xs px-2 py-0.5 rounded font-medium ${confidenceColor[result.confidence] ?? 'bg-gray-light text-gray-mid'}`}>
+          <span className={`inline-block text-xs px-2 py-0.5 rounded font-medium ${confidenceColor[result.confidence] ?? 'bg-gray-light text-gray-mid dark:bg-white/10 dark:text-gray-300'}`}>
             {confidenceLabel[result.confidence] ?? result.confidence}
           </span>
         )}
 
         {result.sources?.length > 0 && (
-          <div className="border-t border-gray-light pt-3 space-y-2">
-            <p className="text-xs font-medium text-gray-mid uppercase tracking-wide">
+          <div className="border-t border-gray-light dark:border-[color:var(--dp-border)] pt-3 space-y-2">
+            <p className="text-xs font-medium text-gray-mid dark:text-[color:var(--dp-text-muted)] uppercase tracking-wide">
               Sources ({result.sources.length})
             </p>
             {result.sources.slice(0, 3).map((src, j) => (
-              <div key={j} className="bg-gray-off rounded-lg p-3">
-                <p className="text-xs text-navy/70 line-clamp-2">{src.content}</p>
+              <div key={j} className="bg-gray-off dark:bg-[color:var(--dp-track-bg)] rounded-lg p-3">
+                <p className="text-xs text-navy/70 dark:text-[color:var(--dp-text-secondary)] line-clamp-2">{src.content}</p>
                 {src.metadata?.chunk_type && (
-                  <p className="text-xs text-gray-mid mt-1">
+                  <p className="text-xs text-gray-mid dark:text-[color:var(--dp-text-muted)] mt-1">
                     {chunkTypeLabel[src.metadata.chunk_type] ?? src.metadata.chunk_type}
                   </p>
                 )}
@@ -67,7 +67,7 @@ export function AssistantBubble({ result }: { result: SearchResult }) {
 export function ErrorBubble({ text }: { text: string }) {
   return (
     <div className="flex justify-start">
-      <div className="bg-red-50 border border-red-200 text-red-700 rounded-2xl rounded-tl-sm px-4 py-2.5 max-w-[80%] text-sm">
+      <div className="bg-red-50 border border-red-200 text-red-700 dark:bg-red-950/40 dark:border-red-800 dark:text-red-300 rounded-2xl rounded-tl-sm px-4 py-2.5 max-w-[80%] text-sm">
         {text}
       </div>
     </div>
@@ -77,10 +77,10 @@ export function ErrorBubble({ text }: { text: string }) {
 export function TypingIndicator() {
   return (
     <div className="flex justify-start">
-      <div className="bg-white border border-gray-border rounded-2xl rounded-tl-sm px-4 py-3">
+      <div className="bg-white border border-gray-border dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)] rounded-2xl rounded-tl-sm px-4 py-3">
         <div className="flex gap-1">
           {[0, 1, 2].map(i => (
-            <span key={i} className="w-1.5 h-1.5 bg-gray-mid rounded-full animate-bounce"
+            <span key={i} className="w-1.5 h-1.5 bg-gray-mid dark:bg-[color:var(--dp-text-muted)] rounded-full animate-bounce"
               style={{ animationDelay: `${i * 150}ms` }} />
           ))}
         </div>


### PR DESCRIPTION
## What
Adds dark mode to the chat/verify share pages and the shared `VerdictCard`/`ChatAnswerCard`/`Bubbles` components, including the verdict and confidence badge colors this issue's acceptance criteria specifically requires.

## Why
Follow-up to MON-155/MON-156/MON-160-167, but a different shape of fix: unlike the deputy/vote pages, `VerdictCard.tsx`, `ChatAnswerCard.tsx`, and `Bubbles.tsx` are already built with Tailwind color utility classes (`bg-white`, `text-navy`, `text-gray-mid`, etc.), not inline hex. Tailwind's static utility classes don't invert automatically in dark mode — `text-navy` resolves to the same fixed hex regardless of theme unless a `dark:` variant is added — so the fix here is adding `dark:` classes, mostly as arbitrary values referencing the existing `--dp-*` CSS variables for consistency with the rest of the app's dark palette, rather than a hex-to-`var()` substitution.

While implementing, found that `chat/page.tsx` (~80 literals, 953 lines) and the quiz UI (`QuizClient.tsx`/`QuizResultSections.tsx`, ~28 literals) are large enough to need their own sub-issues (MON-168, MON-169) — same reasoning as every prior split in this series.

## Changes
- `frontend/src/components/VerdictCard.tsx`: added `dark:` variants throughout, including the four verdict badge states (vrai/faux/trompeur/inverifiable) using each color's `-950/40` dark background + `-300` dark text, the same treatment already applied to `badge-adopte`/`badge-rejete` in MON-156.
- `frontend/src/components/ChatAnswerCard.tsx`: same `dark:` treatment. Left `conf.bg`/`conf.color` (from `lib/chatFormat`'s `CONFIDENCE_META`) and `src.dot`/`src.badgeBg`/`src.badgeColor` (from `mapSource`) untouched — shared color-mapping functions, the same deferred-gap category as `vote-position.ts`/`partyHex()`/`themeColors()`.
- `frontend/src/components/chat/Bubbles.tsx`: `dark:` variants for `AssistantBubble`, `ErrorBubble`, `TypingIndicator`, and the `confidenceColor` badge map (high/medium/low). `UserBubble`'s `bg-navy text-white` needs no change — navy is a fixed dark color, so white text stays legible regardless of theme.
- `frontend/src/app/verifier/v/[id]/page.tsx`, `frontend/src/app/chat/s/[id]/page.tsx`: same `dark:` treatment for their own markup (breadcrumb text, CTA links).
- `frontend/src/app/quiz/s/[id]/page.tsx`: this one is inline-hex based (small) rather than Tailwind — converted its `CREAM`/`RED` consts and CTA button to `--dp-*` variables, including the `--dp-cta-bg` fix (MON-163) since it pairs a solid background with hardcoded white text.

## Testing
- `npm run lint` — clean.
- `npm test` — 149 tests / 20 suites pass, including the existing `VerdictCard.test.tsx`.
- `npm run build` — succeeds.
- **Important caveat specific to this PR:** Tailwind doesn't validate arbitrary-value class strings like `dark:bg-[color:var(--dp-card-bg)]` against real CSS variable names — a typo would compile silently without any build error, unlike the inline-style `var()` substitutions in prior PRs (which show up in emitted CSS/JS and are easy to grep-verify). To catch this, extracted every `var(--dp-*)` reference used in this PR's files and diffed it against the variable names actually defined in `globals.css` — all match, no typos.
- Manual: ran `next dev` and inspected the compiled bundles; confirmed `emerald-950`-style dark verdict classes are present in the `chat/page.js` bundle (via the shared `Bubbles` import), though the share pages themselves need a real verification/chat-share ID to render fully, which wasn't available to fabricate safely in this environment.

## Risks / Notes
- Same known, deliberate gap as prior PRs: `chatFormat.ts`'s `CONFIDENCE_META`/`mapSource` color mappings remain out of scope, deferred to MON-159.
- No visual/screenshot verification was possible in this environment, and this PR in particular relied more on cross-referencing variable names against `globals.css` than on rendering, for the Tailwind-arbitrary-value reason above.

## Breaking Changes
None.

https://claude.ai/code/session_01HVxc7TTP3xnsgNC3mtzxEb