### PR TITLE
feat: dark mode for small static pages and shared chrome (MON-158)

### DIFF
--- a/frontend/src/app/confidentialite/page.tsx
+++ b/frontend/src/app/confidentialite/page.tsx
@@ -12,7 +12,7 @@ export default function ConfidentialitePage() {
     <LegalPageLayout eyebrow="RGPD" title="Politique de confidentialité">
 
       <LegalSection title="Le principe">
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: 0 }}>
           MonÉlu ne demande pas de compte, pas d&apos;e-mail, pas de mot de passe. Aucune donnée personnelle n&apos;est
           nécessaire pour consulter les fiches de députés, les votes ou utiliser la recherche. Ce qui suit détaille
           précisément ce qui est techniquement collecté malgré tout.
@@ -20,7 +20,7 @@ export default function ConfidentialitePage() {
       </LegalSection>
 
       <LegalSection title="Mesure d'audience">
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: 0 }}>
           Le site utilise Vercel Analytics et Vercel Speed Insights pour mesurer la fréquentation et les
           performances de chargement. Ces outils sont sans cookies : ils n&apos;utilisent aucun identifiant
           persistant et ne permettent pas de suivre un visiteur d&apos;une session à l&apos;autre. À ce titre, ils
@@ -31,22 +31,22 @@ export default function ConfidentialitePage() {
       </LegalSection>
 
       <LegalSection title="Stockage local (navigateur)">
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: '0 0 10px' }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: '0 0 10px' }}>
           Deux éléments sont enregistrés dans le <code>localStorage</code> de votre navigateur, jamais transmis à
           nos serveurs :
         </p>
-        <ul style={{ fontSize: '15px', lineHeight: 1.85, color: '#4B5563', margin: 0, paddingLeft: '20px' }}>
+        <ul style={{ fontSize: '15px', lineHeight: 1.85, color: 'var(--dp-text-secondary)', margin: 0, paddingLeft: '20px' }}>
           <li>l&apos;historique de vos conversations avec l&apos;assistant IA (page Chat) ;</li>
           <li>votre préférence d&apos;affichage clair / sombre.</li>
         </ul>
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: '10px 0 0' }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: '10px 0 0' }}>
           Ces données restent sur votre appareil. Vous pouvez les effacer à tout moment en vidant les données de
           site de votre navigateur pour monelu.
         </p>
       </LegalSection>
 
       <LegalSection title="Assistant de recherche (RAG)">
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: 0 }}>
           Les questions que vous posez à l&apos;assistant sont envoyées à notre API, qui interroge un modèle de
           langage hébergé par Groq pour générer une réponse. Ces requêtes ne sont pas associées à une identité -
           aucun compte, aucune adresse IP n&apos;est journalisée à des fins de profilage. Elles peuvent être
@@ -55,24 +55,24 @@ export default function ConfidentialitePage() {
       </LegalSection>
 
       <LegalSection title="Données sur les députés">
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: 0 }}>
           Les informations affichées sur les député·e·s (votes, présence, parti, mandat) concernent des personnes
           publiques dans l&apos;exercice de leur mandat électif et proviennent de sources officielles ouvertes
-          (voir <Link href="/licence-donnees" style={{ color: '#1B2B50' }}>Licence des données</Link>). Ce
+          (voir <Link href="/licence-donnees" style={{ color: 'var(--dp-text)' }}>Licence des données</Link>). Ce
           traitement s&apos;appuie sur l&apos;intérêt légitime d&apos;information du public prévu par le RGPD.
         </p>
       </LegalSection>
 
       <LegalSection title="Vos droits">
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: 0 }}>
           Conformément au RGPD, vous disposez d&apos;un droit d&apos;accès, de rectification et de suppression sur
           toute donnée vous concernant. Pour l&apos;exercer, écrivez à{' '}
-          <a href="mailto:walidelkhoukh99@gmail.com" style={{ color: '#1B2B50' }}>walidelkhoukh99@gmail.com</a>.
+          <a href="mailto:walidelkhoukh99@gmail.com" style={{ color: 'var(--dp-text)' }}>walidelkhoukh99@gmail.com</a>.
         </p>
       </LegalSection>
 
       <LegalSection title="Évolutions à venir">
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: 0 }}>
           Cette politique sera mise à jour si de nouvelles fonctionnalités impliquant des données personnelles
           sont ajoutées, notamment un système d&apos;abonnement par e-mail pour suivre un député ou un thème.
         </p>

--- a/frontend/src/app/developpeurs/page.tsx
+++ b/frontend/src/app/developpeurs/page.tsx
@@ -8,14 +8,14 @@ export const metadata: Metadata = {
   description: "Documentation de l'API MonÉlu : endpoints, limites de débit, clés d'accès et licence des données.",
 }
 
