### PR TITLE
feat: shared ContentSkeleton/AsyncStatus primitives + centralized timing policy (MON-214)

### DIFF
--- a/.claude/skills/plan-epic/SKILL.md
+++ b/.claude/skills/plan-epic/SKILL.md
@@ -76,6 +76,11 @@ Then comment on the epic (`save_comment`) with the plan summary and links, and m
 
 Print the created sub-issue ids and URLs in execution order, marking which one `/solve-mon` should pick up first and which are blocked on an ADR.
 
+Also publish the plan as an Artifact: load the `artifact-design` skill first, then write an HTML file to the session scratchpad directory and publish it with the `Artifact` tool.
+Render the sub-issues as a dependency-ordered chain (numbered nodes, connector between blocked/blocking steps), each card carrying its title linked to the Linear issue URL, one-line scope, and dependency note.
+Use a status line noting how many sub-issues exist, how many are created, and the epic's current state.
+If this report follows step 6 (issues actually created), link the real MON-ids; if the user has not yet approved creation, publish the draft plan instead and mark it as not yet filed - either way, keep the same file path across a single planning session so re-publishing after Linear writes updates the same artifact URL instead of minting a new one.
+
 ## Guard rails
 
 - This skill never writes code, never branches, never opens PRs.

--- a/.claude/skills/plan-epic/SKILL.md
+++ b/.claude/skills/plan-epic/SKILL.md
@@ -76,11 +76,6 @@ Then comment on the epic (`save_comment`) with the plan summary and links, and m
 
 Print the created sub-issue ids and URLs in execution order, marking which one `/solve-mon` should pick up first and which are blocked on an ADR.
 
-Also publish the plan as an Artifact: load the `artifact-design` skill first, then write an HTML file to the session scratchpad directory and publish it with the `Artifact` tool.
-Render the sub-issues as a dependency-ordered chain (numbered nodes, connector between blocked/blocking steps), each card carrying its title linked to the Linear issue URL, one-line scope, and dependency note.
-Use a status line noting how many sub-issues exist, how many are created, and the epic's current state.
-If this report follows step 6 (issues actually created), link the real MON-ids; if the user has not yet approved creation, publish the draft plan instead and mark it as not yet filed - either way, keep the same file path across a single planning session so re-publishing after Linear writes updates the same artifact URL instead of minting a new one.
-
 ## Guard rails
 
 - This skill never writes code, never branches, never opens PRs.

