### PR TITLE
fix: run RAG rebuild and dbt unconditionally in daily ingestion (MON-218)

### DIFF
--- a/.github/workflows/ingest_prod.yml
+++ b/.github/workflows/ingest_prod.yml
@@ -65,16 +65,19 @@ jobs:
         run: python scripts/run_ingestion_prod.py --since $(python3 -c "from datetime import date, timedelta; print(date.today() - timedelta(days=30))")
 
       - name: Rebuild RAG index
-        if: steps.ingest.outputs.new_votes != '0'
+        # Unconditional: vote corrections (upsert DO UPDATE, delta 0) and
+        # summaries that soft-failed yesterday and succeed today must still
+        # get re-embedded, not just runs with new votes (MON-218).
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
         run: python -m rag.pipeline.index_manager build
 
-      # dbt install + profile run unconditionally: snapshots and source
-      # freshness below must run even on no-new-votes days (freshness exists
-      # to alarm on silence; party changes arrive without new votes).
+      # dbt install + profile run unconditionally: snapshots, source
+      # freshness, and dbt run below must all run even on no-new-votes days
+      # (freshness exists to alarm on silence; party changes and vote
+      # corrections arrive without new votes - MON-218).
       - name: Install dbt
         run: pip install "dbt-core>=1.9,<1.10" "dbt-postgres>=1.9,<1.10"
 
@@ -88,7 +91,9 @@ jobs:
         run: python3 scripts/create_dbt_profile.py
 
       - name: Run dbt transformations
-        if: steps.ingest.outputs.new_votes != '0'
+        # Unconditional: a deputy switching groups or a corrected vote (delta
+        # 0) must still rebuild mart_party_alignment/mart_deputy_scorecard,
+        # not wait for the next new-vote day - weeks during recess (MON-218).
         run: |
           cd transform
           dbt deps --profiles-dir .


### PR DESCRIPTION
## What
Removes the `if: steps.ingest.outputs.new_votes != '0'` gate on the "Rebuild RAG index" and "Run dbt transformations" steps in `.github/workflows/ingest_prod.yml`, so both run on every daily ingestion regardless of whether new votes landed.

## Why
Both steps only ran when the votes row-count delta was non-zero, but data changes that matter to the marts and the RAG index arrive without new votes:
- A deputy switches groups: the snapshot captures it, but `mart_party_alignment`/`mart_deputy_scorecard` were not rebuilt - the API kept serving the old group until the next new-vote day (weeks during recess).
- A vote corrected upstream via the upsert `DO UPDATE` path: delta 0, so marts and RAG chunks kept the old numbers.
- Vote summaries that soft-failed one day and succeeded the next (no new votes that day) were never embedded until the next vote landed.

The snapshot/source-freshness steps already run unconditionally for the same reason (see the pre-existing comment in the workflow). This PR extends that reasoning to dbt run and the RAG rebuild. A full run costs ~2 min + $0.006 - the gate was saving almost nothing while causing real staleness.

Source: `ingestion_diagnostic_2026-08-05.md`, Finding #1 / MON-218.

## Changes
- `.github/workflows/ingest_prod.yml`: dropped the `if:` condition on the "Rebuild RAG index" step and the "Run dbt transformations" step; updated the surrounding comments to reflect that dbt run, snapshot, and source freshness all now run unconditionally alongside the RAG rebuild.

## Testing
- Validated the workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ingest_prod.yml'))"`).
- No Python changed, so the pytest/ruff suites are unaffected; not re-run for this PR.
- Not run end-to-end (this is a scheduled/production workflow) - the change is a two-line removal reviewed by inspection; correctness is exercised on the next scheduled run or via `workflow_dispatch`.

## Risks / Notes
- Deploy-risk: every daily weekday ingestion run now always pays the RAG rebuild cost (~2 min + ~$0.006) and dbt run/test, even on a no-new-votes day, instead of skipping them. This was raised with the user before implementing and confirmed as the intended fix.
- The `new_votes` step output is left in place (still written by `scripts/run_ingestion_prod.py` and logged) even though nothing in the workflow gates on it anymore - it remains available for future diagnostics/observability.

## Breaking Changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)