### PR TITLE
frontend: switch nav logo to the dark variant in dark mode (MON-206)

### DIFF
--- a/frontend/src/components/MobileMenu.tsx
+++ b/frontend/src/components/MobileMenu.tsx
@@ -5,9 +5,11 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { MonEluLogo } from './MonEluLogo'
 import { ThemeToggle } from './ThemeToggle'
+import { useTheme } from './ThemeProvider'
 import { FollowedDeputyChip } from './FollowedDeputyChip'
 import { MenuEntry } from './nav/MenuEntry'
 import { aboutSections, exploreSections, isEntryActive } from './nav/navigation'
+import { isLightOnlyPath } from '@/lib/theme'
 
 const sections = [...exploreSections, ...aboutSections]
 
@@ -21,6 +23,7 @@ const FOCUSABLE_SELECTOR =
  */
 export function MobileMenu({ open, onClose }: { open: boolean; onClose: () => void }) {
   const pathname = usePathname()
+  const { theme } = useTheme()
   const dialogRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -85,7 +88,10 @@ export function MobileMenu({ open, onClose }: { open: boolean; onClose: () => vo
       >
         <div className="sticky top-0 z-10 flex items-center justify-between px-5 py-4 bg-white border-b border-gray-border dark:bg-[color:var(--dp-card-bg)] dark:border-[color:var(--dp-border)]">
           <Link href="/" className="flex items-center" onClick={onClose}>
-            <MonEluLogo size={28} variant="light" />
+            <MonEluLogo
+              size={28}
+              variant={theme === 'dark' && !isLightOnlyPath(pathname) ? 'dark' : 'light'}
+            />
           </Link>
           <div className="flex items-center gap-2">
             <ThemeToggle />

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -6,6 +6,8 @@ import { usePathname } from 'next/navigation'
 import { MonEluLogo } from './MonEluLogo'
 import { FollowedDeputyChip } from './FollowedDeputyChip'
 import { ThemeToggle } from './ThemeToggle'
+import { useTheme } from './ThemeProvider'
+import { isLightOnlyPath } from '@/lib/theme'
 import { MenuEntry } from './nav/MenuEntry'
 import {
   aboutSections,
@@ -27,6 +29,7 @@ const linkActive = 'text-navy dark:text-[color:var(--dp-text)]'
 
 export function Nav() {
   const pathname = usePathname()
+  const { theme } = useTheme()
   const [openMenu, setOpenMenu] = useState<MenuId | null>(null)
   const navRef = useRef<HTMLDivElement>(null)
 
@@ -58,7 +61,10 @@ export function Nav() {
       style={{ height: NAV_HEIGHT_PX }}
     >
       <Link href="/" className="flex items-center shrink-0">
-        <MonEluLogo size={32} variant="light" />
+        <MonEluLogo
+          size={32}
+          variant={theme === 'dark' && !isLightOnlyPath(pathname) ? 'dark' : 'light'}
+        />
       </Link>
 
       <div ref={navRef} className="flex items-center gap-9">


### PR DESCRIPTION
## What
Wires the nav logo's existing `light`/`dark` variant to the site's theme state, instead of hardcoding `variant="light"`.

## Why
`Nav.tsx` and `MobileMenu.tsx` both hardcoded `<MonEluLogo variant="light" />`. In dark mode the navbar background switches to a dark navy card color, but the logo kept rendering with the light-variant navy color for the rings and the "Mon" wordmark text. Against the dark navbar this text was nearly invisible - only the red "Élu" and a faint dot pattern survived. `MonEluLogo.tsx` already ships a working `dark` variant (white rings/text); it just wasn't wired to anything.

## Changes
- `Nav.tsx`: reads `useTheme()` and passes `variant={theme === 'dark' && !isLightOnlyPath(pathname) ? 'dark' : 'light'}` to `MonEluLogo`.
- `MobileMenu.tsx`: same fix, mirroring the same pattern.
- Both respect `isLightOnlyPath` (currently just `/`, the cinematic landing page per ADR-027) so the logo stays light there even if the stored theme preference is `dark`, matching the fact that the landing page's navbar never actually goes dark.

## Testing
- `npm run lint` - passes
- `npm test` - 187/187 passing
- `npm run build` - succeeds, no new errors
- Manual: not run in a browser this session; logic mirrors `ThemeToggle.tsx`'s existing `isLightOnlyPath`/theme handling exactly, so behavior should match the navbar's own dark-mode class toggle.

## Risks / Notes
- Low risk, presentational-only change scoped to two nav components.
- Worth a quick visual check in a browser (toggle dark mode, confirm "Mon" is legible in the navbar and mobile sheet, and that `/` still shows the light logo).

## Breaking Changes
None.

https://linear.app/monelu/issue/MON-206/nav-logo-doesnt-switch-to-dark-variant-in-dark-mode