--- a/frontend/__tests__/components/AsyncStatus.test.tsx
+++ b/frontend/__tests__/components/AsyncStatus.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+let mockReducedMotion = false
+
+jest.mock('framer-motion', () => ({
+  useReducedMotion: () => mockReducedMotion,
+}))
+
+import { AsyncStatus } from '@/components/ui/AsyncStatus'
+
+describe('AsyncStatus', () => {
+  beforeEach(() => {
+    mockReducedMotion = false
+  })
+
+  it('renders the contextual status text with aria-busy while in progress', () => {
+    render(<AsyncStatus status="Recherche des sources officielles…" />)
+
+    const status = screen.getByRole('status')
+    expect(status).toHaveAttribute('aria-busy', 'true')
+    expect(screen.getByText('Recherche des sources officielles…')).toBeInTheDocument()
+  })
+
+  it('renders a smaller inline treatment for the inline phase', () => {
+    render(<AsyncStatus status="Chargement…" phase="inline" />)
+
+    expect(screen.getByText('Chargement…')).toHaveClass('text-xs')
+  })
+
+  it('renders the content-phase treatment by default', () => {
+    render(<AsyncStatus status="Analyse en cours…" />)
+
+    expect(screen.getByText('Analyse en cours…')).toHaveClass('text-sm')
+  })
+
+  it('offers a cancel affordance while in progress, when supported', () => {
+    const onCancel = jest.fn()
+    render(<AsyncStatus status="Recherche…" onCancel={onCancel} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /annuler/i }))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('switches to the failure state and clears aria-busy on error', () => {
+    render(<AsyncStatus status="Recherche…" error="La recherche a échoué." onRetry={jest.fn()} />)
+
+    const status = screen.getByRole('status')
+    expect(status).toHaveAttribute('aria-busy', 'false')
+    expect(screen.getByText('La recherche a échoué.')).toBeInTheDocument()
+    expect(screen.queryByText('Recherche…')).not.toBeInTheDocument()
+  })
+
+  it('offers a retry affordance only in the failure state', () => {
+    const onRetry = jest.fn()
+    const { rerender } = render(<AsyncStatus status="Recherche…" onRetry={onRetry} />)
+    expect(screen.queryByRole('button', { name: /réessayer/i })).not.toBeInTheDocument()
+
+    rerender(<AsyncStatus status="Recherche…" error="Échec." onRetry={onRetry} />)
+    fireEvent.click(screen.getByRole('button', { name: /réessayer/i }))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not animate the activity indicator when reduced motion is requested', () => {
+    mockReducedMotion = true
+    const { container } = render(<AsyncStatus status="Recherche…" />)
+
+    const dot = container.querySelector('[aria-hidden="true"]')
+    expect(dot).not.toHaveClass('animate-pulse')
+  })
+
+  it('animates the activity indicator when motion is not reduced', () => {
+    mockReducedMotion = false
+    const { container } = render(<AsyncStatus status="Recherche…" />)
+
+    const dot = container.querySelector('[aria-hidden="true"]')
+    expect(dot).toHaveClass('animate-pulse')
+  })
+})

