### PR TITLE
fix: give deputy photo alt text intentional decorative/descriptive values (MON-196)

### DIFF
--- a/frontend/src/app/accessibilite/page.tsx
+++ b/frontend/src/app/accessibilite/page.tsx
@@ -45,10 +45,6 @@ export default function AccessibilitePage() {
             transitions de l&apos;interface ne tiennent pas compte de la préférence système{' '}
             <code>prefers-reduced-motion</code> (critères RGAA 13.8/13.9 / WCAG 2.3.3).
           </li>
-          <li style={liStyle}>
-            <strong>Texte alternatif minimal sur les photos de député</strong> - l&apos;attribut <code>alt</code>{' '}
-            des portraits contient uniquement le nom du député, sans contexte descriptif (critère RGAA 1.1 / WCAG 1.1.1).
-          </li>
         </ul>
         <p style={{ ...pStyle, margin: '14px 0 0' }}>
           En complément, ces mêmes tests ont confirmé qu&apos;une partie du travail d&apos;accessibilité était déjà en
@@ -60,8 +56,8 @@ export default function AccessibilitePage() {
 
       <LegalSection title="Contenus non accessibles">
         <p style={pStyle}>
-          Les non-conformités listées ci-dessus affectent principalement la page d&apos;accueil et les photos de
-          député. Leur correction est suivie individuellement ; le code source de MonÉlu étant public (voir{' '}
+          La non-conformité listée ci-dessus affecte principalement la page d&apos;accueil. Sa correction est
+          suivie individuellement ; le code source de MonÉlu étant public (voir{' '}
           <Link href="/mentions-legales" style={{ color: 'var(--dp-text)' }}>mentions légales</Link>), l&apos;avancement
           de ces corrections est vérifiable dans l&apos;historique du dépôt.
         </p>

--- a/frontend/src/app/departements/[code]/page.tsx
+++ b/frontend/src/app/departements/[code]/page.tsx
@@ -214,7 +214,7 @@ export default async function DepartmentPage(
                     }}
                   >
                     <div style={{ display: 'flex', alignItems: 'center', gap: 14, minWidth: 0 }}>
-                      <DeputyAvatar name={d.full_name} photoUrl={d.photo_url} size="sm" />
+                      <DeputyAvatar name={d.full_name} photoUrl={d.photo_url} size="sm" decorative />
                       <div style={{ minWidth: 0 }}>
                         <div style={{ fontWeight: 600, fontSize: 15.5, color: NAVY, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
                           {d.full_name}

--- a/frontend/src/app/deputes/DeputiesClient.tsx
+++ b/frontend/src/app/deputes/DeputiesClient.tsx
@@ -346,7 +346,7 @@ export function DeputiesClient({ initial }: { initial: DeputyList }) {
                       >
                         {/* Deputy */}
                         <div style={{ display: 'flex', alignItems: 'center', gap: 14, minWidth: 0 }}>
-                          <DeputyAvatar name={d.full_name} photoUrl={d.photo_url} size="sm" />
+                          <DeputyAvatar name={d.full_name} photoUrl={d.photo_url} size="sm" decorative />
                           <div style={{ minWidth: 0 }}>
                             <div style={{ fontWeight: 600, fontSize: 15.5, color: NAVY, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
                               {d.full_name}

--- a/frontend/src/app/deputes/[id]/dossier/page.tsx
+++ b/frontend/src/app/deputes/[id]/dossier/page.tsx
@@ -80,7 +80,7 @@ export default async function DeputyDossierPage({ params }: { params: Promise<{ 
         <div style={{ display: 'flex', gap: 24, alignItems: 'flex-start', marginBottom: 26 }}>
           <div style={{ width: 80, flexShrink: 0 }}>
             <div style={{ borderRadius: 999, overflow: 'hidden', border: `1px solid ${LINE}` }}>
-              <DeputyAvatar name={deputy.full_name} photoUrl={deputy.photo_url} size="xl" />
+              <DeputyAvatar name={deputy.full_name} photoUrl={deputy.photo_url} size="xl" decorative />
             </div>
           </div>
           <div style={{ flex: 1 }}>

--- a/frontend/src/app/deputes/[id]/page.tsx
+++ b/frontend/src/app/deputes/[id]/page.tsx
@@ -134,7 +134,7 @@ export default async function DeputyPage({ params }: { params: Promise<{ id: str
             {/* Left: photo */}
             <div className="sm:shrink-0" style={{ width: 210 }}>
               <div style={{ borderRadius: 14, overflow: 'hidden', border: `1px solid var(--dp-border-subtle)`, boxShadow: '0 6px 20px var(--dp-avatar-shadow)' }}>
-                <DeputyAvatar name={deputy.full_name} photoUrl={deputy.photo_url} size="2xl" priority />
+                <DeputyAvatar name={deputy.full_name} photoUrl={deputy.photo_url} size="2xl" priority decorative />
               </div>
             </div>
 

--- a/frontend/src/app/deputes/comparer/ComparerClient.tsx
+++ b/frontend/src/app/deputes/comparer/ComparerClient.tsx
@@ -79,7 +79,7 @@ function DeputyPicker({
         display: 'flex', alignItems: 'center', gap: 12, background: 'var(--dp-card-bg)',
         border: `1px solid ${LINE}`, borderRadius: 10, padding: '10px 14px',
       }}>
-        <DeputyAvatar name={selected.full_name} photoUrl={selected.photo_url} size="sm" />
+        <DeputyAvatar name={selected.full_name} photoUrl={selected.photo_url} size="sm" decorative />
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{ fontWeight: 600, fontSize: 15, color: NAVY, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
             {selected.full_name}
@@ -126,7 +126,7 @@ function DeputyPicker({
                 textAlign: 'left',
               }}
             >
-              <DeputyAvatar name={d.full_name} photoUrl={d.photo_url} size="sm" />
+              <DeputyAvatar name={d.full_name} photoUrl={d.photo_url} size="sm" decorative />
               <div style={{ minWidth: 0 }}>
                 <div style={{ fontSize: 14, fontWeight: 600, color: NAVY, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
                   {d.full_name}

--- a/frontend/src/app/groupes/[slug]/page.tsx
+++ b/frontend/src/app/groupes/[slug]/page.tsx
@@ -184,7 +184,7 @@ export default async function GroupPage(
                     }}
                   >
                     <div style={{ display: 'flex', alignItems: 'center', gap: 14, minWidth: 0 }}>
-                      <DeputyAvatar name={m.full_name} photoUrl={m.photo_url} size="sm" />
+                      <DeputyAvatar name={m.full_name} photoUrl={m.photo_url} size="sm" decorative />
                       <div style={{ minWidth: 0 }}>
                         <div style={{ fontWeight: 600, fontSize: 15.5, color: NAVY, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
                           {m.full_name}

--- a/frontend/src/app/mon-depute/page.tsx
+++ b/frontend/src/app/mon-depute/page.tsx
@@ -152,7 +152,7 @@ export default function MonDeputePage() {
           </div>
 
           <div style={{ display: 'flex', gap: 24, alignItems: 'center', flexWrap: 'wrap' }}>
-            <DeputyAvatar name={deputy.full_name} photoUrl={deputy.photo_url} size="lg" />
+            <DeputyAvatar name={deputy.full_name} photoUrl={deputy.photo_url} size="lg" decorative />
             <div style={{ flex: 1, minWidth: 0 }}>
               <h1 className="font-newsreader text-[clamp(26px,3.5vw,38px)]" style={{ fontWeight: 600, color: NAVY, margin: 0, letterSpacing: '-0.015em' }}>
                 {deputy.full_name}

--- a/frontend/src/app/quiz/QuizResultSections.tsx
+++ b/frontend/src/app/quiz/QuizResultSections.tsx
@@ -69,7 +69,7 @@ function DeputyMatchRow({ match, rank }: { match: QuizDeputyMatch; rank?: number
           {rank}
         </span>
       )}
-      <DeputyAvatar name={match.full_name ?? '?'} photoUrl={match.photo_url} size="sm" />
+      <DeputyAvatar name={match.full_name ?? '?'} photoUrl={match.photo_url} size="sm" decorative />
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ fontWeight: 600, fontSize: 15, color: NAVY }}>{match.full_name}</div>
         <div style={{ fontSize: 12.5, color: GRAY, marginTop: 2 }}>
@@ -243,7 +243,7 @@ export function QuizResultSections({
             href={`/deputes/${best.deputy_id}`}
             style={{ ...card, display: 'flex', alignItems: 'center', gap: 20, textDecoration: 'none', borderLeft: `4px solid ${bestHex}` }}
           >
-            <DeputyAvatar name={best.full_name ?? '?'} photoUrl={best.photo_url} size="xl" priority />
+            <DeputyAvatar name={best.full_name ?? '?'} photoUrl={best.photo_url} size="xl" priority decorative />
             <div style={{ flex: 1, minWidth: 0 }}>
               <div style={{ fontWeight: 700, fontSize: 20, color: NAVY }}>{best.full_name}</div>
               <div style={{ fontSize: 14, color: GRAY, marginTop: 4 }}>

--- a/frontend/src/components/DeputyAvatar.tsx
+++ b/frontend/src/components/DeputyAvatar.tsx
@@ -8,6 +8,9 @@ type Props = {
   photoUrl: string | null
   size?: 'sm' | 'lg' | 'xl' | '2xl'
   priority?: boolean
+  /** Set when the deputy's name is already rendered as visible text next to the
+   * avatar, so the image doesn't get announced twice (RGAA 1.1 / WCAG 1.1.1). */
+  decorative?: boolean
 }
 
 const sizes = {
@@ -17,7 +20,7 @@ const sizes = {
   '2xl': { w: 210, h: 262, className: 'text-4xl',           rounded: 'rounded-[14px]' },
 }
 
-export function DeputyAvatar({ name, photoUrl, size = 'sm', priority = false }: Props) {
+export function DeputyAvatar({ name, photoUrl, size = 'sm', priority = false, decorative = false }: Props) {
   const [imgError, setImgError] = useState(false)
   const { w, h, className, rounded } = sizes[size]
   const style = size === '2xl' ? { width: 210, height: 262, flexShrink: 0 } : undefined
@@ -30,7 +33,7 @@ export function DeputyAvatar({ name, photoUrl, size = 'sm', priority = false }: 
       >
         <Image
           src={photoUrl}
-          alt={name}
+          alt={decorative ? '' : name}
           width={w}
           height={h}
           className="object-cover object-top w-full h-full"

--- a/frontend/src/components/home/AssemblyScrollExperience.tsx
+++ b/frontend/src/components/home/AssemblyScrollExperience.tsx
@@ -800,7 +800,7 @@ function CinematicExperience({ stats, leadVote, deputyInfo }: Props) {
                 {deputyInfo?.photoUrl ? (
                   <Image
                     src={deputyInfo.photoUrl}
-                    alt={deputyInfo.name}
+                    alt=""
                     width={94}
                     height={94}
                     style={{ borderRadius: 999, objectFit: 'cover', width: 94, height: 94 }}


### PR DESCRIPTION
## What
Gives every deputy-photo `alt` attribute an intentional value instead of the blanket `alt={name}` default: decorative (`alt=""`) where the deputy's name is already visible as adjacent text, unchanged descriptive otherwise.

## Why
`DeputyAvatar.tsx` and the equivalent raw `<Image>` in `AssemblyScrollExperience.tsx` set `alt={name}` on every deputy portrait. In every current usage the deputy's full name is already rendered as visible text right next to (or below) the photo, so a screen reader announces the name twice per deputy — a minor RGAA 1.1 / WCAG 1.1.1 gap flagged during the RGAA self-audit (MON-113, tracked as MON-196).

## Changes
- `DeputyAvatar.tsx`: added an explicit `decorative?: boolean` prop (default `false`, preserving existing behavior); when `true`, the image's `alt` is `""` instead of the deputy's name.
- Set `decorative` at all 9 call sites where the name is already shown as visible caption text next to the avatar: `mon-depute/page.tsx`, `deputes/[id]/page.tsx`, `deputes/DeputiesClient.tsx`, `groupes/[slug]/page.tsx`, `deputes/comparer/ComparerClient.tsx` (both usages), `deputes/[id]/dossier/page.tsx`, `quiz/QuizResultSections.tsx` (both usages), `departements/[code]/page.tsx`.
- `AssemblyScrollExperience.tsx`: the hero deputy-card photo (name rendered directly below it) now uses `alt=""` instead of `alt={deputyInfo.name}`.
- `accessibilite/page.tsx`: removed the now-fixed "texte alternatif minimal sur les photos de député" non-conformity entry and updated the surrounding summary text, per the issue's second acceptance criterion.

## Testing
- `npm run lint` — clean
- `npx tsc --noEmit` — clean
- `npm test` — 197 tests passed
- `npm run build` — succeeds (known `sitemap.xml` prerender retry noise reproduces on master, unrelated to this change)

## Risks / Notes
- No dense-grid or carousel deputy-photo usage currently exists without an adjacent visible name, so every real call site opted into `decorative`; the prop defaults to descriptive (`false`) for any future usage that doesn't set it explicitly.

## Breaking Changes
None.

https://claude.ai/code/session_01NBXJGrMubD6kHPNLMPfP7Z