### PR TITLE
fix: rank quiz matches by coverage-aware score, not raw agreement ratio (MON-172)

### DIFF
--- a/api/routers/quiz.py
+++ b/api/routers/quiz.py
@@ -38,7 +38,7 @@ import logging
 import os
 import uuid
 from collections import Counter, defaultdict
-from math import ceil
+from math import ceil, sqrt
 from typing import Literal, Optional
 
 from fastapi import APIRouter, HTTPException
@@ -181,6 +181,30 @@ class QuizMatchResponse(BaseModel):
 # ---------------------------------------------------------------------------
 def eligibility_threshold(answered: int) -> int:
     return max(2, ceil(answered / 2))
+
+
+WILSON_Z = 1.96  # 95% confidence — standard default, not tuned for this corpus
+
+
+def ranking_score(matches: int, compared: int) -> float:
+    """Wilson score lower bound — coverage-aware ranking (MON-172).
+
+    Raw `matches/compared` lets a deputy compared on only the eligibility
+    threshold (e.g. 5/5) outrank one compared on nearly every question
+    (e.g. 9/10), because the two ratios don't encode how much evidence
+    backs them. The Wilson lower bound does: at a fixed raw ratio, more
+    comparisons produce a tighter interval and a higher lower bound, so
+    9/10 (0.596) ranks above 5/5 (0.565) even though 5/5 is the bigger raw
+    percentage. Only the sort order changes — `agreement_pct` on the
+    response is still the raw, unadjusted ratio.
+    """
+    if compared == 0:
+        return 0.0
+    phat = matches / compared
+    denom = 1 + WILSON_Z**2 / compared
+    center = phat + WILSON_Z**2 / (2 * compared)
+    margin = WILSON_Z * sqrt((phat * (1 - phat) + WILSON_Z**2 / (4 * compared)) / compared)
+    return (center - margin) / denom
 
 
 def compute_deputy_stats(rows: list[dict], answers: dict[str, str]) -> dict[str, dict]:
@@ -382,7 +406,11 @@ def _compute_match(body: QuizMatchRequest) -> QuizMatchResponse:
 
     eligible = [e for e in stats.values() if e["compared"] >= threshold]
     eligible.sort(
-        key=lambda e: (-e["matches"] / e["compared"], -e["compared"], e["full_name"] or "")
+        key=lambda e: (
+            -ranking_score(e["matches"], e["compared"]),
+            -e["compared"],
+            e["full_name"] or "",
+        )
     )
 
     top_matches = [to_match(e) for e in eligible[:TOP_MATCHES_LIMIT]]
@@ -392,7 +420,10 @@ def _compute_match(body: QuizMatchRequest) -> QuizMatchResponse:
     opposite = None
     if eligible:
         opposite = to_match(
-            min(eligible, key=lambda e: (e["matches"] / e["compared"], -e["compared"]))
+            min(
+                eligible,
+                key=lambda e: (ranking_score(e["matches"], e["compared"]), -e["compared"]),
+            )
         )
         opposite.detail = detail_for(opposite.deputy_id)
 

--- a/tests/unit/test_quiz.py
+++ b/tests/unit/test_quiz.py
@@ -9,6 +9,7 @@ from api.routers.quiz import (
     _strip_detail,
     compute_group_alignment,
     eligibility_threshold,
+    ranking_score,
 )
 
 V1, V2, V3 = (q["vote_id"] for q in QUIZ_QUESTIONS[:3])
@@ -176,6 +177,37 @@ def test_match_ranks_agreement_and_applies_threshold(client, mock_cursor):
     assert body["groups"][0]["agreement_pct"] == 100.0
     assert body["groups"][0]["compared"] == 2
     assert body["groups"][0]["deputy_count"] == 2
