### PR TITLE
feat: privacy-safe quiz funnel events (MON-176)

### DIFF
--- a/frontend/__tests__/components/QuizClient.test.tsx
+++ b/frontend/__tests__/components/QuizClient.test.tsx
@@ -33,6 +33,9 @@ jest.mock('next/navigation', () => ({
 
 import { api } from '@/lib/api'
 import { resolvePostalCodeToDepartment } from '@/lib/postal'
+import { track } from '@vercel/analytics/react'
+
+const mockTrack = track as jest.Mock
 
 const mockQuestions = api.quiz.questions as jest.Mock
 const mockMatch = api.quiz.match as jest.Mock
@@ -157,6 +160,8 @@ describe('QuizClient', () => {
 
     expect(screen.getByText('Quel député vote comme vous ?')).toBeInTheDocument()
     await answerAllQuestions(user)
+    // MON-176: privacy-safe funnel counter — fires once, on the intro CTA.
+    expect(mockTrack).toHaveBeenCalledWith('quiz_start')
     await skipGroupStep(user)
 
     // Optional postal step reached after the last question.
@@ -166,6 +171,8 @@ describe('QuizClient', () => {
     )
 
     await screen.findByText(/Vous votez à 83.3% comme Jeanne Martin/)
+    // MON-176: fires once the match computation succeeds.
+    expect(mockTrack).toHaveBeenCalledWith('quiz_complete')
     expect(mockMatch).toHaveBeenCalledWith(
       [
         { vote_id: 'V1', position: 'pour' },
@@ -410,6 +417,9 @@ describe('QuizClient', () => {
       false
     )
     expect(writeText).toHaveBeenCalledWith('https://mon-elu.vercel.app/quiz/s/abc')
+    // MON-176: fires once the share snapshot is actually created, not on
+    // every click of the share button.
+    expect(mockTrack).toHaveBeenCalledWith('quiz_share')
   })
 
   it('sends include_answers=true when the opt-in checkbox is checked', async () => {

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -7,3 +7,11 @@ jest.mock('next/navigation', () => ({
   useSearchParams: () => ({ get: () => null }),
   usePathname: () => '/',
 }))
+
+// Mock Vercel Analytics — the real package ships ESM-only and Jest's
+// transformIgnorePatterns excludes node_modules, so importing it directly
+// fails to parse.
+jest.mock('@vercel/analytics/react', () => ({
+  track: jest.fn(),
+  Analytics: () => null,
+}))

--- a/frontend/src/app/quiz/QuizClient.tsx
+++ b/frontend/src/app/quiz/QuizClient.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
 import Link from 'next/link'
+import { track } from '@vercel/analytics/react'
 import { api } from '@/lib/api'
 import type { QuizAnswerPosition, QuizMatchResponse, QuizQuestion, QuizShareResult } from '@/lib/api'
 import { resolvePostalCodeToDepartment } from '@/lib/postal'
@@ -75,6 +76,7 @@ function ShareResultButton({
         )
         url = share.share_url
         setShareUrl(url)
+        track('quiz_share')
       } catch {
         setState('error')
         return
@@ -336,6 +338,7 @@ export function QuizClient() {
       )
       setResult(res)
       setPhase('results')
+      track('quiz_complete')
     } catch {
       setMatchError(true)
     } finally {
@@ -409,7 +412,10 @@ export function QuizClient() {
             </p>
           ) : (
             <button
-              onClick={() => setPhase('questions')}
+              onClick={() => {
+                track('quiz_start')
+                setPhase('questions')
+              }}
               disabled={!questions}
               style={{
                 marginTop: 32,

--- a/frontend/src/app/quiz/s/[id]/page.tsx
+++ b/frontend/src/app/quiz/s/[id]/page.tsx
@@ -64,7 +64,7 @@ export default async function QuizSharePage({ params }: { params: Promise<{ id: 
         <QuizResultSections result={share.result} />
         <div style={{ marginTop: 48, textAlign: 'center' }}>
           <Link
-            href={share.result.answers ? `/quiz?compare=${id}` : '/quiz'}
+            href={share.result.answers ? `/quiz?compare=${id}&ref=share` : '/quiz?ref=share'}
             style={{
               display: 'inline-flex',
               alignItems: 'center',


### PR DESCRIPTION
## What
Adds privacy-safe funnel counters to the quiz so the viral loop (intro → questions → postal → results → share) is measurable, and tags share-driven entries so they show up in existing page analytics.

## Why
There was no counting of quiz starts, completions, or share creations anywhere in `frontend/src/app/quiz/QuizClient.tsx`. `POST /quiz/share` inserts a row so share volume is queryable after the fact, but starts, completions, and entry attribution were invisible - if the quiz is meant to be the traffic driver, there was no way to know whether it works or where the funnel leaks.

ADR-025 forbids persisting *answers*, not counting *events* - this stays within that constraint: no answers, no identifiers, just aggregate counters.

Source: `quiz_diagnostic_2026-07-22.md`, Finding #6 (MON-176).

## Changes
- `frontend/src/app/quiz/QuizClient.tsx`:
  - `quiz_start` - fired on the intro "Commencer le quiz" click.
  - `quiz_complete` - fired once `POST /quiz/match` succeeds and the results phase renders.
  - `quiz_share` - fired once a share snapshot is actually created (the first successful `POST /quiz/share`), not on every click of an already-created share link.
  - Uses `track()` from `@vercel/analytics/react` - Vercel Analytics is already mounted in `layout.tsx`, no new dependency.
- `frontend/src/app/quiz/s/[id]/page.tsx`: the "Faites le test" CTA now carries `?ref=share`, composing with the existing `?compare=<id>` param when present, so share-driven entries are attributable in existing page-view analytics without a new event.
- `frontend/jest.setup.ts`: added a global mock for `@vercel/analytics/react` - the real package is ESM-only and fails to parse under Jest's default `transformIgnorePatterns`, the same reason `next/navigation` is mocked there.
- `frontend/__tests__/components/QuizClient.test.tsx`: extended three existing tests (happy path, and the share-creation test) to assert `quiz_start`, `quiz_complete`, and `quiz_share` fire at the right points.

## Testing
- `cd frontend && npm run lint && npm test && npm run build` - lint clean, 164 Jest tests passed (including the new event assertions), `next build` succeeds.
- No backend changes - Python suite untouched by this PR.

## Risks / Notes
- No schema, deploy-config, or API changes - purely frontend, client-side analytics events.
- No new tests for `quiz/s/[id]/page.tsx` itself (a server component) - this repo has no existing coverage for that file or its sibling share pages, so this isn't a new gap.
- Event payloads intentionally carry no properties (no vote_id, no department, no deputy_id) to stay unambiguously privacy-safe per the issue's ask.

## Breaking Changes
None.
