### PR TITLE
frontend: nav bar redesign - Explorer / À propos dropdown menus (MON-205)

### DIFF
--- a/frontend/__tests__/components/MobileMenu.test.tsx
+++ b/frontend/__tests__/components/MobileMenu.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { MobileMenu } from '@/components/MobileMenu'
+import { ThemeProvider } from '@/components/ThemeProvider'
+
+let pathname = '/'
+jest.mock('next/navigation', () => ({
+  usePathname: () => pathname,
+}))
+
+jest.mock('@/lib/api', () => ({
+  api: { deputies: { get: jest.fn() } },
+}))
+
+function renderMenu(open: boolean, onClose = jest.fn()) {
+  return render(
+    <ThemeProvider>
+      <MobileMenu open={open} onClose={onClose} />
+    </ThemeProvider>
+  )
+}
+
+beforeEach(() => {
+  pathname = '/'
+  window.localStorage.clear()
+  document.body.style.overflow = ''
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: jest.fn().mockImplementation(() => ({
+      matches: false,
+      media: '(prefers-color-scheme: dark)',
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    })),
+  })
+})
+
+describe('MobileMenu', () => {
+  it('is hidden from assistive tech when closed', () => {
+    renderMenu(false)
+    expect(screen.getByRole('dialog', { hidden: true })).toHaveAttribute('aria-modal', 'true')
+    expect(screen.getByRole('dialog', { hidden: true }).parentElement).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('locks and restores body scroll while open', () => {
+    const { rerender } = renderMenu(false)
+    expect(document.body.style.overflow).toBe('')
+
+    rerender(
+      <ThemeProvider>
+        <MobileMenu open onClose={jest.fn()} />
+      </ThemeProvider>
+    )
+    expect(document.body.style.overflow).toBe('hidden')
+
+    rerender(
+      <ThemeProvider>
+        <MobileMenu open={false} onClose={jest.fn()} />
+      </ThemeProvider>
+    )
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('calls onClose on Escape while open', () => {
+    const onClose = jest.fn()
+    renderMenu(true, onClose)
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when the backdrop is clicked', () => {
+    const onClose = jest.fn()
+    renderMenu(true, onClose)
+
+    const dialog = screen.getByRole('dialog')
+    // The backdrop is the dialog's previous sibling inside the fixed wrapper.
+    const backdrop = dialog.parentElement?.firstElementChild as HTMLElement
+    fireEvent.click(backdrop)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when an entry is clicked, closing the sheet before navigation', () => {
+    const onClose = jest.fn()
+    renderMenu(true, onClose)
+
+    fireEvent.click(screen.getByRole('link', { name: /députés/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('traps Tab focus inside the dialog', () => {
+    renderMenu(true)
+    const dialog = screen.getByRole('dialog')
+    const focusable = dialog.querySelectorAll('a[href], button:not([disabled])')
+    const first = focusable[0] as HTMLElement
+    const last = focusable[focusable.length - 1] as HTMLElement
+
+    last.focus()
+    expect(document.activeElement).toBe(last)
+    fireEvent.keyDown(window, { key: 'Tab' })
+    expect(document.activeElement).toBe(first)
+
+    first.focus()
+    fireEvent.keyDown(window, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(last)
+  })
+})

--- a/frontend/__tests__/components/Nav.test.tsx
+++ b/frontend/__tests__/components/Nav.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { Nav } from '@/components/Nav'
+import { ThemeProvider } from '@/components/ThemeProvider'
+
+let pathname = '/'
+jest.mock('next/navigation', () => ({
+  usePathname: () => pathname,
+}))
+
+jest.mock('@/lib/api', () => ({
+  api: { deputies: { get: jest.fn() } },
+}))
+
+function renderNav() {
+  return render(
+    <ThemeProvider>
+      <Nav />
+    </ThemeProvider>
+  )
+}
+
+beforeEach(() => {
+  pathname = '/'
+  window.localStorage.clear()
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: jest.fn().mockImplementation(() => ({
+      matches: false,
+      media: '(prefers-color-scheme: dark)',
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    })),
+  })
+})
+
+function explorerTrigger() {
+  return screen.getByRole('button', { name: /explorer/i })
+}
+
+function aproposTrigger() {
+  return screen.getByRole('button', { name: /à propos/i })
+}
+
+describe('Nav', () => {
+  it('opens the Explorer menu on click and marks it expanded', () => {
+    renderNav()
+    const trigger = explorerTrigger()
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    fireEvent.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+
+    const deputiesLink = screen.getByRole('link', { name: /députés/i })
+    expect(deputiesLink).not.toHaveAttribute('tabindex', '-1')
+  })
+
+  it('keeps the panel open when the trigger is clicked again only if reopened', () => {
+    renderNav()
+    const trigger = explorerTrigger()
+
+    fireEvent.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    fireEvent.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('only keeps one menu open at a time', () => {
+    renderNav()
+    fireEvent.click(explorerTrigger())
+    expect(explorerTrigger()).toHaveAttribute('aria-expanded', 'true')
+
+    fireEvent.click(aproposTrigger())
+    expect(aproposTrigger()).toHaveAttribute('aria-expanded', 'true')
+    expect(explorerTrigger()).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('closes the open menu on Escape', () => {
+    renderNav()
+    fireEvent.click(explorerTrigger())
+    expect(explorerTrigger()).toHaveAttribute('aria-expanded', 'true')
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(explorerTrigger()).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('closes the open menu on an outside click', () => {
+    renderNav()
+    fireEvent.click(explorerTrigger())
+    expect(explorerTrigger()).toHaveAttribute('aria-expanded', 'true')
+
+    fireEvent.mouseDown(document.body)
+    expect(explorerTrigger()).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('closes the open menu when a panel entry is clicked', () => {
+    renderNav()
+    fireEvent.click(explorerTrigger())
+    fireEvent.click(screen.getByRole('link', { name: /députés/i }))
+
+    expect(explorerTrigger()).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('closes an open menu when a flat top link (Quiz/Chat IA) is clicked', () => {
+    renderNav()
+    fireEvent.click(explorerTrigger())
+    expect(explorerTrigger()).toHaveAttribute('aria-expanded', 'true')
+
+    fireEvent.click(screen.getByRole('link', { name: /^quiz$/i }))
+
+    expect(explorerTrigger()).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('dispatches the open-search event when Rechercher is clicked, and closes the menu', () => {
+    renderNav()
+    const onOpenSearch = jest.fn()
+    window.addEventListener('monelu:open-search', onOpenSearch)
+
+    fireEvent.click(explorerTrigger())
+    fireEvent.click(screen.getByRole('button', { name: /rechercher/i }))
+
+    expect(onOpenSearch).toHaveBeenCalledTimes(1)
+    expect(explorerTrigger()).toHaveAttribute('aria-expanded', 'false')
+
+    window.removeEventListener('monelu:open-search', onOpenSearch)
+  })
+
+  it('renders no chrome on /embed pages', () => {
+    pathname = '/embed/votes/123'
+    const { container } = renderNav()
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { Analytics } from '@vercel/analytics/react'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import './globals.css'
 import { Nav } from '@/components/Nav'
+import { GlobalSearch } from '@/components/GlobalSearch'
 import { BottomNav } from '@/components/BottomNav'
 import { PageTransition } from '@/components/PageTransition'
 import { FreshnessBadge } from '@/components/FreshnessBadge'
@@ -80,6 +81,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <Suspense fallback={null}>
             <Nav />
           </Suspense>
+          {/* Triggerless: the nav menus and the mobile sheet open it, plus ⌘K. */}
+          <HideOnEmbed><GlobalSearch hideTrigger /></HideOnEmbed>
           <HideOnEmbed><FreshnessBadge /></HideOnEmbed>
           <MainFrame><PageTransition>{children}</PageTransition></MainFrame>
           <Footer />

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,7 +1,8 @@
 'use client'
+import { useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { ThemeToggle } from './ThemeToggle'
+import { MobileMenu } from './MobileMenu'
 
 const items = [
   { href: '/', label: 'Accueil', icon: '⌂' },
@@ -13,27 +14,46 @@ const items = [
 
 export function BottomNav() {
   const path = usePathname()
+  const [menuOpen, setMenuOpen] = useState(false)
+
   if (path.startsWith('/embed')) return null
   return (
-    <nav data-print-hide className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-gray-border dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)] z-50 pb-[env(safe-area-inset-bottom)]">
-      <div className="flex items-center">
-        <div className="grid grid-cols-5 flex-1">
-          {items.map(item => {
-            const active =
-              path === item.href || (item.href !== '/' && path.startsWith(item.href))
-            return (
-              <Link key={item.href} href={item.href}
-                className={`flex flex-col items-center justify-center py-3 gap-0.5 text-xs font-medium transition-colors
-                  ${active
-                    ? 'text-navy dark:text-[color:var(--dp-text)]' : 'text-gray-mid dark:text-[color:var(--dp-text-muted)]'}`}>
-                <span className="text-lg leading-none">{item.icon}</span>
-                <span>{item.label}</span>
-              </Link>
-            )
-          })}
+    <>
+      {/* The sheet carries what the tab bar has no room for — the desktop
+          "Explorer" sections, the secondary links, and the theme toggle. */}
+      <MobileMenu open={menuOpen} onClose={() => setMenuOpen(false)} />
+      <nav data-print-hide className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-gray-border dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)] z-50 pb-[env(safe-area-inset-bottom)]">
+        <div className="flex items-center">
+          <div className="grid grid-cols-5 flex-1">
+            {items.map(item => {
+              const active =
+                path === item.href || (item.href !== '/' && path.startsWith(item.href))
+              return (
+                <Link key={item.href} href={item.href}
+                  className={`flex flex-col items-center justify-center py-3 gap-0.5 text-xs font-medium transition-colors
+                    ${active
+                      ? 'text-navy dark:text-[color:var(--dp-text)]' : 'text-gray-mid dark:text-[color:var(--dp-text-muted)]'}`}>
+                  <span className="text-lg leading-none">{item.icon}</span>
+                  <span>{item.label}</span>
+                </Link>
+              )
+            })}
+          </div>
+          <button
+            type="button"
+            onClick={() => setMenuOpen(true)}
+            aria-label="Ouvrir le menu"
+            aria-expanded={menuOpen}
+            className={`flex shrink-0 flex-col items-center justify-center gap-0.5 px-3 py-3 text-xs font-medium transition-colors
+              ${menuOpen ? 'text-navy dark:text-[color:var(--dp-text)]' : 'text-gray-mid dark:text-[color:var(--dp-text-muted)]'}`}
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" aria-hidden="true">
+              <path d="M4 7h16M4 12h16M4 17h16" />
+            </svg>
+            <span>Menu</span>
+          </button>
         </div>
-        <ThemeToggle className="mr-2 shrink-0" />
-      </div>
-    </nav>
+      </nav>
+    </>
   )
 }

--- a/frontend/src/components/GlobalSearch.tsx
+++ b/frontend/src/components/GlobalSearch.tsx
@@ -23,7 +23,16 @@ type Results = { query: string; deputies: Deputy[]; votes: Vote[] }
 
 const EMPTY_RESULTS: Results = { query: '', deputies: [], votes: [] }
 
-export function GlobalSearch() {
+// The search overlay is mounted once in the layout; the nav menus and the
+// mobile sheet open it by firing this event rather than owning a trigger.
+const OPEN_SEARCH_EVENT = 'monelu:open-search'
+
+export function openGlobalSearch() {
+  window.dispatchEvent(new Event(OPEN_SEARCH_EVENT))
+}
+
+/** `hideTrigger` mounts the overlay without its own button (⌘K / event only). */
+export function GlobalSearch({ hideTrigger = false }: { hideTrigger?: boolean }) {
   const router = useRouter()
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
@@ -49,8 +58,13 @@ export function GlobalSearch() {
         closeSearch()
       }
     }
+    function onOpenRequest() { setOpen(true) }
     window.addEventListener('keydown', onKeyDown)
-    return () => window.removeEventListener('keydown', onKeyDown)
+    window.addEventListener(OPEN_SEARCH_EVENT, onOpenRequest)
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener(OPEN_SEARCH_EVENT, onOpenRequest)
+    }
   }, [])
 
   useEffect(() => {
@@ -113,6 +127,7 @@ export function GlobalSearch() {
 
   return (
     <>
+      {!hideTrigger && (
       <button
         onClick={() => setOpen(true)}
         aria-label="Rechercher (Cmd+K)"
@@ -122,6 +137,7 @@ export function GlobalSearch() {
         <span className="hidden lg:inline">Rechercher</span>
         <span className="hidden lg:inline font-mono" style={{ fontSize: 11, color: '#9CA3AF', border: '1px solid #E4E6EA', borderRadius: 4, padding: '1px 5px' }}>⌘K</span>
       </button>
+      )}
 
       {open && (
         <div

--- a/frontend/src/components/LegalPageLayout.tsx
+++ b/frontend/src/components/LegalPageLayout.tsx
@@ -36,10 +36,10 @@ export function LegalSection({
   title: string
   children: ReactNode
 }) {
-  // 88px = Nav.tsx's NAV_HEIGHT_PX (64) + 24px breathing room, so an anchor
+  // 96px = Nav.tsx's NAV_HEIGHT_PX (72) + 24px breathing room, so an anchor
   // jump doesn't land the heading under the sticky nav.
   return (
-    <section id={id} style={id ? { scrollMarginTop: '88px' } : undefined}>
+    <section id={id} style={id ? { scrollMarginTop: '96px' } : undefined}>
       <h2 style={{ fontWeight: 700, fontSize: '17px', color: 'var(--dp-text)', margin: '0 0 12px' }}>{title}</h2>
       {children}
     </section>

--- a/frontend/src/components/MobileMenu.tsx
+++ b/frontend/src/components/MobileMenu.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import { useEffect } from 'react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { MonEluLogo } from './MonEluLogo'
+import { ThemeToggle } from './ThemeToggle'
+import { FollowedDeputyChip } from './FollowedDeputyChip'
+import { exploreSections, isActivePath, topLinks } from './nav/navigation'
+
+/**
+ * Mobile counterpart of the desktop "Explorer" mega-menu: the same two
+ * sections, opened as a bottom sheet from the bottom nav. Below `md` the site
+ * keeps its bottom tab bar for the primary routes; this sheet carries
+ * everything the tab bar has no room for.
+ */
+export function MobileMenu({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const pathname = usePathname()
+
+  useEffect(() => {
+    if (!open) return
+    function onKeyDown(e: globalThis.KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      document.body.style.overflow = previousOverflow
+    }
+  }, [open, onClose])
+
+  return (
+    <div
+      className={`md:hidden fixed inset-0 z-[60] ${open ? '' : 'pointer-events-none'}`}
+      aria-hidden={!open}
+    >
+      <div
+        className="absolute inset-0 bg-black/40 transition-opacity duration-200"
+        style={{ opacity: open ? 1 : 0 }}
+        onClick={onClose}
+      />
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Menu de navigation"
+        className="absolute inset-x-0 bottom-0 max-h-[88vh] overflow-y-auto rounded-t-2xl bg-white shadow-2xl transition-transform duration-250 ease-out dark:bg-[color:var(--dp-card-bg)]"
+        style={{
+          transform: open ? 'translateY(0)' : 'translateY(100%)',
+          paddingBottom: 'calc(1.5rem + env(safe-area-inset-bottom))',
+        }}
+      >
+        <div className="sticky top-0 flex items-center justify-between px-5 py-4 bg-white border-b border-gray-border dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)]">
+          <Link href="/" className="flex items-center" onClick={onClose}>
+            <MonEluLogo size={28} variant="light" />
+          </Link>
+          <div className="flex items-center gap-2">
+            <ThemeToggle />
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Fermer le menu"
+              className="flex h-9 w-9 items-center justify-center rounded-full text-gray-mid hover:bg-gray-light dark:text-[color:var(--dp-text-muted)]"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" aria-hidden="true">
+                <path d="M18 6 6 18M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <div className="px-5 pt-4">
+          <FollowedDeputyChip />
+        </div>
+
+        {exploreSections.map(section => (
+          <div key={section.title} className="px-5 pt-5">
+            <span className="text-[11px] font-bold uppercase tracking-[0.08em] text-gray-mid dark:text-[color:var(--dp-text-muted)]">
+              {section.title}
+            </span>
+            <div className="mt-3 flex flex-col">
+              {section.entries.map(entry => {
+                const active = isActivePath(pathname, entry.href)
+                return (
+                  <Link
+                    key={entry.href}
+                    href={entry.href}
+                    onClick={onClose}
+                    tabIndex={open ? undefined : -1}
+                    className="flex items-start gap-3 rounded-lg py-3 active:bg-gray-light dark:active:bg-white/5"
+                  >
+                    <span
+                      className={`mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-red-civic ${active ? 'opacity-100' : 'opacity-0'}`}
+                      aria-hidden="true"
+                    />
+                    <span className="mt-0.5 shrink-0 text-navy dark:text-[color:var(--dp-text)]">{entry.icon}</span>
+                    <span>
+                      <span className="block text-[15px] font-semibold text-navy dark:text-[color:var(--dp-text)]">{entry.label}</span>
+                      <span className="block text-[12.5px] mt-0.5 text-gray-mid dark:text-[color:var(--dp-text-muted)]">{entry.description}</span>
+                    </span>
+                  </Link>
+                )
+              })}
+            </div>
+          </div>
+        ))}
+
+        <div className="px-5 pt-6">
+          <span className="text-[11px] font-bold uppercase tracking-[0.08em] text-gray-mid dark:text-[color:var(--dp-text-muted)]">
+            Le site
+          </span>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {topLinks.map(({ href, label }) => {
+              const active = isActivePath(pathname, href)
+              return (
+                <Link
+                  key={href}
+                  href={href}
+                  onClick={onClose}
+                  tabIndex={open ? undefined : -1}
+                  className={`rounded-full border px-4 py-2 text-sm font-semibold transition-colors
+                    ${active
+                      ? 'border-navy bg-navy text-white dark:border-[color:var(--dp-text)]'
+                      : 'border-gray-border text-navy dark:border-[color:var(--dp-border)] dark:text-[color:var(--dp-text)]'}`}
+                >
+                  {label}
+                </Link>
+              )
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/MobileMenu.tsx
+++ b/frontend/src/components/MobileMenu.tsx
@@ -77,11 +77,13 @@ export function MobileMenu({ open, onClose }: { open: boolean; onClose: () => vo
           <FollowedDeputyChip />
         </div>
 
-        {sections.map(section => (
-          <div key={section.title} className="px-5 pt-5">
-            <span className="text-[11px] font-bold uppercase tracking-[0.08em] text-gray-mid dark:text-[color:var(--dp-text-muted)]">
-              {section.title}
-            </span>
+        {sections.map((section, i) => (
+          <div key={section.title ?? i} className="px-5 pt-5">
+            {section.title && (
+              <span className="text-[11px] font-bold uppercase tracking-[0.08em] text-gray-mid dark:text-[color:var(--dp-text-muted)]">
+                {section.title}
+              </span>
+            )}
             <div className="mt-3 flex flex-col gap-4">
               {section.entries.map(entry => (
                 <MenuEntry

--- a/frontend/src/components/MobileMenu.tsx
+++ b/frontend/src/components/MobileMenu.tsx
@@ -1,15 +1,18 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { MonEluLogo } from './MonEluLogo'
 import { ThemeToggle } from './ThemeToggle'
 import { FollowedDeputyChip } from './FollowedDeputyChip'
 import { MenuEntry } from './nav/MenuEntry'
-import { aboutSections, exploreSections, isActivePath } from './nav/navigation'
+import { aboutSections, exploreSections, isEntryActive } from './nav/navigation'
 
 const sections = [...exploreSections, ...aboutSections]
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input, select, textarea, [tabindex]:not([tabindex="-1"])'
 
 /**
  * Mobile counterpart of the desktop dropdowns: the same sections, opened as a
@@ -18,11 +21,36 @@ const sections = [...exploreSections, ...aboutSections]
  */
 export function MobileMenu({ open, onClose }: { open: boolean; onClose: () => void }) {
   const pathname = usePathname()
+  const dialogRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     if (!open) return
+
+    // A real aria-modal dialog needs a focus trap: without one, Tab can walk
+    // focus out into the page content sitting behind the sheet.
+    function focusableElements(): HTMLElement[] {
+      return Array.from(dialogRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR) ?? [])
+    }
+
+    focusableElements()[0]?.focus()
+
     function onKeyDown(e: globalThis.KeyboardEvent) {
-      if (e.key === 'Escape') onClose()
+      if (e.key === 'Escape') {
+        onClose()
+        return
+      }
+      if (e.key !== 'Tab') return
+      const elements = focusableElements()
+      if (elements.length === 0) return
+      const first = elements[0]
+      const last = elements[elements.length - 1]
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
     }
     window.addEventListener('keydown', onKeyDown)
     const previousOverflow = document.body.style.overflow
@@ -45,6 +73,7 @@ export function MobileMenu({ open, onClose }: { open: boolean; onClose: () => vo
       />
 
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-label="Menu de navigation"
@@ -89,7 +118,7 @@ export function MobileMenu({ open, onClose }: { open: boolean; onClose: () => vo
                 <MenuEntry
                   key={entry.label}
                   entry={entry}
-                  active={!!entry.href && !entry.external && isActivePath(pathname, entry.href)}
+                  active={isEntryActive(entry, pathname)}
                   reachable={open}
                   onNavigate={onClose}
                 />

--- a/frontend/src/components/MobileMenu.tsx
+++ b/frontend/src/components/MobileMenu.tsx
@@ -6,13 +6,15 @@ import { usePathname } from 'next/navigation'
 import { MonEluLogo } from './MonEluLogo'
 import { ThemeToggle } from './ThemeToggle'
 import { FollowedDeputyChip } from './FollowedDeputyChip'
-import { exploreSections, isActivePath, topLinks } from './nav/navigation'
+import { MenuEntry } from './nav/MenuEntry'
+import { aboutSections, exploreSections, isActivePath } from './nav/navigation'
+
+const sections = [...exploreSections, ...aboutSections]
 
 /**
- * Mobile counterpart of the desktop "Explorer" mega-menu: the same two
- * sections, opened as a bottom sheet from the bottom nav. Below `md` the site
- * keeps its bottom tab bar for the primary routes; this sheet carries
- * everything the tab bar has no room for.
+ * Mobile counterpart of the desktop dropdowns: the same sections, opened as a
+ * bottom sheet from the bottom nav. Below `md` the site keeps its bottom tab
+ * bar for the primary routes; this sheet carries everything else.
  */
 export function MobileMenu({ open, onClose }: { open: boolean; onClose: () => void }) {
   const pathname = usePathname()
@@ -46,13 +48,13 @@ export function MobileMenu({ open, onClose }: { open: boolean; onClose: () => vo
         role="dialog"
         aria-modal="true"
         aria-label="Menu de navigation"
-        className="absolute inset-x-0 bottom-0 max-h-[88vh] overflow-y-auto rounded-t-2xl bg-white shadow-2xl transition-transform duration-250 ease-out dark:bg-[color:var(--dp-card-bg)]"
+        className="absolute inset-x-0 bottom-0 max-h-[88vh] overflow-y-auto rounded-t-2xl bg-white shadow-2xl transition-transform duration-200 ease-out dark:bg-[color:var(--dp-card-bg)]"
         style={{
           transform: open ? 'translateY(0)' : 'translateY(100%)',
           paddingBottom: 'calc(1.5rem + env(safe-area-inset-bottom))',
         }}
       >
-        <div className="sticky top-0 flex items-center justify-between px-5 py-4 bg-white border-b border-gray-border dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)]">
+        <div className="sticky top-0 z-10 flex items-center justify-between px-5 py-4 bg-white border-b border-gray-border dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)]">
           <Link href="/" className="flex items-center" onClick={onClose}>
             <MonEluLogo size={28} variant="light" />
           </Link>
@@ -75,62 +77,24 @@ export function MobileMenu({ open, onClose }: { open: boolean; onClose: () => vo
           <FollowedDeputyChip />
         </div>
 
-        {exploreSections.map(section => (
+        {sections.map(section => (
           <div key={section.title} className="px-5 pt-5">
             <span className="text-[11px] font-bold uppercase tracking-[0.08em] text-gray-mid dark:text-[color:var(--dp-text-muted)]">
               {section.title}
             </span>
-            <div className="mt-3 flex flex-col">
-              {section.entries.map(entry => {
-                const active = isActivePath(pathname, entry.href)
-                return (
-                  <Link
-                    key={entry.href}
-                    href={entry.href}
-                    onClick={onClose}
-                    tabIndex={open ? undefined : -1}
-                    className="flex items-start gap-3 rounded-lg py-3 active:bg-gray-light dark:active:bg-white/5"
-                  >
-                    <span
-                      className={`mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-red-civic ${active ? 'opacity-100' : 'opacity-0'}`}
-                      aria-hidden="true"
-                    />
-                    <span className="mt-0.5 shrink-0 text-navy dark:text-[color:var(--dp-text)]">{entry.icon}</span>
-                    <span>
-                      <span className="block text-[15px] font-semibold text-navy dark:text-[color:var(--dp-text)]">{entry.label}</span>
-                      <span className="block text-[12.5px] mt-0.5 text-gray-mid dark:text-[color:var(--dp-text-muted)]">{entry.description}</span>
-                    </span>
-                  </Link>
-                )
-              })}
+            <div className="mt-3 flex flex-col gap-4">
+              {section.entries.map(entry => (
+                <MenuEntry
+                  key={entry.label}
+                  entry={entry}
+                  active={!!entry.href && !entry.external && isActivePath(pathname, entry.href)}
+                  reachable={open}
+                  onNavigate={onClose}
+                />
+              ))}
             </div>
           </div>
         ))}
-
-        <div className="px-5 pt-6">
-          <span className="text-[11px] font-bold uppercase tracking-[0.08em] text-gray-mid dark:text-[color:var(--dp-text-muted)]">
-            Le site
-          </span>
-          <div className="mt-3 flex flex-wrap gap-2">
-            {topLinks.map(({ href, label }) => {
-              const active = isActivePath(pathname, href)
-              return (
-                <Link
-                  key={href}
-                  href={href}
-                  onClick={onClose}
-                  tabIndex={open ? undefined : -1}
-                  className={`rounded-full border px-4 py-2 text-sm font-semibold transition-colors
-                    ${active
-                      ? 'border-navy bg-navy text-white dark:border-[color:var(--dp-text)]'
-                      : 'border-gray-border text-navy dark:border-[color:var(--dp-border)] dark:text-[color:var(--dp-text)]'}`}
-                >
-                  {label}
-                </Link>
-              )
-            })}
-          </div>
-        </div>
       </div>
     </div>
   )

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -152,21 +152,31 @@ function Dropdown({
           <div className="flex gap-12 px-8 py-7">
             {sections.map((section, i) => (
               <div
-                key={section.title}
-                className={`flex flex-col gap-[18px] min-w-[230px] ${i > 0 ? 'border-l border-gray-border dark:border-[color:var(--dp-border)] pl-8' : ''}`}
+                key={section.title ?? i}
+                className={`flex flex-col gap-[18px] ${i > 0 ? 'border-l border-gray-border dark:border-[color:var(--dp-border)] pl-8' : ''}`}
               >
-                <span className="text-[11px] font-bold uppercase tracking-[0.08em] text-gray-mid dark:text-[color:var(--dp-text-muted)]">
-                  {section.title}
-                </span>
-                {section.entries.map(entry => (
-                  <MenuEntry
-                    key={entry.label}
-                    entry={entry}
-                    active={!!entry.href && !entry.external && isActivePath(pathname, entry.href)}
-                    reachable={open}
-                    onNavigate={onNavigate}
-                  />
-                ))}
+                {section.title && (
+                  <span className="text-[11px] font-bold uppercase tracking-[0.08em] text-gray-mid dark:text-[color:var(--dp-text-muted)]">
+                    {section.title}
+                  </span>
+                )}
+                <div
+                  className={
+                    section.grid
+                      ? 'grid grid-cols-2 gap-x-12 gap-y-[18px] [&>*]:min-w-[230px]'
+                      : 'flex flex-col gap-[18px] min-w-[230px]'
+                  }
+                >
+                  {section.entries.map(entry => (
+                    <MenuEntry
+                      key={entry.label}
+                      entry={entry}
+                      active={!!entry.href && !entry.external && isActivePath(pathname, entry.href)}
+                      reachable={open}
+                      onNavigate={onNavigate}
+                    />
+                  ))}
+                </div>
               </div>
             ))}
           </div>

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -162,9 +162,12 @@ function Dropdown({
                 )}
                 <div
                   className={
+                    // Fixed tracks, not `grid-cols-2`: the panel is a
+                    // shrink-to-fit absolute box, where `1fr` tracks collapse
+                    // below their content and the entries overlap.
                     section.grid
-                      ? 'grid grid-cols-2 gap-x-12 gap-y-[18px] [&>*]:min-w-[230px]'
-                      : 'flex flex-col gap-[18px] min-w-[230px]'
+                      ? 'grid [grid-template-columns:repeat(2,240px)] gap-x-12 gap-y-6'
+                      : 'flex flex-col gap-[18px] w-[230px]'
                   }
                 >
                   {section.entries.map(entry => (

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -11,6 +11,7 @@ import {
   aboutSections,
   exploreSections,
   isActivePath,
+  isEntryActive,
   sectionHrefs,
   topLinks,
   type NavSection,
@@ -73,7 +74,12 @@ export function Nav() {
         {topLinks.map(({ href, label }) => {
           const active = isActivePath(pathname, href)
           return (
-            <Link key={href} href={href} className={`${linkBase} ${active ? linkActive : ''}`}>
+            <Link
+              key={href}
+              href={href}
+              onClick={() => setOpenMenu(null)}
+              className={`${linkBase} ${active ? linkActive : ''}`}
+            >
               {label}
               {active && (
                 <span className="absolute -bottom-2 left-0 right-0 h-0.5 bg-red-civic" aria-hidden="true" />
@@ -117,73 +123,73 @@ function Dropdown({
 }) {
   const menuActive = sectionHrefs(sections).some(href => isActivePath(pathname, href))
   return (
-      <div className="relative">
-        <button
-          type="button"
-          aria-expanded={open}
-          aria-haspopup="true"
-          onClick={onToggle}
-          className={`flex items-center gap-1.5 cursor-pointer ${linkBase} ${open || menuActive ? linkActive : ''}`}
+    <div className="relative">
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-haspopup="true"
+        onClick={onToggle}
+        className={`flex items-center gap-1.5 cursor-pointer ${linkBase} ${open || menuActive ? linkActive : ''}`}
+      >
+        {label}
+        <svg
+          width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+          strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"
+          className="transition-transform duration-200"
+          style={{ transform: open ? 'rotate(180deg)' : 'rotate(0deg)' }}
         >
-          {label}
-          <svg
-            width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-            strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"
-            className="transition-transform duration-200"
-            style={{ transform: open ? 'rotate(180deg)' : 'rotate(0deg)' }}
-          >
-            <path d="m6 9 6 6 6-6" />
-          </svg>
-          {menuActive && (
-            <span className="absolute -bottom-2 left-0 right-0 h-0.5 bg-red-civic" aria-hidden="true" />
-          )}
-        </button>
+          <path d="m6 9 6 6 6-6" />
+        </svg>
+        {menuActive && (
+          <span className="absolute -bottom-2 left-0 right-0 h-0.5 bg-red-civic" aria-hidden="true" />
+        )}
+      </button>
 
-        <div
-          className="absolute left-1/2 -translate-x-1/2 rounded-[10px] border border-gray-border bg-white shadow-lg transition-[opacity,transform] duration-200 ease-out dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)]"
-          style={{
-            top: 'calc(100% + 18px)',
-            opacity: open ? 1 : 0,
-            transform: `translateX(-50%) translateY(${open ? '0' : '-6px'})`,
-            pointerEvents: open ? 'auto' : 'none',
-          }}
-          aria-hidden={!open}
-        >
-          <div className="flex gap-12 px-8 py-7">
-            {sections.map((section, i) => (
+      <div
+        className="absolute left-1/2 -translate-x-1/2 rounded-[10px] border border-gray-border bg-white shadow-lg transition-[opacity,transform] duration-200 ease-out dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)]"
+        style={{
+          top: 'calc(100% + 18px)',
+          opacity: open ? 1 : 0,
+          transform: `translateX(-50%) translateY(${open ? '0' : '-6px'})`,
+          pointerEvents: open ? 'auto' : 'none',
+        }}
+        aria-hidden={!open}
+      >
+        <div className="flex gap-12 px-8 py-7">
+          {sections.map((section, i) => (
+            <div
+              key={section.title ?? i}
+              className={`flex flex-col gap-[18px] ${i > 0 ? 'border-l border-gray-border dark:border-[color:var(--dp-border)] pl-8' : ''}`}
+            >
+              {section.title && (
+                <span className="text-[11px] font-bold uppercase tracking-[0.08em] text-gray-mid dark:text-[color:var(--dp-text-muted)]">
+                  {section.title}
+                </span>
+              )}
               <div
-                key={section.title ?? i}
-                className={`flex flex-col gap-[18px] ${i > 0 ? 'border-l border-gray-border dark:border-[color:var(--dp-border)] pl-8' : ''}`}
+                className={
+                  // Fixed tracks, not `grid-cols-2`: the panel is a
+                  // shrink-to-fit absolute box, where `1fr` tracks collapse
+                  // below their content and the entries overlap.
+                  section.grid
+                    ? 'grid [grid-template-columns:repeat(2,240px)] gap-x-12 gap-y-6'
+                    : 'flex flex-col gap-[18px] w-[230px]'
+                }
               >
-                {section.title && (
-                  <span className="text-[11px] font-bold uppercase tracking-[0.08em] text-gray-mid dark:text-[color:var(--dp-text-muted)]">
-                    {section.title}
-                  </span>
-                )}
-                <div
-                  className={
-                    // Fixed tracks, not `grid-cols-2`: the panel is a
-                    // shrink-to-fit absolute box, where `1fr` tracks collapse
-                    // below their content and the entries overlap.
-                    section.grid
-                      ? 'grid [grid-template-columns:repeat(2,240px)] gap-x-12 gap-y-6'
-                      : 'flex flex-col gap-[18px] w-[230px]'
-                  }
-                >
-                  {section.entries.map(entry => (
-                    <MenuEntry
-                      key={entry.label}
-                      entry={entry}
-                      active={!!entry.href && !entry.external && isActivePath(pathname, entry.href)}
-                      reachable={open}
-                      onNavigate={onNavigate}
-                    />
-                  ))}
-                </div>
+                {section.entries.map(entry => (
+                  <MenuEntry
+                    key={entry.label}
+                    entry={entry}
+                    active={isEntryActive(entry, pathname)}
+                    reachable={open}
+                    onNavigate={onNavigate}
+                  />
+                ))}
               </div>
-            ))}
-          </div>
+            </div>
+          ))}
         </div>
       </div>
+    </div>
   )
 }

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -4,25 +4,40 @@ import { useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { MonEluLogo } from './MonEluLogo'
-import { GlobalSearch } from './GlobalSearch'
 import { FollowedDeputyChip } from './FollowedDeputyChip'
 import { ThemeToggle } from './ThemeToggle'
-import { exploreHrefs, exploreSections, isActivePath, topLinks } from './nav/navigation'
+import { MenuEntry } from './nav/MenuEntry'
+import {
+  aboutSections,
+  exploreSections,
+  isActivePath,
+  sectionHrefs,
+  topLinks,
+  type NavSection,
+} from './nav/navigation'
 
 export const NAV_HEIGHT_PX = 72
 
+type MenuId = 'explorer' | 'apropos'
+
+const linkBase =
+  'relative text-[14.5px] font-semibold transition-colors text-gray-mid hover:text-navy dark:text-[color:var(--dp-text-muted)] dark:hover:text-[color:var(--dp-text)]'
+const linkActive = 'text-navy dark:text-[color:var(--dp-text)]'
+
 export function Nav() {
   const pathname = usePathname()
-  const [open, setOpen] = useState(false)
-  const menuRef = useRef<HTMLDivElement>(null)
+  const [openMenu, setOpenMenu] = useState<MenuId | null>(null)
+  const navRef = useRef<HTMLDivElement>(null)
 
+  // Menus are click-driven: once open they stay open until Escape, a click
+  // outside, or a click on one of their entries.
   useEffect(() => {
-    if (!open) return
+    if (!openMenu) return
     function onKeyDown(e: globalThis.KeyboardEvent) {
-      if (e.key === 'Escape') setOpen(false)
+      if (e.key === 'Escape') setOpenMenu(null)
     }
     function onPointerDown(e: MouseEvent) {
-      if (!menuRef.current?.contains(e.target as Node)) setOpen(false)
+      if (!navRef.current?.contains(e.target as Node)) setOpenMenu(null)
     }
     window.addEventListener('keydown', onKeyDown)
     window.addEventListener('mousedown', onPointerDown)
@@ -30,16 +45,10 @@ export function Nav() {
       window.removeEventListener('keydown', onKeyDown)
       window.removeEventListener('mousedown', onPointerDown)
     }
-  }, [open])
+  }, [openMenu])
 
   // /embed/* pages are iframed into third-party sites — no site chrome there.
   if (pathname.startsWith('/embed')) return null
-
-  const exploreActive = exploreHrefs.some(href => isActivePath(pathname, href))
-
-  const linkBase =
-    'relative text-[14.5px] font-semibold transition-colors text-gray-mid hover:text-navy dark:text-[color:var(--dp-text-muted)] dark:hover:text-[color:var(--dp-text)]'
-  const linkActive = 'text-navy dark:text-[color:var(--dp-text)]'
 
   return (
     <nav
@@ -51,83 +60,15 @@ export function Nav() {
         <MonEluLogo size={32} variant="light" />
       </Link>
 
-      <div
-        ref={menuRef}
-        className="flex items-center gap-9"
-        onMouseLeave={() => setOpen(false)}
-      >
-        <div className="relative" onMouseEnter={() => setOpen(true)}>
-          <button
-            type="button"
-            aria-expanded={open}
-            aria-haspopup="true"
-            onClick={() => setOpen(o => !o)}
-            className={`flex items-center gap-1.5 cursor-pointer ${linkBase} ${open || exploreActive ? linkActive : ''}`}
-          >
-            Explorer
-            <svg
-              width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-              strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"
-              className="transition-transform duration-200"
-              style={{ transform: open ? 'rotate(180deg)' : 'rotate(0deg)' }}
-            >
-              <path d="m6 9 6 6 6-6" />
-            </svg>
-            {exploreActive && (
-              <span className="absolute -bottom-2 left-0 right-0 h-0.5 bg-red-civic" aria-hidden="true" />
-            )}
-          </button>
-
-          <div
-            className="absolute left-1/2 -translate-x-1/2 rounded-[10px] border border-gray-border bg-white shadow-lg transition-[opacity,transform] duration-200 ease-out dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)]"
-            style={{
-              top: 'calc(100% + 18px)',
-              opacity: open ? 1 : 0,
-              transform: `translateX(-50%) translateY(${open ? '0' : '-6px'})`,
-              pointerEvents: open ? 'auto' : 'none',
-            }}
-            aria-hidden={!open}
-          >
-            <div className="flex gap-12 px-8 py-7">
-              {exploreSections.map((section, i) => (
-                <div
-                  key={section.title}
-                  className={`flex flex-col gap-[18px] min-w-[230px] ${i > 0 ? 'border-l border-gray-border dark:border-[color:var(--dp-border)] pl-8' : ''}`}
-                >
-                  <span className="text-[11px] font-bold uppercase tracking-[0.08em] text-gray-mid dark:text-[color:var(--dp-text-muted)]">
-                    {section.title}
-                  </span>
-                  {section.entries.map(entry => {
-                    const active = isActivePath(pathname, entry.href)
-                    return (
-                      <Link
-                        key={entry.href}
-                        href={entry.href}
-                        tabIndex={open ? undefined : -1}
-                        onClick={() => setOpen(false)}
-                        className="group flex items-start gap-3"
-                      >
-                        <span
-                          className={`mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-red-civic transition-opacity ${active ? 'opacity-100' : 'opacity-0'}`}
-                          aria-hidden="true"
-                        />
-                        <span className="mt-0.5 shrink-0 text-navy dark:text-[color:var(--dp-text)]">{entry.icon}</span>
-                        <span>
-                          <span className="block text-[14.5px] font-semibold text-navy group-hover:text-red-civic transition-colors dark:text-[color:var(--dp-text)]">
-                            {entry.label}
-                          </span>
-                          <span className="block text-[12.5px] mt-0.5 text-gray-mid dark:text-[color:var(--dp-text-muted)]">
-                            {entry.description}
-                          </span>
-                        </span>
-                      </Link>
-                    )
-                  })}
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
+      <div ref={navRef} className="flex items-center gap-9">
+        <Dropdown
+          label="Explorer"
+          sections={exploreSections}
+          pathname={pathname}
+          open={openMenu === 'explorer'}
+          onToggle={() => setOpenMenu(m => (m === 'explorer' ? null : 'explorer'))}
+          onNavigate={() => setOpenMenu(null)}
+        />
 
         {topLinks.map(({ href, label }) => {
           const active = isActivePath(pathname, href)
@@ -140,13 +81,96 @@ export function Nav() {
             </Link>
           )
         })}
+
+        <Dropdown
+          label="À propos"
+          sections={aboutSections}
+          pathname={pathname}
+          open={openMenu === 'apropos'}
+          onToggle={() => setOpenMenu(m => (m === 'apropos' ? null : 'apropos'))}
+          onNavigate={() => setOpenMenu(null)}
+        />
       </div>
 
       <div className="flex items-center gap-4 shrink-0">
         <ThemeToggle />
         <FollowedDeputyChip />
-        <GlobalSearch />
       </div>
     </nav>
+  )
+}
+
+function Dropdown({
+  label,
+  sections,
+  pathname,
+  open,
+  onToggle,
+  onNavigate,
+}: {
+  label: string
+  sections: NavSection[]
+  pathname: string
+  open: boolean
+  onToggle: () => void
+  onNavigate: () => void
+}) {
+  const menuActive = sectionHrefs(sections).some(href => isActivePath(pathname, href))
+  return (
+      <div className="relative">
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-haspopup="true"
+          onClick={onToggle}
+          className={`flex items-center gap-1.5 cursor-pointer ${linkBase} ${open || menuActive ? linkActive : ''}`}
+        >
+          {label}
+          <svg
+            width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+            strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"
+            className="transition-transform duration-200"
+            style={{ transform: open ? 'rotate(180deg)' : 'rotate(0deg)' }}
+          >
+            <path d="m6 9 6 6 6-6" />
+          </svg>
+          {menuActive && (
+            <span className="absolute -bottom-2 left-0 right-0 h-0.5 bg-red-civic" aria-hidden="true" />
+          )}
+        </button>
+
+        <div
+          className="absolute left-1/2 -translate-x-1/2 rounded-[10px] border border-gray-border bg-white shadow-lg transition-[opacity,transform] duration-200 ease-out dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)]"
+          style={{
+            top: 'calc(100% + 18px)',
+            opacity: open ? 1 : 0,
+            transform: `translateX(-50%) translateY(${open ? '0' : '-6px'})`,
+            pointerEvents: open ? 'auto' : 'none',
+          }}
+          aria-hidden={!open}
+        >
+          <div className="flex gap-12 px-8 py-7">
+            {sections.map((section, i) => (
+              <div
+                key={section.title}
+                className={`flex flex-col gap-[18px] min-w-[230px] ${i > 0 ? 'border-l border-gray-border dark:border-[color:var(--dp-border)] pl-8' : ''}`}
+              >
+                <span className="text-[11px] font-bold uppercase tracking-[0.08em] text-gray-mid dark:text-[color:var(--dp-text-muted)]">
+                  {section.title}
+                </span>
+                {section.entries.map(entry => (
+                  <MenuEntry
+                    key={entry.label}
+                    entry={entry}
+                    active={!!entry.href && !entry.external && isActivePath(pathname, entry.href)}
+                    reachable={open}
+                    onNavigate={onNavigate}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
   )
 }

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -1,60 +1,151 @@
 'use client'
 
+import { useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { MonEluLogo } from './MonEluLogo'
 import { GlobalSearch } from './GlobalSearch'
 import { FollowedDeputyChip } from './FollowedDeputyChip'
 import { ThemeToggle } from './ThemeToggle'
+import { exploreHrefs, exploreSections, isActivePath, topLinks } from './nav/navigation'
 
-export const NAV_HEIGHT_PX = 64
-
-const navLinks = [
-  { href: '/deputes', label: 'Députés' },
-  { href: '/votes', label: 'Votes' },
-  { href: '/quiz', label: 'Quiz' },
-  { href: '/chat', label: 'Chat IA' },
-  { href: '/a-propos', label: 'À propos' },
-]
+export const NAV_HEIGHT_PX = 72
 
 export function Nav() {
   const pathname = usePathname()
+  const [open, setOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function onKeyDown(e: globalThis.KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    function onPointerDown(e: MouseEvent) {
+      if (!menuRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('mousedown', onPointerDown)
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('mousedown', onPointerDown)
+    }
+  }, [open])
 
   // /embed/* pages are iframed into third-party sites — no site chrome there.
   if (pathname.startsWith('/embed')) return null
 
+  const exploreActive = exploreHrefs.some(href => isActivePath(pathname, href))
+
+  const linkBase =
+    'relative text-[14.5px] font-semibold transition-colors text-gray-mid hover:text-navy dark:text-[color:var(--dp-text-muted)] dark:hover:text-[color:var(--dp-text)]'
+  const linkActive = 'text-navy dark:text-[color:var(--dp-text)]'
+
   return (
     <nav
       data-print-hide
-      className="hidden md:flex items-center justify-between px-8 bg-white border-b border-gray-border dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)] sticky top-0 z-50"
+      className="hidden md:flex items-center justify-between gap-10 px-11 bg-white border-b border-gray-border dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)] sticky top-0 z-50"
       style={{ height: NAV_HEIGHT_PX }}
     >
-      <Link href="/" className="flex items-center">
+      <Link href="/" className="flex items-center shrink-0">
         <MonEluLogo size={32} variant="light" />
       </Link>
-      <div className="flex items-center gap-8 text-sm font-medium text-gray-mid dark:text-[color:var(--dp-text-muted)]">
-        {navLinks.map(({ href, label }) => {
-          const active = pathname === href || pathname.startsWith(href + '/')
-          return (
-            <Link
-              key={href}
-              href={href}
-              className={`transition-colors hover:text-navy dark:hover:text-[color:var(--dp-text)] ${active ? 'text-navy dark:text-[color:var(--dp-text)] border-b-2 border-red-civic pb-0.5' : ''}`}
+
+      <div
+        ref={menuRef}
+        className="flex items-center gap-9"
+        onMouseLeave={() => setOpen(false)}
+      >
+        <div className="relative" onMouseEnter={() => setOpen(true)}>
+          <button
+            type="button"
+            aria-expanded={open}
+            aria-haspopup="true"
+            onClick={() => setOpen(o => !o)}
+            className={`flex items-center gap-1.5 cursor-pointer ${linkBase} ${open || exploreActive ? linkActive : ''}`}
+          >
+            Explorer
+            <svg
+              width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+              strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"
+              className="transition-transform duration-200"
+              style={{ transform: open ? 'rotate(180deg)' : 'rotate(0deg)' }}
             >
+              <path d="m6 9 6 6 6-6" />
+            </svg>
+            {exploreActive && (
+              <span className="absolute -bottom-2 left-0 right-0 h-0.5 bg-red-civic" aria-hidden="true" />
+            )}
+          </button>
+
+          <div
+            className="absolute left-1/2 -translate-x-1/2 rounded-[10px] border border-gray-border bg-white shadow-lg transition-[opacity,transform] duration-200 ease-out dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)]"
+            style={{
+              top: 'calc(100% + 18px)',
+              opacity: open ? 1 : 0,
+              transform: `translateX(-50%) translateY(${open ? '0' : '-6px'})`,
+              pointerEvents: open ? 'auto' : 'none',
+            }}
+            aria-hidden={!open}
+          >
+            <div className="flex gap-12 px-8 py-7">
+              {exploreSections.map((section, i) => (
+                <div
+                  key={section.title}
+                  className={`flex flex-col gap-[18px] min-w-[230px] ${i > 0 ? 'border-l border-gray-border dark:border-[color:var(--dp-border)] pl-8' : ''}`}
+                >
+                  <span className="text-[11px] font-bold uppercase tracking-[0.08em] text-gray-mid dark:text-[color:var(--dp-text-muted)]">
+                    {section.title}
+                  </span>
+                  {section.entries.map(entry => {
+                    const active = isActivePath(pathname, entry.href)
+                    return (
+                      <Link
+                        key={entry.href}
+                        href={entry.href}
+                        tabIndex={open ? undefined : -1}
+                        onClick={() => setOpen(false)}
+                        className="group flex items-start gap-3"
+                      >
+                        <span
+                          className={`mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-red-civic transition-opacity ${active ? 'opacity-100' : 'opacity-0'}`}
+                          aria-hidden="true"
+                        />
+                        <span className="mt-0.5 shrink-0 text-navy dark:text-[color:var(--dp-text)]">{entry.icon}</span>
+                        <span>
+                          <span className="block text-[14.5px] font-semibold text-navy group-hover:text-red-civic transition-colors dark:text-[color:var(--dp-text)]">
+                            {entry.label}
+                          </span>
+                          <span className="block text-[12.5px] mt-0.5 text-gray-mid dark:text-[color:var(--dp-text-muted)]">
+                            {entry.description}
+                          </span>
+                        </span>
+                      </Link>
+                    )
+                  })}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {topLinks.map(({ href, label }) => {
+          const active = isActivePath(pathname, href)
+          return (
+            <Link key={href} href={href} className={`${linkBase} ${active ? linkActive : ''}`}>
               {label}
+              {active && (
+                <span className="absolute -bottom-2 left-0 right-0 h-0.5 bg-red-civic" aria-hidden="true" />
+              )}
             </Link>
           )
         })}
       </div>
-      <div className="flex items-center gap-4">
+
+      <div className="flex items-center gap-4 shrink-0">
         <ThemeToggle />
         <FollowedDeputyChip />
         <GlobalSearch />
-        <a href="https://monelu-production.up.railway.app/docs"
-          target="_blank"
-          className="text-sm border border-navy text-navy dark:border-[color:var(--dp-text)] dark:text-[color:var(--dp-text)] px-4 py-1.5 rounded hover:bg-navy hover:text-white transition-colors">
-          Explorer l&apos;API →
-        </a>
       </div>
     </nav>
   )

--- a/frontend/src/components/nav/MenuEntry.tsx
+++ b/frontend/src/components/nav/MenuEntry.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import Link from 'next/link'
+import { openGlobalSearch } from '../GlobalSearch'
+import type { NavEntry } from './navigation'
+
+/**
+ * One row of a nav menu — dot (active) · icon · label + description.
+ * Renders as a link, an external link, or a button for action entries,
+ * and is shared by the desktop dropdowns and the mobile sheet.
+ */
+export function MenuEntry({
+  entry,
+  active,
+  reachable,
+  onNavigate,
+}: {
+  entry: NavEntry
+  active: boolean
+  /** False while the menu is closed — keeps hidden rows out of the tab order. */
+  reachable: boolean
+  onNavigate: () => void
+}) {
+  const inner = (
+    <>
+      <span
+        className={`mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-red-civic transition-opacity ${active ? 'opacity-100' : 'opacity-0'}`}
+        aria-hidden="true"
+      />
+      <span className="mt-0.5 shrink-0 text-navy dark:text-[color:var(--dp-text)]">{entry.icon}</span>
+      <span className="text-left">
+        <span className="block text-[14.5px] font-semibold text-navy group-hover:text-red-civic transition-colors dark:text-[color:var(--dp-text)]">
+          {entry.label}
+          {entry.external && <span aria-hidden="true"> ↗</span>}
+        </span>
+        <span className="block text-[12.5px] mt-0.5 text-gray-mid dark:text-[color:var(--dp-text-muted)]">
+          {entry.description}
+        </span>
+      </span>
+    </>
+  )
+
+  const className = 'group flex items-start gap-3 w-full'
+  const tabIndex = reachable ? undefined : -1
+
+  if (entry.action === 'search') {
+    return (
+      <button
+        type="button"
+        tabIndex={tabIndex}
+        className={`${className} cursor-pointer`}
+        onClick={() => { onNavigate(); openGlobalSearch() }}
+      >
+        {inner}
+      </button>
+    )
+  }
+
+  if (entry.external) {
+    return (
+      <a
+        href={entry.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        tabIndex={tabIndex}
+        className={className}
+        onClick={onNavigate}
+      >
+        {inner}
+      </a>
+    )
+  }
+
+  return (
+    <Link href={entry.href!} tabIndex={tabIndex} className={className} onClick={onNavigate}>
+      {inner}
+    </Link>
+  )
+}

--- a/frontend/src/components/nav/MenuEntry.tsx
+++ b/frontend/src/components/nav/MenuEntry.tsx
@@ -31,7 +31,7 @@ export function MenuEntry({
       <span className="text-left">
         <span className="block text-[14.5px] font-semibold text-navy group-hover:text-red-civic transition-colors dark:text-[color:var(--dp-text)]">
           {entry.label}
-          {entry.external && <span aria-hidden="true"> ↗</span>}
+          {entry.kind === 'external' && <span aria-hidden="true"> ↗</span>}
         </span>
         <span className="block text-[12.5px] mt-0.5 text-gray-mid dark:text-[color:var(--dp-text-muted)]">
           {entry.description}
@@ -43,7 +43,7 @@ export function MenuEntry({
   const className = 'group flex items-start gap-3 w-full'
   const tabIndex = reachable ? undefined : -1
 
-  if (entry.action === 'search') {
+  if (entry.kind === 'action') {
     return (
       <button
         type="button"
@@ -56,7 +56,7 @@ export function MenuEntry({
     )
   }
 
-  if (entry.external) {
+  if (entry.kind === 'external') {
     return (
       <a
         href={entry.href}
@@ -72,7 +72,7 @@ export function MenuEntry({
   }
 
   return (
-    <Link href={entry.href!} tabIndex={tabIndex} className={className} onClick={onNavigate}>
+    <Link href={entry.href} tabIndex={tabIndex} className={className} onClick={onNavigate}>
       {inner}
     </Link>
   )

--- a/frontend/src/components/nav/navigation.tsx
+++ b/frontend/src/components/nav/navigation.tsx
@@ -3,16 +3,23 @@ import type { ReactNode } from 'react'
 // Shared information architecture for the top nav (desktop dropdowns) and the
 // mobile menu drawer, so both surfaces stay in sync.
 
-export interface NavEntry {
-  /** Internal route, or an absolute URL when `external`. Omitted for actions. */
-  href?: string
+interface NavEntryBase {
   label: string
   description: string
   icon: ReactNode
-  external?: boolean
-  /** Entries that run something instead of navigating. */
-  action?: 'search'
 }
+
+/** A route within the site. */
+export type NavLinkEntry = NavEntryBase & { kind: 'link'; href: string }
+/** An absolute URL, opened in a new tab. */
+export type NavExternalEntry = NavEntryBase & { kind: 'external'; href: string }
+/** Runs something instead of navigating. */
+export type NavActionEntry = NavEntryBase & { kind: 'action'; action: 'search' }
+
+// A discriminated union, not optional `href`/`external`/`action` fields on one
+// shape — the previous shape let an entry compile with none of the three set
+// and only fail at render, force-unwrapping `href` with `!`.
+export type NavEntry = NavLinkEntry | NavExternalEntry | NavActionEntry
 
 export interface NavSection {
   /** Column heading. Omitted for single-section menus, which need no label. */
@@ -73,16 +80,16 @@ export const exploreSections: NavSection[] = [
   {
     title: 'Parlement',
     entries: [
-      { href: '/deputes', label: 'Députés', description: 'Annuaire des 577 élus', icon: DeputyIcon },
-      { href: '/deputes/comparer', label: 'Comparer', description: 'Deux élus, vote par vote', icon: CompareIcon },
-      { href: '/votes', label: 'Votes', description: 'Chaque scrutin, décrypté et sourcé', icon: VoteIcon },
+      { kind: 'link', href: '/deputes', label: 'Députés', description: 'Annuaire des 577 élus', icon: DeputyIcon },
+      { kind: 'link', href: '/deputes/comparer', label: 'Comparer', description: 'Deux élus, vote par vote', icon: CompareIcon },
+      { kind: 'link', href: '/votes', label: 'Votes', description: 'Chaque scrutin, décrypté et sourcé', icon: VoteIcon },
     ],
   },
   {
     title: 'Outils',
     entries: [
-      { action: 'search', label: 'Rechercher', description: 'Un député, un vote, une question — ⌘K', icon: SearchIcon },
-      { href: API_DOCS_URL, external: true, label: 'API Explorer', description: 'Interroger les données en direct', icon: CodeIcon },
+      { kind: 'action', action: 'search', label: 'Rechercher', description: 'Un député, un vote, une question — ⌘K', icon: SearchIcon },
+      { kind: 'external', href: API_DOCS_URL, label: 'API Explorer', description: 'Interroger les données en direct', icon: CodeIcon },
     ],
   },
 ]
@@ -92,10 +99,10 @@ export const aboutSections: NavSection[] = [
   {
     grid: true,
     entries: [
-      { href: '/a-propos', label: 'À propos', description: 'Pourquoi MonÉlu existe', icon: InfoIcon },
-      { href: '/donnees', label: 'Données', description: 'Sources officielles, mises à jour en continu', icon: DataIcon },
-      { href: '/developpeurs', label: 'Développeurs', description: 'API publique et documentation', icon: CodeIcon },
-      { href: '/methodologie', label: 'Méthodologie', description: 'Comment les scores sont calculés', icon: MethodIcon },
+      { kind: 'link', href: '/a-propos', label: 'À propos', description: 'Pourquoi MonÉlu existe', icon: InfoIcon },
+      { kind: 'link', href: '/donnees', label: 'Données', description: 'Sources officielles, mises à jour en continu', icon: DataIcon },
+      { kind: 'link', href: '/developpeurs', label: 'Développeurs', description: 'API publique et documentation', icon: CodeIcon },
+      { kind: 'link', href: '/methodologie', label: 'Méthodologie', description: 'Comment les scores sont calculés', icon: MethodIcon },
     ],
   },
 ]
@@ -110,7 +117,14 @@ export function isActivePath(pathname: string, href: string): boolean {
   return pathname === href || pathname.startsWith(href + '/')
 }
 
+/** External links and actions never count as the active entry. */
+export function isEntryActive(entry: NavEntry, pathname: string): boolean {
+  return entry.kind === 'link' && isActivePath(pathname, entry.href)
+}
+
 /** Internal hrefs a menu covers — drives the active state of its trigger. */
 export function sectionHrefs(sections: NavSection[]): string[] {
-  return sections.flatMap(s => s.entries.filter(e => e.href && !e.external).map(e => e.href!))
+  return sections.flatMap(s =>
+    s.entries.filter((e): e is NavLinkEntry => e.kind === 'link').map(e => e.href)
+  )
 }

--- a/frontend/src/components/nav/navigation.tsx
+++ b/frontend/src/components/nav/navigation.tsx
@@ -1,20 +1,25 @@
 import type { ReactNode } from 'react'
 
-// Shared information architecture for the top nav (desktop dropdown) and the
+// Shared information architecture for the top nav (desktop dropdowns) and the
 // mobile menu drawer, so both surfaces stay in sync.
 
 export interface NavEntry {
-  href: string
+  /** Internal route, or an absolute URL when `external`. Omitted for actions. */
+  href?: string
   label: string
   description: string
   icon: ReactNode
   external?: boolean
+  /** Entries that run something instead of navigating. */
+  action?: 'search'
 }
 
 export interface NavSection {
   title: string
   entries: NavEntry[]
 }
+
+export const API_DOCS_URL = 'https://monelu-production.up.railway.app/docs'
 
 const iconProps = {
   width: 18,
@@ -40,6 +45,10 @@ const VoteIcon = (
   <svg {...iconProps}><path d="M3 12h4l3 8 4-16 3 8h4" /></svg>
 )
 
+const SearchIcon = (
+  <svg {...iconProps}><circle cx="11" cy="11" r="7" /><path d="m20 20-3.2-3.2" /></svg>
+)
+
 const DataIcon = (
   <svg {...iconProps}><ellipse cx="12" cy="5" rx="8" ry="3" /><path d="M4 5v14a8 3 0 0 0 16 0V5" /><path d="M4 12a8 3 0 0 0 16 0" /></svg>
 )
@@ -52,7 +61,11 @@ const MethodIcon = (
   <svg {...iconProps}><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><polyline points="14 2 14 8 20 8" /><line x1="8" y1="13" x2="16" y2="13" /><line x1="8" y1="17" x2="13" y2="17" /></svg>
 )
 
-/** The "Explorer" mega-menu — two columns on desktop, two blocks on mobile. */
+const InfoIcon = (
+  <svg {...iconProps}><circle cx="12" cy="12" r="9" /><line x1="12" y1="11" x2="12" y2="17" /><circle cx="12" cy="7.5" r="0.8" fill="currentColor" stroke="none" /></svg>
+)
+
+/** The "Explorer" mega-menu — the parliament itself, plus the ways into it. */
 export const exploreSections: NavSection[] = [
   {
     title: 'Parlement',
@@ -60,6 +73,23 @@ export const exploreSections: NavSection[] = [
       { href: '/deputes', label: 'Députés', description: 'Annuaire des 577 élus', icon: DeputyIcon },
       { href: '/deputes/comparer', label: 'Comparer', description: 'Deux élus, vote par vote', icon: CompareIcon },
       { href: '/votes', label: 'Votes', description: 'Chaque scrutin, décrypté et sourcé', icon: VoteIcon },
+    ],
+  },
+  {
+    title: 'Outils',
+    entries: [
+      { action: 'search', label: 'Rechercher', description: 'Un député, un vote, une question — ⌘K', icon: SearchIcon },
+      { href: API_DOCS_URL, external: true, label: 'API Explorer', description: 'Interroger les données en direct', icon: CodeIcon },
+    ],
+  },
+]
+
+/** The "À propos" menu — the project and everything around the data. */
+export const aboutSections: NavSection[] = [
+  {
+    title: 'Le projet',
+    entries: [
+      { href: '/a-propos', label: 'À propos', description: 'Pourquoi MonÉlu existe', icon: InfoIcon },
     ],
   },
   {
@@ -72,16 +102,17 @@ export const exploreSections: NavSection[] = [
   },
 ]
 
-/** Top-level links shown flat next to the "Explorer" trigger. */
+/** Top-level links shown flat between the two dropdown triggers. */
 export const topLinks = [
   { href: '/quiz', label: 'Quiz' },
   { href: '/chat', label: 'Chat IA' },
-  { href: '/a-propos', label: 'À propos' },
 ]
-
-/** Every href reachable through the "Explorer" trigger — drives its active state. */
-export const exploreHrefs = exploreSections.flatMap(s => s.entries.map(e => e.href))
 
 export function isActivePath(pathname: string, href: string): boolean {
   return pathname === href || pathname.startsWith(href + '/')
+}
+
+/** Internal hrefs a menu covers — drives the active state of its trigger. */
+export function sectionHrefs(sections: NavSection[]): string[] {
+  return sections.flatMap(s => s.entries.filter(e => e.href && !e.external).map(e => e.href!))
 }

--- a/frontend/src/components/nav/navigation.tsx
+++ b/frontend/src/components/nav/navigation.tsx
@@ -1,0 +1,87 @@
+import type { ReactNode } from 'react'
+
+// Shared information architecture for the top nav (desktop dropdown) and the
+// mobile menu drawer, so both surfaces stay in sync.
+
+export interface NavEntry {
+  href: string
+  label: string
+  description: string
+  icon: ReactNode
+  external?: boolean
+}
+
+export interface NavSection {
+  title: string
+  entries: NavEntry[]
+}
+
+const iconProps = {
+  width: 18,
+  height: 18,
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 2,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+  'aria-hidden': true,
+}
+
+const DeputyIcon = (
+  <svg {...iconProps}><circle cx="12" cy="8" r="4" /><path d="M4 21v-1a8 8 0 0 1 16 0v1" /></svg>
+)
+
+const CompareIcon = (
+  <svg {...iconProps}><path d="M4 20a8 8 0 0 1 16 0" /><path d="M7 20a5 5 0 0 1 10 0" /><circle cx="12" cy="20" r="1.4" fill="currentColor" stroke="none" /></svg>
+)
+
+const VoteIcon = (
+  <svg {...iconProps}><path d="M3 12h4l3 8 4-16 3 8h4" /></svg>
+)
+
+const DataIcon = (
+  <svg {...iconProps}><ellipse cx="12" cy="5" rx="8" ry="3" /><path d="M4 5v14a8 3 0 0 0 16 0V5" /><path d="M4 12a8 3 0 0 0 16 0" /></svg>
+)
+
+const CodeIcon = (
+  <svg {...iconProps}><polyline points="16 18 22 12 16 6" /><polyline points="8 6 2 12 8 18" /></svg>
+)
+
+const MethodIcon = (
+  <svg {...iconProps}><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><polyline points="14 2 14 8 20 8" /><line x1="8" y1="13" x2="16" y2="13" /><line x1="8" y1="17" x2="13" y2="17" /></svg>
+)
+
+/** The "Explorer" mega-menu — two columns on desktop, two blocks on mobile. */
+export const exploreSections: NavSection[] = [
+  {
+    title: 'Parlement',
+    entries: [
+      { href: '/deputes', label: 'Députés', description: 'Annuaire des 577 élus', icon: DeputyIcon },
+      { href: '/deputes/comparer', label: 'Comparer', description: 'Deux élus, vote par vote', icon: CompareIcon },
+      { href: '/votes', label: 'Votes', description: 'Chaque scrutin, décrypté et sourcé', icon: VoteIcon },
+    ],
+  },
+  {
+    title: 'Ressources',
+    entries: [
+      { href: '/donnees', label: 'Données', description: 'Sources officielles, mises à jour en continu', icon: DataIcon },
+      { href: '/developpeurs', label: 'Développeurs', description: 'API publique et documentation', icon: CodeIcon },
+      { href: '/methodologie', label: 'Méthodologie', description: 'Comment les scores sont calculés', icon: MethodIcon },
+    ],
+  },
+]
+
+/** Top-level links shown flat next to the "Explorer" trigger. */
+export const topLinks = [
+  { href: '/quiz', label: 'Quiz' },
+  { href: '/chat', label: 'Chat IA' },
+  { href: '/a-propos', label: 'À propos' },
+]
+
+/** Every href reachable through the "Explorer" trigger — drives its active state. */
+export const exploreHrefs = exploreSections.flatMap(s => s.entries.map(e => e.href))
+
+export function isActivePath(pathname: string, href: string): boolean {
+  return pathname === href || pathname.startsWith(href + '/')
+}

--- a/frontend/src/components/nav/navigation.tsx
+++ b/frontend/src/components/nav/navigation.tsx
@@ -15,8 +15,11 @@ export interface NavEntry {
 }
 
 export interface NavSection {
-  title: string
+  /** Column heading. Omitted for single-section menus, which need no label. */
+  title?: string
   entries: NavEntry[]
+  /** Lay the entries out as a 2-column grid instead of a single column. */
+  grid?: boolean
 }
 
 export const API_DOCS_URL = 'https://monelu-production.up.railway.app/docs'
@@ -84,17 +87,12 @@ export const exploreSections: NavSection[] = [
   },
 ]
 
-/** The "À propos" menu — the project and everything around the data. */
+/** The "À propos" menu — the project and everything around the data, 2×2. */
 export const aboutSections: NavSection[] = [
   {
-    title: 'Le projet',
+    grid: true,
     entries: [
       { href: '/a-propos', label: 'À propos', description: 'Pourquoi MonÉlu existe', icon: InfoIcon },
-    ],
-  },
-  {
-    title: 'Ressources',
-    entries: [
       { href: '/donnees', label: 'Données', description: 'Sources officielles, mises à jour en continu', icon: DataIcon },
       { href: '/developpeurs', label: 'Développeurs', description: 'API publique et documentation', icon: CodeIcon },
       { href: '/methodologie', label: 'Méthodologie', description: 'Comment les scores sont calculés', icon: MethodIcon },


### PR DESCRIPTION
Closes MON-205.

Applies the nav bar design from the Claude Design canvas (option 4a) to the site chrome, desktop and mobile.

## Desktop

`Nav.tsx` grows from 64px to 72px and is now built from a shared IA definition (`components/nav/navigation.tsx`) rendered by a shared row component (`components/nav/MenuEntry.tsx`).

- **Explorer** dropdown, two labelled columns:
  - *Parlement*: Députés, Comparer, Votes
  - *Outils*: Rechercher (opens the global search), API Explorer (live API docs, external)
- **À propos** dropdown: one unlabelled group laid out 2×2 - À propos, Données, Développeurs, Méthodologie.
- Flat links between the two triggers: Quiz, Chat IA.
- Right cluster keeps the theme toggle and the followed-deputy chip. The standalone "Explorer l'API →" button is gone - developer links live in the menus, in parity with the footer.
- Entries carry an icon, a label and a one-line description. The active entry gets a red dot, the active trigger the red underline.

Menus are **click-driven**: they open on click and stay open until Escape, a click outside, or a click on one of their entries. Hover neither opens nor closes them. One menu is open at a time, `aria-expanded` / `aria-haspopup` are set, and entries of a closed menu are pulled out of the tab order.

## Search

The overlay moved out of the nav: it is mounted once in `layout.tsx` in triggerless mode, and the nav menus, the mobile sheet and ⌘K all open it through a window event. That is what makes `Rechercher` work from inside the mobile bottom sheet, which could not have hosted an overlay nested in the desktop-only nav.

## Mobile

The site uses a bottom tab bar rather than a top bar, so a hamburger header would have meant two navs. Instead:

- the tab bar keeps its five primary routes and gains a **Menu** button in the slot the theme toggle used to occupy;
- that button opens a bottom sheet rendering the same sections through the same row component, plus the followed-deputy chip and the theme toggle;
- the sheet is scroll-locked, has a backdrop, and closes on Escape, backdrop click or navigation.

## Notes for the reviewer

- The design's **Hémicycle** entry has no route - the hemicycle chart only exists inside a vote detail page - so that slot points at `/deputes/comparer`. Happy to change the target.
- The 2×2 group uses fixed 240px grid tracks rather than `grid-cols-2`: the panel is a shrink-to-fit absolute box, where `1fr` tracks collapse below their content and the two columns render on top of each other.
- `NAV_HEIGHT_PX` moved 64 → 72; `LegalPageLayout`'s anchor `scroll-margin-top` was bumped 88 → 96 to match.

## Verification

`tsc --noEmit`, ESLint, 172 jest tests and `next build` all pass. Validated by hand in the dev server on desktop and at mobile widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsRUJXEKaNFk7fru2YnbHY
