### PR TITLE
fix: vote_id validation gate for the quiz question set (MON-171)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,12 @@ jobs:
       - name: Run integration tests
         run: pytest tests/integration/ -v --tb=short -m integration
 
+      - name: Validate quiz vote_ids against production (MON-171)
+        # Catches a typo'd vote_id in a quarterly quiz refresh before it
+        # merges. Hits the public prod API (no secrets), same dependency the
+        # frontend build already has on prod being reachable.
+        run: python scripts/check_quiz_votes.py --api https://monelu-production.up.railway.app
+
   frontend:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/ingest_prod.yml
+++ b/.github/workflows/ingest_prod.yml
@@ -64,14 +64,6 @@ jobs:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
         run: python scripts/run_ingestion_prod.py --since $(python3 -c "from datetime import date, timedelta; print(date.today() - timedelta(days=30))")
 
-      - name: Validate quiz vote_ids (MON-171)
-        # Unconditional: a curated scrutin corrected/renumbered upstream would
-        # silently skew every quiz agreement percentage — fail the job loudly
-        # instead (the failure-notify steps below fire).
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-        run: python scripts/check_quiz_votes.py
-
       - name: Rebuild RAG index
         if: steps.ingest.outputs.new_votes != '0'
         env:
@@ -129,6 +121,16 @@ jobs:
           else
             echo "FRONTEND_URL or REVALIDATE_SECRET not set — skipping revalidation."
           fi
+
+      - name: Validate quiz vote_ids (MON-171)
+        # Unconditional, and deliberately last among the pipeline steps: a
+        # curated scrutin corrected/renumbered upstream would silently skew
+        # every quiz agreement percentage, so fail the job loudly (the
+        # failure-notify steps below fire) — but a quiz-content problem must
+        # not abort the RAG/dbt/cache steps above and stale production data.
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: python scripts/check_quiz_votes.py
 
       - name: Notify success
         run: echo "Ingestion completed at $(date)"

--- a/.github/workflows/ingest_prod.yml
+++ b/.github/workflows/ingest_prod.yml
@@ -64,6 +64,14 @@ jobs:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
         run: python scripts/run_ingestion_prod.py --since $(python3 -c "from datetime import date, timedelta; print(date.today() - timedelta(days=30))")
 
+      - name: Validate quiz vote_ids (MON-171)
+        # Unconditional: a curated scrutin corrected/renumbered upstream would
+        # silently skew every quiz agreement percentage — fail the job loudly
+        # instead (the failure-notify steps below fire).
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: python scripts/check_quiz_votes.py
+
       - name: Rebuild RAG index
         if: steps.ingest.outputs.new_votes != '0'
         env:

--- a/docs/quiz-curation.md
+++ b/docs/quiz-curation.md
@@ -68,9 +68,17 @@ own opinion? If yes, rewrite it.
    new quarter (e.g. `2026-Q4`). Old `QUIZ_VERSION` strings remain attached to
    already-stored `quiz_shares` snapshots (ADR-025) — they are never rewritten,
    so a version bump never invalidates a previously shared result card.
-5. Ship as a PR; `tests/unit/test_quiz.py` asserts every `vote_id` round-trips
-   through the API and that the response `version` matches `QUIZ_VERSION` —
-   no other test needs updating for a content-only refresh.
+5. Ship as a PR.
+   Two automated gates validate the set (MON-171):
+   CI runs `scripts/check_quiz_votes.py --api https://monelu-production.up.railway.app`
+   on every PR, failing if any `vote_id` in `QUIZ_VOTE_IDS` is unknown to the
+   production API — a typo'd id cannot merge.
+   The daily ingestion workflow (`ingest_prod.yml`) re-runs the same script
+   against the production `votes` table, so a curated scrutin later
+   corrected or renumbered upstream fails the ingestion job loudly instead
+   of silently skewing agreement percentages.
+   `tests/unit/test_quiz.py` covers set shape (count, uniqueness, phrasing)
+   with a mocked DB — no test needs updating for a content-only refresh.
 
 ## Current set (2026-Q3)
 

