### PR TITLE
fix: extend revalidation webhook to department/group/theme routes (MON-240)

### DIFF
--- a/frontend/src/app/api/revalidate/route.ts
+++ b/frontend/src/app/api/revalidate/route.ts
@@ -20,11 +20,17 @@ export async function POST(req: NextRequest) {
   if (!expected || !secretsMatch(provided, expected))
     return new Response('Unauthorized', { status: 401 })
 
+  // Every route family reading ingestion-refreshed data (deputy presence/dissidence,
+  // party rosters, vote lists) needs a line here - `/mon-depute` is exempt because it's
+  // a client component that fetches the API directly, with no ISR cache to invalidate.
   revalidatePath('/')
   revalidatePath('/votes')
   revalidatePath('/deputes')
   revalidatePath('/deputes/[id]', 'page')
   revalidatePath('/votes/[id]', 'page')
+  revalidatePath('/departements/[code]', 'page')
+  revalidatePath('/groupes/[slug]', 'page')
+  revalidatePath('/themes/[slug]', 'page')
   revalidatePath('/sitemap.xml')
 
   return Response.json({ revalidated: true, at: new Date().toISOString() })


### PR DESCRIPTION
## What
Extends the ingestion webhook's `revalidatePath` list in `frontend/src/app/api/revalidate/route.ts` to cover the department, group, and theme route families.

## Why
The webhook's revalidate list was frozen at the route set from MON-58: `/`, `/votes`, `/deputes`, `/deputes/[id]`, `/votes/[id]`, `/sitemap.xml`.
Since then `/departements/[code]`, `/groupes/[slug]`, and `/themes/[slug]` shipped, all reading the same daily-refreshed data (presence, dissidence, party rosters, vote lists) with 3600s ISR revalidation as their only refresh path.
After the daily ingest + webhook fire, a deputy's page reflects the new numbers immediately while their group's or department's page can show yesterday's data for up to an hour - the same underlying number disagreeing across pages on a site whose pitch is data trustworthiness.

## Changes
- `frontend/src/app/api/revalidate/route.ts`: added `revalidatePath('/departements/[code]', 'page')`, `revalidatePath('/groupes/[slug]', 'page')`, and `revalidatePath('/themes/[slug]', 'page')`, following the same dynamic-page convention already used for `/deputes/[id]` and `/votes/[id]`.
- Added a comment establishing the convention the issue asked for: any new route family reading ingestion-refreshed data gets a line here.
- `/mon-depute` is intentionally **not** added - it's a `'use client'` page that fetches the API directly at runtime with no ISR cache, so there's nothing for the webhook to invalidate.

## Testing
- `npm run lint` - clean, no warnings or errors.
- `npm test` - 229/229 tests pass (one suite hit a SIGSEGV jest-worker crash on first run, unrelated to this change; reran that suite alone and it passed 3/3).
- `npm run build` - fails prerendering `/votes` with a 500 from the live production API (`NEXT_PUBLIC_API_URL=https://monelu-production.up.railway.app` per `.env.example`), which the build hits directly during SSG. Confirmed this is an environment/network issue unrelated to this change: the diff never touches `/votes` or its data fetching, and a build against a clean `master` checkout hits the same live-API dependency.
- No unit test exists for the revalidate route (none existed before this change either); the change is a straight addition of three `revalidatePath` calls following the existing pattern.

## Risks / Notes
- Pure additive change to the webhook handler - no schema, deploy config, or trigger changes.
- If a future route family reads ingestion-refreshed data, the comment now flags that it needs a line here; tag-based revalidation (mentioned as an alternative in the issue) was not adopted since it would touch every data-fetching call site for a larger, out-of-scope refactor.

## Breaking Changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)