### PR TITLE
feat: redesign the quiz questions phase as a Tinder-style swipe deck (MON-186)

### DIFF
--- a/frontend/__tests__/components/QuizClient.test.tsx
+++ b/frontend/__tests__/components/QuizClient.test.tsx
@@ -22,6 +22,56 @@ jest.mock('@/lib/postal', () => ({
   resolvePostalCodeToDepartment: jest.fn(),
 }))
 
+// MON-186: the swipe deck animates via framer-motion, whose rAF-driven
+// springs and AnimatePresence exit delays are nondeterministic in jsdom.
+// Render plain elements instead: motion.* becomes its tag with the motion
+// props stripped (MotionValue style entries dropped), AnimatePresence
+// renders its children synchronously, and the hooks return inert values.
+jest.mock('framer-motion', () => {
+  const React = jest.requireActual<typeof import('react')>('react')
+  const MOTION_ONLY_PROPS = new Set([
+    'drag', 'dragSnapToOrigin', 'dragElastic', 'onDragEnd', 'whileTap',
+    'initial', 'animate', 'exit', 'transition', 'layout', 'layoutId',
+  ])
+  function clean(props: Record<string, unknown>) {
+    const out: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(props)) {
+      if (MOTION_ONLY_PROPS.has(key)) continue
+      if (key === 'style' && value && typeof value === 'object') {
+        const style: Record<string, unknown> = {}
+        for (const [sk, sv] of Object.entries(value as Record<string, unknown>)) {
+          if (sv !== null && typeof sv === 'object') continue // MotionValue
+          style[sk] = sv
+        }
+        out.style = style
+        continue
+      }
+      out[key] = value
+    }
+    return out
+  }
+  const motion = new Proxy(
+    {},
+    {
+      get: (_target, tag: string) => {
+        const Component = React.forwardRef<unknown, Record<string, unknown>>((props, ref) =>
+          React.createElement(tag, { ...clean(props), ref })
+        )
+        Component.displayName = `motion.${tag}`
+        return Component
+      },
+    }
+  )
+  return {
+    motion,
+    AnimatePresence: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    useMotionValue: (initial: number) => ({ get: () => initial, set: () => {} }),
+    useTransform: () => 0,
+    useReducedMotion: () => false,
+  }
+})
+
 // Overrides jest.setup.ts's blanket next/navigation mock so individual tests
 // can simulate arriving at /quiz?deputy=<id> (MON-183) or /quiz?compare=<id> (MON-184).
 const mockSearchParamsGet = jest.fn<string | null, [string]>(() => null)
@@ -132,11 +182,12 @@ const MATCH_WITH_DEPT: QuizMatchResponse = {
   },
 }
 
+// MON-186: answering via the deck buttons advances immediately - there is no
+// reveal step to click through anymore.
 async function answerAllQuestions(user: ReturnType<typeof userEvent.setup>) {
   await user.click(await screen.findByRole('button', { name: 'Commencer le quiz' }))
   for (let i = 0; i < QUESTIONS.questions.length; i++) {
     await user.click(screen.getByRole('button', { name: 'Pour' }))
-    await user.click(screen.getByRole('button', { name: 'Question suivante' }))
   }
 }
 
@@ -187,57 +238,71 @@ describe('QuizClient', () => {
     expect(screen.queryByText('Les députés de votre département')).not.toBeInTheDocument()
   })
 
-  it('shows a progress indicator, reveals the real outcome, and supports going back', async () => {
+  it('shows a progress indicator, advances on answer, and supports undo', async () => {
     const user = userEvent.setup()
     render(<QuizClient />)
     await user.click(await screen.findByRole('button', { name: 'Commencer le quiz' }))
 
     expect(screen.getByText('Question 1 / 3')).toBeInTheDocument()
-    // The outcome must never appear before an answer is given.
-    expect(screen.queryByText(/291 pour, 241 contre/)).not.toBeInTheDocument()
-
+    // MON-186: no reveal step - answering advances straight to the next card.
     await user.click(screen.getByRole('button', { name: 'Contre' }))
-    // Reveal panel appears with the real tallies before advancing. 291
-    // pour vs 241 contre means "pour" is the majority — the "Contre" answer
-    // is with the minority.
-    await screen.findByText(/291 pour, 241 contre, 12 abstentions/)
-    expect(screen.getByText('Vous étiez avec la minorité.')).toBeInTheDocument()
-    expect(screen.getByText('Question 1 / 3')).toBeInTheDocument()
-
-    await user.click(screen.getByRole('button', { name: 'Question suivante' }))
     expect(screen.getByText('Question 2 / 3')).toBeInTheDocument()
+    expect(screen.queryByText(/L’Assemblée a/)).not.toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: '← Retour' }))
+    await user.click(screen.getByRole('button', { name: 'Revenir à la question précédente' }))
     expect(screen.getByText('Question 1 / 3')).toBeInTheDocument()
-    // The previously selected answer stays highlighted (selected state kept),
-    // and the reveal panel does not persist across back navigation.
-    expect(screen.getByRole('button', { name: 'Contre' })).toHaveStyle({
-      border: '2px solid var(--dp-red)',
-    })
-    expect(screen.queryByText(/291 pour, 241 contre/)).not.toBeInTheDocument()
+
+    // Undo from the first question returns to the intro.
+    await user.click(screen.getByRole('button', { name: 'Revenir à la question précédente' }))
+    expect(screen.getByText('Quel député vote comme vous ?')).toBeInTheDocument()
   })
 
