### PR TITLE
perf: stop desktop preloading the hidden mobile hero image (MON-200)

### DIFF
--- a/frontend/src/components/home/AssemblyScrollExperience.tsx
+++ b/frontend/src/components/home/AssemblyScrollExperience.tsx
@@ -74,11 +74,20 @@ function MobileExperience({ stats, leadVote }: Props) {
   return (
     <section className="md:hidden">
       <div className="relative isolate overflow-hidden bg-navy px-4 pb-10 pt-14 text-white">
+        {/*
+          Deliberately NOT `priority` (MON-200): this section is always mounted and
+          only hidden with `md:hidden`, so a priority preload would make every
+          desktop visitor download this optimized copy on top of the cinematic
+          image set. Lazy loading means a `display:none` section never fetches it,
+          while on mobile the image is in the initial viewport and starts loading
+          at first layout; `fetchPriority="high"` keeps it ahead of the other
+          below-the-fold card images for LCP.
+        */}
         <Image
           src="/exterior-morning.jpg"
           alt="Vue extérieure de l'Assemblée Nationale"
           fill
-          priority
+          fetchPriority="high"
           sizes="100vw"
           className="object-cover object-center"
         />


### PR DESCRIPTION
## What

`MobileExperience` in `AssemblyScrollExperience.tsx` is always mounted and only hidden with `md:hidden`. Its hero `next/image` carried `priority`, which emits `<link rel="preload" as="image" fetchpriority="high">` regardless of viewport - CSS `display:none` does not cancel a preload. Every desktop visitor therefore downloaded an optimized `/_next/image` copy of `exterior-morning.jpg` on top of the three raw cinematic JPEGs, and the console logged the tell-tale `has "fill" prop and "sizes" prop of "100vw", but image is not rendered at full viewport width` warning.

The fix drops `priority` so the image is lazy: a `display:none` section never intersects, so desktop never fetches it. `fetchPriority="high"` is kept so that on mobile - where the image is in the initial viewport and starts loading at first layout - it still outranks the below-the-fold card images for LCP.

`StaticExperience` (reduced-motion branch) is untouched: it is the only component rendered on that path, so its `priority` preload is correct.

## Acceptance criteria

| Criterion | How it is met |
|---|---|
| Mobile hero image is no longer force-preloaded on desktop | `priority` removed; verified against a production build (`npm start`, curl `/`): no `<link rel="preload" as="image" href="/_next/image?url=%2Fexterior-morning.jpg...">` in the served HTML, and the mobile `<img>` now renders `loading="lazy" fetchPriority="high"` |
| Mobile hero still loads promptly | Image stays in the SSR HTML, in the initial mobile viewport, with `fetchPriority="high"` |
| Reduced-motion path unaffected | `StaticExperience` unchanged |

## Test plan

- `npm run lint` - clean
- `npm test` - 170 tests, 21 suites, all pass
- `npm run build` - succeeds
- Production build served locally; home page HTML inspected for the preload links and the image attributes (see above)

## Deploy risk

None. Single component, presentation-only, no schema/API/config change.

## Follow-up (not in this PR)

The mirror of this bug exists in the other direction: `CinematicExperience` is wrapped in `hidden md:block` but its three plain `<img>` tags are eager, and React hoists `<link rel="preload" as="image">` for them - so mobile visitors preload `hemicycle.jpg`, `entrance.jpg` and `exterior-morning.jpg` raw (~1.2 MB) for a section they never see. Left out to keep this PR to the filed scope; worth its own issue.