--- a/scripts/check_quiz_votes.py
+++ b/scripts/check_quiz_votes.py
@@ -36,7 +36,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from api.quiz_data import QUIZ_VERSION, QUIZ_VOTE_IDS  # noqa: E402
 
 MAX_RETRIES = 5
-BACKOFF_BASE = 2  # seconds
+BACKOFF_BASE = 2  # exponential backoff: waits of 1, 2, 4, 8 s between attempts
 
 
 def missing_from_db(database_url: str) -> list[str]:
@@ -79,10 +79,13 @@ def vote_exists_via_api(base_url: str, vote_id: str) -> bool:
 def missing_from_api(base_url: str) -> list[str]:
     """Return quiz vote_ids the live API does not know."""
     missing = []
-    for vote_id in sorted(QUIZ_VOTE_IDS):
+    for i, vote_id in enumerate(sorted(QUIZ_VOTE_IDS)):
+        if i:
+            # Pace at 2 s per request (true 30 req/min) so the check stays
+            # under the API's global rate limit even if the question set grows.
+            time.sleep(2)
         if not vote_exists_via_api(base_url, vote_id):
             missing.append(vote_id)
-        time.sleep(0.5)  # stay well under the API's 30 req/min global rate limit
     return missing
 
 
@@ -97,7 +100,13 @@ def main() -> int:
 
     if args.api:
         source = args.api
-        missing = missing_from_api(args.api)
+        try:
+            missing = missing_from_api(args.api)
+        except RuntimeError as exc:
+            # Prod unreachable is a different failure from a missing vote_id —
+            # keep it to one readable line instead of a traceback in CI logs.
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 1
     else:
         database_url = os.getenv("DATABASE_URL")
         if not database_url:

--- a/scripts/check_quiz_votes.py
+++ b/scripts/check_quiz_votes.py
@@ -1,0 +1,128 @@
+"""
+scripts/check_quiz_votes.py
+Validation gate for the quiz question set (MON-171).
+
+Asserts that every vote_id in api.quiz_data.QUIZ_VOTE_IDS exists in the
+production votes table. QUIZ_VOTE_IDS is self-referential (the request
+validator only checks membership in the curated set), so without this gate a
+typo'd or upstream-renumbered vote_id silently shrinks every deputy's
+`compared` count and skews all agreement percentages — no error, no log.
+
+Two modes:
+
+    python scripts/check_quiz_votes.py
+        DB mode (default) — checks the votes table via DATABASE_URL.
+        Run daily by ingest_prod.yml; catches upstream renumbering.
+
+    python scripts/check_quiz_votes.py --api https://monelu-production.up.railway.app
+        API mode — checks GET /votes/{id} against a live API, no DB
+        credentials needed. Run per-PR by ci.yml; catches a typo'd
+        vote_id in a quarterly refresh before it merges.
+
+Exits 1 with the list of missing vote_ids on any failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+import requests
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from api.quiz_data import QUIZ_VERSION, QUIZ_VOTE_IDS  # noqa: E402
+
+MAX_RETRIES = 5
+BACKOFF_BASE = 2  # seconds
+
+
+def missing_from_db(database_url: str) -> list[str]:
+    """Return quiz vote_ids absent from the votes table."""
+    import psycopg2
+
+    conn = psycopg2.connect(database_url)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT vote_id FROM votes WHERE vote_id = ANY(%s)",
+                (sorted(QUIZ_VOTE_IDS),),
+            )
+            present = {row[0] for row in cur.fetchall()}
+    finally:
+        conn.close()
+    return sorted(QUIZ_VOTE_IDS - present)
+
+
+def vote_exists_via_api(base_url: str, vote_id: str) -> bool:
+    """GET /votes/{id}: 200 = present, 404 = missing; retry 429/5xx/network."""
+    url = f"{base_url.rstrip('/')}/votes/{vote_id}"
+    last_error: str | None = None
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = requests.get(url, timeout=30)
+        except requests.RequestException as exc:
+            last_error = str(exc)
+        else:
+            if resp.status_code == 200:
+                return True
+            if resp.status_code == 404:
+                return False
+            last_error = f"HTTP {resp.status_code}"
+        if attempt < MAX_RETRIES - 1:
+            time.sleep(BACKOFF_BASE**attempt)
+    raise RuntimeError(f"Could not check {url} after {MAX_RETRIES} attempts: {last_error}")
+
+
+def missing_from_api(base_url: str) -> list[str]:
+    """Return quiz vote_ids the live API does not know."""
+    missing = []
+    for vote_id in sorted(QUIZ_VOTE_IDS):
+        if not vote_exists_via_api(base_url, vote_id):
+            missing.append(vote_id)
+        time.sleep(0.5)  # stay well under the API's 30 req/min global rate limit
+    return missing
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--api",
+        metavar="BASE_URL",
+        help="check via GET /votes/{id} on this API instead of DATABASE_URL",
+    )
+    args = parser.parse_args()
+
+    if args.api:
+        source = args.api
+        missing = missing_from_api(args.api)
+    else:
+        database_url = os.getenv("DATABASE_URL")
+        if not database_url:
+            print("DATABASE_URL is not set (or pass --api <base_url>).", file=sys.stderr)
+            return 1
+        source = "votes table"
+        missing = missing_from_db(database_url)
+
+    total = len(QUIZ_VOTE_IDS)
+    if missing:
+        print(
+            f"FAIL: {len(missing)}/{total} quiz vote_ids ({QUIZ_VERSION}) "
+            f"missing from {source}: {', '.join(missing)}",
+            file=sys.stderr,
+        )
+        print(
+            "The quiz would silently skip these scrutins, skewing every agreement "
+            "percentage. Fix api/quiz_data.py (see docs/quiz-curation.md).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK: all {total} quiz vote_ids ({QUIZ_VERSION}) present in {source}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_check_quiz_votes.py
+++ b/tests/unit/test_check_quiz_votes.py
@@ -1,0 +1,62 @@
+"""Unit tests for the quiz vote_id validation gate (MON-171)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from scripts.check_quiz_votes import missing_from_api, vote_exists_via_api
+
+
+def _resp(status_code):
+    resp = MagicMock()
+    resp.status_code = status_code
+    return resp
+
+
+@patch("scripts.check_quiz_votes.time.sleep")
+@patch("scripts.check_quiz_votes.requests.get")
+def test_200_means_present(mock_get, _sleep):
+    mock_get.return_value = _resp(200)
+    assert vote_exists_via_api("https://api.example", "VT1") is True
+    mock_get.assert_called_once()
+
+
+@patch("scripts.check_quiz_votes.time.sleep")
+@patch("scripts.check_quiz_votes.requests.get")
+def test_404_means_missing_without_retry(mock_get, _sleep):
+    mock_get.return_value = _resp(404)
+    assert vote_exists_via_api("https://api.example", "VT1") is False
+    mock_get.assert_called_once()
+
+
+@patch("scripts.check_quiz_votes.time.sleep")
+@patch("scripts.check_quiz_votes.requests.get")
+def test_transient_errors_are_retried_until_success(mock_get, _sleep):
+    mock_get.side_effect = [
+        _resp(429),
+        _resp(503),
+        requests.ConnectionError("boom"),
+        _resp(200),
+    ]
+    assert vote_exists_via_api("https://api.example", "VT1") is True
+    assert mock_get.call_count == 4
+
+
+@patch("scripts.check_quiz_votes.time.sleep")
+@patch("scripts.check_quiz_votes.requests.get")
+def test_retry_exhaustion_raises(mock_get, _sleep):
+    mock_get.return_value = _resp(503)
+    with pytest.raises(RuntimeError, match="HTTP 503"):
+        vote_exists_via_api("https://api.example", "VT1")
+    assert mock_get.call_count == 5
+
+
+@patch("scripts.check_quiz_votes.time.sleep")
+@patch("scripts.check_quiz_votes.requests.get")
+def test_missing_from_api_collects_only_404s(mock_get, _sleep):
+    from api.quiz_data import QUIZ_VOTE_IDS
+
+    first = sorted(QUIZ_VOTE_IDS)[0]
+    mock_get.side_effect = lambda url, timeout: _resp(404 if url.endswith(first) else 200)
+    assert missing_from_api("https://api.example") == [first]


