### PR TITLE
feat: restyle the quiz swipe deck to match the approved mockup (MON-187)

### DIFF
--- a/frontend/__tests__/components/QuizClient.test.tsx
+++ b/frontend/__tests__/components/QuizClient.test.tsx
@@ -257,30 +257,34 @@ describe('QuizClient', () => {
     expect(screen.getByText('Quel député vote comme vous ?')).toBeInTheDocument()
   })
 
-  it('hides the scrutin outcome behind the details toggle, as percentages', async () => {
+  it('shows the context sentence directly on the card, with no toggle', async () => {
     const user = userEvent.setup()
     render(<QuizClient />)
     await user.click(await screen.findByRole('button', { name: 'Commencer le quiz' }))
 
-    // Collapsed by default: neither the context nor the outcome is visible.
-    expect(screen.queryByText('Contexte 1.')).not.toBeInTheDocument()
-    expect(screen.queryByText(/L’Assemblée a adopté ce texte/)).not.toBeInTheDocument()
-
-    await user.click(screen.getByRole('button', { name: 'Détails du scrutin' }))
+    // MON-187: context is always visible, no collapsed "Détails" step and
+    // no percentage/outcome breakdown on the card.
     expect(screen.getByText('Contexte 1.')).toBeInTheDocument()
-    expect(screen.getByText('L’Assemblée a adopté ce texte :')).toBeInTheDocument()
-    // 291 / 241 / 12 of 544 votes cast - percentages, never raw counts.
-    expect(screen.getByText('Pour : 53 %')).toBeInTheDocument()
-    expect(screen.getByText('Contre : 44 %')).toBeInTheDocument()
-    expect(screen.getByText('Abstention : 2 %')).toBeInTheDocument()
-    expect(screen.queryByText(/291 pour/)).not.toBeInTheDocument()
-
-    // Toggling closed hides it again, and it stays closed on the next card.
-    await user.click(screen.getByRole('button', { name: 'Masquer les détails' }))
+    expect(screen.queryByRole('button', { name: /Détails du scrutin/ })).not.toBeInTheDocument()
     expect(screen.queryByText(/L’Assemblée a adopté ce texte/)).not.toBeInTheDocument()
+
     await user.click(screen.getByRole('button', { name: 'Pour' }))
     expect(screen.getByText('Question 2 / 3')).toBeInTheDocument()
-    expect(screen.queryByText(/L’Assemblée a rejeté ce texte/)).not.toBeInTheDocument()
+    expect(screen.getByText('Contexte 2.')).toBeInTheDocument()
+  })
+
+  it('shows the header with the undo arrow, question count and current theme', async () => {
+    const user = userEvent.setup()
+    render(<QuizClient />)
+    await user.click(await screen.findByRole('button', { name: 'Commencer le quiz' }))
+
+    expect(screen.getByText('Question 1 / 3')).toBeInTheDocument()
+    // Theme appears twice: plain text in the header, and as a pill badge on the card.
+    expect(screen.getAllByText('Fin de vie')).toHaveLength(2)
+    expect(screen.getByRole('button', { name: 'Revenir à la question précédente' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Pour' }))
+    expect(screen.getAllByText('Budget')).toHaveLength(2)
   })
 
   it('answers with the arrow keys and undoes with Backspace', async () => {

--- a/frontend/__tests__/components/QuizClient.test.tsx
+++ b/frontend/__tests__/components/QuizClient.test.tsx
@@ -31,7 +31,7 @@ jest.mock('framer-motion', () => {
   const React = jest.requireActual<typeof import('react')>('react')
   const MOTION_ONLY_PROPS = new Set([
     'drag', 'dragSnapToOrigin', 'dragElastic', 'onDragEnd', 'whileTap',
-    'initial', 'animate', 'exit', 'transition', 'layout', 'layoutId',
+    'initial', 'animate', 'exit', 'variants', 'custom', 'transition', 'layout', 'layoutId',
   ])
   function clean(props: Record<string, unknown>) {
     const out: Record<string, unknown> = {}
@@ -257,20 +257,30 @@ describe('QuizClient', () => {
     expect(screen.getByText('Quel député vote comme vous ?')).toBeInTheDocument()
   })
 
-  it('shows the context sentence directly on the card, with no toggle', async () => {
+  it('shows the context sentence directly on the card, with the vote breakdown behind a toggle', async () => {
     const user = userEvent.setup()
     render(<QuizClient />)
     await user.click(await screen.findByRole('button', { name: 'Commencer le quiz' }))
 
-    // MON-187: context is always visible, no collapsed "Détails" step and
-    // no percentage/outcome breakdown on the card.
+    // Context is always visible; the percentage breakdown stays collapsed until toggled.
     expect(screen.getByText('Contexte 1.')).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /Détails du scrutin/ })).not.toBeInTheDocument()
     expect(screen.queryByText(/L’Assemblée a adopté ce texte/)).not.toBeInTheDocument()
 
+    await user.click(screen.getByRole('button', { name: 'Détails du scrutin' }))
+    expect(screen.getByText('L’Assemblée a adopté ce texte :')).toBeInTheDocument()
+    // 291 / 241 / 12 of 544 votes cast - percentages, never raw counts.
+    expect(screen.getByText('Pour : 53 %')).toBeInTheDocument()
+    expect(screen.getByText('Contre : 44 %')).toBeInTheDocument()
+    expect(screen.getByText('Abstention : 2 %')).toBeInTheDocument()
+    expect(screen.queryByText(/291 pour/)).not.toBeInTheDocument()
+
+    // Toggling closed hides it again, and the next card starts collapsed.
+    await user.click(screen.getByRole('button', { name: 'Masquer les détails' }))
+    expect(screen.queryByText(/L’Assemblée a adopté ce texte/)).not.toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: 'Pour' }))
     expect(screen.getByText('Question 2 / 3')).toBeInTheDocument()
     expect(screen.getByText('Contexte 2.')).toBeInTheDocument()
+    expect(screen.queryByText(/L’Assemblée a rejeté ce texte/)).not.toBeInTheDocument()
   })
 
   it('shows the header with the undo arrow, question count and current theme', async () => {

--- a/frontend/src/app/quiz/QuizClient.tsx
+++ b/frontend/src/app/quiz/QuizClient.tsx
@@ -436,43 +436,19 @@ export function QuizClient() {
   }
 
   // -------------------------------------------------------------- questions
-  // MON-186: swipe deck - one card per scrutin, gestures + buttons + keyboard
-  // share one commit path inside QuizDeck. The deck column is narrower than
-  // the shell so the cards keep a card-like aspect on desktop.
+  // MON-186/187: swipe deck - one card per scrutin, gestures + circular
+  // buttons + keyboard share one commit path inside QuizDeck, which also
+  // owns the header (undo, progress, theme) to match the approved mockup.
   if (phase === 'questions' && questions) {
     return (
       <Shell>
-        <div style={{ maxWidth: 420, margin: '0 auto' }}>
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 }}>
-            <div style={kicker}>
-              Question {index + 1} / {questions.length}
-            </div>
-          </div>
-          <div
-            role="progressbar"
-            aria-valuenow={index + 1}
-            aria-valuemin={1}
-            aria-valuemax={questions.length}
-            style={{ height: 6, background: 'var(--dp-border-subtle)', borderRadius: 999, overflow: 'hidden', marginBottom: 24 }}
-          >
-            <div
-              style={{
-                height: '100%',
-                background: NAVY,
-                borderRadius: 999,
-                width: `${((index + 1) / questions.length) * 100}%`,
-                transition: 'width 200ms ease',
-              }}
-            />
-          </div>
-          <QuizDeck
-            questions={questions}
-            index={index}
-            onAnswer={answer}
-            onSkip={skip}
-            onBack={back}
-          />
-        </div>
+        <QuizDeck
+          questions={questions}
+          index={index}
+          onAnswer={answer}
+          onSkip={skip}
+          onBack={back}
+        />
       </Shell>
     )
   }

--- a/frontend/src/app/quiz/QuizDeck.tsx
+++ b/frontend/src/app/quiz/QuizDeck.tsx
@@ -35,11 +35,29 @@ const EXIT: Record<Dir, { x: number; y: number; rotate: number }> = {
   abstention: { x: 0, y: 640, rotate: 0 },
 }
 
-// The glyph + arrow shown per direction in the controls below the deck.
-const DIR_META: Record<Dir, { icon: string; arrow: string; hint: string }> = {
-  contre: { icon: '✕', arrow: '←', hint: 'Glissez à gauche = Contre' },
-  abstention: { icon: '↓', arrow: '↓', hint: 'Glissez vers le bas = Abstention' },
-  pour: { icon: '✓', arrow: '→', hint: 'Glissez à droite = Pour' },
+// The glyph shown inside each circular action button.
+const DIR_ICON: Record<Dir, string> = { contre: '✕', abstention: '↓', pour: '✓' }
+
+// Percentage split of the votes cast (pour + contre + abstention). Null when
+// the live tally join found no row for this scrutin.
+function tallyBullets(q: QuizQuestion): Array<{ label: string; pct: number }> | null {
+  if (q.votes_for == null || q.votes_against == null) return null
+  const abstentions = q.abstentions ?? 0
+  const total = q.votes_for + q.votes_against + abstentions
+  if (total === 0) return null
+  const pct = (n: number) => Math.round((n / total) * 100)
+  const bullets: Array<{ label: string; pct: number }> = [
+    { label: POS.pour.label, pct: pct(q.votes_for) },
+    { label: POS.contre.label, pct: pct(q.votes_against) },
+  ]
+  if (q.abstentions != null) bullets.push({ label: POS.abstention.label, pct: pct(abstentions) })
+  return bullets
+}
+
+function outcomeLine(q: QuizQuestion): string {
+  if (q.result === 'adopté') return 'L’Assemblée a adopté ce texte :'
+  if (q.result === 'rejeté') return 'L’Assemblée a rejeté ce texte :'
+  return 'Résultat du scrutin :'
 }
 
 // Rotated Tinder-style stamp whose opacity is driven by the drag distance.
@@ -87,6 +105,8 @@ function TopCard({ question, onCommit }: { question: QuizQuestion; onCommit: (di
       return `1px solid ${LINE}`
     }
   )
+  const [showInfo, setShowInfo] = useState(false)
+  const bullets = tallyBullets(question)
 
   function handleDragEnd(
     _: unknown,
@@ -152,6 +172,47 @@ function TopCard({ question, onCommit }: { question: QuizQuestion; onCommit: (di
       <p style={{ margin: '14px 0 0', fontSize: 14.5, lineHeight: 1.6, color: GRAY }}>
         {question.context}
       </p>
+      {showInfo && (
+        <div
+          // pan-y + stopped pointer-down so long content stays touch-scrollable
+          // instead of dragging the card.
+          onPointerDownCapture={e => e.stopPropagation()}
+          style={{
+            marginTop: 12, flex: 1, minHeight: 0, overflowY: 'auto', touchAction: 'pan-y',
+            fontSize: 13.5, lineHeight: 1.55, color: GRAY,
+          }}
+        >
+          {bullets ? (
+            <>
+              <p style={{ margin: 0, fontWeight: 600, color: NAVY }}>{outcomeLine(question)}</p>
+              <ul style={{ margin: '6px 0 0', paddingLeft: 20 }}>
+                {bullets.map(b => (
+                  <li key={b.label}>
+                    {b.label} : {b.pct} %
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : (
+            <p style={{ margin: 0, fontWeight: 600, color: NAVY }}>
+              Résultat du scrutin indisponible pour ce texte.
+            </p>
+          )}
+        </div>
+      )}
+      <button
+        onClick={() => setShowInfo(v => !v)}
+        // Keeps a tap on the toggle from starting a card drag.
+        onPointerDownCapture={e => e.stopPropagation()}
+        aria-expanded={showInfo}
+        style={{
+          alignSelf: 'flex-start', marginTop: 12, fontSize: 12.5, fontWeight: 600, color: GRAY,
+          background: 'none', border: `1px solid ${LINE}`, borderRadius: 999,
+          padding: '5px 12px', cursor: 'pointer',
+        }}
+      >
+        {showInfo ? 'Masquer les détails' : 'Détails du scrutin'}
+      </button>
     </motion.div>
   )
 }
@@ -170,9 +231,17 @@ export function QuizDeck({
   onBack: () => void
 }) {
   const reducedMotion = useReducedMotion()
-  // Exit direction of each committed card, keyed by vote_id, so
-  // AnimatePresence knows which way to fling it and undo where to re-enter from.
+  // Exit direction of each committed card, keyed by vote_id, so an undone
+  // card slides back in from the direction it left.
   const [exitDir, setExitDir] = useState<Record<string, Dir>>({})
+  // The direction just committed/skipped, read live by the exiting card's
+  // dynamic `exit` value via AnimatePresence's `custom` prop. A plain object
+  // computed inline (e.g. `exitOf(top.vote_id)`) would go stale: React 18
+  // batches the exitDir and index updates into one render, so by the time
+  // the old top card is actually removed from the tree its `exit` prop was
+  // already captured from the PREVIOUS render, before this commit happened.
+  // `custom` is propagated to already-exiting components, so it isn't.
+  const [pendingExit, setPendingExit] = useState<Dir | null>(null)
 
   const stack = questions.slice(index, index + 3)
   const top = stack[0]
@@ -180,12 +249,14 @@ export function QuizDeck({
   function commit(dir: Dir) {
     if (!top) return
     setExitDir(prev => ({ ...prev, [top.vote_id]: dir }))
+    setPendingExit(dir)
     onAnswer(top.vote_id, dir)
   }
 
   function skip() {
     if (!top) return
     setExitDir(prev => ({ ...prev, [top.vote_id]: 'abstention' }))
+    setPendingExit('abstention')
     onSkip(top.vote_id)
   }
 
@@ -273,10 +344,11 @@ export function QuizDeck({
             />
           )
         })}
-        <AnimatePresence initial={false}>
+        <AnimatePresence initial={false} custom={pendingExit}>
           {top && (
             <motion.div
               key={top.vote_id}
+              custom={pendingExit}
               style={{ position: 'absolute', inset: 0 }}
               initial={
                 exitDir[top.vote_id]
@@ -291,11 +363,16 @@ export function QuizDeck({
                   ? { duration: 0.15 }
                   : { type: 'spring', stiffness: 300, damping: 28 },
               }}
-              exit={
-                reducedMotion
-                  ? { opacity: 0, transition: { duration: 0.15 } }
-                  : { ...exitOf(top.vote_id), opacity: 0, transition: { duration: 0.3, ease: 'easeIn' } }
-              }
+              // Dynamic variant (fed by `custom`) instead of a plain object -
+              // a plain object here would be captured from the render before
+              // this card's commit, before `pendingExit` held the real direction.
+              variants={{
+                exit: (dir: Dir | null) =>
+                  reducedMotion
+                    ? { opacity: 0, transition: { duration: 0.15 } }
+                    : { ...EXIT[dir ?? 'abstention'], opacity: 0, transition: { duration: 0.3, ease: 'easeIn' } },
+              }}
+              exit="exit"
             >
               <TopCard question={top} onCommit={commit} />
             </motion.div>
@@ -325,7 +402,7 @@ export function QuizDeck({
                 background: POS[pos].bg, color: POS[pos].color, fontSize: 26, fontWeight: 700,
               }}
             >
-              {DIR_META[pos].icon}
+              {DIR_ICON[pos]}
             </span>
             <span style={{ fontSize: 14.5, fontWeight: 600, color: POS[pos].color }}>
               {POS[pos].label}
@@ -334,29 +411,7 @@ export function QuizDeck({
         ))}
       </div>
 
-      <div
-        style={{
-          display: 'flex', justifyContent: 'center', gap: 24, marginTop: 22,
-          flexWrap: 'wrap',
-        }}
-      >
-        {(['contre', 'abstention', 'pour'] as const).map(pos => (
-          <span
-            key={pos}
-            style={{
-              display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: GRAY,
-              textAlign: 'center',
-            }}
-          >
-            <span aria-hidden style={{ color: POS[pos].color }}>
-              {DIR_META[pos].arrow}
-            </span>
-            {DIR_META[pos].hint}
-          </span>
-        ))}
-      </div>
-
-      <div style={{ textAlign: 'center', marginTop: 20 }}>
+      <div style={{ textAlign: 'center', marginTop: 22 }}>
         <button
           onClick={skip}
           style={{

--- a/frontend/src/app/quiz/QuizDeck.tsx
+++ b/frontend/src/app/quiz/QuizDeck.tsx
@@ -219,7 +219,9 @@ export function QuizDeck({
           title="Annuler (Retour arrière)"
           style={{
             background: 'none', border: 'none', color: NAVY, fontSize: 20,
-            cursor: 'pointer', padding: 4, justifySelf: 'start',
+            cursor: 'pointer', justifySelf: 'start',
+            // 44x44 hit area (WCAG target size) around the small visible glyph.
+            width: 44, height: 44, display: 'flex', alignItems: 'center', justifyContent: 'center',
           }}
         >
           ←

--- a/frontend/src/app/quiz/QuizDeck.tsx
+++ b/frontend/src/app/quiz/QuizDeck.tsx
@@ -260,12 +260,20 @@ export function QuizDeck({
     onSkip(top.vote_id)
   }
 
+  // Undo removes an uncommitted card, not a just-committed one - it must not
+  // inherit `pendingExit` from the last real commit, or the uncommitted card
+  // would fly off in that stale direction instead of the neutral default.
+  function handleBack() {
+    setPendingExit(null)
+    onBack()
+  }
+
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if (e.key === 'ArrowRight') commit('pour')
       else if (e.key === 'ArrowLeft') commit('contre')
       else if (e.key === 'ArrowDown') commit('abstention')
-      else if (e.key === 'Backspace') onBack()
+      else if (e.key === 'Backspace') handleBack()
       else return
       e.preventDefault()
     }
@@ -285,7 +293,7 @@ export function QuizDeck({
         }}
       >
         <button
-          onClick={onBack}
+          onClick={handleBack}
           aria-label="Revenir à la question précédente"
           title="Annuler (Retour arrière)"
           style={{

--- a/frontend/src/app/quiz/QuizDeck.tsx
+++ b/frontend/src/app/quiz/QuizDeck.tsx
@@ -1,10 +1,11 @@
 'use client'
-// MON-186: Tinder-style swipe deck for the quiz questions phase. One card per
-// scrutin; swipe right = pour, left = contre, down = abstention. The buttons
-// under the stack, the arrow keys and Backspace drive the exact same commit
+// MON-186/187: Tinder-style swipe deck for the quiz questions phase. One card
+// per scrutin; swipe right = pour, left = contre, down = abstention. The
+// circular buttons, the arrow keys and Backspace drive the exact same commit
 // path as the gestures, so touch, mouse, keyboard and assistive tech are all
-// first-class. The old post-answer reveal panel is gone - the scrutin outcome
-// hides behind a per-card "Détails du scrutin" toggle instead.
+// first-class. MON-187 restyled the header, card badge and controls to match
+// the approved mockup; the context paragraph is always visible on the card
+// (no more collapsed "Détails du scrutin" toggle from MON-186).
 import { useEffect, useState } from 'react'
 import {
   AnimatePresence,
@@ -34,26 +35,11 @@ const EXIT: Record<Dir, { x: number; y: number; rotate: number }> = {
   abstention: { x: 0, y: 640, rotate: 0 },
 }
 
-// Percentage split of the votes cast (pour + contre + abstention, MON-186:
-// percentages, not raw counts). Null when the live tally join found no row.
-function tallyBullets(q: QuizQuestion): Array<{ label: string; pct: number }> | null {
-  if (q.votes_for == null || q.votes_against == null) return null
-  const abstentions = q.abstentions ?? 0
-  const total = q.votes_for + q.votes_against + abstentions
-  if (total === 0) return null
-  const pct = (n: number) => Math.round((n / total) * 100)
-  const bullets: Array<{ label: string; pct: number }> = [
-    { label: POS.pour.label, pct: pct(q.votes_for) },
-    { label: POS.contre.label, pct: pct(q.votes_against) },
-  ]
-  if (q.abstentions != null) bullets.push({ label: POS.abstention.label, pct: pct(abstentions) })
-  return bullets
-}
-
-function outcomeLine(q: QuizQuestion): string {
-  if (q.result === 'adopté') return 'L’Assemblée a adopté ce texte :'
-  if (q.result === 'rejeté') return 'L’Assemblée a rejeté ce texte :'
-  return 'Résultat du scrutin :'
+// The glyph + arrow shown per direction in the controls below the deck.
+const DIR_META: Record<Dir, { icon: string; arrow: string; hint: string }> = {
+  contre: { icon: '✕', arrow: '←', hint: 'Glissez à gauche = Contre' },
+  abstention: { icon: '↓', arrow: '↓', hint: 'Glissez vers le bas = Abstention' },
+  pour: { icon: '✓', arrow: '→', hint: 'Glissez à droite = Pour' },
 }
 
 // Rotated Tinder-style stamp whose opacity is driven by the drag distance.
@@ -101,8 +87,6 @@ function TopCard({ question, onCommit }: { question: QuizQuestion; onCommit: (di
       return `1px solid ${LINE}`
     }
   )
-  const [showInfo, setShowInfo] = useState(false)
-  const bullets = tallyBullets(question)
 
   function handleDragEnd(
     _: unknown,
@@ -134,8 +118,8 @@ function TopCard({ question, onCommit }: { question: QuizQuestion; onCommit: (di
       onDragEnd={handleDragEnd}
       style={{
         x, y, rotate, border,
-        position: 'absolute', inset: 0, borderRadius: 16, background: 'var(--dp-card-bg)',
-        boxShadow: '0 10px 30px rgba(0,0,0,0.10)', padding: '22px 22px 18px',
+        position: 'absolute', inset: 0, borderRadius: 20, background: 'var(--dp-card-bg)',
+        boxShadow: '0 10px 30px rgba(0,0,0,0.10)', padding: '24px 22px 22px',
         display: 'flex', flexDirection: 'column', cursor: 'grab', touchAction: 'none',
         userSelect: 'none', zIndex: 3,
       }}
@@ -147,60 +131,27 @@ function TopCard({ question, onCommit }: { question: QuizQuestion; onCommit: (di
         label={POS.abstention.label} color={POS.abstention.color} opacity={absOpacity}
         style={{ left: '50%', x: '-50%', top: 'auto', bottom: 18, fontSize: 18 }}
       />
-      <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: RED }}>
+      <div
+        style={{
+          alignSelf: 'flex-start', padding: '4px 14px', borderRadius: 999,
+          border: `1.5px solid ${RED}`, color: RED, fontWeight: 700, fontSize: 11,
+          letterSpacing: '0.12em', textTransform: 'uppercase',
+        }}
+      >
         {question.theme}
       </div>
       <h2
         className="font-newsreader"
         style={{
-          fontWeight: 600, color: NAVY, margin: '12px 0 0',
-          fontSize: 'clamp(20px,4.5vw,26px)', lineHeight: 1.3, flex: showInfo ? 'none' : 1,
+          fontWeight: 600, color: NAVY, margin: '16px 0 0',
+          fontSize: 'clamp(20px,4.5vw,26px)', lineHeight: 1.3,
         }}
       >
         {question.question}
       </h2>
-      {showInfo && (
-        <div
-          // pan-y + stopped pointer-down so long context stays touch-scrollable
-          // instead of dragging the card.
-          onPointerDownCapture={e => e.stopPropagation()}
-          style={{
-            marginTop: 14, flex: 1, overflowY: 'auto', touchAction: 'pan-y',
-            fontSize: 13.5, lineHeight: 1.55, color: GRAY,
-          }}
-        >
-          <p style={{ margin: 0 }}>{question.context}</p>
-          {bullets ? (
-            <>
-              <p style={{ margin: '10px 0 0', fontWeight: 600, color: NAVY }}>{outcomeLine(question)}</p>
-              <ul style={{ margin: '6px 0 0', paddingLeft: 20 }}>
-                {bullets.map(b => (
-                  <li key={b.label}>
-                    {b.label} : {b.pct} %
-                  </li>
-                ))}
-              </ul>
-            </>
-          ) : (
-            <p style={{ margin: '10px 0 0', fontWeight: 600, color: NAVY }}>
-              Résultat du scrutin indisponible pour ce texte.
-            </p>
-          )}
-        </div>
-      )}
-      <button
-        onClick={() => setShowInfo(v => !v)}
-        // Keeps a tap on the toggle from starting a card drag.
-        onPointerDownCapture={e => e.stopPropagation()}
-        aria-expanded={showInfo}
-        style={{
-          alignSelf: 'flex-start', marginTop: 12, fontSize: 12.5, fontWeight: 600, color: GRAY,
-          background: 'none', border: `1px solid ${LINE}`, borderRadius: 999,
-          padding: '5px 12px', cursor: 'pointer',
-        }}
-      >
-        {showInfo ? 'Masquer les détails' : 'Détails du scrutin'}
-      </button>
+      <p style={{ margin: '14px 0 0', fontSize: 14.5, lineHeight: 1.6, color: GRAY }}>
+        {question.context}
+      </p>
     </motion.div>
   )
 }
@@ -256,6 +207,53 @@ export function QuizDeck({
 
   return (
     <div style={{ maxWidth: 420, margin: '0 auto' }}>
+      <div
+        style={{
+          display: 'grid', gridTemplateColumns: 'auto 1fr auto', alignItems: 'center',
+          gap: 10, marginBottom: 14,
+        }}
+      >
+        <button
+          onClick={onBack}
+          aria-label="Revenir à la question précédente"
+          title="Annuler (Retour arrière)"
+          style={{
+            background: 'none', border: 'none', color: NAVY, fontSize: 20,
+            cursor: 'pointer', padding: 4, justifySelf: 'start',
+          }}
+        >
+          ←
+        </button>
+        <div
+          style={{
+            textAlign: 'center', fontWeight: 700, fontSize: 12, letterSpacing: '0.18em',
+            textTransform: 'uppercase', color: RED,
+          }}
+        >
+          Question {index + 1} / {questions.length}
+        </div>
+        <div style={{ fontSize: 12.5, color: GRAY, justifySelf: 'end', textAlign: 'right' }}>
+          {top?.theme}
+        </div>
+      </div>
+      <div
+        role="progressbar"
+        aria-valuenow={index + 1}
+        aria-valuemin={1}
+        aria-valuemax={questions.length}
+        style={{ height: 6, background: 'var(--dp-border-subtle)', borderRadius: 999, overflow: 'hidden', marginBottom: 24 }}
+      >
+        <div
+          style={{
+            height: '100%',
+            background: NAVY,
+            borderRadius: 999,
+            width: `${((index + 1) / questions.length) * 100}%`,
+            transition: 'width 200ms ease',
+          }}
+        />
+      </div>
+
       <div style={{ position: 'relative', height: 380 }}>
         {/* Back cards, deepest first so the top card paints last. */}
         {stack.slice(1).reverse().map(q => {
@@ -267,7 +265,7 @@ export function QuizDeck({
               initial={false}
               animate={{ scale: 1 - depth * 0.045, y: depth * 14, opacity: 1 - depth * 0.25 }}
               style={{
-                position: 'absolute', inset: 0, borderRadius: 16, background: 'var(--dp-card-bg)',
+                position: 'absolute', inset: 0, borderRadius: 20, background: 'var(--dp-card-bg)',
                 border: `1px solid ${LINE}`, boxShadow: '0 6px 18px rgba(0,0,0,0.06)',
               }}
             />
@@ -303,37 +301,60 @@ export function QuizDeck({
         </AnimatePresence>
       </div>
 
-      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 12, marginTop: 26 }}>
-        <button
-          onClick={onBack}
-          aria-label="Revenir à la question précédente"
-          title="Annuler (Retour arrière)"
-          style={{
-            width: 44, height: 44, borderRadius: '50%', border: `1px solid ${LINE}`,
-            background: 'var(--dp-card-bg)', color: NAVY, fontSize: 18, cursor: 'pointer',
-          }}
-        >
-          ↩
-        </button>
+      <p style={{ textAlign: 'center', fontSize: 13, color: GRAY, margin: '22px 0 14px' }}>
+        Glissez pour choisir
+      </p>
+      <div style={{ display: 'flex', justifyContent: 'center', gap: 28 }}>
         {(['contre', 'abstention', 'pour'] as const).map(pos => (
           <button
             key={pos}
             onClick={() => commit(pos)}
             aria-label={POS[pos].label}
             style={{
-              padding: '12px 18px', borderRadius: 999, fontWeight: 700, fontSize: 14.5,
-              color: POS[pos].color, background: POS[pos].bg, border: `2px solid ${POS[pos].color}`,
-              cursor: 'pointer', minWidth: pos === 'abstention' ? 0 : 108,
+              display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8,
+              background: 'none', border: 'none', cursor: 'pointer', padding: 0,
             }}
           >
-            {pos === 'contre' ? '← ' : ''}
-            {POS[pos].label}
-            {pos === 'pour' ? ' →' : ''}
-            {pos === 'abstention' ? ' ↓' : ''}
+            <span
+              aria-hidden
+              style={{
+                width: 76, height: 76, borderRadius: '50%', display: 'flex',
+                alignItems: 'center', justifyContent: 'center',
+                background: POS[pos].bg, color: POS[pos].color, fontSize: 26, fontWeight: 700,
+              }}
+            >
+              {DIR_META[pos].icon}
+            </span>
+            <span style={{ fontSize: 14.5, fontWeight: 600, color: POS[pos].color }}>
+              {POS[pos].label}
+            </span>
           </button>
         ))}
       </div>
-      <div style={{ textAlign: 'center', marginTop: 14 }}>
+
+      <div
+        style={{
+          display: 'flex', justifyContent: 'center', gap: 24, marginTop: 22,
+          flexWrap: 'wrap',
+        }}
+      >
+        {(['contre', 'abstention', 'pour'] as const).map(pos => (
+          <span
+            key={pos}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: GRAY,
+              textAlign: 'center',
+            }}
+          >
+            <span aria-hidden style={{ color: POS[pos].color }}>
+              {DIR_META[pos].arrow}
+            </span>
+            {DIR_META[pos].hint}
+          </span>
+        ))}
+      </div>
+
+      <div style={{ textAlign: 'center', marginTop: 20 }}>
         <button
           onClick={skip}
           style={{


### PR DESCRIPTION

## What
Restyles the `/quiz` swipe deck (shipped in MON-186) to match a mockup the user supplied, then iterates on that restyle based on live feedback from a localhost review: a new header layout, a pill theme badge on the card, always-visible context with the vote-share breakdown behind a toggle, circular icon buttons, and a fixed exit-fling direction on button clicks. No change to drag thresholds, keyboard handling, or the `answers` state shape.

## Why
MON-186 shipped the drag/gesture mechanics with a first-pass visual treatment. The user then supplied a target design for the card and its surrounding controls, reviewed the result on localhost (PC + mobile), and asked for two corrections: bring back the percentage breakdown they'd asked for in MON-186 (dropped by mistake when matching the mockup), remove the redundant gesture-legend text, and fix the answer buttons flinging the card in the wrong direction.

## Changes
- `QuizDeck.tsx` now owns the whole header block (previously split between `QuizClient` and `QuizDeck`):
  - Undo moves from a standalone circular button under the stack into a plain arrow (`←`) at the top-left of the header - same `onBack` handler, same accessible name (`Revenir à la question précédente`), sized to a 44x44 tap target (review fix).
  - Header center: `QUESTION N / TOTAL`, uppercase, letter-spaced, red - reusing the app's existing kicker look.
  - Header right: the current card's theme in plain gray text.
  - Progress bar moved from `QuizClient` into `QuizDeck` alongside the header (same markup/behavior, just relocated).
- Card face:
  - Theme now also renders as a red-bordered pill badge, top-left on the card itself (in addition to the header's plain-text theme).
  - The context sentence is always visible directly under the question, as in the mockup.
  - The vote-share breakdown (adopté/rejeté + 3 percentage bullets: Pour/Contre/Abstention, share of votes cast) is back behind a "Détails du scrutin" toggle - collapsed by default, since the mockup didn't show it but the feature itself (added in MON-186) was still wanted.
- Controls below the deck:
  - The three answer buttons are circular icon buttons (✕ / ↓ / ✓) using the existing `POS` colors/backgrounds, with the label below each circle. Same `commit()` call, same `aria-label`s (`Contre`/`Abstention`/`Pour`).
  - "Glissez pour choisir" caption above the buttons. The 3-column gesture-legend text below the buttons was removed per feedback (redundant with the caption + button labels).
- **Exit-fling direction fix**: clicking Pour/Contre/Abstention always flung the card downward (the abstention direction) regardless of which button was pressed. Root cause: React 18 batches the "record commit direction" and "advance to next question" state updates into one render, so a plain `exit` object computed inline (`exitOf(top.vote_id)`) was captured from the render *before* the click - stale by definition. Fixed by switching the exiting card's `exit` prop to a framer-motion dynamic variant fed by a new `pendingExit` state via `AnimatePresence`'s `custom` prop, which framer-motion re-evaluates live even after the element leaves the tree. Drag-release commits go through the same `commit()` path and get the same fix.
- `QuizClient.tsx`: the questions-phase block collapses to `<Shell><QuizDeck .../></Shell>` since `QuizDeck` now renders its own header and progress bar.
- Tests: updated to match the restyled DOM (header text/theme duplication, circular button labels, no legend), and a test asserting the details toggle reveals percentages (not raw counts) and stays collapsed by default / across cards.

## Testing
- `npx jest` - 172 tests pass (21 suites).
- `npx tsc --noEmit` and `next lint` clean.
- `npm run build` passes (one `/votes` prerender flake from the production API's rate limiter, confirmed transient and unrelated - passed on retry).
- Manual: reviewed live on localhost (PC + phone on the same network) across all three rounds of changes - mockup restyle, toggle/legend correction, and the exit-direction fix - by the user directly, which is what surfaced the two follow-up requests in this PR.

## Risks / Notes
- Purely visual/structural plus one animation-timing bug fix - no change to drag thresholds, commit logic, keyboard handling, or the `answers` state shape.
- The live tally fields (`votes_for`/`votes_against`/`abstentions`/`result`) remain on `QuizQuestion` and the API response, now rendered again via the details toggle.
- The `pendingExit`/`custom`/`variants` pattern is the idiomatic framer-motion fix for "dynamic data needed by an already-exiting AnimatePresence child" - worth keeping in mind if similar committed-direction animations are added elsewhere in the app.

## Breaking Changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvmgtV4K6ecbDkeDDFF1G9