-const textStyle = { fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }
+const textStyle = { fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: 0 }
 const codeBlockStyle = {
-  background: '#F7F4ED',
-  border: '1px solid #ECE7DC',
+  background: 'var(--dp-page-bg)',
+  border: '1px solid var(--dp-border-subtle)',
   borderRadius: '8px',
   padding: '14px 18px',
   fontSize: '14px',
-  color: '#1B2B50',
+  color: 'var(--dp-text)',
   fontFamily: 'monospace',
   overflowX: 'auto' as const,
 }
@@ -30,7 +30,7 @@ export default function DeveloppeursPage() {
           leurs schémas de réponse :
         </p>
         <p style={textStyle}>
-          <a href={`${API_BASE}/docs`} target="_blank" rel="noopener noreferrer" style={{ color: '#1B2B50', fontWeight: 600 }}>
+          <a href={`${API_BASE}/docs`} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--dp-text)', fontWeight: 600 }}>
             {API_BASE}/docs
           </a>
         </p>
@@ -40,7 +40,7 @@ export default function DeveloppeursPage() {
         <p style={{ ...textStyle, marginBottom: '10px' }}>
           Toute requête anonyme partage un même quota par adresse IP :
         </p>
-        <ul style={{ fontSize: '15px', lineHeight: 1.85, color: '#4B5563', margin: '0 0 10px', paddingLeft: '20px' }}>
+        <ul style={{ fontSize: '15px', lineHeight: 1.85, color: 'var(--dp-text-secondary)', margin: '0 0 10px', paddingLeft: '20px' }}>
           <li><strong>30 requêtes / minute</strong> sur la plupart des endpoints (listes, fiches, votes).</li>
           <li><strong>10 requêtes / minute</strong> sur les endpoints coûteux (scorecards, alignement, recherche sémantique).</li>
         </ul>
@@ -55,7 +55,7 @@ export default function DeveloppeursPage() {
         <p style={{ ...textStyle, marginBottom: '10px' }}>
           Les clés sont émises manuellement pour l&apos;instant - pas d&apos;inscription en libre-service.
           Écrivez à{' '}
-          <a href="mailto:walidelkhoukh99@gmail.com" style={{ color: '#1B2B50' }}>walidelkhoukh99@gmail.com</a>{' '}
+          <a href="mailto:walidelkhoukh99@gmail.com" style={{ color: 'var(--dp-text)' }}>walidelkhoukh99@gmail.com</a>{' '}
           en précisant votre usage prévu (recherche, rédaction, produit) et le volume de requêtes attendu.
         </p>
         <p style={{ ...textStyle, marginBottom: '10px' }}>
@@ -81,7 +81,7 @@ export default function DeveloppeursPage() {
           Les données servies par l&apos;API sont publiées sous la Licence Ouverte / Open Licence 2.0
           (&laquo;&nbsp;Etalab 2.0&nbsp;&raquo;) - réutilisation libre, y compris commerciale, sous réserve
           d&apos;attribution. Détails complets sur la page{' '}
-          <a href="/licence-donnees" style={{ color: '#1B2B50' }}>Licence des données</a>.
+          <a href="/licence-donnees" style={{ color: 'var(--dp-text)' }}>Licence des données</a>.
         </p>
       </LegalSection>
     </LegalPageLayout>

--- a/frontend/src/app/donnees/page.tsx
+++ b/frontend/src/app/donnees/page.tsx
@@ -47,32 +47,32 @@ export default function DonneesPage() {
     <LegalPageLayout eyebrow="Open data" title="Données à emporter">
 
       <LegalSection title="Exports CSV disponibles">
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: '0 0 18px' }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: '0 0 18px' }}>
           Trois exports couvrent l&apos;essentiel du besoin des journalistes et chercheurs. Ils sont
           servis par la même API que le site — mêmes chiffres, aucun décalage. Pour explorer avant
-          de télécharger, la <Link href="/deputes/tableau" style={{ color: '#1B2B50' }}>vue tableau des députés</Link>{' '}
+          de télécharger, la <Link href="/deputes/tableau" style={{ color: 'var(--dp-text)' }}>vue tableau des députés</Link>{' '}
           affiche toutes les scorecards triables sur un écran.
         </p>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
           {EXPORTS.map(e => (
-            <div key={e.pattern} style={{ background: '#F7F4ED', border: '1px solid #ECE7DC', borderRadius: '10px', padding: '16px 20px' }}>
+            <div key={e.pattern} style={{ background: 'var(--dp-page-bg)', border: '1px solid var(--dp-border-subtle)', borderRadius: '10px', padding: '16px 20px' }}>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
-                <span style={{ fontWeight: 700, fontSize: '15px', color: '#1B2B50' }}>{e.name}</span>
+                <span style={{ fontWeight: 700, fontSize: '15px', color: 'var(--dp-text)' }}>{e.name}</span>
                 {e.href && (
                   <a
                     href={e.href}
                     download
-                    style={{ fontSize: '13.5px', fontWeight: 600, color: '#C9302A', textDecoration: 'none', whiteSpace: 'nowrap' }}
+                    style={{ fontSize: '13.5px', fontWeight: 600, color: 'var(--dp-red)', textDecoration: 'none', whiteSpace: 'nowrap' }}
                   >
                     Télécharger ↓
                   </a>
                 )}
               </div>
-              <p style={{ fontSize: '14px', lineHeight: 1.65, color: '#4B5563', margin: '8px 0 10px' }}>{e.what}</p>
-              <div style={{ fontFamily: 'monospace', fontSize: '12.5px', color: '#1B2B50', marginBottom: 8 }}>
+              <p style={{ fontSize: '14px', lineHeight: 1.65, color: 'var(--dp-text-secondary)', margin: '8px 0 10px' }}>{e.what}</p>
+              <div style={{ fontFamily: 'monospace', fontSize: '12.5px', color: 'var(--dp-text)', marginBottom: 8 }}>
                 GET {API_BASE}{e.pattern}
               </div>
-              <div style={{ fontSize: '12px', lineHeight: 1.6, color: '#9CA3AF' }}>
+              <div style={{ fontSize: '12px', lineHeight: 1.6, color: 'var(--dp-text-muted)' }}>
                 Colonnes : {e.columns}
               </div>
             </div>
@@ -81,16 +81,16 @@ export default function DonneesPage() {
       </LegalSection>
 
       <LegalSection title="Format des fichiers">
-        <ul style={{ fontSize: '15px', lineHeight: 1.85, color: '#4B5563', margin: 0, paddingLeft: '20px' }}>
+        <ul style={{ fontSize: '15px', lineHeight: 1.85, color: 'var(--dp-text-secondary)', margin: 0, paddingLeft: '20px' }}>
           <li>Encodage UTF-8 avec BOM — les accents s&apos;affichent correctement dans Excel et LibreOffice.</li>
           <li>Séparateur virgule, fins de ligne CRLF (RFC 4180). Si votre Excel (réglé en français) place tout dans une colonne, passez par « Données → À partir d&apos;un fichier texte/CSV ».</li>
           <li>Les taux (<code style={{ fontSize: '13px' }}>*_rate</code>, <code style={{ fontSize: '13px' }}>*_pct</code>) sont des ratios entre 0 et 1 ; les dates sont au format ISO 8601.</li>
-          <li><code style={{ fontSize: '13px' }}>position</code> vaut <code style={{ fontSize: '13px' }}>pour</code>, <code style={{ fontSize: '13px' }}>contre</code>, <code style={{ fontSize: '13px' }}>abstention</code> ou <code style={{ fontSize: '13px' }}>nonVotant</code> — l&apos;abstention est un acte exprimé, le non-votant était présent sans voter. Détails dans la <Link href="/methodologie" style={{ color: '#1B2B50' }}>méthodologie</Link>.</li>
+          <li><code style={{ fontSize: '13px' }}>position</code> vaut <code style={{ fontSize: '13px' }}>pour</code>, <code style={{ fontSize: '13px' }}>contre</code>, <code style={{ fontSize: '13px' }}>abstention</code> ou <code style={{ fontSize: '13px' }}>nonVotant</code> — l&apos;abstention est un acte exprimé, le non-votant était présent sans voter. Détails dans la <Link href="/methodologie" style={{ color: 'var(--dp-text)' }}>méthodologie</Link>.</li>
         </ul>
       </LegalSection>
 
       <LegalSection title="Fraîcheur des données">
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: 0 }}>
           La base est mise à jour automatiquement chaque jour ouvré (ingestion à 06h00 UTC depuis
           l&apos;open data de l&apos;Assemblée nationale). Les exports reflètent l&apos;état de la base au moment du
           téléchargement. La base de production couvre les scrutins depuis le 1er juillet 2025 ;
@@ -99,25 +99,25 @@ export default function DonneesPage() {
       </LegalSection>
 
       <LegalSection title="Licence et attribution">
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: '0 0 10px' }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: '0 0 10px' }}>
           Les données sont réutilisables librement, y compris commercialement, sous Licence Ouverte
           2.0 (Etalab) — la même licence que les sources officielles. La seule obligation est de
           mentionner la source et la date. Attribution suggérée :
         </p>
-        <div style={{ background: '#F7F4ED', border: '1px solid #ECE7DC', borderRadius: '8px', padding: '14px 18px', fontSize: '14px', color: '#1B2B50', fontFamily: 'monospace' }}>
+        <div style={{ background: 'var(--dp-page-bg)', border: '1px solid var(--dp-border-subtle)', borderRadius: '8px', padding: '14px 18px', fontSize: '14px', color: 'var(--dp-text)', fontFamily: 'monospace' }}>
           Données : Assemblée nationale, via monelu.fr - Licence Ouverte 2.0
         </div>
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: '10px 0 0' }}>
-          Conditions détaillées sur la page <Link href="/licence-donnees" style={{ color: '#1B2B50' }}>Licence des données</Link>.
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: '10px 0 0' }}>
+          Conditions détaillées sur la page <Link href="/licence-donnees" style={{ color: 'var(--dp-text)' }}>Licence des données</Link>.
         </p>
       </LegalSection>
 
       <LegalSection title="Besoin de plus que du CSV ?">
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: 0 }}>
           L&apos;API REST expose les mêmes données en JSON, avec filtres et pagination — documentation
