### PR TITLE
fix: deterministic opposite-deputy tiebreak, suppress when it equals the top match (MON-177)

### DIFF
--- a/api/routers/quiz.py
+++ b/api/routers/quiz.py
@@ -166,6 +166,9 @@ class QuizMatchResponse(BaseModel):
     top_matches: list[QuizDeputyMatch]
     # The eligible deputy who agrees with you the least — same threshold as
     # the ranking, so a 0% on two shared votes never headlines the card.
+    # None when there's no eligible deputy distinct from top_matches[0]
+    # (MON-177) — with only one eligible deputy, this would otherwise echo
+    # the best match.
     opposite: Optional[QuizDeputyMatch] = None
     groups: list[QuizGroupAlignment]
     my_department: Optional[QuizDepartmentResult] = None
@@ -238,6 +241,30 @@ def compute_deputy_stats(rows: list[dict], answers: dict[str, str]) -> dict[str,
 def to_match(entry: dict) -> QuizDeputyMatch:
     pct = round(100 * entry["matches"] / entry["compared"], 1) if entry["compared"] else None
     return QuizDeputyMatch(**entry, agreement_pct=pct)
+
+
+def select_opposite(eligible: list[dict], top_matches: list[QuizDeputyMatch]) -> Optional[dict]:
+    """The eligible deputy who agrees the least, or None (MON-177).
+
+    Ties on ranking_score/compared break on full_name — mirroring the
+    top-matches sort so the result is deterministic instead of depending on
+    DB row order. Returns None when the least-agreeing deputy is the same
+    one as top_matches[0]: with only one eligible deputy, that deputy would
+    otherwise headline both "top match" and "opposite" on the same card.
+    """
+    if not eligible:
+        return None
+    candidate = min(
+        eligible,
+        key=lambda e: (
+            ranking_score(e["matches"], e["compared"]),
+            -e["compared"],
+            e["full_name"] or "",
+        ),
+    )
+    if top_matches and candidate["deputy_id"] == top_matches[0].deputy_id:
+        return None
+    return candidate
 
 
 def compute_group_alignment(
@@ -417,14 +444,10 @@ def _compute_match(body: QuizMatchRequest) -> QuizMatchResponse:
     if top_matches:
         top_matches[0].detail = detail_for(top_matches[0].deputy_id)
 
+    opposite_entry = select_opposite(eligible, top_matches)
     opposite = None
-    if eligible:
-        opposite = to_match(
-            min(
-                eligible,
-                key=lambda e: (ranking_score(e["matches"], e["compared"]), -e["compared"]),
-            )
-        )
+    if opposite_entry is not None:
+        opposite = to_match(opposite_entry)
         opposite.detail = detail_for(opposite.deputy_id)
 
     my_department = None

--- a/tests/unit/test_quiz.py
+++ b/tests/unit/test_quiz.py
@@ -5,11 +5,13 @@ from pydantic import ValidationError
 
 from api.quiz_data import QUIZ_QUESTIONS, QUIZ_VERSION
 from api.routers.quiz import (
+    QuizDeputyMatch,
     QuizMatchRequest,
     _strip_detail,
     compute_group_alignment,
     eligibility_threshold,
     ranking_score,
+    select_opposite,
 )
 
 V1, V2, V3 = (q["vote_id"] for q in QUIZ_QUESTIONS[:3])
@@ -208,6 +210,45 @@ def test_match_prefers_higher_coverage_over_higher_raw_percentage(client, mock_c
     # Displayed percentages are still the raw, unadjusted ratios.
     assert by_id["LOW"]["agreement_pct"] == 100.0
     assert by_id["HIGH"]["agreement_pct"] == 90.0
+
+
+def _entry(deputy_id, matches, compared, name):
+    return {
+        "deputy_id": deputy_id,
+        "full_name": name,
+        "party": None,
+        "party_short": None,
+        "department": None,
+        "photo_url": None,
+        "matches": matches,
+        "compared": compared,
+    }
+
+
+def test_select_opposite_tiebreak_is_deterministic_by_name():
+    """MON-177: equal-ratio ties break on full_name, not dict/DB row order."""
+    # Z and A tie on ranking_score and compared — Z appears first in
+    # `eligible`, which would win the old insertion-order tiebreak.
+    eligible = [
+        _entry("Z", 1, 3, "Zoé Martin"),
+        _entry("A", 1, 3, "Amir Ben"),
+    ]
+    top_matches = [QuizDeputyMatch(deputy_id="BEST", matches=3, compared=3)]
+
+    opposite = select_opposite(eligible, top_matches)
+    assert opposite["deputy_id"] == "A"
+
+
+def test_select_opposite_omitted_when_it_equals_top_match():
+    """MON-177: with a single eligible deputy, opposite must not echo top_matches[0]."""
+    eligible = [_entry("A", 3, 3, "Amélie Roux")]
+    top_matches = [QuizDeputyMatch(deputy_id="A", matches=3, compared=3)]
+
+    assert select_opposite(eligible, top_matches) is None
+
+
+def test_select_opposite_returns_none_for_empty_eligible():
+    assert select_opposite([], []) is None
 
 
 def test_match_department_roster_includes_absent_deputy(client, mock_cursor):


### PR DESCRIPTION
## What
Makes the `/quiz/match` "opposite" deputy deterministic and never equal to the top match.

## Why
`opposite` was `min()` over `(matches/compared, -compared)` with no name tiebreak, so equal-ratio ties resolved by DB row order - two users submitting identical answers could see different "À l'opposé" deputies depending on how `vote_positions` happened to be returned. Separately, when exactly one deputy cleared the eligibility threshold, `opposite` was that same deputy: the card would read "Vous votez à X% comme A" and "À l'opposé de vos votes : A" for the same person.

## Changes
- `api/routers/quiz.py`: extracted `select_opposite(eligible, top_matches)` as a pure helper alongside the file's existing pure-computation helpers (`eligibility_threshold`, `compute_group_alignment`, etc.). It adds the `full_name` tiebreak already used by the top-matches sort, and returns `None` when the least-agreeing deputy is `top_matches[0]`. `_compute_match` now calls this helper instead of an inline `min()`.
- `tests/unit/test_quiz.py`: added `test_select_opposite_tiebreak_is_deterministic_by_name`, `test_select_opposite_omitted_when_it_equals_top_match`, and `test_select_opposite_returns_none_for_empty_eligible`, unit-testing the extracted helper directly rather than through the HTTP endpoint - `/quiz/match` is rate-limited to 10/min and the test module's shared `TestClient` fixture was already near that budget, so exercising the new cases as pure function calls avoids flaking out unrelated tests later in the module.

## Testing
- `pytest tests/unit/test_quiz.py -q` - 35 passed
- `pytest tests/ -m "not integration" -q` - 279 passed (CI's blocking selection)
- `ruff check .` and `ruff format --check .` - clean

## Risks / Notes
- Pure refactor + bugfix; response shape unchanged (`opposite` was already `Optional`), so no frontend changes were needed.
- No behavior change for the common case (multiple eligible deputies with a clear least-agreeing one) - only affects genuine ties and the single-eligible-deputy edge case.

## Breaking Changes
None.