### PR TITLE
fix: WCAG contrast audit for dark-mode tokens and vote/source colors (MON-159)

### DIFF
--- a/frontend/__tests__/components/QuizClient.test.tsx
+++ b/frontend/__tests__/components/QuizClient.test.tsx
@@ -151,7 +151,7 @@ describe('QuizClient', () => {
     expect(screen.getByText('Question 1 / 3')).toBeInTheDocument()
     // The previously selected answer stays highlighted (selected state kept).
     expect(screen.getByRole('button', { name: 'Contre' })).toHaveStyle({
-      border: '2px solid #C9302A',
+      border: '2px solid var(--dp-red)',
     })
   })
 
@@ -212,7 +212,7 @@ describe('QuizClient', () => {
     // Lands on the last question with the previous selection still highlighted.
     expect(screen.getByText('Question 3 / 3')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Pour' })).toHaveStyle({
-      border: '2px solid #1F8A5B',
+      border: '2px solid var(--dp-green)',
     })
   })
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -88,7 +88,12 @@
   --dp-green: #34C283;
   --dp-red: #FF6B60;
   --dp-accent: #E88E85;
-  --dp-abstention: #48546A;
+  /* MON-159: brightened from an earlier #48546A. That value scored 2.21:1
+     against --dp-card-bg, short of the WCAG 1.4.11 3:1 minimum for a
+     non-text UI element (the abstention segment of stacked vote bars
+     conveys its meaning through fill color alone). This value clears 3:1
+     against both --dp-card-bg (3.20:1) and --dp-page-bg (3.49:1). */
+  --dp-abstention: #5E6C88;
   --dp-track-bg: #1B2740;
   --dp-underline: #3A4863;
   --dp-avg-marker: rgba(255,255,255,0.35);

--- a/frontend/src/components/ChatAnswerCard.tsx
+++ b/frontend/src/components/ChatAnswerCard.tsx
@@ -1,7 +1,27 @@
 import Link from 'next/link'
 import { ShareButton } from './ShareButton'
-import { mdToHtml, mapSource, CONFIDENCE_META } from '@/lib/chatFormat'
+import { mdToHtml, mapSource, CONFIDENCE_META, type SourceKind } from '@/lib/chatFormat'
 import type { ChatShareResult } from '@/lib/api'
