### PR TITLE
feat: RGAA accessibility audit and déclaration d'accessibilité (MON-113)

### DIFF
--- a/frontend/src/app/accessibilite/page.tsx
+++ b/frontend/src/app/accessibilite/page.tsx
@@ -77,7 +77,9 @@ export default function AccessibilitePage() {
         <p style={pStyle}>
           Les non-conformités listées ci-dessus affectent principalement la page d&apos;accueil, le pied de page
           (sur l&apos;ensemble du site), l&apos;assistant conversationnel et les photos de député. Leur correction
-          est suivie individuellement dans le suivi de projet public de MonÉlu.
+          est suivie individuellement ; le code source de MonÉlu étant public (voir{' '}
+          <Link href="/mentions-legales" style={{ color: 'var(--dp-text)' }}>mentions légales</Link>), l&apos;avancement
+          de ces corrections est vérifiable dans l&apos;historique du dépôt.
         </p>
       </LegalSection>
 

--- a/frontend/src/app/accessibilite/page.tsx
+++ b/frontend/src/app/accessibilite/page.tsx
@@ -1,0 +1,104 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { LegalPageLayout, LegalSection } from '@/components/LegalPageLayout'
+
+export const metadata: Metadata = {
+  title: "Déclaration d'accessibilité - MonÉlu",
+  description:
+    "État de conformité RGAA de MonÉlu, méthode d'évaluation, non-conformités connues et contact pour signaler un problème d'accessibilité.",
+}
+
+const pStyle = { fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: 0 }
+const liStyle = { fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)' }
+
+export default function AccessibilitePage() {
+  return (
+    <LegalPageLayout eyebrow="Accessibilité" title="Déclaration d'accessibilité">
+
+      <LegalSection title="État de conformité">
+        <p style={pStyle}>
+          MonÉlu s&apos;engage à rendre son site accessible conformément à l&apos;article 47 de la loi n° 2005-102 du 11
+          février 2005 et au Référentiel général d&apos;amélioration de l&apos;accessibilité (RGAA) 4.1.
+        </p>
+        <p style={{ ...pStyle, margin: '10px 0 0' }}>
+          À ce stade, MonÉlu est <strong>non conforme</strong> avec le RGAA 4.1. Le site n&apos;a pas encore fait
+          l&apos;objet d&apos;un audit RGAA complet mené par un prestataire accrédité ; les résultats ci-dessous
+          viennent d&apos;une auto-évaluation interne portant sur un échantillon de pages représentatif (voir
+          méthode ci-dessous), pas d&apos;un audit exhaustif des 106 critères RGAA sur l&apos;ensemble du site.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Méthode d'évaluation">
+        <p style={pStyle}>
+          Auto-évaluation interne réalisée le 27 juillet 2026 par relecture du code source et des interfaces,
+          sans outil d&apos;audit automatisé ni test utilisateur avec des personnes en situation de handicap.
+          Pages couvertes : accueil, liste et fiche député, liste des votes et fiche de scrutin (hémicycle),
+          assistant conversationnel (chat), quiz de correspondance de vote.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Résultats des tests">
+        <p style={pStyle}>Non-conformités identifiées à ce jour :</p>
+        <ul style={{ margin: '10px 0 0', paddingLeft: '20px', display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          <li style={liStyle}>
+            <strong>Contraste insuffisant du pied de page</strong> - les liens légaux du pied de page
+            (<code>#6B7280</code> sur fond <code>#111C35</code>) atteignent un ratio de contraste d&apos;environ
+            3,5:1, sous le minimum de 4,5:1 requis pour du texte de taille normale (critère RGAA 3.2 / WCAG 1.4.3).
+          </li>
+          <li style={liStyle}>
+            <strong>Absence d&apos;indicateur de focus visible global</strong> - aucune règle <code>:focus-visible</code>{' '}
+            n&apos;est définie au niveau global ; certains composants interactifs (dont l&apos;hémicycle) suppriment
+            le contour de focus par défaut du navigateur (critère RGAA 10.7 / WCAG 2.4.7).
+          </li>
+          <li style={liStyle}>
+            <strong>Animations non désactivables</strong> - le défilement animé de la page d&apos;accueil et les
+            transitions de l&apos;interface ne tiennent pas compte de la préférence système{' '}
+            <code>prefers-reduced-motion</code> (critères RGAA 13.8/13.9 / WCAG 2.3.3).
+          </li>
+          <li style={liStyle}>
+            <strong>Réponses du chat non annoncées</strong> - l&apos;assistant conversationnel (<code>/chat</code>)
+            ne place pas les réponses entrantes dans une zone <code>aria-live</code>, si bien que les nouveaux
+            messages ne sont pas annoncés aux utilisateurs de lecteur d&apos;écran (critère RGAA 9.3 / WCAG 4.1.3).
+          </li>
+          <li style={liStyle}>
+            <strong>Texte alternatif minimal sur les photos de député</strong> - l&apos;attribut <code>alt</code>{' '}
+            des portraits contient uniquement le nom du député, sans contexte descriptif (critère RGAA 1.1 / WCAG 1.1.1).
+          </li>
+        </ul>
+        <p style={{ ...pStyle, margin: '14px 0 0' }}>
+          En complément, ces mêmes tests ont confirmé qu&apos;une partie du travail d&apos;accessibilité était déjà en
+          place : l&apos;hémicycle interactif (<code>/votes/[id]</code>) est navigable au clavier avec des libellés{' '}
+          <code>aria-label</code> dynamiques, et la recherche globale expose des rôles <code>dialog</code>/
+          <code>listbox</code> corrects.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Contenus non accessibles">
+        <p style={pStyle}>
+          Les non-conformités listées ci-dessus affectent principalement la page d&apos;accueil, le pied de page
+          (sur l&apos;ensemble du site), l&apos;assistant conversationnel et les photos de député. Leur correction
+          est suivie individuellement dans le suivi de projet public de MonÉlu.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Établissement de cette déclaration">
+        <p style={pStyle}>
+          Cette déclaration a été établie le 27 juillet 2026. Elle sera mise à jour au fur et à mesure de la
+          correction des non-conformités listées ci-dessus et de tout nouvel audit.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Retour d'information et contact">
+        <p style={pStyle}>
+          Si vous n&apos;arrivez pas à accéder à un contenu ou à un service de MonÉlu, vous pouvez contacter
+          l&apos;éditeur pour être orienté vers une solution alternative ou pour signaler un problème :{' '}
+          <a href="mailto:walidelkhoukh99@gmail.com" style={{ color: 'var(--dp-text)' }}>walidelkhoukh99@gmail.com</a>.
+        </p>
+        <p style={{ ...pStyle, margin: '10px 0 0' }}>
+          Voir aussi les <Link href="/mentions-legales" style={{ color: 'var(--dp-text)' }}>mentions légales</Link>.
+        </p>
+      </LegalSection>
+
+    </LegalPageLayout>
+  )
+}

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -7,6 +7,7 @@ const legalLinks = [
   { href: '/mentions-legales', label: 'Mentions légales' },
   { href: '/confidentialite', label: 'Confidentialité' },
   { href: '/licence-donnees', label: 'Licence des données' },
+  { href: '/accessibilite', label: "Accessibilité : non conforme" },
 ]
 
 export function Footer() {


### PR DESCRIPTION
## What
Publishes `/accessibilite`, a déclaration d'accessibilité (RGAA) page, and links it from the footer alongside the other legal pages.

## Why
MonÉlu had never been checked against RGAA (the French accessibility standard). MON-49 (pinch-zoom block) surfaced one WCAG failure incidentally, suggesting more existed. MON-113 asked for a structured self-audit of the main flows plus a published declaration, with any findings tracked as their own follow-up issues rather than fixed inline.

## Changes
- `frontend/src/app/accessibilite/page.tsx`: new page using the existing `LegalPageLayout`/`LegalSection` components (same pattern as `mentions-legales`, `confidentialite`, `licence-donnees` from MON-100). States an honest **non conforme** RGAA 4.1 status, the self-audit method used, and lists the concrete non-conformities found (see below), plus a contact channel for accessibility reports.
- `frontend/src/components/Footer.tsx`: adds the `/accessibilite` link to `legalLinks`.

### Audit findings (filed as sub-issues of MON-113, not fixed in this PR)
- MON-192 — footer legal link color (`#6B7280` on `#111C35`) computes to ~3.5:1 contrast, below the 4.5:1 AA/RGAA 3.2 minimum for normal text.
- MON-193 — no global `:focus-visible` style anywhere in `globals.css`; `HemicycleChart.tsx` explicitly suppresses the default outline.
- MON-194 — no `prefers-reduced-motion` handling anywhere in the frontend; the landing page's scroll-driven experience (`AssemblyScrollExperience.tsx`) animates continuously regardless of the OS preference.
- MON-195 (High) — `/chat` has no `aria-live` region; incoming assistant messages aren't announced to screen readers.
- MON-196 (Low) — deputy photo `alt` text is name-only with no descriptive context; needs a per-usage judgment call (decorative vs. descriptive).

The audit also confirmed some existing accessibility work is solid and didn't need a finding: the hemicycle chart's SVG has a dynamic `aria-label`, keyboard navigation (arrow keys/Enter/Escape), and `role="button"`-per-arc in group view; `GlobalSearch.tsx` has correct `dialog`/`listbox`/`option` roles.

## Testing
- `npm run lint` — clean.
- `npm test` — 172 tests, 21 suites, all passing.
- `npm run build` — compiles and type-checks successfully. The build fails at the `/sitemap.xml` static-generation step with an `API error: 500` — this is documented pre-existing noise (sitemap prerender needs a live API during build) unrelated to this change; nothing here touches `sitemap.ts` or any API route.
- Manually computed the footer contrast ratio (WCAG relative-luminance formula) to confirm the MON-192 finding rather than eyeballing it.

## Risks / Notes
- This PR intentionally does not fix any of the findings above — MON-113's own scope splits "audit + declaration" from "fixes," which become their own tracked issues (MON-192–MON-196).
- The declaration is a genuine internal self-audit (code review across landing, deputy list/profile, votes/hemicycle, chat, quiz), not a certified RGAA audit by an accredited third party — the page says so explicitly rather than overclaiming conformance.
- Like the other legal pages, `/accessibilite` is intentionally left out of `sitemap.ts`, matching the MON-100 precedent.

## Breaking Changes
None.