-  it('allows going back directly from the reveal panel, landing on the answer screen', async () => {
+  it('hides the scrutin outcome behind the details toggle, as percentages', async () => {
     const user = userEvent.setup()
     render(<QuizClient />)
     await user.click(await screen.findByRole('button', { name: 'Commencer le quiz' }))
+
+    // Collapsed by default: neither the context nor the outcome is visible.
+    expect(screen.queryByText('Contexte 1.')).not.toBeInTheDocument()
+    expect(screen.queryByText(/L’Assemblée a adopté ce texte/)).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Détails du scrutin' }))
+    expect(screen.getByText('Contexte 1.')).toBeInTheDocument()
+    expect(screen.getByText('L’Assemblée a adopté ce texte :')).toBeInTheDocument()
+    // 291 / 241 / 12 of 544 votes cast - percentages, never raw counts.
+    expect(screen.getByText('Pour : 53 %')).toBeInTheDocument()
+    expect(screen.getByText('Contre : 44 %')).toBeInTheDocument()
+    expect(screen.getByText('Abstention : 2 %')).toBeInTheDocument()
+    expect(screen.queryByText(/291 pour/)).not.toBeInTheDocument()
+
+    // Toggling closed hides it again, and it stays closed on the next card.
+    await user.click(screen.getByRole('button', { name: 'Détails du scrutin' }))
+    expect(screen.queryByText(/L’Assemblée a adopté ce texte/)).not.toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: 'Pour' }))
-    await user.click(screen.getByRole('button', { name: 'Question suivante' }))
-
-    // Answer question 2 to trigger its reveal panel, then go back without
-    // advancing past it.
-    await user.click(screen.getByRole('button', { name: 'Contre' }))
-    await screen.findByText(/200 pour, 300 contre/)
-
-    await user.click(screen.getByRole('button', { name: '← Retour' }))
-    expect(screen.getByText('Question 1 / 3')).toBeInTheDocument()
-    expect(screen.queryByText(/200 pour, 300 contre/)).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Pour' })).toHaveStyle({
-      border: '2px solid var(--dp-green)',
-    })
+    expect(screen.getByText('Question 2 / 3')).toBeInTheDocument()
+    expect(screen.queryByText(/L’Assemblée a rejeté ce texte/)).not.toBeInTheDocument()
   })
 
