### PR TITLE
fix: honor prefers-reduced-motion for page transitions (MON-194)

### DIFF
--- a/frontend/src/app/accessibilite/page.tsx
+++ b/frontend/src/app/accessibilite/page.tsx
@@ -41,11 +41,6 @@ export default function AccessibilitePage() {
         <p style={pStyle}>Non-conformités identifiées à ce jour :</p>
         <ul style={{ margin: '10px 0 0', paddingLeft: '20px', display: 'flex', flexDirection: 'column', gap: '10px' }}>
           <li style={liStyle}>
-            <strong>Animations non désactivables</strong> - le défilement animé de la page d&apos;accueil et les
-            transitions de l&apos;interface ne tiennent pas compte de la préférence système{' '}
-            <code>prefers-reduced-motion</code> (critères RGAA 13.8/13.9 / WCAG 2.3.3).
-          </li>
-          <li style={liStyle}>
             <strong>Texte alternatif minimal sur les photos de député</strong> - l&apos;attribut <code>alt</code>{' '}
             des portraits contient uniquement le nom du député, sans contexte descriptif (critère RGAA 1.1 / WCAG 1.1.1).
           </li>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -12,6 +12,19 @@
 @keyframes nudge { 0%,100% { transform: translate(-50%,0); } 50% { transform: translate(-50%,5px); } }
 [data-hint] { animation: nudge 2s ease-in-out infinite; }
 
+/* RGAA 13.8/13.9, WCAG 2.3.3: honor the OS "reduce motion" preference as a
+   CSS-level fallback in addition to the JS useReducedMotion() gates - this
+   catches any transition/animation that isn't already gated in script
+   (MON-194). */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 :root {
   --color-bg: theme('colors.gray.off');
   --color-fg: theme('colors.navy.DEFAULT');

--- a/frontend/src/components/PageTransition.tsx
+++ b/frontend/src/components/PageTransition.tsx
@@ -1,15 +1,22 @@
 'use client'
 
 import { usePathname } from 'next/navigation'
+import { useReducedMotion } from 'framer-motion'
 import { useEffect, useRef } from 'react'
 
 export function PageTransition({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
   const ref = useRef<HTMLDivElement>(null)
+  const reduceMotion = useReducedMotion()
 
   useEffect(() => {
     const el = ref.current
     if (!el) return
+    if (reduceMotion) {
+      el.style.opacity = '1'
+      el.style.transform = 'none'
+      return
+    }
     el.style.opacity = '0'
     el.style.transform = 'translateY(6px)'
     const raf = requestAnimationFrame(() => {
@@ -18,7 +25,7 @@ export function PageTransition({ children }: { children: React.ReactNode }) {
       el.style.transform = 'translateY(0)'
     })
     return () => cancelAnimationFrame(raf)
-  }, [pathname])
+  }, [pathname, reduceMotion])
 
   return <div ref={ref}>{children}</div>
 }


### PR DESCRIPTION
## What
Closes the remaining gap in `prefers-reduced-motion` support flagged by the RGAA self-audit (MON-194, RGAA 13.8/13.9 / WCAG 2.3.3), and removes the now-fixed item from the `/accessibilite` declaration.

## Why
The audit found `prefers-reduced-motion` unreferenced by literal grep, but the landing page's cinematic scroll hero (`AssemblyScrollExperience.tsx`) already gates on framer-motion's `useReducedMotion()` and falls back to `StaticExperience` — that's why the string search came up empty even though the behavior existed. Auditing the actual remaining continuous/large-motion effects turned up two real gaps: `PageTransition.tsx`, an unguarded fade + 6px translate that runs on every route change site-wide, and no CSS-level `prefers-reduced-motion` fallback in `globals.css` for anything not already gated in script (e.g. the `nudge` scroll-hint keyframe).

## Changes
- `frontend/src/components/PageTransition.tsx`: read `useReducedMotion()` and skip the fade/translate animation when set, showing content immediately instead.
- `frontend/src/app/globals.css`: add a global `@media (prefers-reduced-motion: reduce)` override that collapses animation/transition durations and disables smooth scrolling, as a CSS-level fallback in addition to the existing JS gates (`AssemblyScrollExperience`, `LiveAssemblyPulse`, `QuizDeck`, and now `PageTransition`).
- `frontend/src/app/accessibilite/page.tsx`: remove the "Animations non désactivables" non-conformity item now that it's fixed, following the same pattern as the MON-192/193/195 fixes.

## Testing
- `npm run lint` — clean.
- `npm test` — 25 suites / 197 tests pass.
- `npm run build` — compiles and type-checks cleanly; the `/votes` prerender step fails locally with a 500 from the API, but that's a pre-existing local-environment gap (no local API/DB running against which to statically generate that page) — confirmed the change only touches `PageTransition.tsx`, `globals.css`, and the static `/accessibilite` page, none of which touch `/votes` data fetching.
- Not manually tested in a real browser with OS-level "reduce motion" toggled (no interactive browser session in this environment) — reasoned through the code path instead: `useReducedMotion()` from framer-motion reflects `matchMedia('(prefers-reduced-motion: reduce)')` synchronously on first client render, so `AssemblyScrollExperience` renders `StaticExperience` and `PageTransition` skips its transition, for a user with the OS preference set.

## Risks / Notes
- No schema, deploy config, or CI workflow changes.
- The global CSS override in `globals.css` is a broad `*` selector; it only fires under `prefers-reduced-motion: reduce` and only clamps animation/transition *duration*, so it shouldn't visually break anything — it just makes the very short hover micro-transitions (e.g. `HemicycleChart` seat dots) effectively instant too, which is expected and desired.

## Breaking Changes
None.
