### PR TITLE
feat: per-question breakdown on the quiz results page (MON-181)

### DIFF
--- a/api/routers/quiz.py
+++ b/api/routers/quiz.py
@@ -98,6 +98,13 @@ class QuizMatchRequest(BaseModel):
         return answers
 
 
+class QuizVoteDetail(BaseModel):
+    vote_id: str
+    # None when the deputy has no expressed position on this vote (nonVotant
+    # or absent) — the frontend renders that as "non comparable", not disagreement.
+    deputy_position: Optional[Literal["pour", "contre", "abstention"]] = None
+
+
 class QuizDeputyMatch(BaseModel):
     deputy_id: str
     full_name: Optional[str] = None
@@ -109,6 +116,9 @@ class QuizDeputyMatch(BaseModel):
     agreement_pct: Optional[float] = None
     matches: int
     compared: int
+    # Per-question breakdown (MON-181) — populated only for the best match and
+    # the opposite; never persisted in quiz_shares (ADR-025 — see share_result).
+    detail: Optional[list[QuizVoteDetail]] = None
 
 
 class QuizGroupAlignment(BaseModel):
@@ -290,17 +300,32 @@ def _compute_match(body: QuizMatchRequest) -> QuizMatchResponse:
                 dept_rows = cur.fetchall()
 
     stats = compute_deputy_stats(rows, answers)
+    position_by_deputy_vote = {(r["deputy_id"], r["vote_id"]): r["position"] for r in rows}
+
+    def detail_for(deputy_id: str) -> list[QuizVoteDetail]:
+        return [
+            QuizVoteDetail(
+                vote_id=vote_id,
+                deputy_position=position_by_deputy_vote.get((deputy_id, vote_id)),
+            )
+            for vote_id in answers
+        ]
 
     eligible = [e for e in stats.values() if e["compared"] >= threshold]
     eligible.sort(
         key=lambda e: (-e["matches"] / e["compared"], -e["compared"], e["full_name"] or "")
     )
 
+    top_matches = [to_match(e) for e in eligible[:TOP_MATCHES_LIMIT]]
+    if top_matches:
+        top_matches[0].detail = detail_for(top_matches[0].deputy_id)
+
     opposite = None
     if eligible:
         opposite = to_match(
             min(eligible, key=lambda e: (e["matches"] / e["compared"], -e["compared"]))
         )
+        opposite.detail = detail_for(opposite.deputy_id)
 
     my_department = None
     if dept_code is not None:
@@ -317,7 +342,7 @@ def _compute_match(body: QuizMatchRequest) -> QuizMatchResponse:
         version=QUIZ_VERSION,
         answered=len(answers),
         eligible_deputies=len(eligible),
-        top_matches=[to_match(e) for e in eligible[:TOP_MATCHES_LIMIT]],
+        top_matches=top_matches,
         opposite=opposite,
         groups=compute_group_alignment(rows, answers, threshold),
         my_department=my_department,
@@ -354,6 +379,23 @@ def _to_share_response(row: dict) -> QuizShareResponse:
     )
 
 
