### PR TITLE
fix: serve deputy avatars unoptimized to stop Vercel image quota exhaustion

### DIFF
--- a/frontend/src/components/DeputyAvatar.tsx
+++ b/frontend/src/components/DeputyAvatar.tsx
@@ -35,6 +35,7 @@ export function DeputyAvatar({ name, photoUrl, size = 'sm', priority = false }: 
           height={h}
           className="object-cover object-top w-full h-full"
           priority={priority}
+          unoptimized
           onError={() => setImgError(true)}
         />
       </div>


### PR DESCRIPTION
## Summary
- Vercel's free-tier image-transformation quota (5,000/month) was fully consumed by deputy portraits: `DeputyAvatar.tsx` renders `next/image` at several distinct sizes (40, 64, 80, 210x262), and each portrait x size x format combination produced a separate cached transformation across ~577 deputies.
- Once exhausted, new (uncached) portrait requests started returning HTTP 402; already-cached images kept working.
- Adds `unoptimized` to the `next/image` usage in `DeputyAvatar.tsx` so deputy portraits are served directly from `assemblee-nationale.fr` instead of going through Vercel's optimizer, since they're already small, fixed-size JPEGs where responsive optimization added little value.

## Test plan
- [ ] Confirm deputy avatars render correctly across deputy list, profile, quiz, groups, and departments pages
- [ ] Confirm no new Vercel image transformations are recorded for `www.assemblee-nationale.fr` portraits after deploy