-          sur la page <Link href="/developpeurs" style={{ color: '#1B2B50' }}>développeurs</Link>. Les exports CSV sont soumis
+          sur la page <Link href="/developpeurs" style={{ color: 'var(--dp-text)' }}>développeurs</Link>. Les exports CSV sont soumis
           au même rate-limiting que le reste de l&apos;API ; pour un usage intensif, écrivez à{' '}
-          <a href="mailto:walidelkhoukh99@gmail.com" style={{ color: '#1B2B50' }}>walidelkhoukh99@gmail.com</a>.
+          <a href="mailto:walidelkhoukh99@gmail.com" style={{ color: 'var(--dp-text)' }}>walidelkhoukh99@gmail.com</a>.
         </p>
       </LegalSection>
 

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -18,10 +18,10 @@ export default function Error({
 
   return (
     <div className="max-w-2xl mx-auto px-4 md:px-8 py-16 text-center">
-      <h2 className="font-serif text-2xl text-navy mb-3">
+      <h2 className="font-serif text-2xl text-navy dark:text-[color:var(--dp-text)] mb-3">
         Une erreur est survenue
       </h2>
-      <p className="text-gray-mid text-sm mb-6">
+      <p className="text-gray-mid dark:text-[color:var(--dp-text-muted)] text-sm mb-6">
         L&apos;API est temporairement indisponible. Les données seront de nouveau accessibles dans quelques instants.
       </p>
       <div className="flex items-center justify-center gap-3">
@@ -33,7 +33,7 @@ export default function Error({
         </button>
         <Link
           href="/"
-          className="border border-navy/30 text-navy px-5 py-2 rounded font-medium text-sm hover:bg-navy/5 transition-colors"
+          className="border border-navy/30 text-navy dark:border-[color:var(--dp-text)]/30 dark:text-[color:var(--dp-text)] px-5 py-2 rounded font-medium text-sm hover:bg-navy/5 transition-colors"
         >
           Accueil
         </Link>

--- a/frontend/src/app/licence-donnees/page.tsx
+++ b/frontend/src/app/licence-donnees/page.tsx
@@ -11,7 +11,7 @@ export default function LicenceDonneesPage() {
     <LegalPageLayout eyebrow="Réutilisation" title="Licence des données">
 
       <LegalSection title="Origine des données">
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: 0 }}>
           Les données servies par MonÉlu (scrutins, positions de vote, fiches de députés) proviennent des flux
           open data officiels de l&apos;Assemblée nationale française et de data.gouv.fr. Ces sources publient
           leurs données sous la Licence Ouverte / Open Licence 2.0, dite &laquo;&nbsp;Etalab 2.0&nbsp;&raquo;.
@@ -19,37 +19,37 @@ export default function LicenceDonneesPage() {
       </LegalSection>
 
       <LegalSection title="Ce que dit la Licence Ouverte 2.0">
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: '0 0 10px' }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: '0 0 10px' }}>
           La Licence Ouverte autorise la réutilisation libre des données, y compris à des fins commerciales, sous
           réserve de :
         </p>
-        <ul style={{ fontSize: '15px', lineHeight: 1.85, color: '#4B5563', margin: 0, paddingLeft: '20px' }}>
+        <ul style={{ fontSize: '15px', lineHeight: 1.85, color: 'var(--dp-text-secondary)', margin: 0, paddingLeft: '20px' }}>
           <li>mentionner la paternité de l&apos;information (source et date de mise à jour) ;</li>
           <li>ne pas induire en erreur des tiers quant au contenu, à la source ou à la date de mise à jour ;</li>
           <li>ne pas suggérer que le producteur original cautionne votre réutilisation.</li>
         </ul>
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: '10px 0 0' }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: '10px 0 0' }}>
           Texte complet :{' '}