+def _strip_detail(data: dict) -> dict:
+    """Remove the per-question detail (MON-181) before persisting a share.
+
+    A quiz share pairs the sharer's answers with a deputy's positions —
+    storing `detail` would leak the sharer's own answers, forbidden by
+    ADR-025 pending MON-179's opt-in revision.
+    """
+    for match in data.get("top_matches", []):
+        match.pop("detail", None)
+    if data.get("opposite"):
+        data["opposite"].pop("detail", None)
+    if data.get("my_department"):
+        for match in data["my_department"].get("deputies", []):
+            match.pop("detail", None)
+    return data
+
+
 @router.post(
     "/share",
     response_model=QuizShareResponse,
@@ -365,6 +407,7 @@ def share_result(request: Request, body: QuizMatchRequest) -> QuizShareResponse:
     # from the client (ADR-025) — a share can only contain server-computed
     # numbers. Nothing else about the request is persisted.
     result = _compute_match(body)
+    stored_result = _strip_detail(result.model_dump())
     try:
         with get_conn() as conn:
             with conn.cursor() as cur:
@@ -374,7 +417,7 @@ def share_result(request: Request, body: QuizMatchRequest) -> QuizShareResponse:
                     VALUES (%s, %s)
                     RETURNING id, result, created_at
                     """,
-                    (result.version, Json(result.model_dump())),
+                    (result.version, Json(stored_result)),
                 )
                 row = cur.fetchone()
             conn.commit()

--- a/frontend/__tests__/components/QuizClient.test.tsx
+++ b/frontend/__tests__/components/QuizClient.test.tsx
@@ -61,6 +61,7 @@ const BEST = {
   agreement_pct: 83.3,
   matches: 5,
   compared: 6,
+  detail: null,
 }
 
 const MATCH: QuizMatchResponse = {
@@ -243,6 +244,41 @@ describe('QuizClient', () => {
       'href',
       '/mon-depute'
     )
+  })
+
+  it('shows the per-question breakdown with the deputy position and votes/[id] links', async () => {
+    const user = userEvent.setup()
+    mockMatch.mockResolvedValue({
+      ...MATCH,
+      top_matches: [
+        {
+          ...BEST,
+          detail: [
+            { vote_id: 'V1', deputy_position: 'pour' },
+            { vote_id: 'V2', deputy_position: 'contre' },
+            { vote_id: 'V3', deputy_position: null },
+          ],
+        },
+        MATCH.top_matches[1],
+      ],
+    })
+    render(<QuizClient />)
+
+    await answerAllQuestions(user) // answers pour/pour/pour
+    await user.click(
+      screen.getByRole('button', { name: 'Passer cette étape et voir mes résultats' })
+    )
+
+    await screen.findByText(/Vous votez à 83.3% comme Jeanne Martin/)
+    await user.click(screen.getByText('Le détail, scrutin par scrutin'))
+
+    expect(screen.getByRole('link', { name: /Auriez-vous voté pour ou contre la question 1/ })).toHaveAttribute(
+      'href',
+      '/votes/V1'
+    )
+    expect(screen.getByText('En accord avec Jeanne Martin')).toBeInTheDocument()
+    expect(screen.getByText('En désaccord avec Jeanne Martin')).toBeInTheDocument()
+    expect(screen.getByText(/non comparable/)).toBeInTheDocument()
   })
 
   it('shares results by creating a snapshot and copying the URL', async () => {

--- a/frontend/src/app/quiz/QuizClient.tsx
+++ b/frontend/src/app/quiz/QuizClient.tsx
@@ -456,7 +456,12 @@ export function QuizClient() {
     return (
       <Shell>
         <div style={{ ...kicker, marginBottom: 16 }}>Vos résultats</div>
-        <QuizResultSections result={result} resolvedNom={resolved?.nom} />
+        <QuizResultSections
+          result={result}
+          resolvedNom={resolved?.nom}
+          questions={questions ?? undefined}
+          answers={answers}
+        />
 
         <section style={{ marginTop: 48, ...card, textAlign: 'center' }}>
           <p style={{ margin: '0 0 16px', fontSize: 15, lineHeight: 1.6, color: 'var(--dp-text-secondary)' }}>

--- a/frontend/src/app/quiz/QuizResultSections.tsx
+++ b/frontend/src/app/quiz/QuizResultSections.tsx
@@ -1,9 +1,15 @@
 'use client'
 import Link from 'next/link'
-import type { QuizDeputyMatch, QuizMatchResponse } from '@/lib/api'
+import type { QuizAnswerPosition, QuizDeputyMatch, QuizMatchResponse, QuizQuestion } from '@/lib/api'
 import { partyHex } from '@/lib/utils'
 import { departmentLabel } from '@/lib/departments'
 import { DeputyAvatar } from '@/components/DeputyAvatar'
+
+const POSITION_LABELS: Record<QuizAnswerPosition, string> = {
+  pour: 'Pour',
+  contre: 'Contre',
+  abstention: 'Abstention',
+}
 
 const NAVY = 'var(--dp-text)'
 const LINE = 'var(--dp-border)'
@@ -81,6 +87,116 @@ function DeputyMatchRow({ match, rank }: { match: QuizDeputyMatch; rank?: number
   )
 }
 
+function PositionBadge({ position }: { position: QuizAnswerPosition | null }) {
+  if (position === null) {
+    return (
+      <span style={{ fontSize: 12.5, fontWeight: 600, color: 'var(--dp-text-muted)' }}>
+        Non exprimé
+      </span>
+    )
+  }
+  const color = position === 'pour' ? 'var(--dp-green)' : position === 'contre' ? 'var(--dp-red)' : 'var(--dp-text-secondary)'
+  const bg = position === 'pour' ? 'var(--dp-badge-pos-bg)' : position === 'contre' ? 'var(--dp-badge-neg-bg)' : 'var(--dp-track-bg)'
+  return (
+    <span
+      style={{
+        fontSize: 12.5,
+        fontWeight: 700,
+        padding: '3px 10px',
+        borderRadius: 999,
+        color,
+        background: bg,
+      }}
+    >
+      {POSITION_LABELS[position]}
+    </span>
+  )
+}
+
+// Per-question breakdown (MON-181) — only rendered when the API returned
+// `detail` (the live results screen; never on a stored share, ADR-025) and
+// the questions/answers are available to label each row.
+function VoteBreakdown({
+  best,
+  questions,
+  answers,
+}: {
+  best: QuizDeputyMatch
+  questions: QuizQuestion[]
+  answers: Record<string, QuizAnswerPosition>
+}) {
+  if (!best.detail) return null
+  const byVoteId = new Map(questions.map(q => [q.vote_id, q]))
+
+  return (
+    <details style={{ ...card, marginTop: 20, padding: 0 }}>
+      <summary
+        style={{
+          cursor: 'pointer',
+          padding: '18px 22px',
+          fontWeight: 600,
+          fontSize: 15,
+          color: NAVY,
+        }}
+      >
+        Le détail, scrutin par scrutin
+      </summary>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: '0 22px 22px' }}>
+        {best.detail.map(d => {
+          const question = byVoteId.get(d.vote_id)
+          const yourAnswer = answers[d.vote_id] ?? null
+          const comparable = d.deputy_position !== null
+          const agrees = comparable && d.deputy_position === yourAnswer
+          return (
+            <div
+              key={d.vote_id}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                gap: 16,
+                padding: '12px 0',
+                borderTop: `1px solid ${LINE}`,
+              }}
+            >
+              <div style={{ minWidth: 0 }}>
+                <div style={{ fontSize: 11.5, fontWeight: 700, letterSpacing: '0.05em', textTransform: 'uppercase', color: 'var(--dp-red)' }}>
+                  {question?.theme ?? 'Scrutin'}
+                </div>
+                <Link
+                  href={`/votes/${d.vote_id}`}
+                  style={{ fontSize: 14, color: NAVY, textDecoration: 'none', fontWeight: 500 }}
+                >
+                  {question?.question ?? d.vote_id}
+                </Link>
+                <div style={{ fontSize: 12.5, color: GRAY, marginTop: 4 }}>
+                  {comparable
+                    ? agrees
+                      ? 'En accord avec ' + best.full_name
+                      : 'En désaccord avec ' + best.full_name
+                    : `Position non comparable — ${best.full_name} n'a pas voté pour ou contre`}
+                </div>
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6, alignItems: 'flex-end', flexShrink: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span style={{ fontSize: 11.5, color: 'var(--dp-text-muted)' }}>Vous</span>
+                  <PositionBadge position={yourAnswer} />
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span style={{ fontSize: 11.5, color: 'var(--dp-text-muted)' }}>
+                    {best.full_name}
+                  </span>
+                  <PositionBadge position={d.deputy_position} />
+                </div>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </details>
+  )
+}
+
 // The full result card: hero best-match, top matches, opposite deputy, group
 // alignment, department comparison. Shared between the live results screen
 // (QuizClient) and the stored share page (/quiz/s/[id]) so both render the
@@ -88,9 +204,15 @@ function DeputyMatchRow({ match, rank }: { match: QuizDeputyMatch; rank?: number
 export function QuizResultSections({
   result,
   resolvedNom,
+  questions,
+  answers,
 }: {
   result: QuizMatchResponse
   resolvedNom?: string
+  // Only available on the live results screen — absent on the stored share
+  // page, which is why the breakdown accordion never renders there.
+  questions?: QuizQuestion[]
+  answers?: Record<string, QuizAnswerPosition>
 }) {
   const best = result.top_matches[0] ?? null
   const others = result.top_matches.slice(1)
@@ -128,6 +250,10 @@ export function QuizResultSections({
               {pctLabel(best)}
             </div>
           </Link>
+
+          {questions && answers && (
+            <VoteBreakdown best={best} questions={questions} answers={answers} />
+          )}
         </>
       ) : (
         <>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -296,6 +296,13 @@ export type QuizQuestionsResponse = {
 
 export type QuizAnswerPosition = 'pour' | 'contre' | 'abstention'
 
+export type QuizVoteDetail = {
+  vote_id: string
+  // null when the deputy has no expressed position on this vote (nonVotant
+  // or absent) — render as "non comparable", not disagreement.
+  deputy_position: QuizAnswerPosition | null
+}
+
 export type QuizDeputyMatch = {
   deputy_id: string
   full_name: string | null
@@ -307,6 +314,9 @@ export type QuizDeputyMatch = {
   agreement_pct: number | null
   matches: number
   compared: number
+  // Per-question breakdown (MON-181) — present only on the best match and
+  // the opposite; absent on stored shares (ADR-025).
+  detail: QuizVoteDetail[] | null
 }
 
 export type QuizGroupAlignment = {

--- a/tests/unit/test_quiz.py
+++ b/tests/unit/test_quiz.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 from api.quiz_data import QUIZ_QUESTIONS, QUIZ_VERSION
 from api.routers.quiz import (
     QuizMatchRequest,
+    _strip_detail,
     compute_group_alignment,
     eligibility_threshold,
 )
@@ -121,6 +122,15 @@ def test_match_ranks_agreement_and_applies_threshold(client, mock_cursor):
     assert top[0]["compared"] == 3
 
     assert body["opposite"]["deputy_id"] == "D"
+
+    # Per-question breakdown (MON-181): populated only for the best match
+    # (top[0]) and the opposite, in answered order, with a null position
+    # where the deputy has no expressed row for that vote.
+    assert [d["vote_id"] for d in top[0]["detail"]] == [V1, V2, V3]
+    assert [d["deputy_position"] for d in top[0]["detail"]] == ["pour", "contre", "abstention"]
+    assert top[1]["detail"] is None
+    assert top[2]["detail"] is None
+    assert [d["deputy_position"] for d in body["opposite"]["detail"]] == ["contre", "pour", None]
 
     # Groupe X: majority pour+contre match on V1/V2, V3 is a 1-1 tie (skipped).
     # Groupe Y: V1 ties, only V2 has a line — compared 1 < threshold, excluded.
@@ -277,6 +287,12 @@ def test_share_recomputes_server_side_and_stores_snapshot(client, mock_cursor):
     assert stored["top_matches"][0]["agreement_pct"] == 100.0
     assert stored["top_matches"][1]["agreement_pct"] == 33.3
 
+    # MON-181: the share snapshot must carry no per-question detail — it
+    # would pair the sharer's own answers with a deputy's positions, leaking
+    # answers (forbidden by ADR-025 pending MON-179's opt-in revision).
+    assert "detail" not in stored["top_matches"][0]
+    assert "detail" not in stored["top_matches"][1]
+
 
 def test_share_rejects_unknown_vote_id(client):
     resp = client.post(
@@ -318,3 +334,32 @@ def test_get_share_unknown_id_returns_404(client, mock_cursor):
 def test_get_share_malformed_id_returns_422(client):
     resp = client.get("/quiz/share/not-a-uuid")
     assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Per-question detail (MON-181)
+# ---------------------------------------------------------------------------
+def test_strip_detail_removes_key_everywhere():
+    data = {
+        "top_matches": [
+            {"deputy_id": "A", "detail": [{"vote_id": V1, "deputy_position": "pour"}]},
+            {"deputy_id": "B", "detail": None},
+        ],
+        "opposite": {"deputy_id": "D", "detail": [{"vote_id": V1, "deputy_position": "contre"}]},
+        "my_department": {
+            "code": "33",
+            "name": "Gironde",
+            "deputies": [
+                {"deputy_id": "A", "detail": [{"vote_id": V1, "deputy_position": "pour"}]}
+            ],
+        },
+    }
+    stripped = _strip_detail(data)
+    assert all("detail" not in m for m in stripped["top_matches"])
+    assert "detail" not in stripped["opposite"]
+    assert all("detail" not in m for m in stripped["my_department"]["deputies"])
+
+
+def test_strip_detail_handles_no_opposite_or_department():
+    data = {"top_matches": [], "opposite": None, "my_department": None}
+    assert _strip_detail(data) == data


### PR DESCRIPTION
## What
Adds a per-question breakdown to the quiz results page: an expandable "Le détail, scrutin par scrutin" accordion showing, for each answered question, your answer, the best-match deputy's actual vote, and a link to the scrutin.

## Why
The result page currently shows a percentage with no receipts. Making the accuracy story visible complements MON-172 (coverage-aware ranking) from the product side. Step 3 of MON-178.

## Changes
- **API** (`api/routers/quiz.py`): added a `QuizVoteDetail` model and a `detail: list[QuizVoteDetail] | None` field on `QuizDeputyMatch`. `_compute_match` populates `detail` only for the best match (`top_matches[0]`) and `opposite`, in answered order, with `deputy_position: null` when the deputy has no expressed position for that vote (nonVotant/absent).
- **Share persistence** (`api/routers/quiz.py`): added `_strip_detail()`, called in `share_result` before the INSERT — `quiz_shares.result` never contains a `detail` key, since it would pair the sharer's answers with a deputy's positions (forbidden by ADR-025 pending MON-179's opt-in revision).
- **Frontend** (`frontend/src/app/quiz/QuizResultSections.tsx`): new `VoteBreakdown` accordion (native `<details>`) rendered under the hero card, gated on `best.detail` being present. Each row shows the question theme, a link to `/votes/[id]`, your answer, the deputy's vote, and an agree/disagree/non-comparable marker. New optional `questions`/`answers` props — only passed on the live results screen (`QuizClient.tsx`), never on the stored share page, so the share page renders exactly as before.
- **Types** (`frontend/src/lib/api.ts`): added `QuizVoteDetail` and the `detail` field on `QuizDeputyMatch`.
- **Tests**: `tests/unit/test_quiz.py` asserts the detail shape on `/match` (best match + opposite, null for non-comparable) and its absence in the stored share payload; `frontend/__tests__/components/QuizClient.test.tsx` covers the accordion rendering and `/votes/[id]` links.

## Testing
- `python3 -m pytest tests/ -m "not integration" -q` — 265 passed
- `ruff check .` / `ruff format --check .` — clean, repo-wide
- `cd frontend && npm run lint && npx tsc --noEmit && npm test && npm run build` — all green (150 Jest tests, full `next build`)

## Risks / Notes
- No schema migration — `detail` is a response-shape addition only, and it's explicitly excluded before the `quiz_shares` INSERT.
- MON-179 (the friend-comparison ADR) is still in Backlog; this PR doesn't touch answer storage or opt-in semantics, so it isn't blocked by it.

## Breaking Changes
None.
