### PR TITLE
feat: show top 3 quiz matches with expand button (MON-191)

### DIFF
--- a/frontend/__tests__/components/QuizResultSections.test.tsx
+++ b/frontend/__tests__/components/QuizResultSections.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { QuizResultSections } from '@/app/quiz/QuizResultSections'
+import type { QuizDeputyMatch, QuizMatchResponse } from '@/lib/api'
+
+function makeMatch(deputy_id: string, agreement_pct: number): QuizDeputyMatch {
+  return {
+    deputy_id,
+    full_name: `Deputy ${deputy_id}`,
+    party: 'Parti Test',
+    party_short: 'PT',
+    department: '75',
+    photo_url: null,
+    agreement_pct,
+    matches: 8,
+    compared: 10,
+    detail: null,
+  }
+}
+
+// MON-191: the ranked "other matches" list shows the top 3 matches overall
+// (hero card + 2 rows) initially, revealing the rest behind a button.
+function makeResult(matchCount: number): QuizMatchResponse {
+  const top_matches = Array.from({ length: matchCount }, (_, i) =>
+    makeMatch(`d${i + 1}`, 90 - i)
+  )
+  return {
+    version: '1',
+    answered: 10,
+    eligible_deputies: 577,
+    top_matches,
+    opposite: null,
+    groups: [],
+    my_department: null,
+    focus: null,
+  }
+}
+
+describe('QuizResultSections - top matches expand (MON-191)', () => {
+  it('shows only the top 3 matches and a "Voir tous les députés" button when there are more', () => {
+    render(<QuizResultSections result={makeResult(6)} />)
+
+    expect(screen.getByText('Deputy d1')).toBeInTheDocument()
+    expect(screen.getByText('Deputy d2')).toBeInTheDocument()
+    expect(screen.getByText('Deputy d3')).toBeInTheDocument()
+    expect(screen.queryByText('Deputy d4')).not.toBeInTheDocument()
+    expect(screen.queryByText('Deputy d5')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Voir tous les députés' })).toBeInTheDocument()
+  })
+
+  it('reveals the remaining matches after clicking the expand button', async () => {
+    const user = userEvent.setup()
+    render(<QuizResultSections result={makeResult(6)} />)
+
+    await user.click(screen.getByRole('button', { name: 'Voir tous les députés' }))
+
+    expect(screen.getByText('Deputy d4')).toBeInTheDocument()
+    expect(screen.getByText('Deputy d5')).toBeInTheDocument()
+    expect(screen.getByText('Deputy d6')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Voir tous les députés' })).not.toBeInTheDocument()
+  })
+
+  it('does not show the expand button when there are 3 or fewer total matches', () => {
+    render(<QuizResultSections result={makeResult(3)} />)
+
+    expect(screen.getByText('Deputy d2')).toBeInTheDocument()
+    expect(screen.getByText('Deputy d3')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Voir tous les députés' })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/quiz/QuizResultSections.tsx
+++ b/frontend/src/app/quiz/QuizResultSections.tsx
@@ -280,7 +280,7 @@ export function QuizResultSections({
           <h2 className="font-newsreader" style={{ fontWeight: 600, fontSize: 22, color: NAVY, margin: '0 0 16px' }}>
             Vos autres meilleurs matchs
           </h2>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <div id="quiz-other-matches" style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
             {visibleOthers.map((m, i) => (
               <DeputyMatchRow key={m.deputy_id} match={m} rank={i + 2} />
             ))}
@@ -289,6 +289,8 @@ export function QuizResultSections({
             <button
               type="button"
               onClick={() => setShowAllOthers(true)}
+              aria-expanded={showAllOthers}
+              aria-controls="quiz-other-matches"
               style={{
                 marginTop: 14,
                 width: '100%',

--- a/frontend/src/app/quiz/QuizResultSections.tsx
+++ b/frontend/src/app/quiz/QuizResultSections.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { useState } from 'react'
 import Link from 'next/link'
 import type { QuizAnswerPosition, QuizDeputyMatch, QuizMatchResponse, QuizQuestion } from '@/lib/api'
 import { partyHex } from '@/lib/utils'
@@ -217,6 +218,10 @@ export function QuizResultSections({
   const best = result.top_matches[0] ?? null
   const others = result.top_matches.slice(1)
   const bestHex = best ? partyHex(best.party) : NAVY
+  // Top 3 matches shown initially (the hero best-match card plus these two),
+  // rest revealed on demand behind "Voir tous les députés".
+  const [showAllOthers, setShowAllOthers] = useState(false)
+  const visibleOthers = showAllOthers ? others : others.slice(0, 2)
 
   return (
     <>
@@ -276,10 +281,30 @@ export function QuizResultSections({
             Vos autres meilleurs matchs
           </h2>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-            {others.map((m, i) => (
+            {visibleOthers.map((m, i) => (
               <DeputyMatchRow key={m.deputy_id} match={m} rank={i + 2} />
             ))}
           </div>
+          {!showAllOthers && others.length > visibleOthers.length && (
+            <button
+              type="button"
+              onClick={() => setShowAllOthers(true)}
+              style={{
+                marginTop: 14,
+                width: '100%',
+                padding: '12px 14px',
+                borderRadius: 10,
+                border: `1px solid ${LINE}`,
+                background: 'var(--dp-card-bg)',
+                color: NAVY,
+                fontSize: 14,
+                fontWeight: 600,
+                cursor: 'pointer',
+              }}
+            >
+              Voir tous les députés
+            </button>
+          )}
         </section>
       )}
 


### PR DESCRIPTION
## What
Quiz results now show only the top 3 deputy matches on first render (the hero best-match card plus two more), with a "Voir tous les députés" button that reveals the rest of the ranked list.

## Why
The full ranked match list could run to dozens of rows and buried the matches users actually care about (their closest matches) under a long scroll. Progressive disclosure keeps the initial view focused. Tracked as MON-191.

## Changes
- `frontend/src/app/quiz/QuizResultSections.tsx`
  - Added local `showAllOthers` state (`useState`) to `QuizResultSections`.
  - "Vos autres meilleurs matchs" now renders `others.slice(0, 2)` by default (2 rows, plus the hero card above it = top 3 total) instead of the full `others` array.
  - Added a "Voir tous les députés" button below the list that flips `showAllOthers` to reveal the remaining matches; the button only renders when there's more to show.
  - This component is shared between the live quiz results screen (`QuizClient.tsx`) and the stored share page (`/quiz/s/[id]`), so both get the same behavior automatically.

## Testing
- `npm run lint` — clean.
- `npm test` — 21 suites / 172 tests, all passing.
- `npm run build` — compiles and type-checks successfully; the build fails afterward at the `/sitemap.xml` prerender step because it needs a live backend during static generation. This is a pre-existing, known issue unrelated to this change (documented in the `solve-mon` skill as reproducing identically on master).
- Not manually exercised in a browser in this environment (no way to run the dev server against a live backend here) — the change is a small, self-contained `useState` slice/expand and was verified by reading the rendered JSX logic and existing component tests.

## Risks / Notes
- Frontend-only, no API or schema changes, no deploy risk.
- The "opposite deputy" and department-comparison sections are untouched and still render in full — only the "autres meilleurs matchs" ranked list is now paginated behind the button.
- Worth a quick manual look in a browser before merge to confirm the button styling matches the rest of the results page.

## Breaking Changes
None.
