### PR TITLE
fix: don't cache broken OG cards for share/verdict routes (MON-173)

### DIFF
--- a/api/routers/quiz.py
+++ b/api/routers/quiz.py
@@ -531,7 +531,10 @@ def share_result(request: Request, body: QuizShareRequest) -> QuizShareResponse:
     response_model=QuizShareResponse,
     summary="Relisez un résultat partagé (aucun recalcul)",
 )
-@limiter.limit(tiered_limit(30))
+# Immutable public snapshot behind an unguessable UUID (MON-173): OG scrapers
+# (X, WhatsApp, Facebook, Telegram) and Vercel edge egress funnel through few
+# IPs, so the base per-IP limit was tripping during viral spikes.
+@limiter.limit(tiered_limit(300))
 def get_share(request: Request, share_id: uuid.UUID) -> QuizShareResponse:
     with get_conn() as conn:
         with conn.cursor() as cur:

--- a/api/routers/search.py
+++ b/api/routers/search.py
@@ -173,7 +173,10 @@ def share_answer(request: Request, body: ShareRequest):
     response_model=ShareResponse,
     summary="Relisez une réponse partagée (aucun appel IA)",
 )
-@limiter.limit(tiered_limit(30))
+# Immutable public snapshot behind an unguessable UUID (MON-173): OG scrapers
+# (X, WhatsApp, Facebook, Telegram) and Vercel edge egress funnel through few
+# IPs, so the base per-IP limit was tripping during viral spikes.
+@limiter.limit(tiered_limit(300))
 def get_share(request: Request, share_id: uuid.UUID):
     with get_conn() as conn:
         with conn.cursor() as cur:

--- a/api/routers/verify.py
+++ b/api/routers/verify.py
@@ -152,7 +152,10 @@ def verify(request: Request, body: VerifyRequest):
     response_model=VerifyResponse,
     summary="Relisez un verdict enregistré (aucun appel IA)",
 )
-@limiter.limit(tiered_limit(30))
+# Immutable public snapshot behind an unguessable UUID (MON-173): OG scrapers
+# (X, WhatsApp, Facebook, Telegram) and Vercel edge egress funnel through few
+# IPs, so the base per-IP limit was tripping during viral spikes.
+@limiter.limit(tiered_limit(300))
 def get_verification(request: Request, verification_id: uuid.UUID):
     with get_conn() as conn:
         with conn.cursor() as cur:

--- a/frontend/src/app/chat/s/[id]/opengraph-image.tsx
+++ b/frontend/src/app/chat/s/[id]/opengraph-image.tsx
@@ -15,13 +15,21 @@ function truncate(text: string, max: number): string {
 export default async function OGImage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
   const share = await fetch(
-    `${process.env.NEXT_PUBLIC_API_URL ?? 'https://monelu-production.up.railway.app'}/search/share/${id}`
+    `${process.env.NEXT_PUBLIC_API_URL ?? 'https://monelu-production.up.railway.app'}/search/share/${id}`,
+    { signal: AbortSignal.timeout(5000) }
   )
     .then(r => (r.ok ? r.json() : null))
     .catch(() => null)
 
-  const question = share ? truncate(share.question, 120) : 'Réponse introuvable'
-  const answer = share ? truncate(share.answer.replace(/\*\*/g, ''), 220) : ''
+  // Don't cache a failure render under `revalidate = 86400` above — a thrown
+  // error bypasses the route's cache, so the next scrape retries instead of
+  // getting stuck with a stale "Réponse introuvable" card for a day.
+  if (!share) {
+    throw new Error(`Chat share ${id} unavailable`)
+  }
+
+  const question = truncate(share.question, 120)
+  const answer = truncate(share.answer.replace(/\*\*/g, ''), 220)
 
   return new ImageResponse(
     (

--- a/frontend/src/app/quiz/s/[id]/opengraph-image.tsx
+++ b/frontend/src/app/quiz/s/[id]/opengraph-image.tsx
@@ -18,10 +18,18 @@ type ShareBest = {
 export default async function OGImage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
   const share = await fetch(
-    `${process.env.NEXT_PUBLIC_API_URL ?? 'https://monelu-production.up.railway.app'}/quiz/share/${id}`
+    `${process.env.NEXT_PUBLIC_API_URL ?? 'https://monelu-production.up.railway.app'}/quiz/share/${id}`,
+    { signal: AbortSignal.timeout(5000) }
   )
     .then(r => (r.ok ? r.json() : null))
     .catch(() => null)
+
+  // Don't cache a failure render under `revalidate = 86400` above — a thrown
+  // error bypasses the route's cache, so the next scrape retries instead of
+  // getting stuck with a stale "Résultat introuvable" card for a day.
+  if (!share) {
+    throw new Error(`Quiz share ${id} unavailable`)
+  }
 
   const best: ShareBest | null = share?.result?.top_matches?.[0] ?? null
   const headline =

--- a/frontend/src/app/quiz/s/[id]/opengraph-image.tsx
+++ b/frontend/src/app/quiz/s/[id]/opengraph-image.tsx
@@ -31,7 +31,7 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
     throw new Error(`Quiz share ${id} unavailable`)
   }
 
-  const best: ShareBest | null = share?.result?.top_matches?.[0] ?? null
+  const best: ShareBest | null = share.result?.top_matches?.[0] ?? null
   const headline =
     best && best.agreement_pct !== null
       ? `Je vote à ${best.agreement_pct}% comme ${best.full_name}`

--- a/frontend/src/app/verifier/v/[id]/opengraph-image.tsx
+++ b/frontend/src/app/verifier/v/[id]/opengraph-image.tsx
@@ -22,15 +22,23 @@ function truncate(text: string, max: number): string {
 export default async function OGImage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
   const verdict = await fetch(
-    `${process.env.NEXT_PUBLIC_API_URL ?? 'https://monelu-production.up.railway.app'}/verify/${id}`
+    `${process.env.NEXT_PUBLIC_API_URL ?? 'https://monelu-production.up.railway.app'}/verify/${id}`,
+    { signal: AbortSignal.timeout(5000) }
   )
     .then(r => (r.ok ? r.json() : null))
     .catch(() => null)
 
-  const style = VERDICT_STYLES[verdict?.verdict] ?? VERDICT_STYLES.inverifiable
-  const claim = verdict ? truncate(verdict.claim, 150) : 'Vérification introuvable'
-  const citations = verdict?.citations?.length ?? 0
-  const horizon = verdict?.data_horizon ?? null
+  // Don't cache a failure render under `revalidate = 86400` above — a thrown
+  // error bypasses the route's cache, so the next scrape retries instead of
+  // getting stuck with a stale "Vérification introuvable" card for a day.
+  if (!verdict) {
+    throw new Error(`Verification ${id} unavailable`)
+  }
+
+  const style = VERDICT_STYLES[verdict.verdict] ?? VERDICT_STYLES.inverifiable
+  const claim = truncate(verdict.claim, 150)
+  const citations = verdict.citations?.length ?? 0
+  const horizon = verdict.data_horizon ?? null
 
   return new ImageResponse(
     (


### PR DESCRIPTION
## What
Stops a viral spike from baking broken "Résultat introuvable" OG cards into feeds for 24h, across the quiz, chat, and verify share/verdict routes.

## Why
The three OG image routes (`quiz/s/[id]`, `chat/s/[id]`, `verifier/v/[id]`) fetch the underlying share/verdict from the API with no timeout and, on any failure (429, 5xx, network error), silently render a fallback "not found" card - which then gets cached for a day under `revalidate = 86400`.

The underlying API endpoints were rate-limited at 30 req/min per IP.
OG scrapers (X, WhatsApp, Facebook, Telegram) and Vercel edge egress funnel through a small pool of IPs, so exactly the success scenario the quiz/chat/verify share features are built for - many distinct links circulating and being scraped at once - trips that limit and each affected link shows a broken card for a day.

Source: `quiz_diagnostic_2026-07-22.md`, Finding #3 (MON-173).

## Changes
- `frontend/src/app/quiz/s/[id]/opengraph-image.tsx`, `chat/s/[id]/opengraph-image.tsx`, `verifier/v/[id]/opengraph-image.tsx`:
  - Added a 5s fetch timeout (`AbortSignal.timeout(5000)`) so a hung API call can't stall image generation.
  - On a failed/missing fetch, throw instead of falling back to placeholder copy - the thrown error bypasses the route's `revalidate = 86400` cache, so the next scrape retries against a fresh fetch instead of being stuck behind a stale broken card.
- `api/routers/quiz.py` (`GET /quiz/share/{id}`), `api/routers/search.py` (`GET /search/share/{id}`), `api/routers/verify.py` (`GET /verify/{id}`):
  - Raised the per-IP rate limit from 30/min to 300/min. All three serve immutable public snapshots behind unguessable UUIDs (no recompute, no LLM call) - enumeration is already prevented by the UUID keyspace, so a much higher ceiling still bounds abuse without tripping on legitimate scraper bursts from a handful of shared IPs.

## Testing
- `python3 -m pytest tests/ -m "not integration" -q` - 274 passed
- `ruff check .` / `ruff format --check .` - clean
- `cd frontend && npm run lint && npm test && npm run build` - lint clean, 164 Jest tests passed, `next build` succeeds (type-check passes; the three OG image routes still compile as dynamic routes)

## Risks / Notes
- No schema or deploy-config changes.
- The rate limit increase (30 → 300/min) applies only to three read-only, UUID-keyed, immutable-snapshot endpoints - not exposed to any write or compute-heavy path.
- The same "cache the failure" pattern was also present on `votes/[id]/opengraph-image.tsx` and `deputes/[id]/opengraph-image.tsx`, but those fetch mutable, enumerable resources (not immutable UUID snapshots) and weren't called out in the issue - left out of scope here to keep the fix focused; worth a follow-up issue if desired.

## Breaking Changes
None.
