### PR TITLE
fix: round MonEluLogo SVG coordinates to stop the site-wide hydration mismatch (MON-199)

### DIFF
--- a/frontend/__tests__/components/MonEluLogo.test.tsx
+++ b/frontend/__tests__/components/MonEluLogo.test.tsx
@@ -1,0 +1,46 @@
+import { render } from '@testing-library/react'
+
+import { MonEluLogo } from '@/components/MonEluLogo'
+
+// Raw trig floats (e.g. 23.966679003209208) serialize differently on the server
+// and on the client, which caused a hydration mismatch on every page load
+// (MON-199). Every rendered coordinate must be short enough to round-trip
+// identically through both serializers.
+const MAX_DECIMALS = 3
+
+function decimals(value: string): number {
+  const dot = value.indexOf('.')
+  return dot === -1 ? 0 : value.length - dot - 1
+}
+
+describe('MonEluLogo', () => {
+  it('renders all ring segments', () => {
+    const { container } = render(<MonEluLogo />)
+    // 3 rings × 7 segments, plus the deputy body rect
+    expect(container.querySelectorAll('rect')).toHaveLength(3 * 7 + 1)
+    expect(container.querySelector('circle')).toBeInTheDocument()
+  })
+
+  it('rounds every numeric SVG attribute to a hydration-safe precision', () => {
+    const { container } = render(<MonEluLogo />)
+    const numeric = /-?\d+(\.\d+)?/g
+
+    for (const el of Array.from(container.querySelectorAll('rect, circle'))) {
+      for (const attr of Array.from(el.attributes)) {
+        for (const match of attr.value.match(numeric) ?? []) {
+          // Message carries the offending attribute so a failure is self-explanatory
+          expect(`${attr.name}="${attr.value}" → ${decimals(match)} decimals`).toBe(
+            `${attr.name}="${attr.value}" → ${Math.min(decimals(match), MAX_DECIMALS)} decimals`,
+          )
+        }
+      }
+    }
+  })
+
+  it('renders the wordmark unless hidden', () => {
+    const { container, rerender } = render(<MonEluLogo />)
+    expect(container.textContent).toContain('MonÉlu')
+    rerender(<MonEluLogo hideWordmark />)
+    expect(container.textContent).toBe('')
+  })
+})