+
+// MON-159: this card renders inside the shared --dp-* theme (unlike
+// chat/page.tsx, which has its own independent light/dark toggle - see
+// MON-168), so its confidence/source badges use dark:-aware Tailwind
+// classes and CSS variables rather than CONFIDENCE_META's / mapSource's raw
+// hex, which stay light-only fallbacks for chat/page.tsx's own system.
+const CONFIDENCE_BADGE_CLASS: Record<string, string> = {
+  high: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300',
+  medium: 'bg-amber-100 text-amber-800 dark:bg-amber-950/40 dark:text-amber-300',
+  low: 'bg-red-100 text-red-800 dark:bg-red-950/40 dark:text-red-300',
+}
+
+const SOURCE_KIND_STYLE: Record<SourceKind, { dot?: string; badgeBg: string; badgeColor: string }> = {
+  positive: { dot: 'var(--dp-green)', badgeBg: 'var(--dp-badge-pos-bg)', badgeColor: 'var(--dp-green)' },
+  negative: { dot: 'var(--dp-red)', badgeBg: 'var(--dp-badge-neg-bg)', badgeColor: 'var(--dp-red)' },
+  default: { dot: 'var(--dp-text)', badgeBg: 'var(--dp-track-bg)', badgeColor: 'var(--dp-text-secondary)' },
+  // deputy's dot is a real per-party brand color (group_color) - left as
+  // src.dot below, deferred like partyHex() elsewhere in the app.
+  deputy: { badgeBg: 'var(--dp-track-bg)', badgeColor: 'var(--dp-text-secondary)' },
+}
 
 export function ChatAnswerCard({ result }: { result: ChatShareResult }) {
   const conf = result.confidence ? CONFIDENCE_META[result.confidence] : undefined
@@ -10,10 +30,9 @@ export function ChatAnswerCard({ result }: { result: ChatShareResult }) {
   return (
     <div className="bg-white border border-gray-border dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)] rounded-xl p-6 shadow-sm">
       <div className="flex items-start justify-between gap-3 mb-4">
-        {conf ? (
+        {conf && result.confidence ? (
           <span
-            className="inline-block text-xs font-bold uppercase tracking-wide px-3 py-1.5 rounded-full"
-            style={{ background: conf.bg, color: conf.color }}
+            className={`inline-block text-xs font-bold uppercase tracking-wide px-3 py-1.5 rounded-full ${CONFIDENCE_BADGE_CLASS[result.confidence] ?? ''}`}
           >
             {conf.label}
           </span>
@@ -48,9 +67,10 @@ export function ChatAnswerCard({ result }: { result: ChatShareResult }) {
           <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-mid dark:text-[color:var(--dp-text-muted)] mb-2">Sources</h3>
           <div className="flex flex-wrap gap-2">
             {sources.map((src, si) => {
+              const kindStyle = SOURCE_KIND_STYLE[src.kind]
               const inner = (
                 <>
-                  <div className="w-2.5 h-2.5 rounded-full shrink-0" style={{ background: src.dot }} />
+                  <div className="w-2.5 h-2.5 rounded-full shrink-0" style={{ background: kindStyle.dot ?? src.dot }} />
                   <div className="min-w-0 flex-1">
                     <div className="text-xs font-semibold text-navy dark:text-[color:var(--dp-text)] truncate">{src.label}</div>
                     {src.sub && <div className="text-[11px] text-gray-mid dark:text-[color:var(--dp-text-muted)] truncate">{src.sub}</div>}
@@ -58,7 +78,7 @@ export function ChatAnswerCard({ result }: { result: ChatShareResult }) {
                   {src.badge && (
                     <div
                       className="shrink-0 text-[10px] font-bold px-2 py-0.5 rounded-full whitespace-nowrap"
-                      style={{ background: src.badgeBg, color: src.badgeColor }}
+                      style={{ background: kindStyle.badgeBg, color: kindStyle.badgeColor }}
                     >
                       {src.badge}
                     </div>

--- a/frontend/src/lib/chatFormat.ts
+++ b/frontend/src/lib/chatFormat.ts
@@ -21,7 +21,14 @@ export function mdToHtml(text: string): string {
   }).join('')
 }
 
-export type SourceCard = { dot: string; label: string; sub: string; badge: string; badgeBg: string; badgeColor: string; href?: string }
+// MON-159: `kind` lets dark-mode-aware callers (ChatAnswerCard) pick a
+// themed badge/dot color without breaking chat/page.tsx, which still reads
+// dot/badgeBg/badgeColor directly (its own pre-existing light/dark toggle
+// predates the shared --dp-* system - see ADR discussion on MON-168).
+// `deputy` is excluded from the "always same" kinds because its dot is a
+// real per-party brand color (group_color), not a theme token.
+export type SourceKind = 'deputy' | 'positive' | 'negative' | 'default'
+export type SourceCard = { dot: string; label: string; sub: string; badge: string; badgeBg: string; badgeColor: string; kind: SourceKind; href?: string }
 
 export function mapSource(src: SearchResult['sources'][0]): SourceCard {
   const meta = src.metadata || {}
@@ -32,7 +39,7 @@ export function mapSource(src: SearchResult['sources'][0]): SourceCard {
       label: meta.deputy_name || meta.full_name || meta.name || 'Député',
       sub: [meta.department, meta.circonscription, meta.party].filter(Boolean).join(' · ') || '',
       badge: meta.group_short || meta.group || meta.party || '',
-      badgeBg: '#F1F5F9', badgeColor: '#475569',
+      badgeBg: '#F1F5F9', badgeColor: '#475569', kind: 'deputy',
       href: meta.deputy_id ? `/deputes/${meta.deputy_id}` : undefined,
     }
   }
@@ -45,6 +52,7 @@ export function mapSource(src: SearchResult['sources'][0]): SourceCard {
       badge: meta.result || '',
       badgeBg: adopted ? '#DCFCE7' : '#FEE2E2',
       badgeColor: adopted ? '#15803D' : '#DC2626',
+      kind: adopted ? 'positive' : 'negative',
       href: meta.vote_id ? `/votes/${meta.vote_id}` : undefined,
     }
   }
@@ -52,7 +60,7 @@ export function mapSource(src: SearchResult['sources'][0]): SourceCard {
     dot: '#1B2B50',
     label: src.content.slice(0, 55) + (src.content.length > 55 ? '…' : ''),
     sub: `Pertinence ${Math.round(src.similarity * 100)} %`,
-    badge: type, badgeBg: '#EFF3FB', badgeColor: '#1B2B50',
+    badge: type, badgeBg: '#EFF3FB', badgeColor: '#1B2B50', kind: 'default',
   }
 }
 

--- a/frontend/src/lib/vote-position.ts
+++ b/frontend/src/lib/vote-position.ts
@@ -1,10 +1,12 @@
-const RED = '#C9302A'
-
+// MON-159: these reference the shared --dp-* CSS variables (globals.css) so
+// vote-position badges pick up dark mode automatically on every page that
+// already uses that system, rather than staying pastel-on-dark as flagged
+// throughout MON-103's dark-mode sub-issues (MON-155/162/163/165/166).
 export const POS = {
-  pour:       { label: 'Pour',       color: '#1F8A5B', bg: '#EAF5EF' },
-  contre:     { label: 'Contre',     color: RED,        bg: '#FBE9E7' },
-  abstention: { label: 'Abstention', color: '#6B7280',  bg: '#F0F1F3' },
-  nonVotant:  { label: 'Non votant', color: '#9CA3AF',  bg: '#F5F6F7' },
+  pour:       { label: 'Pour',       color: 'var(--dp-green)',          bg: 'var(--dp-badge-pos-bg)' },
+  contre:     { label: 'Contre',     color: 'var(--dp-red)',            bg: 'var(--dp-badge-neg-bg)' },
+  abstention: { label: 'Abstention', color: 'var(--dp-text-secondary)', bg: 'var(--dp-track-bg)' },
+  nonVotant:  { label: 'Non votant', color: 'var(--dp-text-muted)',     bg: 'var(--dp-track-bg)' },
 } as const
 
 export type VotePositionKey = keyof typeof POS


### PR DESCRIPTION
## What
Computed WCAG contrast ratios across the dark-mode `--dp-*` token palette (and the color maps it feeds) and fixed the one genuine failure found: `--dp-abstention` in `.dark`.
Also extended dark-mode awareness to two color maps that were still returning static light-only hex (`vote-position.ts` fully, `chatFormat.ts`'s source-badge colors additively).

## Why
MON-159 asks for a contrast audit closing out the MON-103 dark-mode epic: verify every `--dp-*` token and its dependent color maps meet WCAG AA (4.5:1 text / 3:1 non-text UI) in dark mode, fix genuine dark-mode regressions, and leave a written record of findings for anything intentionally deferred.

No browser was available for this pass, so the audit was done by computing WCAG relative-luminance contrast ratios directly from the hex values in `globals.css` and the color maps in `lib/utils.ts` / `lib/chatFormat.ts` with a small script implementing the standard formula.

## Changes

- **`globals.css`** — `.dark`'s `--dp-abstention` changed from `#48546A` (2.21:1 against `--dp-card-bg`, below the WCAG 1.4.11 3:1 floor for a non-text UI element — the abstention segment of stacked vote bars conveys meaning through fill color alone) to `#5E6C88` (3.20:1 vs `--dp-card-bg`, 3.49:1 vs `--dp-page-bg`). Light-mode `:root` value (`#D1D5DB`) is untouched, per the issue's constraint to adjust dark-mode values only.
- **`lib/vote-position.ts`** — converted the pour/contre/abstention/nonVotant badge map from static hex to the shared `--dp-*` CSS variables, so it now switches with dark mode like every other MON-103 sub-issue's badges. Safe: all 5 consumers (deputy dossier/profile, comparer, quiz, vote timeline) render `pos.color`/`pos.bg` via inline styles only.
- **`lib/chatFormat.ts`** — added an additive `kind: SourceKind` field to `mapSource()`'s return value (`'deputy' | 'positive' | 'negative' | 'default'`). `CONFIDENCE_META` and the existing raw hex fields are untouched, since `chat/page.tsx` still reads them directly through its own independent light/dark toggle (MON-168 — deliberately not unified in this epic, see that issue's closing note).
- **`components/ChatAnswerCard.tsx`** — added `CONFIDENCE_BADGE_CLASS` (dark:-aware Tailwind classes, mirroring the pattern already used in `Bubbles.tsx`) and `SOURCE_KIND_STYLE` (CSS-var-based per-kind style map) and switched this card's confidence/source badges onto them instead of the raw hex from `chatFormat.ts`. The `deputy` kind still falls back to `src.dot` (the real per-party brand color), unchanged.
- **`__tests__/components/QuizClient.test.tsx`** — updated two assertions whose expected hardcoded hex border colors became CSS variable strings after the `vote-position.ts` conversion.

## Contrast findings

**Fixed:**
- `--dp-abstention` (dark): 2.21:1 → 3.20:1 vs card-bg (see above).

**Checked, no fix needed (intentional subtlety, not an information-conveying failure):**
- `--dp-border` / `--dp-border-subtle` vs `--dp-page-bg` in both themes score under 3:1 — this matches the equally-subtle light-mode originals and isn't the sole carrier of information (borders sit alongside labeled content), so it's treated as a deliberate low-contrast design choice, not a regression.
- All Tailwind-based dark badge colors from earlier merged MON-103 PRs (badge-adopte/rejete, VerdictCard's 4 verdict states, FreshnessBadge, Bubbles confidence colors, ChatAnswerCard's caveat box) were re-verified and pass comfortably (8.5:1–11.5:1).

**Found, deferred as out of scope for this issue:**
- `--dp-cta-bg` (`#E0786E`) paired with hardcoded white CTA text scores 2.97:1 — below the 3:1 floor. This is a *constant* token (same value in both themes, by design — see the `--dp-active-bg`/`--dp-cta-bg` comment in `globals.css`), so it's a pre-existing light-mode issue, not something dark mode introduced. MON-159's mandate is to adjust dark-mode token values, not light-mode ones, so this is documented here rather than fixed.
- `partyHex()` (`lib/utils.ts`) is used as a solid background with hardcoded white text in two places (`VoteDetailClient.tsx` avatar circles, `GlobalSearch.tsx` result avatars). Two of the eleven party brand colors fail white-text contrast in both themes: "Ensemble pour la République" (`#C79A2E`, 2.60:1) and "Les Démocrates" (`#F97316`, 2.80:1). These are real political party brand colors, identical in both themes, and not introduced by dark mode — changing them would be a separate brand/design decision beyond a contrast audit, so this is flagged here rather than fixed.
- `themeColors()` (`lib/utils.ts`, topic pill colors) is theme-invariant (same hex in both light and dark) and was not touched, for the same reason.

## Testing
- `npm run lint` — clean.
- `npm test -- --ci` — 149/149 passing, 20/20 suites (includes the 2 updated `QuizClient.test.tsx` assertions).
- `npm run build` — succeeds.
- Manual grep cross-check of every new `var(--dp-*)` reference against variables actually defined in `globals.css` — no typos.
- Contrast ratios computed via a WCAG relative-luminance script against every dark-mode `--dp-*` pairing and the `PARTY_HEX`/`themeColors()` maps.

## Risks / Notes
- No visual/browser verification was performed (not available in this environment) — the audit is mathematically exact for the color pairings checked but doesn't catch layout-dependent contrast issues (e.g. text over photos/gradients).
- The `--dp-cta-bg` white-text finding and the two `partyHex()` brand-color findings are real, pre-existing accessibility gaps, left deliberately unfixed here as out of scope — worth a follow-up issue if the project wants full AA compliance including light-mode/brand-color surfaces.

## Breaking Changes
None.
