### PR TITLE
feat: dedicated OG image for /quiz + fix hardcoded share URL (MON-174)

### DIFF
--- a/frontend/src/app/quiz/opengraph-image.tsx
+++ b/frontend/src/app/quiz/opengraph-image.tsx
@@ -1,0 +1,81 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = 'Quel député vote comme vous ? — MonÉlu'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+// Static hook card, no data fetch — safe to cache for a long time.
+export const revalidate = 86400
+
+export default function OGImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: '#0D1F3C',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          padding: '80px',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            color: 'rgba(255,255,255,0.55)',
+            fontSize: 18,
+            letterSpacing: '0.15em',
+            textTransform: 'uppercase',
+            marginBottom: 28,
+            fontFamily: 'sans-serif',
+          }}
+        >
+          MonÉlu
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            color: '#ffffff',
+            fontSize: 60,
+            lineHeight: 1.2,
+            fontFamily: 'serif',
+            maxWidth: 1000,
+            marginBottom: 28,
+          }}
+        >
+          Quel député vote comme vous ?
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            color: 'rgba(255,255,255,0.75)',
+            fontSize: 28,
+            lineHeight: 1.5,
+            fontFamily: 'sans-serif',
+            maxWidth: 1000,
+          }}
+        >
+          10 vrais scrutins, 577 députés
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            color: 'rgba(255,255,255,0.6)',
+            fontSize: 22,
+            fontFamily: 'sans-serif',
+            marginTop: 44,
+          }}
+        >
+          mon-elu.vercel.app/quiz — faites le test
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}

--- a/frontend/src/app/quiz/s/[id]/page.tsx
+++ b/frontend/src/app/quiz/s/[id]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { api } from '@/lib/api'
+import { SITE_URL } from '@/lib/seo'
 import { QuizResultSections } from '../../QuizResultSections'
 
 // Quiz shares are immutable snapshots of server-computed results (ADR-025,
@@ -35,7 +36,7 @@ export async function generateMetadata({
   return {
     title,
     description,
-    openGraph: { title, description, url: `https://mon-elu.vercel.app/quiz/s/${id}` },
+    openGraph: { title, description, url: `${SITE_URL}/quiz/s/${id}` },
     twitter: { card: 'summary_large_image', title, description },
   }
 }


### PR DESCRIPTION
## What
Adds a dedicated Open Graph image for `/quiz` and fixes a hardcoded production URL in the quiz share page.

## Why
`/quiz` is the most-linked quiz URL — nav, footer, three homepage placements, and the CTA at the bottom of every share page all point to it — but it had no `opengraph-image.tsx` and inherited the generic site-wide banner. Share *snapshots* (`/quiz/s/[id]`) already get a custom navy OG card, so the invitation step of the viral loop looked generic while the result step was polished. Source: `quiz_diagnostic_2026-07-22.md`, Findings #4 and #8.

## Changes
- Added `frontend/src/app/quiz/opengraph-image.tsx`: a static OG card (no data fetch) in the same visual language as the share-snapshot card (`quiz/s/[id]/opengraph-image.tsx`), with the hook "Quel député vote comme vous ? — 10 vrais scrutins, 577 députés".
- Replaced the hardcoded `https://mon-elu.vercel.app` in `frontend/src/app/quiz/s/[id]/page.tsx` with `SITE_URL` from `@/lib/seo` (Finding #8).

## Testing
- `npm run lint` — no ESLint warnings or errors.
- `npm test` — 20 suites / 164 tests passed.
- `npm run build` — succeeds; `/quiz/opengraph-image` route generated alongside the existing OG routes.
- `ruff check .` / `ruff format --check .` — repo-wide, all clean (no backend files touched).

## Risks / Notes
- Static image, so no cost or data-fetch risk; cached via `revalidate = 86400` like the other OG routes.
- No migration or deploy-config changes.

## Breaking Changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)