### PR TITLE
fix: accessibility, motion, and dark-mode QA pass across loading states (MON-217)

### DIFF
--- a/frontend/__tests__/components/AsyncStatus.test.tsx
+++ b/frontend/__tests__/components/AsyncStatus.test.tsx
@@ -60,6 +60,21 @@ describe('AsyncStatus', () => {
     expect(onRetry).toHaveBeenCalledTimes(1)
   })
 
+  it('focuses the cancel button on mount when autoFocusAction is set (MON-217)', () => {
+    render(<AsyncStatus status="Recherche…" onCancel={jest.fn()} autoFocusAction />)
+    expect(screen.getByRole('button', { name: /annuler/i })).toHaveFocus()
+  })
+
+  it('focuses the retry button on mount when autoFocusAction is set (MON-217)', () => {
+    render(<AsyncStatus status="Recherche…" error="Échec." onRetry={jest.fn()} autoFocusAction />)
+    expect(screen.getByRole('button', { name: /réessayer/i })).toHaveFocus()
+  })
+
+  it('does not steal focus when autoFocusAction is left off', () => {
+    render(<AsyncStatus status="Recherche…" onCancel={jest.fn()} />)
+    expect(screen.getByRole('button', { name: /annuler/i })).not.toHaveFocus()
+  })
+
   it('does not animate the activity indicator when reduced motion is requested', () => {
     mockReducedMotion = true
     const { container } = render(<AsyncStatus status="Recherche…" />)

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -692,6 +692,7 @@ function ChatInner() {
                       <AsyncStatus
                         status={msg.verifying ? VERIFY_LOADING_TEXT : SEARCH_LOADING_TEXT}
                         onCancel={cancelActive}
+                        autoFocusAction
                         className="flex flex-col gap-1"
                       />
                     </div>
@@ -731,6 +732,7 @@ function ChatInner() {
                               }
                             : undefined
                         }
+                        autoFocusAction
                         className="flex flex-col gap-1"
                       />
                     </div>

--- a/frontend/src/components/ui/AsyncStatus.tsx
+++ b/frontend/src/components/ui/AsyncStatus.tsx
@@ -13,6 +13,15 @@ export interface AsyncStatusProps {
   onRetry?: () => void
   /** Cancel affordance shown only while the operation is still in progress. */
   onCancel?: () => void
+  /**
+   * Focuses the cancel/retry button as soon as it mounts. Without this, a
+   * keyboard user who just submitted stays focused on the input they typed
+   * into — which sits later in the DOM than this status region in the usual
+   * chat layout (messages above, input fixed below), so plain forward-Tab
+   * skips over the newly-appeared action entirely (MON-217). Off by default
+   * since not every AsyncStatus placement has that DOM ordering problem.
+   */
+  autoFocusAction?: boolean
   className?: string
 }
 
@@ -28,6 +37,7 @@ export function AsyncStatus({
   error = null,
   onRetry,
   onCancel,
+  autoFocusAction = false,
   className = '',
 }: AsyncStatusProps) {
   const reduceMotion = useReducedMotion()
@@ -54,6 +64,7 @@ export function AsyncStatus({
             <button
               type="button"
               onClick={onCancel}
+              autoFocus={autoFocusAction}
               className="text-sm underline underline-offset-2"
             >
               Annuler
@@ -63,6 +74,7 @@ export function AsyncStatus({
             <button
               type="button"
               onClick={onRetry}
+              autoFocus={autoFocusAction}
               className="text-sm underline underline-offset-2"
             >
               Réessayer


### PR DESCRIPTION
## What

The final sub-issue in the MON-207 epic: a cross-cutting QA pass over everything MON-214/215/216 shipped (reduced motion, dark-mode contrast, keyboard access, screen-reader cycle, cached/throttled network, mobile viewport), fixing one real gap it found rather than filing it onward.

## Why

MON-214/215/216 each shipped with their own unit tests and manual verification, but nothing had checked the *system* end to end - across viewports, themes, motion preference, and input modality at once. This issue is that check.

## Changes

- `frontend/src/components/ui/AsyncStatus.tsx`: new opt-in `autoFocusAction` prop that focuses the cancel/retry button on mount.
- `frontend/src/app/chat/page.tsx`: wired `autoFocusAction` on both the typing-state and error-state `AsyncStatus` instances.
- `frontend/__tests__/components/AsyncStatus.test.tsx`: three new tests for the prop (focuses cancel, focuses retry, does nothing when unset).

## QA pass findings

All checks below were run against the live production API (not mocks) via a scripted Playwright pass, plus the existing unit suites.

**Bug found and fixed:**
- **Keyboard access to cancel/retry was broken.** In `/chat`, `AsyncStatus`'s Annuler/Réessayer button renders inside the message list, which sits *above* the input bar in the DOM (messages accumulate above a fixed-position textarea). A keyboard user who just pressed Enter to submit stays focused in the textarea - and forward-Tab from there skips straight past the newly-appeared cancel button to the page's disclaimer link, never reaching it. Confirmed with a scripted Tab-order walk (landed on `assemblee-nationale.fr`, not `Annuler`) and confirmed the button was only reachable via 3x Shift+Tab - not a discoverable path. Fixed with `autoFocusAction`: focus now moves to Annuler/Réessayer the instant it mounts, verified live (focus lands there immediately, Enter activates it, no Tab needed).

**Verified clean, no gaps:**
- **Reduced motion**: `.dp-skeleton-block`'s shimmer computed `animation-duration: 1e-06s` (0.001ms) under `prefers-reduced-motion: reduce` - the existing MON-194 global CSS rule catches it automatically, no component-level change needed. `AsyncStatus`'s activity dot already omits `animate-pulse` under reduced motion (tested since MON-214).
- **Dark mode**: `/votes`, `/deputes`, and `/chat` all render correctly in dark mode - verified visually (screenshots), tokens are the existing contrast-vetted `var(--dp-*)` set already used elsewhere in the app.
- **Screen-reader question-answer cycle**: confirmed on both chat search and claim verification - `role="status"` + `aria-busy="true"` while in flight, then the sr-only `aria-live="polite"` region announces the completed answer/verdict once it lands (e.g. `"Nouvelle réponse : Positions de vote par groupe parlementaire : ..."`, `"Vérification terminée : trompeur"`).
- **API failure → retry**: confirmed live with a mocked 500 response - retry button appears, is keyboard-focusable (now auto-focused), and resubmits correctly.
- **Cached / throttled network**: `/votes`' client-side filter refetch under 900ms CDP-throttled latency settles cleanly (confirmed with a patient poll after an initial false-negative in a too-eager first check - the request completes and the skeleton clears within ~1.5s, matching the timing policy). Cached ISR navigation to `/votes` shows no loader per MON-215's existing verification.
- **Mobile viewport** (390×844): `/votes` skeleton and `/chat` loading state both render with no horizontal overflow.

**Not independently re-verified in this pass** (already covered by MON-214/215/216's own test suites and manual checks, not re-litigated here): exact 100ms/500ms/1.5s/8s timing-phase boundaries - `frontend/__tests__/lib/loadingPolicy.test.ts` already asserts these deterministically with fake timers, which is a more precise instrument than a live wall-clock screenshot race would be.

## Testing

- `npm test` - full suite, 232/232 passing.
- `npm run lint` / `npm run build` - clean.
- Manual verification as described above (Playwright against the live production API): reduced motion, keyboard focus order (before and after the fix), dark mode, screen-reader-relevant ARIA state, API failure/retry, throttled refetch, mobile viewport.

## Risks / Notes

- No DB/schema/deploy-config changes. `AsyncStatus`'s new prop is optional and defaults to off, so no existing usage changes behavior.
- This closes out the MON-207 epic (MON-214, MON-215, MON-216 already merged).

## Breaking Changes

None.