-          <a href="https://www.etalab.gouv.fr/licence-ouverte-open-licence" target="_blank" rel="noopener noreferrer" style={{ color: '#1B2B50' }}>
+          <a href="https://www.etalab.gouv.fr/licence-ouverte-open-licence" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--dp-text)' }}>
             etalab.gouv.fr/licence-ouverte-open-licence
           </a>
         </p>
       </LegalSection>
 
       <LegalSection title="Réutiliser les données MonÉlu">
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: '0 0 10px' }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: '0 0 10px' }}>
           Que vous consommiez l&apos;API REST, exportiez un tableau en CSV, ou intégriez une fiche de vote sur
           votre propre site, les mêmes conditions Etalab 2.0 s&apos;appliquent puisque MonÉlu ne fait que
           structurer et redistribuer les données sources - il n&apos;en devient pas propriétaire. Attribution
           suggérée :
         </p>
-        <div style={{ background: '#F7F4ED', border: '1px solid #ECE7DC', borderRadius: '8px', padding: '14px 18px', fontSize: '14px', color: '#1B2B50', fontFamily: 'monospace' }}>
+        <div style={{ background: 'var(--dp-page-bg)', border: '1px solid var(--dp-border-subtle)', borderRadius: '8px', padding: '14px 18px', fontSize: '14px', color: 'var(--dp-text)', fontFamily: 'monospace' }}>
           Données : Assemblée nationale, via monelu.fr - Licence Ouverte 2.0
         </div>
       </LegalSection>
 
       <LegalSection title="Ce qui n'est pas couvert">
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: 0 }}>
           Le code source de la plateforme (ingestion, API, interface) est distribué séparément sur GitHub sous sa
           propre licence de dépôt, indépendante de la licence des données elles-mêmes. Les résumés en langage
           clair générés par l&apos;assistant IA sont une aide à la lecture et n&apos;ont pas valeur de source
