### PR TITLE
feat: agenda ingestion - migration + ingest_agenda.py (MON-210)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "CLAUDE.md",
         "hashed_secret": "ffddd4c9867f24ed207b1da5b50693e6d85a7889",
         "is_verified": false,
-        "line_number": 174
+        "line_number": 175
       }
     ],
     "README.md": [
@@ -252,5 +252,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-28T21:33:11Z"
+  "generated_at": "2026-08-03T20:41:40Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ Assemblée Nationale Open Data (ZIPs)
 **`scripts/`** — Data ingestion and maintenance
 - Scripts fetch ZIPs from the AN open data portal with exponential-backoff retry (5 attempts, 2 s base) and upsert via `ON CONFLICT ... DO UPDATE`
 - `migrate.py` doubles as the Railway start hook (runs before uvicorn in `railway.json`)
-- `run_ingestion_prod.py` orchestrates the full pipeline for production runs
+- `run_ingestion_prod.py` orchestrates the full pipeline for production runs, including `ingest_agenda.py` (MON-210) as a non-critical step - an agenda-feed failure must not block core deputies/votes/positions ingestion
 - `create_dbt_profile.py` generates `transform/profiles.yml` from `DBT_*` env vars (used by CI and deploy workflows)
 
 **`transform/`** — dbt project
@@ -158,6 +158,7 @@ Assemblée Nationale Open Data (ZIPs)
 | `chat_shares` | Stored chat/RAG answer snapshots (MON-66, ADR-024): immutable snapshots behind `/chat/s/<id>` share URLs |
 | `quiz_shares` | Stored quiz result snapshots (MON-139, ADR-025): server-recomputed, immutable snapshots behind `/quiz/s/<id>` share URLs; `result` JSONB optionally carries the sharer's answers when they opt in (MON-184, ADR-028) |
 | `feedback` | Generic user-feedback sink (MON-70, MON-101): `type`-discriminated rows (`chat` thumbs / `report` data-page error reports) with a JSONB `payload`; weekly manual triage query in `docs/monitoring.md` |
+| `agenda_items` | Séance publique ODJ points (MON-210, ADR-030): one denormalized row per point, upserted only - never deleted. `dossier_id` joins `votes.dossier_id`. `last_seen_at` plus `reunion_etat`/`point_etat` (not `DELETE`) are how cancelled or dropped items are reflected |
 
 Important data quirks:
 - `nonVotant` ≠ `abstention`: present in chamber but did not vote vs. formally abstained

--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ Next.js 15 (App Router) + Tailwind + Framer Motion, deployed on Vercel separatel
 | `ingest_votes.py` | Downloads Scrutins ZIP, upserts votes (`--since` flag) |
 | `ingest_positions.py` | Extracts individual deputy positions from Scrutins ZIP |
 | `ingest_organes.py` | Parses `Organes.json` for parliamentary group membership |
+| `ingest_agenda.py` | Downloads the Agenda ZIP, upserts séance publique ODJ points (`--since` flag, MON-210) |
 | `run_ingestion_prod.py` | Orchestrates the full pipeline with timing summary |
 | `update_party.py` | Resolves GP party names and expands department codes |
 | `backfill_party_labels.py` | Enforces the 12 canonical group labels behind `/groups/{slug}` |

--- a/data/migrations/009_agenda.sql
+++ b/data/migrations/009_agenda.sql
@@ -1,0 +1,33 @@
+-- MonÉlu — agenda ingestion: séance publique ODJ points (MON-210, ADR-030)
+-- Idempotent: CREATE TABLE IF NOT EXISTS — safe to re-run.
+
+-- One denormalized row per ODJ point, with the parent réunion's fields
+-- inlined. Refreshed by upsert only (CLAUDE.md decision 8) — cancellations
+-- and silent drops are both reflected via reunion_etat / point_etat and
+-- last_seen_at, never by DELETE. See ADR-030 for the full reasoning.
+CREATE TABLE IF NOT EXISTS agenda_items (
+    point_uid       TEXT PRIMARY KEY,        -- ODJ point uid, e.g. RUANR5L17S2026IDS29879PT50907
+    reunion_uid     TEXT NOT NULL,           -- parent réunion uid
+    sitting_start   TIMESTAMPTZ NOT NULL,    -- réunion timeStampDebut
+    sitting_end     TIMESTAMPTZ,             -- réunion timeStampFin
+    objet           TEXT,                    -- free text; may be a one-word stub
+    point_type      TEXT,                    -- typePointODJ ("Vote solennel", "Discussion", …)
+    travaux_nature  TEXT,                    -- natureTravauxODJ (ODJPR | ODJSN | ODJAN)
+    procedure_label TEXT,                    -- point procedure; present on ~5 % of points
+    dossier_id      TEXT,                    -- dossiersLegislatifsRefs.dossierRef; joins votes.dossier_id
+    reunion_etat    TEXT NOT NULL,           -- réunion cycleDeVie.etat (Confirmé | Annulé | Supprimé | Eventuel)
+    point_etat      TEXT,                    -- point cycleDeVie.etat
+    published_at    DATE,                    -- cycleDeVie.chrono.creation, when the item was scheduled
+    cancelled_at    DATE,                    -- cycleDeVie.chrono.cloture, set when cancelled
+    objet_hash      TEXT,                    -- sha256 of objet; drives summary regeneration
+    summary_plain   TEXT,                    -- Groq one-liner; NULL for stubs, by design
+    theme           TEXT,                    -- one of VALID_THEMES, or NULL
+    last_seen_at    TIMESTAMPTZ NOT NULL,    -- stamped on every ingestion run
+    ingested_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Every API query is a date window (MON-212's GET /agenda).
+CREATE INDEX IF NOT EXISTS idx_agenda_items_sitting_start ON agenda_items (sitting_start);
+
+-- Joins to votes.dossier_id (ADR-030 decision 4).
+CREATE INDEX IF NOT EXISTS idx_agenda_items_dossier_id ON agenda_items (dossier_id);

--- a/scripts/ingest_agenda.py
+++ b/scripts/ingest_agenda.py
@@ -1,0 +1,279 @@
+"""
+ingest_agenda.py
+Downloads the Agenda ZIP export from the Assemblée Nationale open-data portal
+and upserts each séance publique ODJ point into the agenda_items table
+(MON-210, ADR-030).
+
+Only réunions of @xsi:type "seance_type" (séance publique) are ingested;
+commission réunions are skipped by design (ADR-030 decision 3).
+
+Refresh is soft-state: every touched row is upserted with last_seen_at
+stamped, nothing is ever deleted. A réunion that becomes Annulé/Supprimé
+still has its rows upserted with the new état — the API (MON-212) is
+responsible for hiding cancelled/stale items, not this script.
+
+Usage:
+    python scripts/ingest_agenda.py                       # default: rolling 90 days
+    python scripts/ingest_agenda.py --since 2026-01-01     # current year only
+    python scripts/ingest_agenda.py --zip-path /tmp/Agenda.json.zip
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import logging
+import os
+import zipfile
+from datetime import date, timedelta
+
+import psycopg2.extras
+from dotenv import load_dotenv
+
+try:
+    from scripts._http import connect_with_retry, download_with_retry
+except ImportError:  # running as a plain file: python scripts/ingest_agenda.py
+    from _http import connect_with_retry, download_with_retry
+
+load_dotenv()
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+log = logging.getLogger(__name__)
+
+AN_BASE_URL = os.getenv("AN_API_BASE_URL", "https://data.assemblee-nationale.fr")
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+AGENDA_ZIP_PATH = "/static/openData/repository/17/vp/reunions/Agenda.json.zip"
+
+SEANCE_XSI_TYPE = "seance_type"
+CANCELLED_ETATS = {"Annulé", "Supprimé"}
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+
+def fetch_all_reunions(zip_path: str | None = None) -> list[dict]:
+    """Load every réunion record from a local ZIP or the AN portal."""
+    if zip_path:
+        log.info("Reading agenda ZIP from %s…", zip_path)
+        with open(zip_path, "rb") as fh:
+            raw = fh.read()
+    else:
+        url = f"{AN_BASE_URL}{AGENDA_ZIP_PATH}"
+        log.info("Downloading agenda ZIP from %s…", url)
+        raw = download_with_retry(url)
+
+    reunions = []
+    with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+        names = [n for n in zf.namelist() if n.startswith("json/reunion/") and n.endswith(".json")]
+        log.info("ZIP contains %d réunion files.", len(names))
+        for name in names:
+            with zf.open(name) as f:
+                data = json.load(f)
+            reunion = data.get("reunion") or data
+            reunions.append(reunion)
+    return reunions
+
+
+# ---------------------------------------------------------------------------
+# Transform
+# ---------------------------------------------------------------------------
+
+
+def _odj_points(reunion: dict) -> list[dict]:
+    """Return the réunion's ODJ points.
+
+    pointODJ is a bare object when the sitting has a single point and a list
+    when it has several — both shapes occur in the feed.
+    """
+    points = ((reunion.get("ODJ") or {}).get("pointsODJ") or {}).get("pointODJ")
+    if points is None:
+        return []
+    return points if isinstance(points, list) else [points]
+
+
+def _as_date(value: str | None) -> str | None:
+    if not value:
+        return None
+    return value[:10]
+
+
+def _first_ref(value) -> str | None:
+    """dossierRef (and similar) may arrive as a bare string, a dict with
+    #text, or a list when several apply — always take the first plain ref."""
+    if value is None:
+        return None
+    if isinstance(value, list):
+        value = value[0] if value else None
+    if isinstance(value, dict):
+        return value.get("#text") or value.get("ref")
+    return str(value) if value else None
+
+
+def _dossier_id(point: dict) -> str | None:
+    refs = point.get("dossiersLegislatifsRefs") or {}
+    return _first_ref(refs.get("dossierRef"))
+
+
+def parse_point(reunion: dict, point: dict) -> dict | None:
+    """Flatten one réunion + one of its ODJ points into an agenda_items row."""
+    try:
+        point_uid = point.get("uid") or ""
+        reunion_uid = reunion.get("uid") or ""
+        if not point_uid or not reunion_uid:
+            return None
+
+        sitting_start = reunion.get("timeStampDebut") or None
+        if not sitting_start:
+            return None
+        sitting_end = reunion.get("timeStampFin") or None
+
+        reunion_life = reunion.get("cycleDeVie") or {}
+        reunion_etat = reunion_life.get("etat") or ""
+        reunion_chrono = reunion_life.get("chrono") or {}
+
+        point_life = point.get("cycleDeVie") or {}
+        point_etat = point_life.get("etat") or None
+        point_chrono = point_life.get("chrono") or reunion_chrono
+
+        objet = point.get("objet") or None
+        if isinstance(objet, dict):
+            objet = objet.get("#text")
+        objet = str(objet).strip() if objet else None
+
+        procedure = point.get("procedure") or None
+        if isinstance(procedure, dict):
+            procedure = procedure.get("libelle") or procedure.get("#text")
+
+        return {
+            "point_uid": point_uid,
+            "reunion_uid": reunion_uid,
+            "sitting_start": sitting_start,
+            "sitting_end": sitting_end,
+            "objet": objet,
+            "point_type": point.get("typePointODJ") or None,
+            "travaux_nature": point.get("natureTravauxODJ") or None,
+            "procedure_label": str(procedure) if procedure else None,
+            "dossier_id": _dossier_id(point),
+            "reunion_etat": reunion_etat,
+            "point_etat": point_etat,
+            "published_at": _as_date(point_chrono.get("creation")),
+            "cancelled_at": _as_date(point_chrono.get("cloture")),
+            "objet_hash": hashlib.sha256(objet.encode("utf-8")).hexdigest() if objet else None,
+        }
+    except Exception as exc:
+        log.debug("Could not parse ODJ point %s — %s", point.get("uid"), exc)
+        return None
+
+
+def parse_reunions(reunions: list[dict], since: str | None = None) -> list[dict]:
+    """Filter to séance publique réunions and flatten every ODJ point."""
+    records: list[dict] = []
+    skipped_type = 0
+    skipped_date = 0
+    for reunion in reunions:
+        if reunion.get("@xsi:type") != SEANCE_XSI_TYPE:
+            skipped_type += 1
+            continue
+        sitting_date = (reunion.get("timeStampDebut") or "")[:10]
+        if since and sitting_date and sitting_date < since:
+            skipped_date += 1
+            continue
+        for point in _odj_points(reunion):
+            record = parse_point(reunion, point)
+            if record is not None:
+                records.append(record)
+
+    log.info(
+        "Parsed %d ODJ points from séance publique réunions "
+        "(skipped %d non-séance réunions, %d before --since).",
+        len(records),
+        skipped_type,
+        skipped_date,
+    )
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Upsert
+# ---------------------------------------------------------------------------
+
+UPSERT_SQL = """
+INSERT INTO agenda_items (
+    point_uid, reunion_uid, sitting_start, sitting_end,
+    objet, point_type, travaux_nature, procedure_label, dossier_id,
+    reunion_etat, point_etat, published_at, cancelled_at, objet_hash,
+    last_seen_at, ingested_at
+) VALUES (
+    %(point_uid)s, %(reunion_uid)s, %(sitting_start)s, %(sitting_end)s,
+    %(objet)s, %(point_type)s, %(travaux_nature)s, %(procedure_label)s, %(dossier_id)s,
+    %(reunion_etat)s, %(point_etat)s, %(published_at)s, %(cancelled_at)s, %(objet_hash)s,
+    NOW(), NOW()
+)
+ON CONFLICT (point_uid) DO UPDATE SET
+    reunion_uid     = EXCLUDED.reunion_uid,
+    sitting_start   = EXCLUDED.sitting_start,
+    sitting_end     = EXCLUDED.sitting_end,
+    objet           = EXCLUDED.objet,
+    point_type      = EXCLUDED.point_type,
+    travaux_nature  = EXCLUDED.travaux_nature,
+    procedure_label = EXCLUDED.procedure_label,
+    dossier_id      = EXCLUDED.dossier_id,
+    reunion_etat    = EXCLUDED.reunion_etat,
+    point_etat      = EXCLUDED.point_etat,
+    published_at    = EXCLUDED.published_at,
+    cancelled_at    = EXCLUDED.cancelled_at,
+    objet_hash      = EXCLUDED.objet_hash,
+    last_seen_at    = NOW();
+"""
+
+
+def upsert_agenda_items(records: list[dict]) -> None:
+    conn = connect_with_retry(DATABASE_URL)
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                psycopg2.extras.execute_batch(cur, UPSERT_SQL, records, page_size=500)
+        log.info("Upsert complete — %d agenda items written.", len(records))
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Ingest AN séance publique agenda into MonÉlu DB")
+    parser.add_argument(
+        "--since",
+        default=(date.today() - timedelta(days=90)).isoformat(),
+        help="Only ingest réunions on or after this date (YYYY-MM-DD). Default: rolling 90 days.",
+    )
+    parser.add_argument(
+        "--zip-path",
+        default=None,
+        help="Path to an already-downloaded Agenda.json.zip (skips the download).",
+    )
+    args = parser.parse_args()
+
+    if not DATABASE_URL:
+        raise EnvironmentError("DATABASE_URL is not set. Copy .env.example to .env and fill it in.")
+
+    log.info("=== Starting agenda ingestion (since %s) ===", args.since)
+    reunions = fetch_all_reunions(zip_path=args.zip_path)
+    records = parse_reunions(reunions, since=args.since)
+    upsert_agenda_items(records)
+    log.info("=== Agenda ingestion finished ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ingest_agenda.py
+++ b/scripts/ingest_agenda.py
@@ -139,6 +139,10 @@ def parse_point(reunion: dict, point: dict) -> dict | None:
         reunion_etat = reunion_life.get("etat") or ""
         reunion_chrono = reunion_life.get("chrono") or {}
 
+        # point_etat is stored as-is from the feed and is not guaranteed to be
+        # updated in lockstep with reunion_etat when a sitting is cancelled —
+        # readers (MON-212) should treat reunion_etat as the authoritative
+        # cancellation signal and point_etat as a secondary, point-level one.
         point_life = point.get("cycleDeVie") or {}
         point_etat = point_life.get("etat") or None
         point_chrono = point_life.get("chrono") or reunion_chrono
@@ -255,8 +259,12 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Ingest AN séance publique agenda into MonÉlu DB")
     parser.add_argument(
         "--since",
-        default=(date.today() - timedelta(days=90)).isoformat(),
-        help="Only ingest réunions on or after this date (YYYY-MM-DD). Default: rolling 90 days.",
+        # Matches ingest_votes.py / run_ingestion_prod.py's default so a
+        # standalone run behaves the same as the orchestrated one — the
+        # orchestrator always passes --since explicitly, but this default is
+        # what you get running the script directly with no flag.
+        default=(date.today() - timedelta(days=365)).isoformat(),
+        help="Only ingest réunions on or after this date (YYYY-MM-DD). Default: rolling 12 months.",
     )
     parser.add_argument(
         "--zip-path",

--- a/scripts/run_ingestion_prod.py
+++ b/scripts/run_ingestion_prod.py
@@ -168,6 +168,15 @@ def main() -> None:
             if t_party is None:
                 soft_failures.append("Fix party + department names")
 
+            # Non-critical: the agenda export is a separate feed (MON-210,
+            # ADR-030) from the scrutins/deputies ZIPs above, so a failure here
+            # must not block core votes/deputies/positions ingestion.
+            t_agenda = run_step(
+                "Agenda", "ingest_agenda.py", ["--since", args.since], critical=False
+            )
+            if t_agenda is None:
+                soft_failures.append("Agenda")
+
         n_deputies = row_count(lock_conn, "deputies")
         n_votes = row_count(lock_conn, "votes")
         n_positions = row_count(lock_conn, "vote_positions")
@@ -211,6 +220,7 @@ def main() -> None:
         log.info("║  Votes     : %6d   (%5.1fs)      ║", n_votes, t_votes)
         log.info("║  Positions : %6d   (%5.1fs)      ║", n_positions, t_positions)
         log.info("║  Party fix :          (%s)      ║", _fmt(t_party))
+        log.info("║  Agenda    :          (%s)      ║", _fmt(t_agenda))
         log.info("║  Summaries :          (%s)      ║", _fmt(t_summaries))
         log.info("╠══════════════════════════════════════╣")
         log.info("║  Total time: %.1fs                   ║", total_elapsed)

--- a/tests/fixtures/agenda_sample.json
+++ b/tests/fixtures/agenda_sample.json
@@ -1,0 +1,109 @@
+[
+  {
+    "uid": "RUANR5L17S2026IDS29879",
+    "@xsi:type": "seance_type",
+    "timeStampDebut": "2026-01-14T09:30:00",
+    "timeStampFin": "2026-01-14T13:00:00",
+    "cycleDeVie": {
+      "etat": "Confirmé",
+      "chrono": { "creation": "2026-01-05", "cloture": null }
+    },
+    "ODJ": {
+      "pointsODJ": {
+        "pointODJ": {
+          "uid": "RUANR5L17S2026IDS29879PT50907",
+          "objet": "Discussion du projet de loi de finances pour 2027",
+          "typePointODJ": "Discussion générale",
+          "natureTravauxODJ": "ODJAN",
+          "procedure": { "libelle": "Procédure accélérée" },
+          "dossiersLegislatifsRefs": { "dossierRef": "DLR5L17N53980" },
+          "cycleDeVie": {
+            "etat": "Confirmé",
+            "chrono": { "creation": "2026-01-05", "cloture": null }
+          }
+        }
+      }
+    }
+  },
+  {
+    "uid": "RUANR5L17S2026IDS29900",
+    "@xsi:type": "seance_type",
+    "timeStampDebut": "2026-01-15T15:00:00",
+    "timeStampFin": "2026-01-15T20:00:00",
+    "cycleDeVie": {
+      "etat": "Confirmé",
+      "chrono": { "creation": "2026-01-06", "cloture": null }
+    },
+    "ODJ": {
+      "pointsODJ": {
+        "pointODJ": [
+          {
+            "uid": "RUANR5L17S2026IDS29900PT50920",
+            "objet": "Questions au Gouvernement",
+            "typePointODJ": "Questions au Gouvernement",
+            "natureTravauxODJ": "ODJAN",
+            "cycleDeVie": {
+              "etat": "Confirmé",
+              "chrono": { "creation": "2026-01-06", "cloture": null }
+            }
+          },
+          {
+            "uid": "RUANR5L17S2026IDS29900PT50921",
+            "objet": "Vote solennel sur la proposition de loi relative à la transition énergétique",
+            "typePointODJ": "Vote solennel",
+            "natureTravauxODJ": "ODJAN",
+            "dossiersLegislatifsRefs": { "dossierRef": "DLR5L17N54012" },
+            "cycleDeVie": {
+              "etat": "Confirmé",
+              "chrono": { "creation": "2026-01-06", "cloture": null }
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "uid": "RUANR5L17S2026IDS29950",
+    "@xsi:type": "seance_type",
+    "timeStampDebut": "2026-01-20T09:30:00",
+    "timeStampFin": "2026-01-20T13:00:00",
+    "cycleDeVie": {
+      "etat": "Annulé",
+      "chrono": { "creation": "2026-01-10", "cloture": "2026-01-18" }
+    },
+    "ODJ": {
+      "pointsODJ": {
+        "pointODJ": {
+          "uid": "RUANR5L17S2026IDS29950PT50999",
+          "objet": "Discussion",
+          "typePointODJ": "Discussion générale",
+          "natureTravauxODJ": "ODJAN",
+          "cycleDeVie": {
+            "etat": "Annulé",
+            "chrono": { "creation": "2026-01-10", "cloture": "2026-01-18" }
+          }
+        }
+      }
+    }
+  },
+  {
+    "uid": "RUANR5L17C2026IDS30000",
+    "@xsi:type": "commission_type",
+    "timeStampDebut": "2026-01-14T09:00:00",
+    "timeStampFin": "2026-01-14T11:00:00",
+    "cycleDeVie": {
+      "etat": "Confirmé",
+      "chrono": { "creation": "2026-01-05", "cloture": null }
+    },
+    "ODJ": {
+      "pointsODJ": {
+        "pointODJ": {
+          "uid": "RUANR5L17C2026IDS30000PT60000",
+          "objet": "Examen du rapport annuel",
+          "typePointODJ": "Examen de rapport",
+          "natureTravauxODJ": "ODJPR"
+        }
+      }
+    }
+  }
+]

--- a/tests/test_agenda_parsers.py
+++ b/tests/test_agenda_parsers.py
@@ -1,0 +1,126 @@
+"""
+Tests for the agenda ZIP parser (MON-210, ADR-030).
+
+All pure-function tests — no mocks, no DB, no network. Covers the single-point
+vs list-point pointODJ shape, séance-vs-commission filtering, a cancelled
+réunion, and a point with no dossierRef.
+"""
+
+import json
+from pathlib import Path
+
+from scripts.ingest_agenda import _odj_points, parse_point, parse_reunions
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load_reunions() -> list[dict]:
+    return json.loads((FIXTURES / "agenda_sample.json").read_text())
+
+
+def _reunion(uid: str) -> dict:
+    return next(r for r in _load_reunions() if r["uid"] == uid)
+
+
+# ---------------------------------------------------------------------------
+# _odj_points — single-point vs list shape
+# ---------------------------------------------------------------------------
+
+
+def test_odj_points_single_bare_object():
+    reunion = _reunion("RUANR5L17S2026IDS29879")
+    points = _odj_points(reunion)
+    assert len(points) == 1
+    assert points[0]["uid"] == "RUANR5L17S2026IDS29879PT50907"
+
+
+def test_odj_points_list_shape():
+    reunion = _reunion("RUANR5L17S2026IDS29900")
+    points = _odj_points(reunion)
+    assert len(points) == 2
+    assert {p["uid"] for p in points} == {
+        "RUANR5L17S2026IDS29900PT50920",
+        "RUANR5L17S2026IDS29900PT50921",
+    }
+
+
+def test_odj_points_empty_when_missing():
+    assert _odj_points({}) == []
+
+
+# ---------------------------------------------------------------------------
+# parse_point
+# ---------------------------------------------------------------------------
+
+
+def test_parse_point_with_dossier_ref():
+    reunion = _reunion("RUANR5L17S2026IDS29879")
+    point = _odj_points(reunion)[0]
+    record = parse_point(reunion, point)
+    assert record is not None
+    assert record["point_uid"] == "RUANR5L17S2026IDS29879PT50907"
+    assert record["reunion_uid"] == "RUANR5L17S2026IDS29879"
+    assert record["dossier_id"] == "DLR5L17N53980"
+    assert record["procedure_label"] == "Procédure accélérée"
+    assert record["reunion_etat"] == "Confirmé"
+    assert record["published_at"] == "2026-01-05"
+    assert record["cancelled_at"] is None
+    assert record["objet_hash"] is not None
+
+
+def test_parse_point_without_dossier_ref():
+    """A point with no dossierRef (e.g. Questions au Gouvernement) parses fine
+    and carries dossier_id=None rather than raising."""
+    reunion = _reunion("RUANR5L17S2026IDS29900")
+    point = next(p for p in _odj_points(reunion) if p["uid"] == "RUANR5L17S2026IDS29900PT50920")
+    record = parse_point(reunion, point)
+    assert record is not None
+    assert record["dossier_id"] is None
+    assert record["objet"] == "Questions au Gouvernement"
+
+
+def test_parse_point_missing_uid_returns_none():
+    reunion = _reunion("RUANR5L17S2026IDS29879")
+    assert parse_point(reunion, {}) is None
+
+
+def test_parse_point_missing_sitting_start_returns_none():
+    assert parse_point({"uid": "R1"}, {"uid": "P1"}) is None
+
+
+# ---------------------------------------------------------------------------
+# Cancelled réunion — reflected, not dropped (ADR-030)
+# ---------------------------------------------------------------------------
+
+
+def test_cancelled_reunion_reflected_in_etat_and_cancelled_at():
+    reunion = _reunion("RUANR5L17S2026IDS29950")
+    point = _odj_points(reunion)[0]
+    record = parse_point(reunion, point)
+    assert record is not None
+    assert record["reunion_etat"] == "Annulé"
+    assert record["point_etat"] == "Annulé"
+    assert record["cancelled_at"] == "2026-01-18"
+
+
+# ---------------------------------------------------------------------------
+# parse_reunions — séance-only filtering + --since window
+# ---------------------------------------------------------------------------
+
+
+def test_parse_reunions_filters_out_commission():
+    records = parse_reunions(_load_reunions())
+    reunion_uids = {r["reunion_uid"] for r in records}
+    assert "RUANR5L17C2026IDS30000" not in reunion_uids
+
+
+def test_parse_reunions_includes_all_seance_points():
+    records = parse_reunions(_load_reunions())
+    # 1 (single) + 2 (list) + 1 (cancelled) = 4 séance ODJ points
+    assert len(records) == 4
+
+
+def test_parse_reunions_since_filters_older_sittings():
+    records = parse_reunions(_load_reunions(), since="2026-01-16")
+    reunion_uids = {r["reunion_uid"] for r in records}
+    assert reunion_uids == {"RUANR5L17S2026IDS29950"}


### PR DESCRIPTION
## What
Adds the agenda ingestion pipeline for MON-110: a new `agenda_items` table and `scripts/ingest_agenda.py`, which pulls the AN agenda export and lands séance publique ODJ points in the database.

## Why
ADR-030 (MON-209) fixed the table shape and refresh semantics for the agenda feature.
This PR implements exactly that: one denormalized `agenda_items` table, upserted only, scoped to séance publique.
It unblocks MON-212 (`GET /agenda` endpoints) and MON-211 (plain-French summaries).

## Changes
- `data/migrations/009_agenda.sql` — creates `agenda_items` per the ADR-030 column set, `CREATE TABLE IF NOT EXISTS` (safe to re-run), with indexes on `sitting_start` (date-window queries) and `dossier_id` (the join to `votes`).
- `scripts/ingest_agenda.py` — downloads/reads the `Agenda.json.zip` export, filters to `@xsi:type = seance_type` (séance publique only), flattens each réunion's ODJ point(s) (`pointODJ` is a bare object for a single point and a list for several — both handled), and upserts on `point_uid` with `last_seen_at` stamped on every touched row. Cancellations are reflected via `reunion_etat`/`point_etat` and `cancelled_at`, never via `DELETE` (upsert-only rule, CLAUDE.md decision 8).
- `scripts/run_ingestion_prod.py` — wires in an "Agenda" step via `run_step(..., critical=False)`, matching the party-fix/summaries pattern: an agenda-feed outage must not block core deputies/votes/positions ingestion. No workflow file changes needed — `.github/workflows/ingest_prod.yml` already invokes `run_ingestion_prod.py`.
- `tests/test_agenda_parsers.py` + `tests/fixtures/agenda_sample.json` — pure-function tests over a committed JSON fixture covering: the single-point vs list `pointODJ` shape, séance-vs-commission filtering, a cancelled réunion (`Annulé`), a point with no `dossierRef`, and the `--since` window.
- `CLAUDE.md` / `README.md` — documented the new table and script.

Out of scope by design (ADR-030 / follow-up issues): `summary_plain`/`theme` population (MON-211), `GET /agenda` (MON-212).

## Testing
- `python3 -m pytest tests/ -m "not integration" -q` — 352 passed (baseline unchanged).
- `python3 -m ruff check .` and `python3 -m ruff format --check .` — clean.
- Manually built a zip fixture from `tests/fixtures/agenda_sample.json` and ran `fetch_all_reunions` + `parse_reunions` against it end-to-end — correctly parses 4 séance ODJ points, filters out the commission réunion, and reflects the cancelled réunion's état.
- Not tested: the live `--zip-path` upsert against a running Postgres and the `make migrate` idempotency check — Docker wasn't available in this environment. The parsing/transform logic (the part with real risk of AN-feed-shape bugs) is covered by the unit tests above; the upsert SQL itself mirrors the already-proven `ingest_votes.py` pattern.

## Risks / Notes
- New migration (`009_agenda.sql`) — additive only (`CREATE TABLE IF NOT EXISTS` + two indexes), no changes to existing tables.
- Reviewers should verify the live DB path (`make migrate` then `python scripts/ingest_agenda.py --zip-path <fixture>` twice) before merge, since it wasn't possible to run here.
- `run_ingestion_prod.py`'s summary log block now has a 5-line body instead of 4; purely cosmetic.

## Breaking Changes
None.
