### PR TITLE
feat: dark mode for the quiz page (MON-169)

### DIFF
--- a/frontend/src/app/quiz/QuizClient.tsx
+++ b/frontend/src/app/quiz/QuizClient.tsx
@@ -8,12 +8,12 @@ import type { ResolvedDepartment } from '@/lib/postal'
 import { POS } from '@/lib/vote-position'
 import { card, QuizResultSections } from './QuizResultSections'
 
-const NAVY = '#1B2B50'
-const CREAM = '#F7F4ED'
-const LINE = '#E4E6EA'
-const ACCENT = '#E0786E'
-const RED = '#C9302A'
-const GRAY = '#6B7280'
+const NAVY = 'var(--dp-text)'
+const CREAM = 'var(--dp-page-bg)'
+const LINE = 'var(--dp-border)'
+const ACCENT = 'var(--dp-cta-bg)'
+const RED = 'var(--dp-red)'
+const GRAY = 'var(--dp-text-secondary)'
 
 // Mirrors MIN_ANSWERS in api/routers/quiz.py — the backend rejects fewer.
 const MIN_ANSWERS = 3
@@ -92,7 +92,7 @@ function ShareResultButton({
         background: ACCENT, color: '#fff', padding: '11px 22px', borderRadius: 9,
         fontWeight: 600, fontSize: 14.5, border: 'none',
         cursor: state === 'creating' ? 'wait' : 'pointer',
-        boxShadow: '0 2px 8px rgba(224,120,110,0.35)',
+        boxShadow: '0 2px 8px var(--dp-cta-shadow)',
       }}
     >
       {state === 'creating'
@@ -217,7 +217,7 @@ export function QuizClient() {
           >
             Quel député vote comme vous ?
           </h1>
-          <p style={{ margin: '18px auto 0', maxWidth: 520, fontSize: 16, lineHeight: 1.65, color: '#4B5563' }}>
+          <p style={{ margin: '18px auto 0', maxWidth: 520, fontSize: 16, lineHeight: 1.65, color: 'var(--dp-text-secondary)' }}>
             Une dizaine de vrais scrutins de l’Assemblée nationale, posés en français courant.
             Répondez pour, contre ou abstention — à la fin, on compare vos réponses aux votes
             réels des 577 députés.
@@ -247,7 +247,7 @@ export function QuizClient() {
                 border: 'none',
                 cursor: questions ? 'pointer' : 'wait',
                 opacity: questions ? 1 : 0.6,
-                boxShadow: '0 2px 8px rgba(224,120,110,0.35)',
+                boxShadow: '0 2px 8px var(--dp-cta-shadow)',
               }}
             >
               {questions ? 'Commencer le quiz' : 'Chargement…'}
@@ -275,7 +275,7 @@ export function QuizClient() {
           aria-valuenow={index + 1}
           aria-valuemin={1}
           aria-valuemax={questions.length}
-          style={{ height: 6, background: '#E7E2D6', borderRadius: 999, overflow: 'hidden', marginBottom: 30 }}
+          style={{ height: 6, background: 'var(--dp-border-subtle)', borderRadius: 999, overflow: 'hidden', marginBottom: 30 }}
         >
           <div
             style={{
@@ -354,7 +354,7 @@ export function QuizClient() {
             >
               Encore quelques réponses
             </h2>
-            <p style={{ margin: '16px 0 28px', fontSize: 15.5, lineHeight: 1.6, color: '#4B5563' }}>
+            <p style={{ margin: '16px 0 28px', fontSize: 15.5, lineHeight: 1.6, color: 'var(--dp-text-secondary)' }}>
               Il faut au moins {MIN_ANSWERS} réponses exprimées pour un résultat significatif —
               vous en avez donné {answeredCount}.
             </p>
@@ -379,7 +379,7 @@ export function QuizClient() {
             >
               Et votre député à vous ?
             </h2>
-            <p style={{ margin: '16px 0 24px', fontSize: 15.5, lineHeight: 1.6, color: '#4B5563' }}>
+            <p style={{ margin: '16px 0 24px', fontSize: 15.5, lineHeight: 1.6, color: 'var(--dp-text-secondary)' }}>
               Donnez votre code postal pour comparer aussi vos réponses aux votes des députés de
               votre département. Facultatif — il n’est ni envoyé à nos serveurs tel quel, ni conservé.
             </p>
@@ -400,7 +400,7 @@ export function QuizClient() {
                 aria-label="Code postal"
                 style={{
                   flex: '1 1 200px', padding: '12px 16px', borderRadius: 9,
-                  border: `1px solid ${LINE}`, fontSize: 15.5, color: NAVY, background: '#fff',
+                  border: `1px solid ${LINE}`, fontSize: 15.5, color: NAVY, background: 'var(--dp-card-bg)',
                 }}
               />
               <button
@@ -459,7 +459,7 @@ export function QuizClient() {
         <QuizResultSections result={result} resolvedNom={resolved?.nom} />
 
         <section style={{ marginTop: 48, ...card, textAlign: 'center' }}>
-          <p style={{ margin: '0 0 16px', fontSize: 15, lineHeight: 1.6, color: '#4B5563' }}>
+          <p style={{ margin: '0 0 16px', fontSize: 15, lineHeight: 1.6, color: 'var(--dp-text-secondary)' }}>
             Partagez votre résultat, ou suivez un de ces députés vote après vote.
           </p>
           <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap' }}>
@@ -469,7 +469,7 @@ export function QuizClient() {
             <Link
               href="/mon-depute"
               style={{
-                fontSize: 14.5, color: NAVY, background: '#fff', border: `1px solid ${LINE}`,
+                fontSize: 14.5, color: NAVY, background: 'var(--dp-card-bg)', border: `1px solid ${LINE}`,
                 padding: '11px 22px', borderRadius: 9, fontWeight: 600, textDecoration: 'none',
               }}
             >
@@ -478,7 +478,7 @@ export function QuizClient() {
             <button
               onClick={restart}
               style={{
-                fontSize: 14.5, color: NAVY, background: '#fff', border: `1px solid ${LINE}`,
+                fontSize: 14.5, color: NAVY, background: 'var(--dp-card-bg)', border: `1px solid ${LINE}`,
                 padding: '11px 22px', borderRadius: 9, fontWeight: 600, cursor: 'pointer',
               }}
             >

--- a/frontend/src/app/quiz/QuizResultSections.tsx
+++ b/frontend/src/app/quiz/QuizResultSections.tsx
@@ -5,12 +5,12 @@ import { partyHex } from '@/lib/utils'
 import { departmentLabel } from '@/lib/departments'
 import { DeputyAvatar } from '@/components/DeputyAvatar'
 
-const NAVY = '#1B2B50'
-const LINE = '#E4E6EA'
-const GRAY = '#6B7280'
+const NAVY = 'var(--dp-text)'
+const LINE = 'var(--dp-border)'
+const GRAY = 'var(--dp-text-secondary)'
 
 export const card: React.CSSProperties = {
-  background: '#fff',
+  background: 'var(--dp-card-bg)',
   border: `1px solid ${LINE}`,
   borderRadius: 12,
   padding: '22px 24px',
@@ -22,7 +22,7 @@ function AgreementBar({ pct, color }: { pct: number; color: string }) {
       style={{
         position: 'relative',
         height: 8,
-        background: '#EEF0F2',
+        background: 'var(--dp-track-bg)',
         borderRadius: 999,
         overflow: 'hidden',
       }}
@@ -53,12 +53,12 @@ function DeputyMatchRow({ match, rank }: { match: QuizDeputyMatch; rank?: number
         padding: '12px 14px',
         borderRadius: 10,
         textDecoration: 'none',
-        background: '#fff',
+        background: 'var(--dp-card-bg)',
         border: `1px solid ${LINE}`,
       }}
     >
       {rank !== undefined && (
-        <span className="font-mono" style={{ fontSize: 13, color: '#9CA3AF', width: 20 }}>
+        <span className="font-mono" style={{ fontSize: 13, color: 'var(--dp-text-muted)', width: 20 }}>
           {rank}
         </span>
       )}
@@ -75,7 +75,7 @@ function DeputyMatchRow({ match, rank }: { match: QuizDeputyMatch; rank?: number
         <div className="font-mono" style={{ fontWeight: 700, fontSize: 18, color: hex }}>
           {pctLabel(match)}
         </div>
-        <div style={{ fontSize: 11.5, color: '#9CA3AF' }}>{comparedLabel(match)}</div>
+        <div style={{ fontSize: 11.5, color: 'var(--dp-text-muted)' }}>{comparedLabel(match)}</div>
       </div>
     </Link>
   )
@@ -122,7 +122,7 @@ export function QuizResultSections({
               <div style={{ fontSize: 14, color: GRAY, marginTop: 4 }}>
                 {[best.party, departmentLabel(best.department)].filter(Boolean).join(' · ')}
               </div>
-              <div style={{ fontSize: 13, color: '#9CA3AF', marginTop: 4 }}>{comparedLabel(best)}</div>
+              <div style={{ fontSize: 13, color: 'var(--dp-text-muted)', marginTop: 4 }}>{comparedLabel(best)}</div>
             </div>
             <div className="font-mono" style={{ fontWeight: 700, fontSize: 34, color: bestHex }}>
               {pctLabel(best)}
@@ -137,7 +137,7 @@ export function QuizResultSections({
           >
             Pas assez de votes comparables
           </h1>
-          <p style={{ margin: '14px 0 0', fontSize: 15.5, lineHeight: 1.6, color: '#4B5563' }}>
+          <p style={{ margin: '14px 0 0', fontSize: 15.5, lineHeight: 1.6, color: 'var(--dp-text-secondary)' }}>
             Aucun député n’a exprimé de position sur assez de scrutins de votre sélection pour
             établir une comparaison fiable. Réessayez en répondant à davantage de questions.
           </p>


### PR DESCRIPTION
## What
Adds dark mode to `/quiz` (all four phases: intro, questions, postal, results) by converting `QuizClient.tsx` and `QuizResultSections.tsx`'s inline hex-literal styling to the shared `--dp-*` CSS variable palette.

## Why
Follow-up to MON-157, converting the quiz UI files that were split off for size (~28 literals combined across 715 lines).

## Changes
- `frontend/src/app/quiz/QuizClient.tsx`: local `NAVY`/`CREAM`/`LINE`/`ACCENT`/`RED`/`GRAY` consts and all other inline hex/`rgba()` literals now reference `--dp-*` variables. Every `ACCENT` usage in this file pairs a solid background with hardcoded white text (share button, intro CTA, postal-step CTAs) — unlike `ComparerClient.tsx` (MON-162), where `ACCENT` was also used decoratively for a legend dot — so the `ACCENT` const itself is redefined to `var(--dp-cta-bg)` rather than needing per-site special-casing.
- `frontend/src/app/quiz/QuizResultSections.tsx`: same conversion, reusing the shared card/track/text tokens.
- `frontend/src/app/quiz/page.tsx`: confirmed (per MON-157's note) to have no styling of its own — no changes needed.

## Testing
- `npm run lint` — clean.
- `npm test` — 149 tests / 20 suites pass, including the existing `QuizClient.test.tsx`.
- `npm run build` — succeeds.
- Manual: ran `next dev`, curled `/quiz` — the intro phase renders synchronously (no `localStorage` gate like `mon-depute` had), so curl confirmed 6 of the relevant `--dp-*` variables directly. The remaining 4 (`--dp-border`, `--dp-card-bg`, `--dp-track-bg`, `--dp-text-muted`), which only appear in the questions/results phases reached via client-side state transitions, were confirmed present with no typos in the compiled `.next/static/chunks/app/quiz/page.js` bundle.

## Risks / Notes
- Same known, deliberate gap as prior PRs: `POS` (from `lib/vote-position.ts`) and `partyHex()` colors — used for the pour/contre/abstention answer buttons and deputy-match party accents — remain out of scope, deferred to MON-159.
- No visual/screenshot verification was possible in this environment.

## Breaking Changes
None.

https://claude.ai/code/session_01HVxc7TTP3xnsgNC3mtzxEb