@@ -58,9 +58,9 @@ export default function LicenceDonneesPage() {
       </LegalSection>
 
       <LegalSection title={'Une question sur un usage précis ?'}>
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: 0 }}>
           Écrivez à{' '}
-          <a href="mailto:walidelkhoukh99@gmail.com" style={{ color: '#1B2B50' }}>walidelkhoukh99@gmail.com</a> - en
+          <a href="mailto:walidelkhoukh99@gmail.com" style={{ color: 'var(--dp-text)' }}>walidelkhoukh99@gmail.com</a> - en
           particulier pour tout usage à grande échelle de l&apos;API (au-delà du rate-limiting public).
         </p>
       </LegalSection>

--- a/frontend/src/app/loading.tsx
+++ b/frontend/src/app/loading.tsx
@@ -1,7 +1,7 @@
 export default function Loading() {
   return (
     <div className="max-w-4xl mx-auto px-4 md:px-8 py-12 text-center">
-      <div className="text-gray-mid text-sm">Chargement…</div>
+      <div className="text-gray-mid dark:text-[color:var(--dp-text-muted)] text-sm">Chargement…</div>
     </div>
   )
 }

--- a/frontend/src/app/mentions-legales/page.tsx
+++ b/frontend/src/app/mentions-legales/page.tsx
@@ -12,49 +12,49 @@ export default function MentionsLegalesPage() {
     <LegalPageLayout eyebrow="Informations légales" title="Mentions légales">
 
       <LegalSection title="Éditeur du site">
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: 0 }}>
           MonÉlu est édité à titre individuel par Walid Elkhoukh.
           <br />
-          Contact : <a href="mailto:walidelkhoukh99@gmail.com" style={{ color: '#1B2B50' }}>walidelkhoukh99@gmail.com</a>
+          Contact : <a href="mailto:walidelkhoukh99@gmail.com" style={{ color: 'var(--dp-text)' }}>walidelkhoukh99@gmail.com</a>
           <br />
           Directeur de la publication : Walid Elkhoukh.
         </p>
       </LegalSection>
 
       <LegalSection title="Hébergement">
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: '0 0 10px' }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: '0 0 10px' }}>
           L&apos;interface (frontend) est hébergée par Vercel Inc., 340 S Lemon Ave #4133, Walnut, CA 91789, États-Unis.
         </p>
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: '0 0 10px' }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: '0 0 10px' }}>
           L&apos;API et le pipeline de données sont hébergés par Railway Corporation, San Francisco, États-Unis.
         </p>
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: 0 }}>
           La base de données est hébergée par Supabase Inc. (infrastructure gérée sur AWS).
         </p>
       </LegalSection>
 
       <LegalSection title="Nature du site">
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: 0 }}>
           MonÉlu est un site d&apos;information citoyenne à but non lucratif. Il republique et met en forme des données
           publiques issues de l&apos;Assemblée nationale française et d&apos;autres sources open data officielles
-          (voir <Link href="/licence-donnees" style={{ color: '#1B2B50' }}>Licence des données</Link>). Aucun produit
+          (voir <Link href="/licence-donnees" style={{ color: 'var(--dp-text)' }}>Licence des données</Link>). Aucun produit
           ou service n&apos;est vendu sur ce site.
         </p>
       </LegalSection>
 
       <LegalSection title="Propriété intellectuelle">
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: 0 }}>
           Le code source de MonÉlu est public sur{' '}
-          <a href="https://github.com/Walid-peach" target="_blank" rel="noopener noreferrer" style={{ color: '#1B2B50' }}>GitHub</a>.
+          <a href="https://github.com/Walid-peach" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--dp-text)' }}>GitHub</a>.
           Les données parlementaires affichées restent la propriété de leurs producteurs respectifs et sont
           redistribuées sous les conditions de leur licence d&apos;origine.
         </p>
       </LegalSection>
 
       <LegalSection title="Contact">