### PR DESCRIPTION
## What

Adds a real validation gate asserting every quiz `vote_id` exists in production, and corrects `docs/quiz-curation.md` step 5, which claimed a test that never existed (MON-171).

## Why

`QUIZ_VOTE_IDS` in `api/quiz_data.py` is self-referential: the request validator only checks membership in the curated set itself.
If a quarterly refresh ships a typo'd `vote_id`, or a curated scrutin is corrected/renumbered upstream, the positions SELECT simply returns no rows for that vote - every deputy's `compared` count silently shrinks and all agreement percentages on every future share card are skewed, with no error or log.
The curation doc claimed `tests/unit/test_quiz.py` guarded against this; it does not (it only checks count, uniqueness, and phrasing, with a mocked DB).

## Changes

- New `scripts/check_quiz_votes.py`: asserts every member of `QUIZ_VOTE_IDS` exists, exiting 1 with the missing ids. Two modes:
  - DB mode (default): checks the `votes` table via `DATABASE_URL`.
  - API mode (`--api <base_url>`): checks `GET /votes/{id}` with retry on 429/5xx/network (200 = present, 404 = missing), 0.5 s pacing to stay under the API's rate limit. No credentials needed.
- `ci.yml`: new step in `lint-and-test` running API mode against the production API on every PR - a typo'd `vote_id` in a refresh can no longer merge.
- `ingest_prod.yml`: new unconditional step after ingestion running DB mode - an upstream-renumbered scrutin fails the daily job loudly, and the existing failure-notify/email steps fire.
- `docs/quiz-curation.md`: step 5 of the refresh process now describes these two gates instead of the nonexistent round-trip test.

## Acceptance criteria mapping

- *"Add a real gate: a step in `ingest_prod.yml` ... asserting each member of `QUIZ_VOTE_IDS` exists in the prod `votes` table, failing loudly"* → DB-mode step in `ingest_prod.yml`; a failure fails the job and triggers the existing notification steps.
- *"Cheap 80% version: a test hitting live `GET /votes/{id}`, run in CI only"* → API-mode step in `ci.yml` per PR (implemented as a script step rather than a pytest test so the unit suite stays network-free).
- *"Correct `docs/quiz-curation.md` step 5 to describe whatever gate actually exists"* → done.

## Testing

- `python scripts/check_quiz_votes.py --api https://monelu-production.up.railway.app` run for real: `OK: all 10 quiz vote_ids (2026-Q3) present`.
- Failure path exercised for real: a fake id (`VTANR5L17V9999999`) is detected as missing via the API 404 path; a real id returns present.
- `pytest tests/ -m "not integration"`: 274 passed, 0 failed.
- `ruff check .` and `ruff format --check .`: clean repo-wide.

## Risks / Notes

- The new CI step makes every PR depend on the production API being reachable - the same dependency the frontend build job already has (it prerenders against prod). If prod is down, the step fails; that is arguably signal, not noise.
- `ingest_prod.yml` change adds a step only; the cron trigger and existing step semantics are untouched.
- The DB-mode step runs before the RAG/dbt steps, so a missing vote_id also skips the day's downstream work - intentional (fail loudly, fix fast).

## Breaking Changes

None.