--- a/frontend/__tests__/components/ContentSkeleton.test.tsx
+++ b/frontend/__tests__/components/ContentSkeleton.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+
+import { ContentSkeleton, SkeletonBlock } from '@/components/ui/ContentSkeleton'
+
+describe('ContentSkeleton', () => {
+  it('exposes aria-busy and a status role on the wrapper', () => {
+    render(
+      <ContentSkeleton>
+        <SkeletonBlock className="h-4 w-24" />
+      </ContentSkeleton>
+    )
+
+    const status = screen.getByRole('status')
+    expect(status).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('announces a screen-reader label while hiding the decorative shapes', () => {
+    render(
+      <ContentSkeleton label="Chargement des députés…">
+        <SkeletonBlock data-testid="shape" />
+      </ContentSkeleton>
+    )
+
+    expect(screen.getByText('Chargement des députés…')).toHaveClass('sr-only')
+    const shapeWrapper = screen.getByText('Chargement des députés…').nextSibling as HTMLElement
+    expect(shapeWrapper).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('marks each decorative block as aria-hidden individually', () => {
+    const { container } = render(
+      <ContentSkeleton>
+        <SkeletonBlock className="h-4 w-24" />
+        <SkeletonBlock className="h-4 w-16" />
+      </ContentSkeleton>
+    )
+
+    const blocks = container.querySelectorAll('.dp-skeleton-block')
+    expect(blocks).toHaveLength(2)
+    blocks.forEach(block => expect(block).toHaveAttribute('aria-hidden', 'true'))
+  })
+})

--- a/frontend/__tests__/lib/loadingPolicy.test.ts
+++ b/frontend/__tests__/lib/loadingPolicy.test.ts
@@ -1,0 +1,68 @@
+import { act, renderHook } from '@testing-library/react'
+
+import {
+  LOADING_INLINE_MS,
+  LOADING_NO_INDICATOR_MS,
+  useLoadingPhase,
+} from '@/lib/loadingPolicy'
+
+describe('useLoadingPhase', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('stays "none" when not loading', () => {
+    const { result } = renderHook(() => useLoadingPhase(false))
+    expect(result.current).toBe('none')
+  })
+
+  it('stays "none" for a fast completion under the no-indicator threshold', () => {
+    const { result, rerender } = renderHook(({ isLoading }) => useLoadingPhase(isLoading), {
+      initialProps: { isLoading: true },
+    })
+
+    act(() => {
+      jest.advanceTimersByTime(LOADING_NO_INDICATOR_MS - 50)
+    })
+    expect(result.current).toBe('none')
+
+    rerender({ isLoading: false })
+    expect(result.current).toBe('none')
+  })
+
+  it('moves to "inline" once the no-indicator threshold elapses', () => {
+    const { result } = renderHook(() => useLoadingPhase(true))
+
+    act(() => {
+      jest.advanceTimersByTime(LOADING_NO_INDICATOR_MS + 50)
+    })
+    expect(result.current).toBe('inline')
+  })
+
+  it('moves to "content" once the inline threshold elapses (delayed completion)', () => {
+    const { result } = renderHook(() => useLoadingPhase(true))
+
+    act(() => {
+      jest.advanceTimersByTime(LOADING_INLINE_MS + 50)
+    })
+    expect(result.current).toBe('content')
+  })
+
+  it('resets to "none" as soon as loading stops, even mid-content phase', () => {
+    const { result, rerender } = renderHook(({ isLoading }) => useLoadingPhase(isLoading), {
+      initialProps: { isLoading: true },
+    })
+
+    act(() => {
+      jest.advanceTimersByTime(LOADING_INLINE_MS + 50)
+    })
+    expect(result.current).toBe('content')
+
+    rerender({ isLoading: false })
+    expect(result.current).toBe('none')
+  })
+})

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -12,6 +12,26 @@
 @keyframes nudge { 0%,100% { transform: translate(-50%,0); } 50% { transform: translate(-50%,5px); } }
 [data-hint] { animation: nudge 2s ease-in-out infinite; }
 
+/* MON-207/MON-214: shared skeleton shimmer for ContentSkeleton's SkeletonBlock.
+   Neutralized by the prefers-reduced-motion rule below (animation-duration
+   forced to 0.001ms), same mechanism as the rest of MON-194's motion gating. */
+.dp-skeleton-block {
+  border-radius: 6px;
+  background: linear-gradient(
+    90deg,
+    var(--dp-border-subtle) 25%,
+    var(--dp-border) 37%,
+    var(--dp-border-subtle) 63%
+  );
+  background-size: 400% 100%;
+  animation: dp-skeleton-shimmer 1.6s ease-in-out infinite;
+}
+
+@keyframes dp-skeleton-shimmer {
+  0% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
 /* RGAA 13.8/13.9, WCAG 2.3.3: honor the OS "reduce motion" preference as a
    CSS-level fallback in addition to the JS useReducedMotion() gates - this
    catches any transition/animation that isn't already gated in script

--- a/frontend/src/components/ui/AsyncStatus.tsx
+++ b/frontend/src/components/ui/AsyncStatus.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useReducedMotion } from 'framer-motion'
+
+export interface AsyncStatusProps {
+  /** Contextual status text, e.g. "Recherche des sources officielles…" */
+  status: string
+  /** Loading-policy phase (see lib/loadingPolicy) — 'inline' renders a smaller treatment. */
+  phase?: 'inline' | 'content'
+  /** When set, renders the failure state with this message instead of the status. */
+  error?: string | null
+  /** Retry affordance shown only in the failure state. */
+  onRetry?: () => void
+  /** Cancel affordance shown only while the operation is still in progress. */
+  onCancel?: () => void
+  className?: string
+}
+
+/**
+ * Contextual progress indicator for operations whose duration or output
+ * shape is unpredictable (MON-207: chat, claim verification). Deliberately
+ * text-based rather than skeleton-shaped — do not use for generated
+ * responses, whose final shape can't be anticipated.
+ */
+export function AsyncStatus({
+  status,
+  phase = 'content',
+  error = null,
+  onRetry,
+  onCancel,
+  className = '',
+}: AsyncStatusProps) {
+  const reduceMotion = useReducedMotion()
+  const isError = Boolean(error)
+
+  return (
+    <div className={className} role="status" aria-busy={!isError}>
+      <div className="flex items-center gap-2">
+        {!isError && (
+          <span
+            aria-hidden="true"
+            className={`inline-block w-2 h-2 rounded-full bg-[color:var(--dp-accent)] ${
+              reduceMotion ? '' : 'animate-pulse'
+            }`}
+          />
+        )}
+        <span className={phase === 'inline' ? 'text-xs' : 'text-sm'}>
+          {isError ? error : status}
+        </span>
+      </div>
+      {(onCancel || onRetry) && (
+        <div className="flex gap-3 mt-2">
+          {!isError && onCancel && (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="text-sm underline underline-offset-2"
+            >
+              Annuler
+            </button>
+          )}
+          {isError && onRetry && (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="text-sm underline underline-offset-2"
+            >
+              Réessayer
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/ContentSkeleton.tsx
+++ b/frontend/src/components/ui/ContentSkeleton.tsx
@@ -1,0 +1,39 @@
+import type { CSSProperties, ReactNode } from 'react'
+
+/**
+ * A single decorative skeleton shape (a placeholder for an image, a line of
+ * text, a badge, etc.). Always aria-hidden — the loading state itself is
+ * announced once by the surrounding ContentSkeleton, not by every block.
+ */
+export function SkeletonBlock({
+  className = '',
+  style,
+}: {
+  className?: string
+  style?: CSSProperties
+}) {
+  return <div aria-hidden="true" className={`dp-skeleton-block ${className}`} style={style} />
+}
+
+/**
+ * Wraps a set of SkeletonBlock shapes that reproduce a predictable final
+ * layout (MON-207: /deputes and /votes cards). The wrapper carries the
+ * aria-busy/status semantics for assistive tech; the shapes inside stay
+ * decorative and are hidden from screen readers.
+ */
+export function ContentSkeleton({
+  children,
+  label = 'Chargement du contenu…',
+  className = '',
+}: {
+  children: ReactNode
+  label?: string
+  className?: string
+}) {
+  return (
+    <div className={className} role="status" aria-busy="true">
+      <span className="sr-only">{label}</span>
+      <div aria-hidden="true">{children}</div>
+    </div>
+  )
+}

--- a/frontend/src/lib/loadingPolicy.ts
+++ b/frontend/src/lib/loadingPolicy.ts
@@ -1,0 +1,48 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+/**
+ * MON-207/MON-214: centralized loading-treatment thresholds. Pages must read
+ * these rather than hardcoding their own delay values, so the policy stays
+ * consistent app-wide and can be tuned in one place.
+ */
+export const LOADING_NO_INDICATOR_MS = 200
+export const LOADING_INLINE_MS = 1500
+
+export type LoadingPhase = 'none' | 'inline' | 'content'
+
+/**
+ * Maps a raw `isLoading` boolean to a loading-treatment phase per the
+ * MON-207 timing policy:
+ * - `none`: not loading, or loading for less than LOADING_NO_INDICATOR_MS — show nothing.
+ * - `inline`: loading past LOADING_NO_INDICATOR_MS but under LOADING_INLINE_MS — subtle inline activity.
+ * - `content`: loading past LOADING_INLINE_MS — a layout-matched skeleton or a contextual status.
+ */
+export function useLoadingPhase(isLoading: boolean): LoadingPhase {
+  const [phase, setPhase] = useState<LoadingPhase>('none')
+  // React's documented "adjusting state when a prop changes" pattern: a
+  // render-phase setState conditioned on a previous-value mismatch, not an
+  // effect. This resets the phase the instant a new loading session starts
+  // (or a fast one ends) without the cascading-render issue effect-body
+  // setState calls have.
+  const [prevIsLoading, setPrevIsLoading] = useState(isLoading)
+  if (isLoading !== prevIsLoading) {
+    setPrevIsLoading(isLoading)
+    setPhase('none')
+  }
+
+  useEffect(() => {
+    if (!isLoading) return
+
+    const inlineTimer = setTimeout(() => setPhase('inline'), LOADING_NO_INDICATOR_MS)
+    const contentTimer = setTimeout(() => setPhase('content'), LOADING_INLINE_MS)
+
+    return () => {
+      clearTimeout(inlineTimer)
+      clearTimeout(contentTimer)
+    }
+  }, [isLoading])
+
+  return phase
+}


### PR DESCRIPTION
## What

Adds the shared frontend primitives MON-207's adaptive loading-state system is built on: a `ContentSkeleton` component for predictable-layout loading, an `AsyncStatus` component for unpredictable-duration operations, and a `useLoadingPhase` hook that centralizes the timing policy (no loader up to 200ms, subtle activity 200ms-1.5s, full skeleton/status past that). No pages are wired up yet.

## Why

MonÉlu currently has no shared loading-state pattern: `/votes` and `/deputes` show a bare "Chargement…" string, and chat/verification show a bouncing-dots `TypingIndicator`, each implemented independently with no timing discipline (so fast cached responses can flash a loader). MON-207 is the epic; this is sub-issue MON-214, the foundation the other three sub-issues (MON-215: `/deputes`+`/votes`, MON-216: chat+verification, MON-217: QA pass) build on.

## Changes

- `frontend/src/lib/loadingPolicy.ts` - `LOADING_NO_INDICATOR_MS`/`LOADING_INLINE_MS` constants and a `useLoadingPhase(isLoading)` hook returning `'none' | 'inline' | 'content'`. Resets via React's "adjusting state when a prop changes" render-phase pattern rather than an effect-body `setState`, to satisfy the React Compiler's `set-state-in-effect`/purity lint rules.
- `frontend/src/components/ui/ContentSkeleton.tsx` - `ContentSkeleton` wrapper (`role="status"`, `aria-busy="true"`, sr-only label) plus a `SkeletonBlock` primitive for individual decorative shapes (always `aria-hidden`).
- `frontend/src/components/ui/AsyncStatus.tsx` - contextual status component with a pulsing activity dot (gated by `useReducedMotion`, matching the pattern already used in `PageTransition.tsx`), a cancel affordance while in progress, and a retry affordance in the failure state (`aria-busy` flips to `false` on error).
- `frontend/src/app/globals.css` - `.dp-skeleton-block` shimmer, neutralized automatically by the existing MON-194 `prefers-reduced-motion` global rule (no extra JS motion-gating needed for the skeleton itself).
- An unrelated `.claude/skills/plan-epic/SKILL.md` commit that had ridden along on this branch (from earlier in the session, before MON-214 was picked up) was split out into #301 and reverted here per review feedback - this PR's diff is now scoped to MON-214 only.

## Testing

- `npx jest loadingPolicy ContentSkeleton AsyncStatus` - 16 new tests covering fast completion (stays `'none'`), delayed completion (`'inline'` then `'content'`), reset on loading-session change, failure state (aria-busy clears, retry shown), cancel-while-in-progress, and reduced-motion (activity dot doesn't get `animate-pulse`).
- `npm test` - full suite, 213/213 passing (28 suites).
- `npm run lint` - clean (`next lint`, including the React Compiler hooks/purity rules).
- `npm run build` - succeeds; type-checks clean. The `/sitemap.xml` prerender step failed once with an API 500 (no local backend running) - reproduced the same failure on a clean `origin/master` checkout, confirmed it's the known intermittent flake (a retry on both branches succeeded), not a regression from this change.

## Risks / Notes

- No page integration in this PR by design - `ContentSkeleton`/`AsyncStatus`/`useLoadingPhase` aren't imported anywhere yet. MON-215 and MON-216 wire them into `/deputes`+`/votes` and chat+verification respectively.
- No DB/schema/deploy-config changes.

## Breaking Changes

None.
