### PR TITLE
feat: self-perception reveal for quiz results (MON-182)

### DIFF
--- a/frontend/__tests__/components/QuizClient.test.tsx
+++ b/frontend/__tests__/components/QuizClient.test.tsx
@@ -104,6 +104,12 @@ async function answerAllQuestions(user: ReturnType<typeof userEvent.setup>) {
   }
 }
 
+// Passes through the optional self-perception group step without predicting.
+async function skipGroupStep(user: ReturnType<typeof userEvent.setup>) {
+  expect(screen.getByText('De quel groupe vous sentez-vous le plus proche ?')).toBeInTheDocument()
+  await user.click(screen.getByRole('button', { name: 'Je préfère ne pas dire / passer' }))
+}
+
 beforeEach(() => {
   jest.clearAllMocks()
   mockQuestions.mockResolvedValue(QUESTIONS)
@@ -117,6 +123,7 @@ describe('QuizClient', () => {
 
     expect(screen.getByText('Quel député vote comme vous ?')).toBeInTheDocument()
     await answerAllQuestions(user)
+    await skipGroupStep(user)
 
     // Optional postal step reached after the last question.
     expect(screen.getByText('Et votre député à vous ?')).toBeInTheDocument()
@@ -162,6 +169,7 @@ describe('QuizClient', () => {
     render(<QuizClient />)
 
     await answerAllQuestions(user)
+    await skipGroupStep(user)
     await user.type(screen.getByLabelText('Code postal'), '33000')
     await user.click(screen.getByRole('button', { name: 'Voir mes résultats' }))
 
@@ -179,6 +187,7 @@ describe('QuizClient', () => {
     render(<QuizClient />)
 
     await answerAllQuestions(user)
+    await skipGroupStep(user)
     await user.type(screen.getByLabelText('Code postal'), '99999')
     await user.click(screen.getByRole('button', { name: 'Voir mes résultats' }))
 
@@ -194,6 +203,7 @@ describe('QuizClient', () => {
     await user.click(screen.getByRole('button', { name: 'Pour' }))
     await user.click(screen.getByRole('button', { name: 'Passer cette question' }))
     await user.click(screen.getByRole('button', { name: 'Abstention' }))
+    await skipGroupStep(user)
 
     expect(screen.getByText('Encore quelques réponses')).toBeInTheDocument()
     expect(
@@ -206,6 +216,7 @@ describe('QuizClient', () => {
     render(<QuizClient />)
 
     await answerAllQuestions(user)
+    await skipGroupStep(user)
     expect(screen.getByText('Et votre député à vous ?')).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: '← Revenir aux questions' }))
@@ -222,6 +233,7 @@ describe('QuizClient', () => {
     render(<QuizClient />)
 
     await answerAllQuestions(user)
+    await skipGroupStep(user)
     await user.click(
       screen.getByRole('button', { name: 'Passer cette étape et voir mes résultats' })
     )
@@ -263,6 +275,7 @@ describe('QuizClient', () => {
     render(<QuizClient />)
 
     await answerAllQuestions(user)
+    await skipGroupStep(user)
     await user.type(screen.getByLabelText('Code postal'), '33000')
     await user.click(screen.getByRole('button', { name: 'Voir mes résultats' }))
     await screen.findByText('Les députés de votre département')
@@ -289,6 +302,7 @@ describe('QuizClient', () => {
     render(<QuizClient />)
 
     await answerAllQuestions(user)
+    await skipGroupStep(user)
     await user.click(
       screen.getByRole('button', { name: 'Passer cette étape et voir mes résultats' })
     )
@@ -304,6 +318,7 @@ describe('QuizClient', () => {
     render(<QuizClient />)
 
     await answerAllQuestions(user)
+    await skipGroupStep(user)
     await user.click(
       screen.getByRole('button', { name: 'Passer cette étape et voir mes résultats' })
     )
@@ -322,5 +337,62 @@ describe('QuizClient', () => {
       expect(screen.getByText(/Impossible de charger le questionnaire/)).toBeInTheDocument()
     )
     expect(screen.queryByRole('button', { name: /Commencer le quiz/ })).not.toBeInTheDocument()
+  })
+
+  it('skips the self-perception step in one tap with no gap line and no group in the payload', async () => {
+    const user = userEvent.setup()
+    mockMatch.mockResolvedValue(MATCH)
+    render(<QuizClient />)
+
+    await answerAllQuestions(user)
+    await skipGroupStep(user)
+    await user.click(
+      screen.getByRole('button', { name: 'Passer cette étape et voir mes résultats' })
+    )
+
+    await screen.findByText(/Vous votez à 83.3% comme Jeanne Martin/)
+    // Skipping the prediction renders no gap/confirmation line at all.
+    expect(screen.queryByText(/vos réponses vous/)).not.toBeInTheDocument()
+    // No network call — match or share — ever carries the predicted group.
+    expect(mockMatch).toHaveBeenCalledWith(expect.any(Array), undefined)
+  })
+
+  it('confirms the prediction when the actual top group matches the guess', async () => {
+    const user = userEvent.setup()
+    mockMatch.mockResolvedValue(MATCH)
+    render(<QuizClient />)
+
+    await answerAllQuestions(user)
+    expect(screen.getByText('De quel groupe vous sentez-vous le plus proche ?')).toBeInTheDocument()
+    await user.click(
+      screen.getByRole('button', { name: 'Socialistes et apparentés' })
+    )
+    await user.click(
+      screen.getByRole('button', { name: 'Passer cette étape et voir mes résultats' })
+    )
+
+    await screen.findByText(
+      'Vous aviez vu juste : vos réponses vous placent bien près de Socialistes et apparentés (75%)'
+    )
+    // The prediction is never sent to the match endpoint (ADR-025: client-side only).
+    expect(mockMatch).toHaveBeenCalledWith(expect.any(Array), undefined)
+  })
+
+  it('shows the gap line when the guess and the actual top group differ', async () => {
+    const user = userEvent.setup()
+    mockMatch.mockResolvedValue(MATCH)
+    render(<QuizClient />)
+
+    await answerAllQuestions(user)
+    await user.click(
+      screen.getByRole('button', { name: 'Rassemblement National' })
+    )
+    await user.click(
+      screen.getByRole('button', { name: 'Passer cette étape et voir mes résultats' })
+    )
+
+    await screen.findByText(
+      'Vous vous sentiez proche de Rassemblement National - vos réponses vous rapprochent de Socialistes et apparentés (75%)'
+    )
   })
 })

--- a/frontend/src/app/quiz/QuizClient.tsx
+++ b/frontend/src/app/quiz/QuizClient.tsx
@@ -6,6 +6,8 @@ import type { QuizAnswerPosition, QuizMatchResponse, QuizQuestion } from '@/lib/
 import { resolvePostalCodeToDepartment } from '@/lib/postal'
 import type { ResolvedDepartment } from '@/lib/postal'
 import { POS } from '@/lib/vote-position'
+import { CANONICAL_GROUP_LABELS } from '@/lib/groups'
+import { partyHex } from '@/lib/utils'
 import { card, QuizResultSections } from './QuizResultSections'
 
 const NAVY = 'var(--dp-text)'
@@ -18,7 +20,7 @@ const GRAY = 'var(--dp-text-secondary)'
 // Mirrors MIN_ANSWERS in api/routers/quiz.py — the backend rejects fewer.
 const MIN_ANSWERS = 3
 
-type Phase = 'intro' | 'questions' | 'postal' | 'results'
+type Phase = 'intro' | 'questions' | 'group' | 'postal' | 'results'
 
 const kicker: React.CSSProperties = {
   fontWeight: 700,
@@ -112,6 +114,7 @@ export function QuizClient() {
   const [questionsError, setQuestionsError] = useState(false)
   const [index, setIndex] = useState(0)
   const [answers, setAnswers] = useState<Record<string, QuizAnswerPosition>>({})
+  const [predictedGroup, setPredictedGroup] = useState<string | null>(null)
 
   const [postalInput, setPostalInput] = useState('')
   const [resolving, setResolving] = useState(false)
@@ -155,7 +158,7 @@ export function QuizClient() {
 
   function advance() {
     if (questions && index < questions.length - 1) setIndex(index + 1)
-    else setPhase('postal')
+    else setPhase('group')
   }
 
   function back() {
@@ -198,6 +201,7 @@ export function QuizClient() {
     setPhase('intro')
     setIndex(0)
     setAnswers({})
+    setPredictedGroup(null)
     setPostalInput('')
     setPostalError(null)
     setResolved(null)
@@ -340,6 +344,75 @@ export function QuizClient() {
     )
   }
 
+  // ------------------------------------------------------------------ group
+  if (phase === 'group') {
+    return (
+      <Shell>
+        <div style={{ ...kicker, marginBottom: 16 }}>Encore une chose</div>
+        <h2
+          className="font-newsreader text-[clamp(24px,3.5vw,34px)]"
+          style={{ fontWeight: 600, color: NAVY, margin: 0, letterSpacing: '-0.01em' }}
+        >
+          De quel groupe vous sentez-vous le plus proche ?
+        </h2>
+        <p style={{ margin: '16px 0 24px', fontSize: 15.5, lineHeight: 1.6, color: 'var(--dp-text-secondary)' }}>
+          Facultatif — cette réponse reste dans votre navigateur, elle n’est jamais envoyée ni
+          enregistrée. À la fin, on compare votre ressenti à vos votes réels.
+        </p>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          {CANONICAL_GROUP_LABELS.map(label => {
+            const hex = partyHex(label)
+            return (
+              <button
+                key={label}
+                onClick={() => {
+                  setPredictedGroup(label)
+                  setPhase('postal')
+                }}
+                style={{
+                  padding: '13px 18px',
+                  borderRadius: 10,
+                  fontWeight: 600,
+                  fontSize: 15,
+                  textAlign: 'left',
+                  cursor: 'pointer',
+                  color: hex,
+                  background: 'var(--dp-card-bg)',
+                  border: `2px solid ${hex}`,
+                }}
+              >
+                {label}
+              </button>
+            )
+          })}
+        </div>
+        <div style={{ marginTop: 22, display: 'flex', gap: 20, flexWrap: 'wrap', alignItems: 'center' }}>
+          <button
+            onClick={() => {
+              setPredictedGroup(null)
+              setPhase('postal')
+            }}
+            style={{
+              background: ACCENT, color: '#fff', padding: '12px 26px', borderRadius: 9,
+              fontWeight: 600, fontSize: 15, border: 'none', cursor: 'pointer',
+            }}
+          >
+            Je préfère ne pas dire / passer
+          </button>
+          <button
+            onClick={() => {
+              setPhase('questions')
+              if (questions) setIndex(questions.length - 1)
+            }}
+            style={{ fontSize: 14.5, color: GRAY, background: 'none', border: 'none', cursor: 'pointer', textDecoration: 'underline', padding: 4 }}
+          >
+            ← Retour
+          </button>
+        </div>
+      </Shell>
+    )
+  }
+
   // ----------------------------------------------------------------- postal
   if (phase === 'postal') {
     const enough = answeredCount >= MIN_ANSWERS
@@ -456,6 +529,21 @@ export function QuizClient() {
     return (
       <Shell>
         <div style={{ ...kicker, marginBottom: 16 }}>Vos résultats</div>
+        {predictedGroup && result.groups.length > 0 && (
+          <div
+            style={{
+              ...card,
+              marginBottom: 24,
+              borderLeft: `4px solid ${partyHex(result.groups[0].party)}`,
+            }}
+          >
+            <p style={{ margin: 0, fontSize: 15.5, lineHeight: 1.6, color: NAVY, fontWeight: 600 }}>
+              {result.groups[0].party === predictedGroup
+                ? `Vous aviez vu juste : vos réponses vous placent bien près de ${result.groups[0].party} (${result.groups[0].agreement_pct}%)`
+                : `Vous vous sentiez proche de ${predictedGroup} - vos réponses vous rapprochent de ${result.groups[0].party} (${result.groups[0].agreement_pct}%)`}
+            </p>
+          </div>
+        )}
         <QuizResultSections result={result} resolvedNom={resolved?.nom} />
 
         <section style={{ marginTop: 48, ...card, textAlign: 'center' }}>

--- a/frontend/src/lib/groups.ts
+++ b/frontend/src/lib/groups.ts
@@ -17,6 +17,9 @@ const GROUP_SLUGS: Record<string, string> = {
   'non-inscrits': 'Non inscrit',
 }
 
+/** The 12 canonical labels, in the same order as GROUP_SLUGS — used by the quiz's self-perception picker (MON-182). */
+export const CANONICAL_GROUP_LABELS: string[] = Object.values(GROUP_SLUGS)
+
 const NAME_TO_SLUG = new Map(
   Object.entries(GROUP_SLUGS).map(([slug, name]) => [name, slug])
 )


### PR DESCRIPTION
## What
Adds an optional "self-perception" step to the quiz (`frontend/src/app/quiz/QuizClient.tsx`): between the last question and the postal step, the user can pick which parliamentary group they feel closest to (or skip). On the results screen, if a prediction was given, a gap line above the hero card compares that guess to the group the user's answers actually align most with (`result.groups[0]`).

## Why
Step 4 of MON-178 (quiz v2 engagement and viral loop). The gap between self-image and actual voting agreement is one of the most shareable sentences a political quiz can produce, and it costs nothing beyond frontend state - no new backend surface, no persistence.

## Changes
- `frontend/src/lib/groups.ts`: exported `CANONICAL_GROUP_LABELS`, the 12 canonical party labels (already keyed by `GROUP_SLUGS`) in stable order, for reuse by the quiz picker.
- `frontend/src/app/quiz/QuizClient.tsx`:
  - New `'group'` phase inserted between `'questions'` and `'postal'` in the `Phase` union and in `advance()`.
  - Group-picker UI: one button per canonical label (colored via `partyHex`) plus a prominent "Je préfère ne pas dire / passer" skip action, and a back link to the last question.
  - New `predictedGroup` client-side state, reset in `restart()`. It is never read by `submit()`, `confirmPostal()`, or `ShareResultButton` - it never reaches `/quiz/match` or `/quiz/share`, and it is never rendered by the shared `QuizResultSections` component used by the stored `/quiz/s/[id]` share page, consistent with ADR-025's stored-snapshot model.
  - Results screen: a gap/confirmation line rendered above `QuizResultSections`, driven by comparing `predictedGroup` to `result.groups[0].party` - a match renders "Vous aviez vu juste...", a mismatch renders "Vous vous sentiez proche de X - vos réponses vous rapprochent de Y (NN%)". Nothing renders if no prediction was given or `result.groups` is empty.
- `frontend/__tests__/components/QuizClient.test.tsx`: added a `skipGroupStep` helper (threaded through all existing flows that walk past the last question, since the new step now sits in between) and three new tests - skip-in-one-tap with no gap line and no group in the match payload, predicted-match confirmation line, predicted-mismatch gap line.

## Testing
- `npm test` (frontend, full Jest suite): 20 suites / 152 tests passing.
- `npm run lint`: clean.
- `npm run build`: succeeds (the Railway `fetch failed` lines during static generation are known offline-sandbox noise, unrelated to this change - reproduces identically on `master`).
- Manual read-through of the acceptance criteria:
  - Picker is skippable in one tap; skipping reproduces the exact pre-existing flow (verified by test).
  - Prediction-match and prediction-mismatch render the correct line, sourced from `result.groups[0]`.
  - No network call (`api.quiz.match`, `api.quiz.share`) ever receives the predicted group - verified in tests and by code inspection of the call sites.

## Risks / Notes
- Frontend-only change, no schema/API/deploy impact.
- The 12-label list includes "Non inscrit" for canonical completeness (per scope: "source them like the rest of the frontend does"); it's an unlikely self-identification pick but kept for consistency with `GROUP_SLUGS`/`CANONICAL_LABELS` elsewhere in the codebase rather than special-casing it out.

## Breaking Changes
None.

https://claude.ai/code/session_018FJHEVYAvF89uQpge8KHny