### PR TITLE
fix: advance API key cache timestamp on failed reload (MON-229)

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -41,21 +41,30 @@ def _hash_key(raw_key: str) -> str:
 def _reload_cache() -> None:
     global _cache_by_hash, _cache_loaded_at
     fresh: dict[str, ApiKeyRecord] = {}
-    with get_conn() as conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT key_hash, id, label, rate_limit_multiplier
-                FROM api_keys
-                WHERE revoked_at IS NULL
-                """
-            )
-            for row in cur.fetchall():
-                fresh[row["key_hash"]] = ApiKeyRecord(
-                    id=row["id"],
-                    label=row["label"],
-                    rate_limit_multiplier=row["rate_limit_multiplier"],
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT key_hash, id, label, rate_limit_multiplier
+                    FROM api_keys
+                    WHERE revoked_at IS NULL
+                    """
                 )
+                for row in cur.fetchall():
+                    fresh[row["key_hash"]] = ApiKeyRecord(
+                        id=row["id"],
+                        label=row["label"],
+                        rate_limit_multiplier=row["rate_limit_multiplier"],
+                    )
+    except Exception:
+        # Advance the timestamp even on failure (MON-229) - otherwise every
+        # keyed request repeats this blocking query on the event loop until
+        # a reload finally succeeds, stalling all concurrent requests for up
+        # to the statement timeout each time. The stale cache is kept as-is.
+        with _cache_lock:
+            _cache_loaded_at = time.monotonic()
+        raise
     with _cache_lock:
         _cache_by_hash = fresh
         _cache_loaded_at = time.monotonic()

--- a/tests/unit/test_api_keys.py
+++ b/tests/unit/test_api_keys.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import api.auth as auth
 from api.limiter import rate_limit_key, tiered_limit
 
@@ -38,6 +40,33 @@ def test_resolve_api_key_unknown_key_returns_none():
     auth._cache_loaded_at = time.monotonic()
     with patch.object(auth, "_reload_cache"):
         assert auth.resolve_api_key("not-a-real-key") is None
+    _reset_cache()
+
+
+def test_reload_cache_advances_timestamp_on_failure():
+    """MON-229: a failed reload must still bump _cache_loaded_at, or every
+    subsequent keyed request repeats the blocking DB call until it succeeds."""
+    _reset_cache()
+    record = auth.ApiKeyRecord(id=1, label="Test", rate_limit_multiplier=4)
+    auth._cache_by_hash[auth._hash_key("secret")] = record
+
+    with patch.object(auth, "get_conn", side_effect=RuntimeError("db down")):
+        with pytest.raises(RuntimeError):
+            auth._reload_cache()
+
+    assert auth._cache_loaded_at > 0.0
+    assert auth._cache_by_hash[auth._hash_key("secret")] == record
+    _reset_cache()
+
+
+def test_resolve_api_key_does_not_retry_storm_after_failed_reload():
+    """A failed reload should only be retried after the TTL, not on every request."""
+    _reset_cache()
+    with patch.object(auth, "get_conn", side_effect=RuntimeError("db down")):
+        auth.resolve_api_key("secret")  # first call: attempts + fails + advances timestamp
+        with patch.object(auth, "_reload_cache") as reload_mock:
+            auth.resolve_api_key("secret")  # second call: cache no longer stale, no retry
+        reload_mock.assert_not_called()
     _reset_cache()
 
 


### PR DESCRIPTION
## What
`api/auth.py`'s `_reload_cache()` now advances `_cache_loaded_at` even when the reload fails, and keeps the existing (stale) cache intact instead of leaving the timestamp unadvanced.

## Why
`rate_limit_key` (`api/limiter.py`) is invoked synchronously by SlowAPIMiddleware inside the async event loop on every request. Anonymous requests return early, but a keyed request with a stale cache (every 300s) triggers `_reload_cache()`, which runs a blocking psycopg2 query directly on the event loop.

Before this fix, if that reload failed (DB hiccup, network blip, etc.), `_cache_loaded_at` was never advanced - so the cache stayed "stale" forever, and *every subsequent keyed request* re-attempted the same blocking DB query on the event loop until a reload finally succeeded. Each failed attempt could stall all concurrent requests for up to the statement timeout. Same defect class as MON-14, currently bounded only by the small number of issued API keys.

Source: `api_diagnostic_2026-08-05.md`, Finding #2 / MON-229.

## Changes
- `api/auth.py`: wrapped the DB query in `_reload_cache()` in a `try/except`. On failure, advances `_cache_loaded_at` under the existing lock (bounding retries to once per TTL window, not once per request) and re-raises so the caller's existing warning log still fires. On success, behavior is unchanged.
- `tests/unit/test_api_keys.py`: added `test_reload_cache_advances_timestamp_on_failure` (verifies the timestamp advances and the existing cache is preserved on a failed reload) and `test_resolve_api_key_does_not_retry_storm_after_failed_reload` (verifies a second keyed request right after a failed reload does not trigger another reload attempt).

## Testing
- `python3 -m pytest tests/unit/test_api_keys.py -q` - 13 passed (11 existing + 2 new).
- `python3 -m pytest tests/ -m "not integration" -q` - 358 passed, 32 deselected (full CI-blocking selection, no regressions).
- `ruff check .` and `ruff format --check .` - clean.

## Risks / Notes
- Minimal, surgical fix scoped to the exact defect described in the issue (advancing the timestamp on failure). The issue's other suggested option - refreshing the cache from a background thread instead of the request path - was not pursued; it's a larger architectural change and the timestamp fix alone removes the retry-storm risk.
- No schema, deploy config, or API-surface changes.

## Breaking Changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)