-        <p style={{ fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }}>
+        <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: 0 }}>
           Pour toute question relative au site, à une donnée affichée ou à ces mentions légales, écrivez à{' '}
-          <a href="mailto:walidelkhoukh99@gmail.com" style={{ color: '#1B2B50' }}>walidelkhoukh99@gmail.com</a>.
+          <a href="mailto:walidelkhoukh99@gmail.com" style={{ color: 'var(--dp-text)' }}>walidelkhoukh99@gmail.com</a>.
           Réponse sous 48 h pour les questions techniques.
         </p>
       </LegalSection>

--- a/frontend/src/app/methodologie/page.tsx
+++ b/frontend/src/app/methodologie/page.tsx
@@ -10,9 +10,9 @@ export const metadata: Metadata = {
     "Comment MonÉlu calcule chaque chiffre affiché : présence, alignement de parti, majorité, et limites connues.",
 }
 
-const textStyle = { fontSize: '15px', lineHeight: 1.75, color: '#4B5563', margin: 0 }
-const linkStyle = { color: '#1B2B50', fontWeight: 600 }
-const sourceLineStyle = { fontSize: '13.5px', color: '#6B7280', margin: '10px 0 0' }
+const textStyle = { fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: 0 }
+const linkStyle = { color: 'var(--dp-text)', fontWeight: 600 }
+const sourceLineStyle = { fontSize: '13.5px', color: 'var(--dp-text-secondary)', margin: '10px 0 0' }
 
 export default function MethodologiePage() {
   return (
@@ -180,7 +180,7 @@ export default function MethodologiePage() {
       </LegalSection>
 
       <LegalSection id="limites" title="Limites connues">
-        <ul style={{ fontSize: '15px', lineHeight: 1.85, color: '#4B5563', margin: 0, paddingLeft: '20px' }}>
+        <ul style={{ fontSize: '15px', lineHeight: 1.85, color: 'var(--dp-text-secondary)', margin: 0, paddingLeft: '20px' }}>
           <li>
             <strong>Non-votant ≠ abstention</strong> : un non-votant était présent sans exprimer d&apos;opinion ;
             une abstention est une position exprimée. Les pourcentages pour/contre/abstention affichés se
@@ -223,7 +223,7 @@ export default function MethodologiePage() {
       <LegalSection id="contact" title="Une erreur ou une incohérence à signaler ?">
         <p style={textStyle}>
           Écrivez à{' '}
-          <a href="mailto:walidelkhoukh99@gmail.com" style={{ color: '#1B2B50' }}>walidelkhoukh99@gmail.com</a> en
+          <a href="mailto:walidelkhoukh99@gmail.com" style={{ color: 'var(--dp-text)' }}>walidelkhoukh99@gmail.com</a> en
           précisant le député, le scrutin ou la page concernée. Toute correction de méthode fait l&apos;objet
           d&apos;une mise à jour de cette page.
         </p>

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -3,11 +3,11 @@ import Link from 'next/link'
 export default function NotFound() {
   return (
     <div className="max-w-2xl mx-auto px-4 md:px-8 py-16 text-center">
-      <div className="font-newsreader text-[64px] leading-none text-navy/20 mb-2">404</div>
-      <h2 className="font-serif text-2xl text-navy mb-3">
+      <div className="font-newsreader text-[64px] leading-none text-navy/20 dark:text-[color:var(--dp-text)]/20 mb-2">404</div>
+      <h2 className="font-serif text-2xl text-navy dark:text-[color:var(--dp-text)] mb-3">
         Page introuvable
       </h2>
-      <p className="text-gray-mid text-sm mb-6">
+      <p className="text-gray-mid dark:text-[color:var(--dp-text-muted)] text-sm mb-6">
         Ce député, ce vote ou cette page n&apos;existe pas ou plus.
       </p>
       <div className="flex items-center justify-center gap-3 flex-wrap">
@@ -19,19 +19,19 @@ export default function NotFound() {
         </Link>
         <Link
           href="/deputes"
-          className="border border-navy/30 text-navy px-5 py-2 rounded font-medium text-sm hover:bg-navy/5 transition-colors"
+          className="border border-navy/30 text-navy dark:border-[color:var(--dp-text)]/30 dark:text-[color:var(--dp-text)] px-5 py-2 rounded font-medium text-sm hover:bg-navy/5 transition-colors"
         >
           Voir les députés
         </Link>
         <Link
           href="/votes"
-          className="border border-navy/30 text-navy px-5 py-2 rounded font-medium text-sm hover:bg-navy/5 transition-colors"
+          className="border border-navy/30 text-navy dark:border-[color:var(--dp-text)]/30 dark:text-[color:var(--dp-text)] px-5 py-2 rounded font-medium text-sm hover:bg-navy/5 transition-colors"
         >
           Voir les votes
         </Link>
         <Link
           href="/chat"
-          className="border border-navy/30 text-navy px-5 py-2 rounded font-medium text-sm hover:bg-navy/5 transition-colors"
+          className="border border-navy/30 text-navy dark:border-[color:var(--dp-text)]/30 dark:text-[color:var(--dp-text)] px-5 py-2 rounded font-medium text-sm hover:bg-navy/5 transition-colors"
         >
           Rechercher
         </Link>

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -15,7 +15,7 @@ export function BottomNav() {
   const path = usePathname()
   if (path.startsWith('/embed')) return null
   return (
-    <nav data-print-hide className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-gray-border z-50 pb-[env(safe-area-inset-bottom)]">
+    <nav data-print-hide className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-gray-border dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)] z-50 pb-[env(safe-area-inset-bottom)]">
       <div className="flex items-center">
         <div className="grid grid-cols-5 flex-1">
           {items.map(item => {
@@ -25,7 +25,7 @@ export function BottomNav() {
               <Link key={item.href} href={item.href}
                 className={`flex flex-col items-center justify-center py-3 gap-0.5 text-xs font-medium transition-colors
                   ${active
-                    ? 'text-navy' : 'text-gray-mid'}`}>
+                    ? 'text-navy dark:text-[color:var(--dp-text)]' : 'text-gray-mid dark:text-[color:var(--dp-text-muted)]'}`}>
                 <span className="text-lg leading-none">{item.icon}</span>
                 <span>{item.label}</span>
               </Link>

--- a/frontend/src/components/FreshnessBadge.tsx
+++ b/frontend/src/components/FreshnessBadge.tsx
@@ -35,8 +35,8 @@ export async function FreshnessBadge() {
     <div
       className={`flex items-center justify-center gap-2 py-1.5 text-xs font-medium border-b ${
         stale
-          ? 'bg-amber-50 text-amber-700 border-amber-200'
-          : 'bg-gray-off text-gray-mid border-gray-border'
+          ? 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-800'
+          : 'bg-gray-off text-gray-mid border-gray-border dark:bg-[color:var(--dp-page-bg)] dark:text-[color:var(--dp-text-muted)] dark:border-[color:var(--dp-border)]'
       }`}
     >
       <span

--- a/frontend/src/components/LegalPageLayout.tsx
+++ b/frontend/src/components/LegalPageLayout.tsx
@@ -8,17 +8,17 @@ interface LegalPageLayoutProps {
 
 export function LegalPageLayout({ eyebrow, title, children }: LegalPageLayoutProps) {
   return (
-    <div style={{ background: '#F7F4ED', minHeight: '100vh' }}>
-      <div style={{ padding: '72px 56px 56px', background: 'linear-gradient(180deg,#ffffff 0%,#F7F4ED 100%)', borderBottom: '1px solid #ECE7DC' }}>
+    <div style={{ background: 'var(--dp-page-bg)', minHeight: '100vh' }}>
+      <div style={{ padding: '72px 56px 56px', background: 'linear-gradient(180deg,var(--dp-card-bg) 0%,var(--dp-page-bg) 100%)', borderBottom: '1px solid var(--dp-border-subtle)' }}>
         <div style={{ maxWidth: '760px', margin: '0 auto' }}>
           <div className="text-red-civic font-semibold text-xs tracking-[0.18em] uppercase mb-4">{eyebrow}</div>
-          <h1 className="font-newsreader text-headline" style={{ fontWeight: 600, lineHeight: 1.1, letterSpacing: '-0.02em', color: '#1B2B50', margin: 0 }}>
+          <h1 className="font-newsreader text-headline" style={{ fontWeight: 600, lineHeight: 1.1, letterSpacing: '-0.02em', color: 'var(--dp-text)', margin: 0 }}>
             {title}
           </h1>
         </div>
       </div>
 
-      <div style={{ padding: '56px', background: '#fff' }}>
+      <div style={{ padding: '56px', background: 'var(--dp-card-bg)' }}>
         <div style={{ maxWidth: '760px', margin: '0 auto', display: 'flex', flexDirection: 'column', gap: '36px' }}>
           {children}
         </div>
@@ -40,7 +40,7 @@ export function LegalSection({
   // jump doesn't land the heading under the sticky nav.
   return (
     <section id={id} style={id ? { scrollMarginTop: '88px' } : undefined}>
-      <h2 style={{ fontWeight: 700, fontSize: '17px', color: '#1B2B50', margin: '0 0 12px' }}>{title}</h2>
+      <h2 style={{ fontWeight: 700, fontSize: '17px', color: 'var(--dp-text)', margin: '0 0 12px' }}>{title}</h2>
       {children}
     </section>
   )

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -26,20 +26,20 @@ export function Nav() {
   return (
     <nav
       data-print-hide
-      className="hidden md:flex items-center justify-between px-8 bg-white border-b border-gray-border sticky top-0 z-50"
+      className="hidden md:flex items-center justify-between px-8 bg-white border-b border-gray-border dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)] sticky top-0 z-50"
       style={{ height: NAV_HEIGHT_PX }}
     >
       <Link href="/" className="flex items-center">
         <MonEluLogo size={32} variant="light" />
       </Link>
-      <div className="flex items-center gap-8 text-sm font-medium text-gray-mid">
+      <div className="flex items-center gap-8 text-sm font-medium text-gray-mid dark:text-[color:var(--dp-text-muted)]">
         {navLinks.map(({ href, label }) => {
           const active = pathname === href || pathname.startsWith(href + '/')
           return (
             <Link
               key={href}
               href={href}
-              className={`transition-colors hover:text-navy ${active ? 'text-navy border-b-2 border-red-civic pb-0.5' : ''}`}
+              className={`transition-colors hover:text-navy dark:hover:text-[color:var(--dp-text)] ${active ? 'text-navy dark:text-[color:var(--dp-text)] border-b-2 border-red-civic pb-0.5' : ''}`}
             >
               {label}
             </Link>
@@ -52,7 +52,7 @@ export function Nav() {
         <GlobalSearch />
         <a href="https://monelu-production.up.railway.app/docs"
           target="_blank"
-          className="text-sm border border-navy text-navy px-4 py-1.5 rounded hover:bg-navy hover:text-white transition-colors">
+          className="text-sm border border-navy text-navy dark:border-[color:var(--dp-text)] dark:text-[color:var(--dp-text)] px-4 py-1.5 rounded hover:bg-navy hover:text-white transition-colors">
           Explorer l&apos;API →
         </a>
       </div>


### PR DESCRIPTION
## What
Adds dark mode to six static content pages (via their shared `LegalPageLayout`), the app's error/not-found/loading states, and the remaining shared chrome (`Nav`, `BottomNav`, `FreshnessBadge`).

## Why
Follow-up to MON-155-157/160-169, closing out MON-158's scope minus two things discovered along the way: `a-propos/page.tsx` (~133 literals, 492 lines) is far larger than the rest and split into MON-170, and the original scope listed a `/partager` page that turned out to be a `route.ts` API handler with no UI at all.

## Changes
- `frontend/src/components/LegalPageLayout.tsx`: converts the shared page frame and section headings used by all six small static pages. Converting this once, rather than per-page, is why six pages fit in one PR alongside the shared chrome.
- `frontend/src/app/confidentialite/page.tsx`, `methodologie/page.tsx`, `mentions-legales/page.tsx`, `licence-donnees/page.tsx`, `developpeurs/page.tsx`, `donnees/page.tsx`: each page's own body-text/link/code-block literals converted to `--dp-*` variables.
- `frontend/src/app/error.tsx`, `not-found.tsx`, `loading.tsx`: Tailwind-based (not inline hex) — added `dark:` variants, following the same arbitrary-value-referencing-`--dp-*` pattern established in MON-157.
- `frontend/src/components/Nav.tsx`, `BottomNav.tsx`: same Tailwind `dark:` treatment. Both render on the landing page too (only `/embed` is excluded), but MON-154's route-aware forcing already keeps `/` light regardless of the stored theme, so no extra per-component logic was needed.
- `frontend/src/components/FreshnessBadge.tsx`: `dark:` variants for both its stale/fresh states.

## Deliberately NOT converted
- **`Footer.tsx`**: a permanently-dark navy bar (`#111C35` background, white/gray text) by original design — it renders on every page including the landing page and never changes with the theme toggle today. This reads as an intentional fixed-brand element (consistent with the landing page's own fixed navy/red treatment per ADR-027), not a dark-mode gap. Converting it to invert with the theme would be a visual design change, not a bug fix, so left untouched.
- **`global-error.tsx`**: this file renders its own bare `<html><body>` outside the normal `RootLayout` (Next.js's documented pattern for a root-level error boundary), so `ThemeProvider`, the `dark` class, and the no-flash script are never present when it renders. Any `dark:` classes added here would be unreachable dead code — left light-only, for a structural reason rather than a design one.
- **`/partager`**: confirmed to be `route.ts`, an API route handler with no rendered UI. The original MON-103 scope bullet listing it as a static page doesn't match reality.

## Testing
- `npm run lint` — clean.
- `npm test` — 149 tests / 20 suites pass.
- `npm run build` — succeeds.
- Cross-checked every `var(--dp-*)` reference used in this PR's Tailwind arbitrary-value classes against the variable names actually defined in `globals.css` (same discipline as MON-157, since Tailwind doesn't validate these at build time) — all match, no typos.
- Manual: ran `next dev`, curled all six static pages plus `/votes` (exercising `Nav`) and a nonexistent route (exercising `not-found.tsx`) — confirmed the expected `--dp-*` variables render in each response with no leaked literal hex from the converted code.

## Risks / Notes
- No visual/screenshot verification was possible in this environment.

## Breaking Changes
None.

https://claude.ai/code/session_01HVxc7TTP3xnsgNC3mtzxEb