+
+
+def test_ranking_score_prefers_coverage_at_equal_or_higher_raw_rate():
+    # 9/10 (90%) outranks 5/5 (100%) — more evidence at a slightly lower raw
+    # rate beats the eligibility floor's worth of evidence at a perfect rate.
+    assert ranking_score(9, 10) > ranking_score(5, 5)
+    # Same raw rate (100%), more comparisons still ranks higher.
+    assert ranking_score(10, 10) > ranking_score(5, 5)
+
+
+def test_match_prefers_higher_coverage_over_higher_raw_percentage(client, mock_cursor):
+    """MON-172: a 5/5 (100%) deputy must not outrank a 9/10 (90%) deputy."""
+    vote_ids = [q["vote_id"] for q in QUIZ_QUESTIONS]
+    answers = [{"vote_id": vid, "position": "pour"} for vid in vote_ids]
+
+    rows = [_row("LOW", vid, "pour") for vid in vote_ids[:5]]
+    rows += [_row("HIGH", vid, "pour") for vid in vote_ids[:9]]
+    rows.append(_row("HIGH", vote_ids[9], "contre"))
+    mock_cursor.fetchall.return_value = rows
+
+    resp = client.post("/quiz/match", json={"answers": answers})
+    assert resp.status_code == 200
+    body = resp.json()
+
+    top = body["top_matches"]
+    assert [m["deputy_id"] for m in top] == ["HIGH", "LOW"]
+
+    by_id = {m["deputy_id"]: m for m in top}
+    # Displayed percentages are still the raw, unadjusted ratios.
+    assert by_id["LOW"]["agreement_pct"] == 100.0
+    assert by_id["HIGH"]["agreement_pct"] == 90.0
 
 
 def test_match_department_roster_includes_absent_deputy(client, mock_cursor):


### PR DESCRIPTION
## What
Ranks quiz match results by a coverage-aware score (Wilson score lower bound) instead of the raw `matches/compared` agreement ratio, so a low-coverage deputy can no longer outrank a high-coverage one on the share card.

## Why
Eligible deputies sorted by `(-matches/compared, -compared, name)`. With 10 answers the eligibility threshold is 5, so a deputy who expressed a position on only 5 of 10 quiz scrutins and matched all 5 outranked a deputy at 9/10 - the hero card and OG image would read "Je vote à 100% comme X", computed over half the questionnaire. That's the most-shared number on the card and the least statistically grounded one - an easy credibility takedown for a trust-first civic brand.

## Changes
- `api/routers/quiz.py`: added `ranking_score(matches, compared)`, the Wilson score lower bound (95% CI, z=1.96) over the raw agreement rate. Used as the primary sort key for `top_matches` and as the selection key for `opposite`, replacing the raw `matches/compared` ratio. `agreement_pct` on the response is unchanged - still the true, unadjusted percentage; only ranking order is affected.
- `tests/unit/test_quiz.py`: added `test_ranking_score_prefers_coverage_at_equal_or_higher_raw_rate` (unit test on the scoring function) and `test_match_prefers_higher_coverage_over_higher_raw_percentage` (end-to-end: a 5/5 deputy no longer outranks a 9/10 deputy, while both keep their true raw `agreement_pct`).

## Testing
- `pytest tests/unit/test_quiz.py -q` - 32 passed
- `pytest tests/ -m "not integration" -q` - 276 passed (CI's blocking selection)
- `ruff check .` and `ruff format --check .` - clean

## Risks / Notes
- Pure ranking-order change; response shape (`agreement_pct`, `matches`, `compared`) is untouched, so no frontend changes were needed.
- `compute_group_alignment`'s group ranking (`groups.sort` by raw `agreement_pct`) is unchanged - the issue and its acceptance criteria are scoped to the deputy ranking (`top_matches` / `opposite`) that headlines the hero card and OG image, not group alignment.
- z=1.96 (95% confidence) is a standard default, not tuned against this corpus; worth revisiting if ranking behavior ever needs adjustment.

## Breaking Changes
None.