### PR TITLE
frontend: render-gate mobile cinematic experience (MON-202)

### DIFF
--- a/frontend/src/components/home/AssemblyScrollExperience.tsx
+++ b/frontend/src/components/home/AssemblyScrollExperience.tsx
@@ -1,7 +1,7 @@
 'use client'
 // Typography exception: this cinematic scroll component uses inline styles throughout
 // because all colors, opacities, and sizes are computed dynamically by the animation engine.
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import { useReducedMotion } from 'framer-motion'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -978,8 +978,31 @@ function CinematicExperience({ stats, leadVote, deputyInfo }: Props) {
   )
 }
 
+const DESKTOP_QUERY = '(min-width: 768px)'
+
+function subscribeToDesktopMatch(callback: () => void) {
+  const mql = window.matchMedia(DESKTOP_QUERY)
+  mql.addEventListener('change', callback)
+  return () => mql.removeEventListener('change', callback)
+}
+
+function getIsDesktopMatch() {
+  return window.matchMedia(DESKTOP_QUERY).matches
+}
+
+function getIsDesktopServerSnapshot() {
+  return false
+}
+
 export function AssemblyScrollExperience({ stats, leadVote, deputyInfo }: Props) {
   const reduceMotion = useReducedMotion()
+  // Server snapshot is always false, so hydration never mismatches; resolves
+  // to the real viewport right after mount (MON-202). This is a render gate,
+  // not a CSS hide - `CinematicExperience` (and its 1.2 MB of raw JPEG plus
+  // its scroll-animation effect) does not mount at all until this confirms
+  // desktop, unlike `useReducedMotion` above which resolves the same way but
+  // for a different axis.
+  const isDesktop = useSyncExternalStore(subscribeToDesktopMatch, getIsDesktopMatch, getIsDesktopServerSnapshot)
 
   if (reduceMotion) {
     return <StaticExperience stats={stats} leadVote={leadVote} deputyInfo={deputyInfo} />
@@ -987,9 +1010,11 @@ export function AssemblyScrollExperience({ stats, leadVote, deputyInfo }: Props)
 
   return (
     <>
-      <div className="hidden md:block">
-        <CinematicExperience stats={stats} leadVote={leadVote} deputyInfo={deputyInfo} />
-      </div>
+      {isDesktop && (
+        <div className="hidden md:block">
+          <CinematicExperience stats={stats} leadVote={leadVote} deputyInfo={deputyInfo} />
+        </div>
+      )}
       <MobileExperience stats={stats} leadVote={leadVote} deputyInfo={deputyInfo} />
     </>
   )


### PR DESCRIPTION
## What

Render-gates the desktop `CinematicExperience` in `AssemblyScrollExperience.tsx` behind a client-side viewport match, instead of only CSS-hiding it on mobile.

## Why

`CinematicExperience` was always mounted and merely `display:none`'d on mobile via `hidden md:block`.
Being hidden with CSS does not stop React from mounting it or the browser from fetching its assets.
Every mobile visitor was therefore:

- Downloading ~1.2 MB of raw, unoptimized JPEG (`hemicycle.jpg`, `entrance.jpg`, `exterior-morning.jpg`) via three plain `<img>` tags, plus React-hoisted `<link rel="preload" as="image">` tags for them.
- Running the component's scroll-animation `useEffect`: building the ~1,000-seat hemicycle dot field, attaching `scroll`/`resize` listeners, and driving a `requestAnimationFrame` loop against a hidden subtree.

This is the mobile half of the defect that MON-200 (PR #282) fixed on the desktop side.

## Changes

- `frontend/src/components/home/AssemblyScrollExperience.tsx`:
  - Added a `useSyncExternalStore`-based `isDesktop` match against `(min-width: 768px)`, with a server snapshot that is always `false` so hydration never mismatches (same resolution shape as the existing `useReducedMotion()` check on this component, per the issue's guidance).
  - `CinematicExperience` is now only rendered into the tree when `isDesktop` is `true` — it does not mount, run its effect, or request its images until the client confirms a desktop viewport.
  - `MobileExperience` stays unconditionally in the server-rendered output (unchanged), so it continues to hold the LCP hero image.

## Testing

- `npm run lint` — clean (initially caught a `react-hooks/set-state-in-effect` violation from a first draft using `useEffect` + `useState`; switched to `useSyncExternalStore`, which is the canonical hydration-safe pattern for this and resolved it).
- `npm test -- --watchAll=false` — 24 suites / 187 tests passing, no regressions.
- `npm run build` — succeeds (the `/sitemap.xml` prerender retry warning is known noise, unrelated to this change, reproduces on master).
- Manual verification: built and served the production bundle, fetched `/` with `curl`, and inspected the HTML:
  - No raw `<img src="/hemicycle.jpg">` / `entrance.jpg` / `exterior-morning.jpg` (the cinematic's unoptimized tags) present.
  - No `<link rel="preload" as="image">` for any of the three JPEGs.
  - No `CinematicExperience` DOM markers (`data-bg`, `data-entry`, `data-fit`, `data-camera`, `data-scene6`, etc.) present at all.
  - Only the pre-existing, unrelated `MobileExperience` `next/image` lazy-loaded variants for `entrance.jpg`/`hemicycle.jpg`/`exterior-morning.jpg` remain (unaffected by this change).

## Risks / Notes

- Desktop now mounts `CinematicExperience` one frame after hydration instead of on first paint — this is the explicitly accepted tradeoff called out in the issue (the scroll experience only starts on scroll, so a one-frame mount delay is not user-visible). `MobileExperience` stays CSS-hidden (`md:hidden`) on desktop from first paint regardless, so there is no flash of the mobile layout during that frame.
- `useReducedMotion()` is checked first and unaffected — `StaticExperience` remains the only thing rendered when reduced motion is requested.
- No test file exists for this component (it's a purely visual/animation component); verification here relied on lint/unit/build plus manual HTML inspection of the served bundle, as noted above.

## Breaking Changes

None.