--- a/frontend/__tests__/components/MonEluLogo.test.tsx
+++ b/frontend/__tests__/components/MonEluLogo.test.tsx
@@ -24,17 +24,20 @@ describe('MonEluLogo', () => {
   it('rounds every numeric SVG attribute to a hydration-safe precision', () => {
     const { container } = render(<MonEluLogo />)
     const numeric = /-?\d+(\.\d+)?/g
+    const offenders: string[] = []
 
     for (const el of Array.from(container.querySelectorAll('rect, circle'))) {
       for (const attr of Array.from(el.attributes)) {
         for (const match of attr.value.match(numeric) ?? []) {
-          // Message carries the offending attribute so a failure is self-explanatory
-          expect(`${attr.name}="${attr.value}" → ${decimals(match)} decimals`).toBe(
-            `${attr.name}="${attr.value}" → ${Math.min(decimals(match), MAX_DECIMALS)} decimals`,
-          )
+          if (decimals(match) > MAX_DECIMALS) {
+            offenders.push(`<${el.tagName}> ${attr.name}="${attr.value}"`)
+          }
         }
       }
     }
+
+    // Asserting against [] rather than a count so a failure names the attribute
+    expect(offenders).toEqual([])
   })
 
   it('renders the wordmark unless hidden', () => {

--- a/frontend/src/components/MonEluLogo.tsx
+++ b/frontend/src/components/MonEluLogo.tsx
@@ -17,6 +17,14 @@ const RINGS = [
   { r: 28, w: 9,  h: 6, rx: 3 },
 ] as const
 
+// Trig-derived coordinates are rounded to a fixed precision before rendering.
+// React's SSR float-to-string serialization and the browser's own attribute
+// formatting disagree on the trailing digits of raw floats, which produced a
+// hydration mismatch on every page load (MON-199).
+function round3(v: number): number {
+  return Math.round(v * 1000) / 1000
+}
+
 function segColor(deg: number, navy: string, gray: string, red: string): string {
   if (deg <= 240) return navy   // 180 · 210 · 240
   if (deg === 270) return gray  // 270
@@ -51,13 +59,13 @@ export function MonEluLogo({ size = 28, variant = 'light', hideWordmark = false 
         {RINGS.map((ring, ri) =>
           ANGLES.map((deg, si) => {
             const rad = (deg * Math.PI) / 180
-            const x   = CX + ring.r * Math.cos(rad)
-            const y   = CY + ring.r * Math.sin(rad)
+            const x   = round3(CX + ring.r * Math.cos(rad))
+            const y   = round3(CY + ring.r * Math.sin(rad))
             return (
               <rect
                 key={`${ri}-${si}`}
-                x={x - ring.w / 2}
-                y={y - ring.h / 2}
+                x={round3(x - ring.w / 2)}
+                y={round3(y - ring.h / 2)}
                 width={ring.w}
                 height={ring.h}
                 rx={ring.rx}

--- a/frontend/src/components/MonEluLogo.tsx
+++ b/frontend/src/components/MonEluLogo.tsx
@@ -76,8 +76,8 @@ export function MonEluLogo({ size = 28, variant = 'light', hideWordmark = false 
           })
         )}
         {/* Deputy at the podium */}
-        <circle cx={CX} cy={FIGURE_CY} r={FIGURE_R} fill={navy} />
-        <rect x={CX - FIGURE_BW / 2} y={FIGURE_CY + FIGURE_R} width={FIGURE_BW} height={FIGURE_BH} rx={3} fill={navy} />
+        <circle cx={CX} cy={round3(FIGURE_CY)} r={FIGURE_R} fill={navy} />
+        <rect x={round3(CX - FIGURE_BW / 2)} y={round3(FIGURE_CY + FIGURE_R)} width={FIGURE_BW} height={FIGURE_BH} rx={3} fill={navy} />
       </svg>
 
       {!hideWordmark && (


### PR DESCRIPTION
## What & why

`MonEluLogo` computed each ring segment's `x` / `y` / `transform` from raw `ring.r * Math.cos(rad)` floats with no rounding. React's SSR float-to-string serialization and the browser's own attribute formatting disagree on the trailing significant digits of those exact values, so the logo subtree diffed and was patched on **every** hydration:

```
<rect x={30.49999999999998}
+   y={23.966679003209208}
-   y="23.9666790032092"
```

The logo renders inside `Nav`, so this fired on every page view in production, not just the landing page in dev - permanently occupying the dev-overlay issue badge and burying the signal for real problems.

Fix: round the trig-derived coordinates to 3 decimals (`round3`) before rendering, so both serializers emit the identical string. 3 decimals is far below the visible threshold in a 130x88 viewBox scaled to a 28px logo - the rendering is pixel-identical.

## Acceptance criteria

| Criterion | How it's met |
|---|---|
| Round `x`, `y`, and the numeric values in `transform` to fixed precision | `round3()` applied to `x`/`y` at computation and again to the `x - w/2` / `y - h/2` rect offsets; the `transform` string interpolates the already-rounded `x`/`y` |
| Server and client serialize the identical string | Dev-server SSR markup now emits `rotate(150,39,26.967)`; no float longer than 3 decimals appears in the served HTML |
| No hydration mismatch on page load | Root cause removed; the rendered attribute set is now representable identically by both serializers |

## Test plan

- New `frontend/__tests__/components/MonEluLogo.test.tsx`: asserts every numeric attribute on every rendered `rect`/`circle` has at most 3 decimals, plus segment-count and wordmark coverage. **Verified it fails without the fix** (`x="11.466679003209194" -> 15 decimals`) and passes with it.
- `npm test` - 23 suites / 178 tests pass.
- `npm run lint` - clean.
- `ruff check .` + `ruff format --check .` repo-wide - clean (no Python touched).
- Manual SSR check: started `next dev`, curled a page, confirmed the `<rect>` attributes and `rotate(...)` transforms are all short-form.

## Risks

None. Frontend-only, no schema, no API, no deploy config. Purely a serialization-precision change to a decorative SVG.

Note: `npm run build` fails locally on `/votes` prerender with `API error: 429` - the known rate-limit flake against the prod API, reproduces on master and is unrelated to this change. The build reached the prerender stage, so the `tsc` type check passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBwXYG2iEvvSdFWfZTyhfr