### PR TITLE
fix: exit 1 on high parse-skip rate in deputies/votes ingestion (MON-220)

### DIFF
--- a/scripts/ingest_deputies.py
+++ b/scripts/ingest_deputies.py
@@ -14,6 +14,7 @@ import io
 import json
 import logging
 import os
+import sys
 import zipfile
 
 import psycopg2
@@ -35,6 +36,10 @@ log = logging.getLogger(__name__)
 
 AN_API_BASE_URL = os.getenv("AN_API_BASE_URL", "https://data.assemblee-nationale.fr")
 DATABASE_URL = os.getenv("DATABASE_URL")
+
+# Abort the run if more than this share of records fail to parse — a silent
+# AN format change should fail loudly, not ship a skeleton dataset (MON-220).
+SKIP_RATE_THRESHOLD = 0.05
 
 # Static export — one ZIP, one JSON file per deputy
 DEPUTIES_ZIP_PATH = (
@@ -198,7 +203,7 @@ def upsert_deputies(raw_items: list[dict]) -> int:
     skipped = len(raw_items) - len(records)
     skip_rate = skipped / len(raw_items) if raw_items else 0.0
     log.info("Parsed %d valid records (skipped %d unparseable).", len(records), skipped)
-    if skip_rate > 0.05:
+    if skip_rate > SKIP_RATE_THRESHOLD:
         log.error(
             "High parse failure rate: %d/%d records skipped (%.0f%%). "
             "Check the AN data format for unexpected changes.",
@@ -206,6 +211,10 @@ def upsert_deputies(raw_items: list[dict]) -> int:
             len(raw_items),
             skip_rate * 100,
         )
+        # Abort without upserting: writing the surviving records would still
+        # stamp them with a fresh ingested_at, masking the failure from dbt
+        # source freshness checks (MON-220).
+        sys.exit(1)
     _upsert_records(records)
     return len(records)
 

--- a/scripts/ingest_votes.py
+++ b/scripts/ingest_votes.py
@@ -16,6 +16,7 @@ import io
 import json
 import logging
 import os
+import sys
 import zipfile
 from datetime import date, timedelta
 
@@ -40,6 +41,10 @@ AN_BASE_URL = os.getenv("AN_API_BASE_URL", "https://data.assemblee-nationale.fr"
 DATABASE_URL = os.getenv("DATABASE_URL")
 
 SCRUTINS_ZIP_PATH = "/static/openData/repository/17/loi/scrutins/Scrutins.json.zip"
+
+# Abort the run if more than this share of records fail to parse — a silent
+# AN format change should fail loudly, not ship a skeleton dataset (MON-220).
+SKIP_RATE_THRESHOLD = 0.05
 
 
 # ---------------------------------------------------------------------------
@@ -197,11 +202,21 @@ def fetch_all_votes(since: str | None = None) -> list[dict]:
 def upsert_votes(raw_items: list[dict]) -> int:
     """Parse raw scrutin dicts and upsert into votes table. Returns count written."""
     records = [r for item in raw_items if (r := parse_vote(item)) is not None]
-    log.info(
-        "Parsed %d valid records (skipped %d unparseable).",
-        len(records),
-        len(raw_items) - len(records),
-    )
+    skipped = len(raw_items) - len(records)
+    skip_rate = skipped / len(raw_items) if raw_items else 0.0
+    log.info("Parsed %d valid records (skipped %d unparseable).", len(records), skipped)
+    if skip_rate > SKIP_RATE_THRESHOLD:
+        log.error(
+            "High parse failure rate: %d/%d records skipped (%.0f%%). "
+            "Check the AN data format for unexpected changes.",
+            skipped,
+            len(raw_items),
+            skip_rate * 100,
+        )
+        # Abort without upserting: writing the surviving records would still
+        # stamp them with a fresh ingested_at, masking the failure from dbt
+        # source freshness checks (MON-220).
+        sys.exit(1)
     _upsert_records(records)
     return len(records)
 

--- a/tests/unit/test_ingest_skip_rate_guard.py
+++ b/tests/unit/test_ingest_skip_rate_guard.py
@@ -1,0 +1,55 @@
+"""
+Tests for the parse-failure skip-rate guard in ingest_deputies.py and
+ingest_votes.py (MON-220): a high parse-skip rate must exit 1 instead of
+silently upserting a skeleton dataset with fresh ingested_at stamps.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from scripts.ingest_deputies import upsert_deputies
+from scripts.ingest_votes import upsert_votes
+
+
+def _deputy_item(uid: str) -> dict:
+    return {"uid": {"#text": uid}, "etatCivil": {"ident": {"prenom": "Jean", "nom": "Dupont"}}}
+
+
+def _vote_item(uid: str) -> dict:
+    return {"uid": uid, "dateScrutin": "2026-01-01"}
+
+
+class TestIngestDeputiesSkipRateGuard:
+    def test_high_skip_rate_exits_without_upserting(self):
+        # 2 valid, 19 unparseable (missing uid) => skip rate > 5%
+        raw_items = [_deputy_item("PA1"), _deputy_item("PA2")] + [{}] * 19
+        with patch("scripts.ingest_deputies._upsert_records") as mock_upsert:
+            with pytest.raises(SystemExit) as exc_info:
+                upsert_deputies(raw_items)
+        assert exc_info.value.code == 1
+        mock_upsert.assert_not_called()
+
+    def test_low_skip_rate_upserts_normally(self):
+        raw_items = [_deputy_item(f"PA{i}") for i in range(20)] + [{}]
+        with patch("scripts.ingest_deputies._upsert_records") as mock_upsert:
+            count = upsert_deputies(raw_items)
+        assert count == 20
+        mock_upsert.assert_called_once()
+
+
+class TestIngestVotesSkipRateGuard:
+    def test_high_skip_rate_exits_without_upserting(self):
+        raw_items = [_vote_item("v1"), _vote_item("v2")] + [{}] * 19
+        with patch("scripts.ingest_votes._upsert_records") as mock_upsert:
+            with pytest.raises(SystemExit) as exc_info:
+                upsert_votes(raw_items)
+        assert exc_info.value.code == 1
+        mock_upsert.assert_not_called()
+
+    def test_low_skip_rate_upserts_normally(self):
+        raw_items = [_vote_item(f"v{i}") for i in range(20)] + [{}]
+        with patch("scripts.ingest_votes._upsert_records") as mock_upsert:
+            count = upsert_votes(raw_items)
+        assert count == 20
+        mock_upsert.assert_called_once()


### PR DESCRIPTION
## What
Makes `ingest_deputies.py` and `ingest_votes.py` exit 1 when their parse-failure
skip rate exceeds 5%, instead of logging an error and upserting a partial dataset
as a green run.

## Why
`upsert_deputies()` already computed `skip_rate` and called `log.error()` above the
5% threshold, but then upserted whatever parsed and returned normally. The step is
marked critical in `run_ingestion_prod.py`, but that orchestrator only fails a
critical step on a raised exception — a silent AN format change that nulled out
95% of records still exited 0. Worse, the surviving rows get fresh `ingested_at`
stamps, so dbt source freshness tests would not catch the failure either.
Mandate dates, circonscriptions, and photos would silently freeze without anyone
noticing. `ingest_votes.py` had no skip-rate guard at all, only a log line.

## Changes
- `scripts/ingest_deputies.py`: extracted the 5% threshold to a `SKIP_RATE_THRESHOLD`
  module constant and added `sys.exit(1)` above it, before `_upsert_records()` runs —
  a high skip rate now aborts without writing anything.
- `scripts/ingest_votes.py`: added the same `skip_rate` computation, `log.error()`,
  `SKIP_RATE_THRESHOLD` constant, and `sys.exit(1)` guard (previously it only logged
  a skip count with no threshold check at all).
- `tests/unit/test_ingest_skip_rate_guard.py` (new): covers both scripts — a high
  skip rate raises `SystemExit(1)` and never calls `_upsert_records`; a low skip
  rate upserts normally and returns the parsed count.

`run_ingestion_prod.py`'s `run_step()` already raises `RuntimeError` on a non-zero
exit code for critical steps (deputies and votes both run with `critical=True`), so
no orchestrator change was needed — the existing critical-step failure handling and
`::error::`/exception propagation now actually fires for this case.

## Testing
- `tests/unit/test_ingest_skip_rate_guard.py` (new, 4 cases: high/low skip rate for
  both deputies and votes) — verified directly against `upsert_deputies()` /
  `upsert_votes()` with `_upsert_records` mocked, since the local sandbox in this
  session could not get `pytest` past `tests/conftest.py`'s `api.main` import
  (multi-minute cold import chain — fastapi/sentry/openai/groq — unrelated to this
  change and reproducible on `master` too). All 4 assertions passed: `SystemExit`
  code 1 with `_upsert_records` uncalled above threshold; normal upsert with the
  correct count below it.
- `ruff check .` and `ruff format --check .` — clean repo-wide.
- Pre-commit hooks passed on commit (ruff, trailing whitespace, secrets detection,
  etc).
- Did not run the full `pytest` suite or CI locally for the reason above — CI will
  run it standalone.

## Risks / Notes
- No schema, deploy config, or DB migration changes.
- Behavior change: a >5% parse-skip run for deputies or votes now hard-fails the
  ingestion pipeline (`ingest_prod.yml` cron) instead of silently succeeding with
  partial data. This is the intended fix, but worth flagging since it changes when
  the daily cron goes red.
- `ingest_positions.py` was mentioned nowhere in the issue and left untouched —
  out of scope for MON-220.

## Breaking Changes
None.
