### PR TITLE
chore: publish artifact as part of plan-epic final report

### DIFF
--- a/.claude/skills/plan-epic/SKILL.md
+++ b/.claude/skills/plan-epic/SKILL.md
@@ -76,6 +76,11 @@ Then comment on the epic (`save_comment`) with the plan summary and links, and m
 
 Print the created sub-issue ids and URLs in execution order, marking which one `/solve-mon` should pick up first and which are blocked on an ADR.
 
+Also publish the plan as an Artifact: load the `artifact-design` skill first, then write an HTML file to the session scratchpad directory and publish it with the `Artifact` tool.
+Render the sub-issues as a dependency-ordered chain (numbered nodes, connector between blocked/blocking steps), each card carrying its title linked to the Linear issue URL, one-line scope, and dependency note.
+Use a status line noting how many sub-issues exist, how many are created, and the epic's current state.
+If this report follows step 6 (issues actually created), link the real MON-ids; if the user has not yet approved creation, publish the draft plan instead and mark it as not yet filed - either way, keep the same file path across a single planning session so re-publishing after Linear writes updates the same artifact URL instead of minting a new one.
+
 ## Guard rails
 
 - This skill never writes code, never branches, never opens PRs.


### PR DESCRIPTION
## What
Adds an artifact-publishing step to the `/plan-epic` skill's final report so every epic decomposition also renders a visual dependency-chain breakdown, not just plain text.

## Why
Split out of #300 (MON-214) at that PR's own review's request — this doc-only change to `.claude/skills/plan-epic/SKILL.md` is unrelated to MON-214's scope and belongs in its own PR.

## Changes
- `.claude/skills/plan-epic/SKILL.md`: step 7 now also publishes an HTML Artifact of the sub-issue plan (dependency-ordered cards linking to the created Linear issues), loading `artifact-design` first and reusing the same scratchpad file path across a planning session so re-publishing after Linear writes updates the same URL.

## Testing
Not applicable — this only changes Claude Code skill instructions, no application code.

## Risks / Notes
None. No app code, no deploy surface.

## Breaking Changes
None.