### PR TITLE
docs: refresh README against the current codebase

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -158,7 +158,7 @@
         "filename": "README.md",
         "hashed_secret": "09b30f6138f119acf5e4d3d7ad571e8c0b9f2059",
         "is_verified": false,
-        "line_number": 186
+        "line_number": 265
       }
     ],
     "frontend/public/sw.js": [
@@ -252,5 +252,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-19T19:38:30Z"
+  "generated_at": "2026-07-28T20:44:49Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -158,7 +158,7 @@
         "filename": "README.md",
         "hashed_secret": "09b30f6138f119acf5e4d3d7ad571e8c0b9f2059",
         "is_verified": false,
-        "line_number": 265
+        "line_number": 266
       }
     ],
     "frontend/public/sw.js": [
@@ -252,5 +252,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-28T20:44:49Z"
+  "generated_at": "2026-07-28T21:33:11Z"
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 MonÉlu is a civic transparency platform that makes the voting record of every deputy in the French Assemblée Nationale fully accessible — in plain language, in real time. Built for journalists, researchers, and engaged citizens who shouldn't need to dig through government ZIP exports to understand how their representatives vote.
 
-**Live:** https://monelu-production.up.railway.app · **API docs:** `/docs`
+**Site:** https://mon-elu.vercel.app · **API:** https://monelu-production.up.railway.app · **API docs:** `/docs`
 
 ---
 
@@ -33,47 +33,104 @@ Assemblée Nationale Open Data (ZIP exports)
   → Supabase PostgreSQL          deputies · votes · vote_positions · document_chunks
   → dbt (GitHub Actions)         staging → intermediate → analytics_marts
   → api/routers/                 direct psycopg2, RealDictCursor, parameterized SQL
-  → Railway (FastAPI)            JSON API · POST /search (RAG)
-  → Next.js (frontend/)          Cinematic landing page · live stats · RAG search UI
+  → Railway (FastAPI)            JSON API · POST /search (RAG) · POST /verify (fact-check)
+  → Next.js (frontend/, Vercel)  Landing page · deputy / vote / group / department / theme
+                                 pages · chat · fact-check · vote-matching quiz
 ```
 
-The API tier is fully stateless. All state lives in Supabase (managed Postgres with pgvector). Railway restarts on failure; `/health` returns live DB counts on every check.
+The API tier is fully stateless. All state lives in Supabase (managed Postgres with pgvector). Railway restarts on failure; `/health` returns live DB counts on every check. Errors are reported to Sentry when `SENTRY_DSN` / `NEXT_PUBLIC_SENTRY_DSN` are set - the integration no-ops when they are not (see [`docs/monitoring.md`](docs/monitoring.md)).
+
+---
+
+## Documentation
+
+| Doc | What's in it |
+|---|---|
+| [`docs/decisions.md`](docs/decisions.md) | Architecture Decision Records (ADR-001 → ADR-029) - read before changing anything structural |
+| [`CLAUDE.md`](CLAUDE.md) | Working guide for AI assistants on this repo |
+| [`docs/monitoring.md`](docs/monitoring.md) | Sentry setup, health checks, weekly feedback triage query |
+| [`docs/branch_protection.md`](docs/branch_protection.md) | Required checks and merge rules |
+| [`docs/quiz-curation.md`](docs/quiz-curation.md) | How the quiz question set is curated and refreshed |
+| [`docs/pr-attention-score.md`](docs/pr-attention-score.md) | PR review prioritisation heuristic |
 
 ---
 
 ## API Endpoints
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/` | API root (JSON) — use the Next.js frontend for the landing experience |
-| GET | `/deputies` | List all deputies (`search`, `department` filters) |
-| GET | `/deputies/{id}` | Deputy profile |
-| GET | `/deputies/{id}/scorecard` | Presence rate, vote breakdown by position |
-| GET | `/votes` | List votes (`result` filter) |
-| GET | `/votes/latest` | Last 10 votes |
-| GET | `/votes/{id}` | Vote detail + all individual positions |
-| GET | `/health` | API status + live record counts + dbt mart row counts |
-| POST | `/search` | Natural language query over the legislative corpus *(Phase 2)* |
-| POST | `/verify` | Fact-check a claim about a deputy's votes — structured verdict + citations |
-| GET | `/verify/{id}` | Stored verdict snapshot (no LLM call) — backs the share URL |
-| GET | `/quiz/questions` | Curated quiz question set (versioned repo file, ADR-025) |
-| POST | `/quiz/match` | Stateless vote-matching quiz computation — nothing persisted or logged |
-| POST | `/quiz/share` | Store an immutable quiz result snapshot (recomputed server-side) |
-| GET | `/quiz/share/{id}` | Stored quiz result snapshot — backs the `/quiz/s/<id>` share URL |
+Full interactive reference at `/docs`. Rate limits are per endpoint (column *rpm*) - see [Rate Limiting](#rate-limiting).
+
+### Core data
+
+| Method | Endpoint | rpm | Description |
+|--------|----------|-----|-------------|
+| GET | `/` | - | Redirects to the Next.js frontend |
+| GET | `/health` | - | API status, live record counts, last ingestion, dbt mart row counts |
+| GET | `/deputies` | 30 | List deputies (`search`, `department` filters) |
+| GET | `/deputies/stats` | 30 | Aggregate counts by party, department, mandate status |
+| GET | `/deputies/{id}` | 30 | Deputy profile |
+| GET | `/deputies/{id}/votes` | 30 | A deputy's voting record |
+| GET | `/deputies/{id}/scorecard` | 10 | Presence rate, vote breakdown by position |
+| GET | `/deputies/{id}/alignment` | 10 | Alignment with the deputy's own parliamentary group |
+| GET | `/deputies/{id}/dissident-votes` | 10 | Votes where the deputy broke with their group |
+| GET | `/deputies/{id}/diverging-votes` | 10 | Votes where the deputy diverged from the chamber majority |
+| GET | `/votes` | 30 | List votes (`result` filter) |
+| GET | `/votes/latest` | 30 | Last 10 votes |
+| GET | `/votes/{id}` | 30 | Vote detail + all individual positions |
+| GET | `/departments/{code}` | 30 | Department page data - deputies, aggregates, split votes (MON-107) |
+| GET | `/groups/{slug}` | 30 | Parliamentary group page data - members, dissidence, divided votes (ADR-026) |
+| GET | `/themes/{slug}` | 30 | Theme hub - per-theme stats, party positioning, vote list (MON-106) |
+
+### CSV exports (MON-97)
+
+| Method | Endpoint | rpm | Description |
+|--------|----------|-----|-------------|
+| GET | `/deputies/scorecards` | 10 | Every deputy's scorecard in one response (dense table view) |
+| GET | `/deputies/scorecard.csv` | 10 | Every deputy's scorecard as CSV |
+| GET | `/deputies/{id}/votes.csv` | 10 | One deputy's full voting record as CSV |
+| GET | `/votes/{id}/positions.csv` | 10 | Every deputy's position on one vote as CSV |
+
+### Intelligence layer
+
+| Method | Endpoint | rpm | Description |
+|--------|----------|-----|-------------|
+| POST | `/search/` | 10 | Natural-language query over the legislative corpus *(Phase 2)* |
+| POST | `/search/share` | 30 | Store a chat answer as an immutable snapshot (no LLM call, ADR-024) |
+| GET | `/search/share/{id}` | 300 | Stored chat answer - backs the `/chat/s/<id>` share URL |
+| POST | `/verify/` | 10 | Fact-check a claim about a deputy's votes - structured verdict + citations |
+| GET | `/verify/{id}` | 300 | Stored verdict snapshot (no LLM call) - backs `/verifier/v/<id>` |
+
+### Quiz (ADR-025)
+
+| Method | Endpoint | rpm | Description |
+|--------|----------|-----|-------------|
+| GET | `/quiz/questions` | 30 | Curated question set (versioned repo file) + live vote tallies |
+| GET | `/quiz/weekly` | 30 | The scrutin of the week, picked automatically |
+| POST | `/quiz/match` | 10 | Stateless agreement computation - nothing persisted or logged |
+| POST | `/quiz/share` | 10 | Store an immutable result snapshot (recomputed server-side) |
+| GET | `/quiz/share/{id}` | 300 | Stored result snapshot - backs the `/quiz/s/<id>` share URL |
+
+### Feedback and API keys
+
+| Method | Endpoint | rpm | Description |
+|--------|----------|-----|-------------|
+| POST | `/feedback/chat` | 10 | Thumbs up/down on a chat answer (MON-70) |
+| POST | `/feedback/report` | 10 | Report an error on a data page (MON-101) |
+| GET | `/keys/usage` | 10 | Per-endpoint, per-day usage for the calling API key |
 
 ---
 
 ## Rate Limiting
 
-Implemented with [slowapi](https://github.com/laurentS/slowapi), keyed by remote IP.
+Implemented with [slowapi](https://github.com/laurentS/slowapi). Anonymous requests are keyed by remote IP; requests carrying a valid API key are keyed by key id and get the endpoint's base limit multiplied by that key's `rate_limit_multiplier` (`api/limiter.py`). There is no global default limit - every endpoint declares its own, listed in the *rpm* column above.
 
-| Scope | Limit |
+| Tier | Typical limit |
 |---|---|
-| Global default | 30 req / min |
-| `GET /deputies/{id}/scorecard` | 10 req / min |
-| `POST /search` | 10 req / min |
-| `POST /verify` | 10 req / min |
-| `POST /quiz/match`, `POST /quiz/share` | 10 req / min |
+| Read endpoints | 30 req / min |
+| Expensive reads (scorecards, CSV exports) | 10 req / min |
+| LLM-backed (`POST /search/`, `POST /verify/`) | 10 req / min |
+| Stored-snapshot reads (share URLs) | 300 req / min |
+
+API keys are issued manually (`api_keys` table, sha256-hashed) and sent in the `X-API-Key` header; usage is counted per key, per endpoint, per day in `api_key_usage`.
 
 On limit exceeded: HTTP 429 · `{"error": "Too Many Requests", "detail": "..."}` · `Retry-After` + `X-RateLimit-*` headers.
 
@@ -83,7 +140,9 @@ On limit exceeded: HTTP 429 · `{"error": "Too Many Requests", "detail": "..."}`
 
 **Core:** FastAPI · PostgreSQL 15 + pgvector (Supabase) · Python 3.11 · Railway · slowapi
 
-**Frontend:** Next.js 15 · React 18 · Tailwind CSS · Framer Motion · SWR
+**Frontend:** Next.js 15 · React 18 · Tailwind CSS · Framer Motion · SWR · Vercel
+
+**Monitoring:** Sentry (API + frontend), opt-in via `SENTRY_DSN` / `NEXT_PUBLIC_SENTRY_DSN`
 
 **Phase 2 — RAG:** OpenAI `text-embedding-3-small` · Groq `llama-3.3-70b-versatile` · tiktoken · MLflow
 
@@ -111,6 +170,7 @@ Static ZIP exports only — no REST API exists at the source (see ADR-010).
 
 - Docker + Docker Compose
 - Python 3.11+
+- Node.js 20+ (frontend only)
 
 ### Steps
 
@@ -128,6 +188,14 @@ make fix-deputies
 make api        # → http://localhost:8000/docs
 ```
 
+For the frontend:
+
+```bash
+cd frontend && npm install
+cp .env.example .env.local   # point NEXT_PUBLIC_API_URL at http://localhost:8000
+npm run dev                  # → http://localhost:3000
+```
+
 ### Makefile reference
 
 ```
@@ -142,17 +210,24 @@ make psql           psql into the running Postgres container
 make check-db       table sizes, row counts, pgvector status
 
 make rag-index      truncate + re-embed all chunks (~$0.006)
+make rag-notable    build the notable-deputy chunks (ADR-017)
+make rag-laws       build the law-summary chunks
 make rag-stats      chunk counts by type
 make rag-clear      truncate document_chunks
 make rag-test       run 3 sample queries end-to-end
-make rag-eval       MLflow k=3 vs k=5 evaluation
+make rag-test-sql   check which sample questions the SQL router claims
+make rag-eval       MLflow evaluation (router + retrieval suites)
 make mlflow-ui      MLflow dashboard at http://localhost:5001
 
-make dbt-run        run all dbt models (staging → marts)
+make dbt-run        run all dbt models (staging → intermediate → marts)
 make dbt-test       run all dbt tests
 make dbt-docs       generate + serve docs at http://localhost:8082
 make dbt-lineage    open lineage graph in browser
 make dbt-clean      remove compiled dbt artifacts
+
+make frontend-dev   next dev   → http://localhost:3000
+make frontend-build next build
+make frontend-start next start (serves the production build)
 ```
 
 
@@ -167,15 +242,19 @@ A full dbt project (`transform/`) sits between raw ingestion and the FastAPI lay
 | Layer | Schema | Materialisation | Models |
 |---|---|---|---|
 | **Staging** | `analytics_staging` | View | `stg_deputies`, `stg_votes`, `stg_vote_positions` |
-| **Marts** | `analytics_marts` | Table | `mart_deputy_scorecard`, `mart_vote_summary` |
+| **Intermediate** | `analytics_intermediate` | Table (overrides the layer default) | `int_party_vote_majority` |
+| **Marts** | `analytics_marts` | Table | `mart_deputy_scorecard`, `mart_vote_summary`, `mart_party_alignment` |
 
 ### What FastAPI reads
 
 | Endpoint | Source |
 |---|---|
 | `GET /deputies/{id}/scorecard` | `analytics_marts.mart_deputy_scorecard` |
+| `GET /deputies/{id}/alignment` · `/dissident-votes` | `analytics_marts.mart_party_alignment` |
 | `GET /votes` · `GET /votes/latest` | `analytics_marts.mart_vote_summary` |
 | `GET /votes/{id}` | `analytics_marts.mart_vote_summary` + raw `vote_positions` |
+| `GET /groups/{slug}` | `mart_deputy_scorecard` + `mart_party_alignment` + raw `vote_positions` |
+| `GET /departments/{code}` · `GET /themes/{slug}` | Raw tables only - no mart dependency |
 | Landing page latest votes | `analytics_marts.mart_vote_summary` |
 
 ### Production deployment
@@ -191,9 +270,10 @@ Required GitHub secrets: `DBT_HOST` · `DBT_PORT` · `DBT_USER` · `DBT_PASSWORD
 
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
-| `ci.yml` | Every PR to `master` | ruff lint + pytest + dbt compile + dbt test (posts results as PR comment) |
+| `ci.yml` | Every PR to `master` | ruff lint + pytest (unit and integration) + frontend lint / test / build + dbt compile + dbt test (posts results as PR comment) |
 | `deploy.yml` | Merge to `master` | dbt run + test against prod Supabase |
 | `ingest_prod.yml` | Daily 06:00 UTC, weekdays | Ingest votes + deputies + rebuild RAG index |
+| `summarize_backfill.yml` | Daily 07:00 UTC | Backfill plain-French vote summaries (runs after the Groq TPD reset) |
 | `dbt_docs.yml` | Push to `master` touching `transform/` | Deploy lineage docs to GitHub Pages |
 
 All PRs must pass CI before merge — see [`docs/branch_protection.md`](docs/branch_protection.md).
@@ -205,21 +285,26 @@ All PRs must pass CI before merge — see [`docs/branch_protection.md`](docs/bra
 ```
 rag/
 ├── pipeline/
-│   ├── chunker.py        Five chunk strategies: vote, deputy, party, global_stats, notable_deputy
-│   ├── embedder.py       Batched OpenAI embedding (100 chunks/batch) → document_chunks
-│   └── index_manager.py  CLI: build / stats / clear
+│   ├── chunker.py                 vote · deputy · party · global_stats chunk strategies
+│   ├── chunk_notable_deputies.py  vote-by-vote chunks for high-profile deputies (ADR-017)
+│   ├── chunk_law_summaries.py     plain-French summaries of the main texts
+│   ├── embedder.py                Batched OpenAI embedding (100 chunks/batch) → document_chunks
+│   └── index_manager.py           CLI: build / stats / clear
 ├── chain/
-│   ├── retriever.py      pgvector cosine similarity (ivfflat.probes=10, notable deputy pinning)
-│   ├── prompts.py        French civic assistant system prompt + RAG template
-│   └── rag_chain.py      ask() — retrieve → format → Groq LLM
+│   ├── retriever.py       pgvector exact cosine similarity + chunk_type / deputy / result filters
+│   ├── hybrid_retriever.py  BM25 + vector blend - not on the live path, kept for eval (ADR-013)
+│   ├── sql_router.py      ranking-intent questions answered by SQL, not retrieval
+│   ├── llm_router.py      routes a question to SQL vs RAG; detect_claim() for the verify nudge
+│   ├── prompts.py         TTL-cached French civic assistant system prompt + RAG template
+│   ├── rag_chain.py       ask() - retrieve → format → Groq LLM
+│   └── verify.py          verify_claim() - structured fact-check verdict (ADR-022)
 └── experiments/
-    └── mlflow_eval.py    11 golden Q&A pairs, keyword scoring, k=3 vs k=5 experiment
+    └── mlflow_eval.py     11 golden Q&A pairs: router suite (SQL ground truth) + retrieval suite
 ```
 
-**Index stats:** 3,741 chunks · avg 87 tokens · ~$0.0065 to embed · $0 per query (question embedding only)
+**Index stats (2026-07):** ~5,900 chunks - 5,105 vote · 645 deputy · 102 notable_deputy · 20 law_summary · 12 party · 1 global_stats. ~$0.006 to embed the full corpus · $0 per query beyond the question embedding.
 
-Notable deputy pinning (Attal, Le Pen, etc.) adds one exact-match lookup before the vector search.
-The IVFFlat index was dropped (migration 003) — at ~3.7k chunks an exact cosine scan is faster and gives perfect recall.
+The IVFFlat index was dropped (migration 003) - at this corpus size an exact cosine scan is faster and gives perfect recall. The notable-deputy retrieval pin was removed with it (MON-76): an MLflow pin-on/pin-off run showed the exact scan already ranks the deputy's own chunk first. See ADR-008 in [`docs/decisions.md`](docs/decisions.md).
 
 ---
 
@@ -273,6 +358,31 @@ design.
 | `metadata` | JSONB | `chunk_type`, `vote_id` or `deputy_id`, etc. |
 | `embedding` | vector(1536) | OpenAI text-embedding-3-small |
 
+### Supporting tables
+
+| Table | Purpose |
+|---|---|
+| `api_keys` | Manually issued public API keys - sha256 hash, label, `rate_limit_multiplier` |
+| `api_key_usage` | Per-key, per-endpoint, per-day request counters |
+| `verifications` | Immutable fact-check verdict snapshots behind `/verifier/v/<id>` (ADR-022) |
+| `chat_shares` | Immutable chat answer snapshots behind `/chat/s/<id>` (ADR-024) |
+| `quiz_shares` | Server-recomputed quiz result snapshots behind `/quiz/s/<id>` (ADR-025); `result` JSONB optionally carries the sharer's answers when they opt in (ADR-028) |
+| `feedback` | `type`-discriminated feedback sink (chat thumbs / data-page reports) with a JSONB payload |
+
+### Migrations
+
+`data/migrations/` is applied by `scripts/migrate.py`, which keeps a `schema_migrations` ledger so each file runs exactly once. All statements are `IF NOT EXISTS`-guarded and safe to re-run.
+
+| File | What it adds |
+|---|---|
+| `001_init.sql` | Core schema: `deputies`, `votes`, `vote_positions`, `document_chunks` |
+| `002_vote_summaries.sql` | `votes.summary_plain` + `votes.theme` |
+| `003_schema_cleanup.sql` | Drops dead indexes, including IVFFlat (see the RAG section) |
+| `004_api_keys.sql` | `api_keys` + `api_key_usage` |
+| `005_feedback.sql` · `005_verifications.sql` | `feedback`, `verifications` |
+| `006_drop_position_id.sql` | Removes the redundant surrogate key on `vote_positions` |
+| `007_chat_shares.sql` · `008_quiz_shares.sql` | Share snapshot tables |
+
 ---
 
 ## Code Structure
@@ -281,29 +391,48 @@ design.
 
 | Module | Purpose |
 |---|---|
-| `main.py` | App entry point — CORS, rate limiting, exception handlers, landing page, health check |
-| `limiter.py` | Shared slowapi `Limiter` instance |
-| `routers/deputies.py` | Deputy list, profile, and scorecard endpoints |
-| `routers/votes.py` | Vote list, latest, and detail endpoints |
-| `routers/search.py` | `POST /search` — RAG query endpoint |
-| `routers/verify.py` | `POST /verify` + `GET /verify/{id}` — fact-check verdicts (ADR-022) |
-| `routers/quiz.py` | `/quiz/*` — vote-matching quiz: questions, stateless matching, share snapshots (ADR-025) |
-| `quiz_data.py` | Curated, versioned quiz question set — updated quarterly by PR (ADR-025) |
+| `main.py` | App entry point - CORS, rate limiting, Sentry, exception handlers, API-key usage middleware, health check |
+| `auth.py` | API key resolution from the `X-API-Key` header |
+| `db.py` | psycopg2 connection helper |
+| `limiter.py` | Shared slowapi `Limiter` + `tiered_limit()` (per-key multipliers) |
+| `csv_export.py` | Streaming CSV response helper (MON-97) |
+| `routers/deputies.py` | Deputy list, profile, scorecard, alignment, dissident/diverging votes, CSV exports |
+| `routers/votes.py` | Vote list, latest, detail, positions CSV |
+| `routers/departments.py` | `GET /departments/{code}` - department page data (MON-107) |
+| `routers/groups.py` | `GET /groups/{slug}` - parliamentary group page data (ADR-026) |
+| `routers/themes.py` | `GET /themes/{slug}` - theme hub pages (MON-106) |
+| `routers/search.py` | `POST /search/` - RAG query, plus chat share snapshots (ADR-024) |
+| `routers/verify.py` | `POST /verify/` + `GET /verify/{id}` - fact-check verdicts (ADR-022) |
+| `routers/quiz.py` | `/quiz/*` - questions, weekly scrutin, stateless matching, share snapshots (ADR-025) |
+| `routers/feedback.py` | Chat thumbs and data-page error reports (MON-70, MON-101) |
+| `routers/keys.py` | `GET /keys/usage` - usage accounting for the calling key |
+| `quiz_data.py` | Curated, versioned quiz question set - updated quarterly by PR (ADR-025) |
+| `departments_data.py` · `groups_data.py` · `themes_data.py` | Canonical code/slug ↔ label maps, mirrored in `frontend/src/lib/` |
 | `schemas.py` | Pydantic response models (all fields `Optional` to match DB NULLs) |
 
 ### Frontend (`frontend/`)
 
+Next.js 15 (App Router) + Tailwind + Framer Motion, deployed on Vercel separately from the FastAPI backend. Dark mode is supported (ADR-027).
+
+| Route | Purpose |
+|---|---|
+| `/` | Landing page - cinematic scroll experience, live stats, hero search |
+| `/deputes` · `/deputes/[id]` · `/deputes/tableau` · `/deputes/comparer` | Deputy directory, profile, dense sortable table, side-by-side comparison |
+| `/votes` · `/votes/[id]` | Vote list and vote detail with per-deputy positions |
+| `/groupes/[slug]` · `/departements/[code]` · `/themes/[slug]` | Group, department, and theme hub pages |
+| `/chat` · `/chat/s/[id]` | RAG chat (the fact-check UI lives here, ADR-023) and shared answer snapshots |
+| `/verifier` · `/verifier/v/[id]` | Redirect to the chat · shared fact-check verdicts |
+| `/quiz` · `/quiz/s/[id]` | Vote-matching quiz and shared results |
+| `/mon-depute` · `/partager` · `/embed` | Personal deputy view, share cards, embeddable widgets |
+| `/donnees` · `/developpeurs` · `/methodologie` · `/api` | Open data, API docs, methodology |
+| `/a-propos` · `/accessibilite` · `/mentions-legales` · `/confidentialite` · `/licence-donnees` | Institutional pages |
+
 | Module | Purpose |
 |---|---|
-| `src/app/page.tsx` | Root page — fetches deputies, votes, scorecards and renders `AssemblyScrollExperience` |
-| `src/components/home/AssemblyScrollExperience.tsx` | Cinematic 5-scene horizontal scroll experience |
-| `src/components/home/LiveAssemblyPulse.tsx` | Live stats panel (vote counts, adoption rate, recent votes via API) |
-| `src/components/home/TrustRow.tsx` | Trust strip — "577 députés · données officielles AN" |
-| `src/components/HeroSearch.tsx` | Search bar wired to `POST /search` |
 | `src/lib/api.ts` | Typed API client for all backend endpoints |
-
-Built with Next.js 15 (App Router) + Tailwind + Framer Motion.
-Deployed separately from the FastAPI backend.
+| `src/lib/seo.ts` · `src/app/sitemap.ts` | Canonical site URL, metadata helpers, generated sitemap |
+| `src/components/home/` | Landing-page scenes, live pulse panel, trust strip |
+| `src/components/HeroSearch.tsx` · `GlobalSearch.tsx` | Search entry points wired to the API |
 
 ### Ingestion (`scripts/`)
 
@@ -312,10 +441,15 @@ Deployed separately from the FastAPI backend.
 | `ingest_deputies.py` | Downloads AMO10 ZIP, upserts deputy profiles |
 | `ingest_votes.py` | Downloads Scrutins ZIP, upserts votes (`--since` flag) |
 | `ingest_positions.py` | Extracts individual deputy positions from Scrutins ZIP |
+| `ingest_organes.py` | Parses `Organes.json` for parliamentary group membership |
 | `run_ingestion_prod.py` | Orchestrates the full pipeline with timing summary |
 | `update_party.py` | Resolves GP party names and expands department codes |
-| `migrate.py` | Applies `001_init.sql` — also the Railway start hook |
+| `backfill_party_labels.py` | Enforces the 12 canonical group labels behind `/groups/{slug}` |
+| `generate_vote_summaries.py` | LLM-generated plain-French vote summaries (`summarize_backfill.yml`) |
+| `create_dbt_profile.py` | Writes `transform/profiles.yml` from `DBT_*` env vars (CI + deploy) |
+| `migrate.py` | Applies pending migrations against the ledger - also the Railway start hook |
 | `check_db_size.py` | Prints table sizes and DB storage usage |
+| `purge_test_fixtures.py` | Removes test fixture rows from a database |
 
 All scripts use exponential-backoff retry (5 attempts, 2 s base) and upsert via `ON CONFLICT ... DO UPDATE`.
 
@@ -323,10 +457,11 @@ All scripts use exponential-backoff retry (5 attempts, 2 s base) and upsert via 
 
 ## Security
 
-- **CORS:** `allow_credentials=False`, `allow_methods=["GET", "POST"]` — POST required for `/search`
+- **CORS:** `allow_credentials=False`, `allow_methods=["GET", "POST"]` - POST required for `/search`. An empty `CORS_ORIGINS` blocks all cross-origin requests and logs a startup warning
 - **Input validation:** `limit` capped at 200, `offset` at 100,000 on all list endpoints
-- **Error handling:** Global 500 handler returns a generic message — no tracebacks or DSNs in responses
-- **Rate limiting:** 60 req/min global, 10 req/min on scorecard, keyed by IP
+- **Error handling:** Global 500 handler returns a generic message - no tracebacks or DSNs in responses
+- **Rate limiting:** Per-endpoint limits (30 / 10 / 300 rpm), keyed by API key id or remote IP
+- **API keys:** Stored as sha256 hashes only; issued manually, never self-service
 - **No secrets in git:** All credentials via environment variables; `.env` is gitignored
 
 ---
@@ -350,6 +485,16 @@ pre-commit install       # runs automatically on every git commit
 | `ruff-format` | Black-compatible formatting |
 
 Lint config: `ruff.toml` — line length 100, `T201` (print) allowed in `scripts/` and `rag/`.
+
+### Tests
+
+```bash
+pytest tests/ -m "not integration"    # unit tests - no database required
+pytest tests/integration -m integration
+cd frontend && npm test               # Jest + Testing Library
+```
+
+Both suites run on every PR via `ci.yml` and block merge on failure.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The API tier is fully stateless. All state lives in Supabase (managed Postgres w
 
 | Doc | What's in it |
 |---|---|
-| [`docs/decisions.md`](docs/decisions.md) | Architecture Decision Records (ADR-001 → ADR-029) - read before changing anything structural |
+| [`docs/decisions.md`](docs/decisions.md) | The full decisions log (ADR-001 to ADR-029, ADR-015 unused) - read before changing anything structural |
 | [`CLAUDE.md`](CLAUDE.md) | Working guide for AI assistants on this repo |
 | [`docs/monitoring.md`](docs/monitoring.md) | Sentry setup, health checks, weekly feedback triage query |
 | [`docs/branch_protection.md`](docs/branch_protection.md) | Required checks and merge rules |
@@ -254,7 +254,8 @@ A full dbt project (`transform/`) sits between raw ingestion and the FastAPI lay
 | `GET /votes` · `GET /votes/latest` | `analytics_marts.mart_vote_summary` |
 | `GET /votes/{id}` | `analytics_marts.mart_vote_summary` + raw `vote_positions` |
 | `GET /groups/{slug}` | `mart_deputy_scorecard` + `mart_party_alignment` + raw `vote_positions` |
-| `GET /departments/{code}` · `GET /themes/{slug}` | Raw tables only - no mart dependency |
+| `GET /departments/{code}` | Raw tables, plus the marts for the highlight rates on a dedicated connection - falls back to raw-only when the marts are absent |
+| `GET /themes/{slug}` | Raw tables only - no mart dependency |
 | Landing page latest votes | `analytics_marts.mart_vote_summary` |
 
 ### Production deployment
@@ -285,8 +286,10 @@ All PRs must pass CI before merge — see [`docs/branch_protection.md`](docs/bra
 ```
 rag/
 ├── pipeline/
-│   ├── chunker.py                 vote · deputy · party · global_stats chunk strategies
-│   ├── chunk_notable_deputies.py  vote-by-vote chunks for high-profile deputies (ADR-017)
+│   ├── chunker.py                 Five strategies: vote · deputy · party · global_stats ·
+│   │                              notable_deputy; chunk_all() emits the whole corpus
+│   ├── chunk_notable_deputies.py  Index builder for the notable-deputy chunks (ADR-017,
+│   │                              `make rag-notable`) - has its own already_indexed guard
 │   ├── chunk_law_summaries.py     plain-French summaries of the main texts
 │   ├── embedder.py                Batched OpenAI embedding (100 chunks/batch) → document_chunks
 │   └── index_manager.py           CLI: build / stats / clear
@@ -302,7 +305,7 @@ rag/
     └── mlflow_eval.py     11 golden Q&A pairs: router suite (SQL ground truth) + retrieval suite
 ```
 
-**Index stats (2026-07):** ~5,900 chunks - 5,105 vote · 645 deputy · 102 notable_deputy · 20 law_summary · 12 party · 1 global_stats. ~$0.006 to embed the full corpus · $0 per query beyond the question embedding.
+**Index stats (2026-07, refresh with `make rag-stats`):** ~5,900 chunks - 5,105 vote · 645 deputy · 102 notable_deputy · 20 law_summary · 12 party · 1 global_stats. ~$0.006 to embed the full corpus · $0 per query beyond the question embedding.
 
 The IVFFlat index was dropped (migration 003) - at this corpus size an exact cosine scan is faster and gives perfect recall. The notable-deputy retrieval pin was removed with it (MON-76): an MLflow pin-on/pin-off run showed the exact scan already ranks the deputy's own chunk first. See ADR-008 in [`docs/decisions.md`](docs/decisions.md).
 
@@ -423,8 +426,11 @@ Next.js 15 (App Router) + Tailwind + Framer Motion, deployed on Vercel separatel
 | `/chat` · `/chat/s/[id]` | RAG chat (the fact-check UI lives here, ADR-023) and shared answer snapshots |
 | `/verifier` · `/verifier/v/[id]` | Redirect to the chat · shared fact-check verdicts |
 | `/quiz` · `/quiz/s/[id]` | Vote-matching quiz and shared results |
-| `/mon-depute` · `/partager` · `/embed` | Personal deputy view, share cards, embeddable widgets |
-| `/donnees` · `/developpeurs` · `/methodologie` · `/api` | Open data, API docs, methodology |
+| `/mon-depute` | Personal deputy view |
+| `/embed/votes/[id]` | Embeddable vote widget |
+| `/partager` | Web Share Target endpoint (MON-115) - normalises an OS share payload into a claim and redirects to `/chat?mode=verify` |
+| `/donnees` · `/developpeurs` · `/methodologie` | Open data, API usage guide, methodology |
+| `/api/revalidate` | Internal ISR revalidation webhook, guarded by a shared secret - not a public route |
 | `/a-propos` · `/accessibilite` · `/mentions-legales` · `/confidentialite` · `/licence-donnees` | Institutional pages |
 
 | Module | Purpose |


### PR DESCRIPTION
## Why

The README had drifted well behind the code. Concrete examples of what was wrong:

- It listed **13 endpoints**; the API now exposes ~35 (departments, groups, themes, CSV exports, chat/quiz shares, feedback, key usage were all missing).
- It documented a **global 30 rpm rate limit keyed by IP**. There is no global default anymore - `api/limiter.py` sets `default_limits=[]` and every endpoint declares its own, with API-key requests getting `base * rate_limit_multiplier`.
- It still described the **IVFFlat index and notable-deputy retrieval pin**, both removed (migration 003 / MON-76, ADR-008).
- Index stats said **3,741 chunks**; it's ~5,900 across six chunk types.
- The Security section claimed **"60 req/min global"** - a number that was never right for the current code.

## What changed

Docs only - no code touched.

- **API Endpoints** - split into core data / CSV exports / intelligence layer / quiz / feedback+keys, each row carrying its real rpm.
- **Rate Limiting** - describes the tiered scheme and the `X-API-Key` header, with a tier summary instead of a stale per-endpoint list.
- **dbt** - adds the intermediate layer and `mart_party_alignment`; maps the newer endpoints (`/groups`, `/departments`, `/themes`, alignment) to what they actually read.
- **RAG** - current module tree (`sql_router`, `llm_router`, `verify`, `chunk_notable_deputies`, `chunk_law_summaries`), chunk counts by type, and why IVFFlat and the pin are gone.
- **Database** - supporting tables (`api_keys`, `api_key_usage`, `verifications`, `chat_shares`, `quiz_shares`, `feedback`) and the migration ledger.
- **Code Structure** - full router list, `api/` support modules, and a frontend route map replacing the four-component table from the landing-page-only era.
- **New sections** - Documentation index (ADRs, monitoring, branch protection, quiz curation), Tests, frontend local setup, Sentry in the stack and architecture notes.
- **Makefile reference** - adds `rag-notable`, `rag-laws`, `rag-test-sql`, `frontend-*`.
- **CI/CD** - adds `summarize_backfill.yml`; `ci.yml` row now mentions the frontend lint/test/build gate.

`.secrets.baseline` line numbers were bumped by the pre-commit `detect-secrets` hook.

## Verification

Every claim was checked against the code rather than against `CLAUDE.md`: route decorators in `api/routers/*.py`, `api/limiter.py`, `api/auth.py`, `transform/dbt_project.yml` + model files, `data/migrations/`, `rag/`, `Makefile`, `frontend/src/app/`, `frontend/package.json`, and `.github/workflows/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WP6jMbQU9NDfQfKB9zK4Zw