-  it('skipping a question shows no reveal and advances directly', async () => {
+  it('answers with the arrow keys and undoes with Backspace', async () => {
+    const user = userEvent.setup()
+    render(<QuizClient />)
+    await user.click(await screen.findByRole('button', { name: 'Commencer le quiz' }))
+
+    await user.keyboard('{ArrowRight}')
+    expect(screen.getByText('Question 2 / 3')).toBeInTheDocument()
+    await user.keyboard('{ArrowLeft}')
+    expect(screen.getByText('Question 3 / 3')).toBeInTheDocument()
+    await user.keyboard('{Backspace}')
+    expect(screen.getByText('Question 2 / 3')).toBeInTheDocument()
+    await user.keyboard('{ArrowLeft}')
+    await user.keyboard('{ArrowDown}')
+
+    // Past the last card, the flow continues into the group step, with the
+    // keyboard answers recorded (pour / contre / abstention).
+    expect(screen.getByText('De quel groupe vous sentez-vous le plus proche ?')).toBeInTheDocument()
+  })
+
+  it('skipping a question advances directly and records no answer', async () => {
     const user = userEvent.setup()
     render(<QuizClient />)
     await user.click(await screen.findByRole('button', { name: 'Commencer le quiz' }))
@@ -286,10 +351,8 @@ describe('QuizClient', () => {
     await user.click(await screen.findByRole('button', { name: 'Commencer le quiz' }))
 
     await user.click(screen.getByRole('button', { name: 'Pour' }))
-    await user.click(screen.getByRole('button', { name: 'Question suivante' }))
     await user.click(screen.getByRole('button', { name: 'Passer cette question' }))
     await user.click(screen.getByRole('button', { name: 'Abstention' }))
-    await user.click(screen.getByRole('button', { name: 'Question suivante' }))
     await skipGroupStep(user)
 
     expect(screen.getByText('Encore quelques réponses')).toBeInTheDocument()
@@ -307,11 +370,8 @@ describe('QuizClient', () => {
     expect(screen.getByText('Et votre député à vous ?')).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: '← Revenir aux questions' }))
-    // Lands on the last question with the previous selection still highlighted.
+    // Lands back on the last question's card.
     expect(screen.getByText('Question 3 / 3')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Pour' })).toHaveStyle({
-      border: '2px solid var(--dp-green)',
-    })
   })
 
   it('links results to the matched deputy profiles', async () => {

--- a/frontend/__tests__/components/QuizClient.test.tsx
+++ b/frontend/__tests__/components/QuizClient.test.tsx
@@ -276,7 +276,7 @@ describe('QuizClient', () => {
     expect(screen.queryByText(/291 pour/)).not.toBeInTheDocument()
 
     // Toggling closed hides it again, and it stays closed on the next card.
-    await user.click(screen.getByRole('button', { name: 'Détails du scrutin' }))
+    await user.click(screen.getByRole('button', { name: 'Masquer les détails' }))
     expect(screen.queryByText(/L’Assemblée a adopté ce texte/)).not.toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: 'Pour' }))
     expect(screen.getByText('Question 2 / 3')).toBeInTheDocument()

--- a/frontend/src/app/quiz/QuizClient.tsx
+++ b/frontend/src/app/quiz/QuizClient.tsx
@@ -7,10 +7,10 @@ import { api } from '@/lib/api'
 import type { QuizAnswerPosition, QuizMatchResponse, QuizQuestion, QuizShareResult } from '@/lib/api'
 import { resolvePostalCodeToDepartment } from '@/lib/postal'
 import type { ResolvedDepartment } from '@/lib/postal'
-import { POS } from '@/lib/vote-position'
 import { CANONICAL_GROUP_LABELS } from '@/lib/groups'
 import { partyHex } from '@/lib/utils'
 import { pctLabel, card, QuizResultSections } from './QuizResultSections'
+import { QuizDeck } from './QuizDeck'
 
 const NAVY = 'var(--dp-text)'
 const CREAM = 'var(--dp-page-bg)'
@@ -205,9 +205,6 @@ export function QuizClient() {
   const [questionsError, setQuestionsError] = useState(false)
   const [index, setIndex] = useState(0)
   const [answers, setAnswers] = useState<Record<string, QuizAnswerPosition>>({})
-  // vote_id currently showing its reveal panel, or null. Cleared on advance
-  // and on back navigation — the reveal never persists across questions.
-  const [revealVoteId, setRevealVoteId] = useState<string | null>(null)
   const [predictedGroup, setPredictedGroup] = useState<string | null>(null)
   const [focusDeputyName, setFocusDeputyName] = useState<string | null>(null)
 
@@ -293,9 +290,11 @@ export function QuizClient() {
 
   const answeredCount = Object.keys(answers).length
 
+  // MON-186: answering advances immediately - the swipe deck has no blocking
+  // reveal step; the scrutin outcome lives behind the card's details toggle.
   function answer(voteId: string, position: QuizAnswerPosition) {
     setAnswers(prev => ({ ...prev, [voteId]: position }))
-    setRevealVoteId(voteId)
+    advance()
   }
 
   function skip(voteId: string) {
@@ -307,18 +306,12 @@ export function QuizClient() {
     advance()
   }
 
-  function goNext() {
-    setRevealVoteId(null)
-    advance()
-  }
-
   function advance() {
     if (questions && index < questions.length - 1) setIndex(index + 1)
     else setPhase('group')
   }
 
   function back() {
-    setRevealVoteId(null)
     if (index > 0) setIndex(index - 1)
     else setPhase('intro')
   }
@@ -443,139 +436,42 @@ export function QuizClient() {
   }
 
   // -------------------------------------------------------------- questions
+  // MON-186: swipe deck - one card per scrutin, gestures + buttons + keyboard
+  // share one commit path inside QuizDeck. The deck column is narrower than
+  // the shell so the cards keep a card-like aspect on desktop.
   if (phase === 'questions' && questions) {
-    const q = questions[index]
-    const selected = answers[q.vote_id]
-    const revealing = revealVoteId === q.vote_id
-    const tallyKnown = q.votes_for != null && q.votes_against != null
-    const resultVerb =
-      q.result === 'adopté' ? 'adopté' : q.result === 'rejeté' ? 'rejeté' : null
-    const resultLine = tallyKnown
-      ? (resultVerb ? `L’Assemblée a ${resultVerb} ce texte : ` : 'Résultat du scrutin : ') +
-        `${q.votes_for} pour, ${q.votes_against} contre` +
-        (q.abstentions != null
-          ? `, ${q.abstentions} abstention${q.abstentions > 1 ? 's' : ''}`
-          : '') +
-        '.'
-      : null
-    const majority =
-      tallyKnown && q.votes_for !== q.votes_against
-        ? q.votes_for! > q.votes_against!
-          ? 'pour'
-          : 'contre'
-        : null
-    const outcomeLine =
-      selected === 'abstention'
-        ? 'Vous vous êtes abstenu·e sur ce texte.'
-        : majority
-          ? selected === majority
-            ? 'Vous étiez avec la majorité.'
-            : 'Vous étiez avec la minorité.'
-          : null
     return (
       <Shell>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 }}>
-          <div style={kicker}>
-            Question {index + 1} / {questions.length}
+        <div style={{ maxWidth: 420, margin: '0 auto' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 }}>
+            <div style={kicker}>
+              Question {index + 1} / {questions.length}
+            </div>
           </div>
-          <div style={{ fontSize: 12.5, color: GRAY }}>{q.theme}</div>
-        </div>
-        <div
-          role="progressbar"
-          aria-valuenow={index + 1}
-          aria-valuemin={1}
-          aria-valuemax={questions.length}
-          style={{ height: 6, background: 'var(--dp-border-subtle)', borderRadius: 999, overflow: 'hidden', marginBottom: 30 }}
-        >
           <div
-            style={{
-              height: '100%',
-              background: NAVY,
-              borderRadius: 999,
-              width: `${((index + 1) / questions.length) * 100}%`,
-              transition: 'width 200ms ease',
-            }}
-          />
-        </div>
-
-        <h2
-          className="font-newsreader text-[clamp(22px,3.5vw,32px)]"
-          style={{ fontWeight: 600, color: NAVY, margin: 0, letterSpacing: '-0.01em', lineHeight: 1.3 }}
-        >
-          {q.question}
-        </h2>
-        <p style={{ margin: '14px 0 30px', fontSize: 14.5, lineHeight: 1.6, color: GRAY }}>{q.context}</p>
-
-        {revealing ? (
-          <div
-            style={{
-              padding: '20px 22px',
-              borderRadius: 10,
-              background: 'var(--dp-card-bg)',
-              border: `1px solid ${LINE}`,
-            }}
+            role="progressbar"
+            aria-valuenow={index + 1}
+            aria-valuemin={1}
+            aria-valuemax={questions.length}
+            style={{ height: 6, background: 'var(--dp-border-subtle)', borderRadius: 999, overflow: 'hidden', marginBottom: 24 }}
           >
-            <p style={{ margin: 0, fontSize: 15.5, lineHeight: 1.6, color: NAVY, fontWeight: 600 }}>
-              {resultLine ?? 'Résultat du scrutin indisponible pour ce texte.'}
-            </p>
-            {outcomeLine && (
-              <p style={{ margin: '10px 0 0', fontSize: 14, color: GRAY }}>{outcomeLine}</p>
-            )}
-          </div>
-        ) : (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-            {(['pour', 'contre', 'abstention'] as const).map(pos => {
-              const { label, color, bg } = POS[pos]
-              const active = selected === pos
-              return (
-                <button
-                  key={pos}
-                  onClick={() => answer(q.vote_id, pos)}
-                  style={{
-                    padding: '15px 20px',
-                    borderRadius: 10,
-                    fontWeight: 600,
-                    fontSize: 16,
-                    textAlign: 'left',
-                    cursor: 'pointer',
-                    color,
-                    background: bg,
-                    border: `2px solid ${active ? color : 'transparent'}`,
-                  }}
-                >
-                  {label}
-                </button>
-              )
-            })}
-          </div>
-        )}
-
-        <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 28 }}>
-          <button
-            onClick={back}
-            style={{ fontSize: 14, color: NAVY, background: 'none', border: 'none', cursor: 'pointer', textDecoration: 'underline', padding: 4 }}
-          >
-            ← Retour
-          </button>
-          {revealing ? (
-            <button
-              onClick={goNext}
+            <div
               style={{
-                background: ACCENT, color: '#fff', padding: '10px 22px', borderRadius: 9,
-                fontWeight: 600, fontSize: 14.5, border: 'none', cursor: 'pointer',
-                boxShadow: '0 2px 8px var(--dp-cta-shadow)',
+                height: '100%',
+                background: NAVY,
+                borderRadius: 999,
+                width: `${((index + 1) / questions.length) * 100}%`,
+                transition: 'width 200ms ease',
               }}
-            >
-              Question suivante
-            </button>
-          ) : (
-            <button
-              onClick={() => skip(q.vote_id)}
-              style={{ fontSize: 14, color: GRAY, background: 'none', border: 'none', cursor: 'pointer', textDecoration: 'underline', padding: 4 }}
-            >
-              Passer cette question
-            </button>
-          )}
+            />
+          </div>
+          <QuizDeck
+            questions={questions}
+            index={index}
+            onAnswer={answer}
+            onSkip={skip}
+            onBack={back}
+          />
         </div>
       </Shell>
     )

--- a/frontend/src/app/quiz/QuizDeck.tsx
+++ b/frontend/src/app/quiz/QuizDeck.tsx
@@ -1,0 +1,342 @@
+'use client'
+// MON-186: Tinder-style swipe deck for the quiz questions phase. One card per
+// scrutin; swipe right = pour, left = contre, down = abstention. The buttons
+// under the stack, the arrow keys and Backspace drive the exact same commit
+// path as the gestures, so touch, mouse, keyboard and assistive tech are all
+// first-class. The old post-answer reveal panel is gone - the scrutin outcome
+// hides behind a per-card "Détails du scrutin" toggle instead.
+import { useEffect, useState } from 'react'
+import {
+  AnimatePresence,
+  motion,
+  useMotionValue,
+  useReducedMotion,
+  useTransform,
+} from 'framer-motion'
+import type { QuizAnswerPosition, QuizQuestion } from '@/lib/api'
+import { POS } from '@/lib/vote-position'
+
+const NAVY = 'var(--dp-text)'
+const LINE = 'var(--dp-border)'
+const RED = 'var(--dp-red)'
+const GRAY = 'var(--dp-text-secondary)'
+
+// A drag commits once the card travels this far or is flung this fast.
+const SWIPE_OFFSET = 100
+const SWIPE_VELOCITY = 500
+
+type Dir = Exclude<QuizAnswerPosition, 'nonVotant'>
+
+// Where a committed card flies off to (and where an undone card re-enters from).
+const EXIT: Record<Dir, { x: number; y: number; rotate: number }> = {
+  pour: { x: 560, y: -40, rotate: 18 },
+  contre: { x: -560, y: -40, rotate: -18 },
+  abstention: { x: 0, y: 640, rotate: 0 },
+}
+
+// Percentage split of the votes cast (pour + contre + abstention, MON-186:
+// percentages, not raw counts). Null when the live tally join found no row.
+function tallyBullets(q: QuizQuestion): Array<{ label: string; pct: number }> | null {
+  if (q.votes_for == null || q.votes_against == null) return null
+  const abstentions = q.abstentions ?? 0
+  const total = q.votes_for + q.votes_against + abstentions
+  if (total === 0) return null
+  const pct = (n: number) => Math.round((n / total) * 100)
+  const bullets: Array<{ label: string; pct: number }> = [
+    { label: POS.pour.label, pct: pct(q.votes_for) },
+    { label: POS.contre.label, pct: pct(q.votes_against) },
+  ]
+  if (q.abstentions != null) bullets.push({ label: POS.abstention.label, pct: pct(abstentions) })
+  return bullets
+}
+
+function outcomeLine(q: QuizQuestion): string {
+  if (q.result === 'adopté') return 'L’Assemblée a adopté ce texte :'
+  if (q.result === 'rejeté') return 'L’Assemblée a rejeté ce texte :'
+  return 'Résultat du scrutin :'
+}
+
+// Rotated Tinder-style stamp whose opacity is driven by the drag distance.
+function Stamp({
+  label,
+  color,
+  opacity,
+  style,
+}: {
+  label: string
+  color: string
+  opacity: ReturnType<typeof useTransform<number, number>>
+  style?: React.CSSProperties
+}) {
+  return (
+    <motion.div
+      aria-hidden
+      style={{
+        position: 'absolute', top: 18, padding: '4px 12px', borderRadius: 8,
+        border: `3px solid ${color}`, color, fontWeight: 800, fontSize: 22,
+        letterSpacing: '0.08em', textTransform: 'uppercase', pointerEvents: 'none',
+        background: 'var(--dp-card-bg)', opacity, ...style,
+      }}
+    >
+      {label}
+    </motion.div>
+  )
+}
+
+function TopCard({ question, onCommit }: { question: QuizQuestion; onCommit: (dir: Dir) => void }) {
+  const x = useMotionValue(0)
+  const y = useMotionValue(0)
+  const rotate = useTransform(x, [-200, 200], [-12, 12])
+  const pourOpacity = useTransform(x, [30, SWIPE_OFFSET], [0, 1])
+  const contreOpacity = useTransform(x, [-30, -SWIPE_OFFSET], [0, 1])
+  const absOpacity = useTransform([x, y], ([vx, vy]: number[]) =>
+    Math.abs(vx) < 60 ? Math.min(Math.max((vy - 30) / (SWIPE_OFFSET - 30), 0), 1) : 0
+  )
+  const border = useTransform(
+    [pourOpacity, contreOpacity, absOpacity],
+    ([p, c, a]: number[]) => {
+      if (p > 0.05) return `2px solid rgba(34,139,94,${0.2 + p * 0.8})`
+      if (c > 0.05) return `2px solid rgba(196,52,52,${0.2 + c * 0.8})`
+      if (a > 0.05) return `2px solid rgba(120,120,120,${0.2 + a * 0.8})`
+      return `1px solid ${LINE}`
+    }
+  )
+  const [showInfo, setShowInfo] = useState(false)
+  const bullets = tallyBullets(question)
+
+  function handleDragEnd(
+    _: unknown,
+    info: { offset: { x: number; y: number }; velocity: { x: number; y: number } }
+  ) {
+    const { offset, velocity } = info
+    const fastX = Math.abs(velocity.x) > SWIPE_VELOCITY
+    const fastY = velocity.y > SWIPE_VELOCITY
+    // Horizontal wins whenever it dominates the drag, so a diagonal fling
+    // never registers as an accidental abstention.
+    if ((offset.x > SWIPE_OFFSET || (fastX && velocity.x > 0)) && Math.abs(offset.x) >= offset.y) {
+      onCommit('pour')
+    } else if (
+      (offset.x < -SWIPE_OFFSET || (fastX && velocity.x < 0)) &&
+      Math.abs(offset.x) >= offset.y
+    ) {
+      onCommit('contre')
+    } else if (offset.y > SWIPE_OFFSET || fastY) {
+      onCommit('abstention')
+    }
+    // Below threshold: dragSnapToOrigin springs the card back.
+  }
+
+  return (
+    <motion.div
+      drag
+      dragSnapToOrigin
+      dragElastic={0.9}
+      onDragEnd={handleDragEnd}
+      style={{
+        x, y, rotate, border,
+        position: 'absolute', inset: 0, borderRadius: 16, background: 'var(--dp-card-bg)',
+        boxShadow: '0 10px 30px rgba(0,0,0,0.10)', padding: '22px 22px 18px',
+        display: 'flex', flexDirection: 'column', cursor: 'grab', touchAction: 'none',
+        userSelect: 'none', zIndex: 3,
+      }}
+      whileTap={{ cursor: 'grabbing' }}
+    >
+      <Stamp label={POS.pour.label} color={POS.pour.color} opacity={pourOpacity} style={{ left: 16, rotate: '-12deg' }} />
+      <Stamp label={POS.contre.label} color={POS.contre.color} opacity={contreOpacity} style={{ right: 16, rotate: '12deg' }} />
+      <Stamp
+        label={POS.abstention.label} color={POS.abstention.color} opacity={absOpacity}
+        style={{ left: '50%', x: '-50%', top: 'auto', bottom: 18, fontSize: 18 }}
+      />
+      <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: RED }}>
+        {question.theme}
+      </div>
+      <h2
+        className="font-newsreader"
+        style={{
+          fontWeight: 600, color: NAVY, margin: '12px 0 0',
+          fontSize: 'clamp(20px,4.5vw,26px)', lineHeight: 1.3, flex: showInfo ? 'none' : 1,
+        }}
+      >
+        {question.question}
+      </h2>
+      {showInfo && (
+        <div style={{ marginTop: 14, flex: 1, overflowY: 'auto', fontSize: 13.5, lineHeight: 1.55, color: GRAY }}>
+          <p style={{ margin: 0 }}>{question.context}</p>
+          {bullets ? (
+            <>
+              <p style={{ margin: '10px 0 0', fontWeight: 600, color: NAVY }}>{outcomeLine(question)}</p>
+              <ul style={{ margin: '6px 0 0', paddingLeft: 20 }}>
+                {bullets.map(b => (
+                  <li key={b.label}>
+                    {b.label} : {b.pct} %
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : (
+            <p style={{ margin: '10px 0 0', fontWeight: 600, color: NAVY }}>
+              Résultat du scrutin indisponible pour ce texte.
+            </p>
+          )}
+        </div>
+      )}
+      <button
+        onClick={() => setShowInfo(v => !v)}
+        // Keeps a tap on the toggle from starting a card drag.
+        onPointerDownCapture={e => e.stopPropagation()}
+        aria-expanded={showInfo}
+        aria-label="Détails du scrutin"
+        style={{
+          alignSelf: 'flex-start', marginTop: 12, fontSize: 12.5, fontWeight: 600, color: GRAY,
+          background: 'none', border: `1px solid ${LINE}`, borderRadius: 999,
+          padding: '5px 12px', cursor: 'pointer',
+        }}
+      >
+        {showInfo ? 'Masquer les détails' : 'ℹ Détails du scrutin'}
+      </button>
+    </motion.div>
+  )
+}
+
+export function QuizDeck({
+  questions,
+  index,
+  onAnswer,
+  onSkip,
+  onBack,
+}: {
+  questions: QuizQuestion[]
+  index: number
+  onAnswer: (voteId: string, position: QuizAnswerPosition) => void
+  onSkip: (voteId: string) => void
+  onBack: () => void
+}) {
+  const reducedMotion = useReducedMotion()
+  // Exit direction of each committed card, keyed by vote_id, so
+  // AnimatePresence knows which way to fling it and undo where to re-enter from.
+  const [exitDir, setExitDir] = useState<Record<string, Dir>>({})
+
+  const stack = questions.slice(index, index + 3)
+  const top = stack[0]
+
+  function commit(dir: Dir) {
+    if (!top) return
+    setExitDir(prev => ({ ...prev, [top.vote_id]: dir }))
+    onAnswer(top.vote_id, dir)
+  }
+
+  function skip() {
+    if (!top) return
+    setExitDir(prev => ({ ...prev, [top.vote_id]: 'abstention' }))
+    onSkip(top.vote_id)
+  }
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'ArrowRight') commit('pour')
+      else if (e.key === 'ArrowLeft') commit('contre')
+      else if (e.key === 'ArrowDown') commit('abstention')
+      else if (e.key === 'Backspace') onBack()
+      else return
+      e.preventDefault()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [questions, index])
+
+  const exitOf = (voteId: string) => EXIT[exitDir[voteId] ?? 'abstention']
+
+  return (
+    <div style={{ maxWidth: 420, margin: '0 auto' }}>
+      <div style={{ position: 'relative', height: 380 }}>
+        {/* Back cards, deepest first so the top card paints last. */}
+        {stack.slice(1).reverse().map(q => {
+          const depth = stack.indexOf(q)
+          return (
+            <motion.div
+              key={q.vote_id}
+              aria-hidden
+              initial={false}
+              animate={{ scale: 1 - depth * 0.045, y: depth * 14, opacity: 1 - depth * 0.25 }}
+              style={{
+                position: 'absolute', inset: 0, borderRadius: 16, background: 'var(--dp-card-bg)',
+                border: `1px solid ${LINE}`, boxShadow: '0 6px 18px rgba(0,0,0,0.06)',
+              }}
+            />
+          )
+        })}
+        <AnimatePresence initial={false}>
+          {top && (
+            <motion.div
+              key={top.vote_id}
+              style={{ position: 'absolute', inset: 0 }}
+              initial={
+                exitDir[top.vote_id]
+                  ? reducedMotion
+                    ? { opacity: 0 }
+                    : exitOf(top.vote_id)
+                  : false
+              }
+              animate={{
+                x: 0, y: 0, rotate: 0, opacity: 1,
+                transition: reducedMotion
+                  ? { duration: 0.15 }
+                  : { type: 'spring', stiffness: 300, damping: 28 },
+              }}
+              exit={
+                reducedMotion
+                  ? { opacity: 0, transition: { duration: 0.15 } }
+                  : { ...exitOf(top.vote_id), opacity: 0, transition: { duration: 0.3, ease: 'easeIn' } }
+              }
+            >
+              <TopCard question={top} onCommit={commit} />
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 12, marginTop: 26 }}>
+        <button
+          onClick={onBack}
+          aria-label="Revenir à la question précédente"
+          title="Annuler (Retour arrière)"
+          style={{
+            width: 44, height: 44, borderRadius: '50%', border: `1px solid ${LINE}`,
+            background: 'var(--dp-card-bg)', color: NAVY, fontSize: 18, cursor: 'pointer',
+          }}
+        >
+          ↩
+        </button>
+        {(['contre', 'abstention', 'pour'] as const).map(pos => (
+          <button
+            key={pos}
+            onClick={() => commit(pos)}
+            aria-label={POS[pos].label}
+            style={{
+              padding: '12px 18px', borderRadius: 999, fontWeight: 700, fontSize: 14.5,
+              color: POS[pos].color, background: POS[pos].bg, border: `2px solid ${POS[pos].color}`,
+              cursor: 'pointer', minWidth: pos === 'abstention' ? 0 : 108,
+            }}
+          >
+            {pos === 'contre' ? '← ' : ''}
+            {POS[pos].label}
+            {pos === 'pour' ? ' →' : ''}
+            {pos === 'abstention' ? ' ↓' : ''}
+          </button>
+        ))}
+      </div>
+      <div style={{ textAlign: 'center', marginTop: 14 }}>
+        <button
+          onClick={skip}
+          style={{
+            fontSize: 13, color: GRAY, background: 'none', border: 'none',
+            cursor: 'pointer', textDecoration: 'underline',
+          }}
+        >
+          Passer cette question
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/quiz/QuizDeck.tsx
+++ b/frontend/src/app/quiz/QuizDeck.tsx
@@ -160,7 +160,15 @@ function TopCard({ question, onCommit }: { question: QuizQuestion; onCommit: (di
         {question.question}
       </h2>
       {showInfo && (
-        <div style={{ marginTop: 14, flex: 1, overflowY: 'auto', fontSize: 13.5, lineHeight: 1.55, color: GRAY }}>
+        <div
+          // pan-y + stopped pointer-down so long context stays touch-scrollable
+          // instead of dragging the card.
+          onPointerDownCapture={e => e.stopPropagation()}
+          style={{
+            marginTop: 14, flex: 1, overflowY: 'auto', touchAction: 'pan-y',
+            fontSize: 13.5, lineHeight: 1.55, color: GRAY,
+          }}
+        >
           <p style={{ margin: 0 }}>{question.context}</p>
           {bullets ? (
             <>
@@ -185,14 +193,13 @@ function TopCard({ question, onCommit }: { question: QuizQuestion; onCommit: (di
         // Keeps a tap on the toggle from starting a card drag.
         onPointerDownCapture={e => e.stopPropagation()}
         aria-expanded={showInfo}
-        aria-label="Détails du scrutin"
         style={{
           alignSelf: 'flex-start', marginTop: 12, fontSize: 12.5, fontWeight: 600, color: GRAY,
           background: 'none', border: `1px solid ${LINE}`, borderRadius: 999,
           padding: '5px 12px', cursor: 'pointer',
         }}
       >
-        {showInfo ? 'Masquer les détails' : 'ℹ Détails du scrutin'}
+        {showInfo ? 'Masquer les détails' : 'Détails du scrutin'}
       </button>
     </motion.div>
   )


### PR DESCRIPTION

## What
Replaces the form-like questions phase of `/quiz` with a Tinder-style card deck.
Swipe right = pour, left = contre, down = abstention.
The blocking post-answer reveal panel is removed in favor of a per-card "Détails du scrutin" toggle showing the outcome as percentages.

## Why
The quiz is the viral-loop surface, but each question rendered as a full page of text with three identical buttons and a mandatory reveal interstitial.
A card deck keeps the momentum (answering flings the card, the next one is already peeking) while keeping the civic-education content one tap away.
Validated with a localhost POC before implementation (MON-186).

## Changes
- New `frontend/src/app/quiz/QuizDeck.tsx`: card stack with framer-motion drag physics (already a dependency, no new packages).
  - Commit threshold on offset (~100px) or velocity; sub-threshold drags spring back (`dragSnapToOrigin`).
  - Rotated Pour/Contre/Abstention stamps and a colored border fade in with drag distance, using the shared `POS` / `--dp-*` tokens (dark mode included).
  - Horizontal dominance guard so a diagonal fling never registers as an accidental abstention; `touch-action: none` keeps the drag from fighting page scroll.
  - Buttons under the stack (`↩`, `← Contre`, `Abstention ↓`, `Pour →`), arrow keys, and Backspace all drive the same commit path as the gestures.
  - Undo pulls the previous card back onto the stack from the direction it left; undo on the first card returns to the intro (previous `← Retour` behavior).
  - "Détails du scrutin" toggle, collapsed by default: context + adopté/rejeté line + 3 bullets with percentages of votes cast (never raw counts). Null tallies degrade to the existing "indisponible" line.
  - `prefers-reduced-motion` swaps flings for fades (`useReducedMotion`).
  - No tutorial overlay: the labeled buttons with direction arrows are the affordance.
- `QuizClient.tsx`: questions phase now renders the deck in a 420px column; `revealVoteId` state and the reveal/`Question suivante` flow removed; `answer()` advances immediately.
  Intro, group, postal, results, share, friend comparison, and focus-deputy flows are untouched, as are all API calls and the `answers` state shape.
- `QuizClient.test.tsx`: framer-motion mocked to render plain elements (jsdom-deterministic), reveal-panel tests replaced by deck tests (advance-on-answer, undo, details toggle with percentage assertions, keyboard path).

## Testing
- `npx jest` - 171 tests pass (21 suites), including 26 in the quiz suite.
- `npx tsc --noEmit` and `next lint` clean; `npm run build` passes.
  (One `/votes` prerender flake from the production API rate limiter reproduced and passed on retry - known noise, unrelated to this change.)
- Manual: the interaction model (gestures, stamps, buttons, undo, details toggle) was exercised in the localhost POC that this PR productionizes.

## Risks / Notes
- Swipe thresholds (100px offset / 500px/s velocity) are first-pass values; tune after real-device feedback.
- The last card's exit animation is cut short by the phase switch to the group step - cosmetic, can be polished later.
- Analytics events (`quiz_start`, `quiz_complete`, `quiz_share`) are unchanged, so funnel continuity holds.

## Breaking Changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvmgtV4K6ecbDkeDDFF1G9
