### PR TITLE
fix: report homepage backend fetch failures to Sentry instead of silently degrading (MON-201)

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/nextjs'
 import { api, Vote, Deputy, Scorecard, QuizWeeklyQuestion } from '@/lib/api'
 import { AssemblyScrollExperience } from '@/components/home/AssemblyScrollExperience'
 import { ThemeNavSection } from '@/components/home/ThemeNavSection'
@@ -61,7 +62,9 @@ async function getStats() {
           picked = await api.deputies.get(middle.deputy_id)
           pickedPosition = middle.position as (typeof votingPositions)[number]
         }
-      } catch { /* ignore */ }
+      } catch (err) {
+        Sentry.captureException(err)
+      }
     }
 
     if (!picked) {
@@ -84,11 +87,14 @@ async function getStats() {
           abstentions: sc.abstentions ?? 0,
           votePosition: pickedPosition,
         }
-      } catch { /* ignore */ }
+      } catch (err) {
+        Sentry.captureException(err)
+      }
     }
 
     return { health, featuredVote, deputyInfo }
-  } catch {
+  } catch (err) {
+    Sentry.captureException(err)
     return { health: null, featuredVote: null, deputyInfo: null }
   }
 }
@@ -96,7 +102,8 @@ async function getStats() {
 async function getWeeklyQuizQuestion(): Promise<QuizWeeklyQuestion | null> {
   try {
     return await api.quiz.weekly()
-  } catch {
+  } catch (err) {
+    Sentry.captureException(err)
     return null
   }
 }


### PR DESCRIPTION
## What
Report homepage backend fetch failures to Sentry instead of swallowing them silently.

## Why
`frontend/src/app/page.tsx`'s `getStats()` and `getWeeklyQuizQuestion()` caught every error from `/health`, `/votes`, `/deputies`, and `/quiz/weekly` and returned a hardcoded fallback with zero telemetry - no `Sentry.captureException`, no `console.error`. A sustained backend outage would silently present stale `FALLBACK_STATS` numbers as if they were live, and make the "Scrutin de la semaine" quiz widget disappear entirely (`WeeklyQuizWidget` returns `null` when its question is `null`), with nobody finding out. Sentry is already wired for the frontend (`instrumentation.ts` → `sentry.server.config.ts`) but was never invoked on this path. Filed as MON-201 from the 2026-07-28 frontend diagnostic pass (`notes/dispatch/frontend_diagnostic_2026-07-28.md`, Finding #3).

## Changes
- `frontend/src/app/page.tsx`: added `Sentry.captureException(err)` to all four `catch` blocks in `getStats()` and `getWeeklyQuizQuestion()` (the outer catch in each function, plus the two inner defensive catches around the optional "featured deputy" enrichment), following the existing pattern already used in `app/error.tsx` / `app/global-error.tsx`. The fallback behavior (hardcoded stats, `null` quiz question) is unchanged - only the missing telemetry is added.

## Testing
- `npx tsc --noEmit` - no errors
- `npm run lint` - no warnings/errors
- `npm test` - 22 suites / 175 tests passing
- `npm run build` - production build succeeds (135/135 static pages); the build environment has no network access to the production API, so every one of these fetches genuinely failed during the build, exercising all four new `Sentry.captureException` calls without breaking the build

## Risks / Notes
- No behavior change for end users - the homepage still degrades to fallback stats / a missing quiz widget on backend failure, it's just now observable. `SENTRY_DSN` must be set in the deploy environment for this to actually report (already documented as opt-in in CLAUDE.md).

## Breaking Changes
None.
