### PR TITLE
fix: enforce unique migration numeric prefixes going forward (MON-226)

### DIFF
--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -13,7 +13,9 @@ Usage:
 import glob
 import logging
 import os
+import re
 import sys
+from collections import defaultdict
 
 import psycopg2
 import psycopg2.extras
@@ -26,6 +28,34 @@ log = logging.getLogger(__name__)
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MIGRATIONS_DIR = os.path.join(PROJECT_ROOT, "data", "migrations")
+
+MIGRATION_PREFIX_RE = re.compile(r"^(\d+)_")
+
+# 005_feedback.sql / 005_verifications.sql were both already applied before this
+# check existed. Renaming applied files would re-run them under the filename-keyed
+# ledger, so they're grandfathered here rather than fixed (MON-226) - this set
+# must never gain new entries.
+GRANDFATHERED_DUPLICATE_PREFIXES = {"005"}
+
+
+def assert_unique_numeric_prefixes(migration_files: list[str]) -> None:
+    """Numeric prefixes are the ordering contract humans read - two files sharing
+    one collide silently once a later migration depends on ordering (MON-226)."""
+    by_prefix = defaultdict(list)
+    for migration_file in migration_files:
+        filename = os.path.basename(migration_file)
+        match = MIGRATION_PREFIX_RE.match(filename)
+        if match:
+            by_prefix[match.group(1)].append(filename)
+
+    duplicates = {
+        prefix: names
+        for prefix, names in by_prefix.items()
+        if len(names) > 1 and prefix not in GRANDFATHERED_DUPLICATE_PREFIXES
+    }
+    if duplicates:
+        details = "; ".join(f"{prefix}: {names}" for prefix, names in sorted(duplicates.items()))
+        raise AssertionError(f"Duplicate migration numeric prefixes found - {details}")
 
 
 def _applied_migrations(conn) -> set[str]:
@@ -50,6 +80,12 @@ def main() -> None:
     migration_files = sorted(glob.glob(os.path.join(MIGRATIONS_DIR, "*.sql")))
     if not migration_files:
         log.error("No migration files found in %s", MIGRATIONS_DIR)
+        sys.exit(1)
+
+    try:
+        assert_unique_numeric_prefixes(migration_files)
+    except AssertionError as exc:
+        log.error(str(exc))
         sys.exit(1)
 
     log.info("Connecting to database…")

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -29,7 +29,7 @@ log = logging.getLogger(__name__)
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MIGRATIONS_DIR = os.path.join(PROJECT_ROOT, "data", "migrations")
 
-MIGRATION_PREFIX_RE = re.compile(r"^(\d+)_")
+MIGRATION_PREFIX_RE = re.compile(r"^(\d{3})_")
 
 # 005_feedback.sql / 005_verifications.sql were both already applied before this
 # check existed. Renaming applied files would re-run them under the filename-keyed

--- a/tests/unit/test_migrate_prefixes.py
+++ b/tests/unit/test_migrate_prefixes.py
@@ -1,0 +1,32 @@
+"""
+Guards the migration numeric-prefix ordering contract (MON-226): two files
+sharing a prefix would sort ambiguously once a later migration depends on order.
+"""
+
+import glob
+import os
+
+import pytest
+
+from scripts.migrate import (
+    MIGRATIONS_DIR,
+    assert_unique_numeric_prefixes,
+)
+
+
+def test_current_migration_files_pass():
+    migration_files = sorted(glob.glob(os.path.join(MIGRATIONS_DIR, "*.sql")))
+    assert_unique_numeric_prefixes(migration_files)
+
+
+def test_new_duplicate_prefix_is_rejected():
+    with pytest.raises(AssertionError, match="010"):
+        assert_unique_numeric_prefixes(["010_x.sql", "010_y.sql", "011_z.sql"])
+
+
+def test_grandfathered_005_duplicate_is_allowed():
+    assert_unique_numeric_prefixes(["005_feedback.sql", "005_verifications.sql"])
+
+
+def test_non_matching_filenames_are_ignored():
+    assert_unique_numeric_prefixes(["README.sql", "001_init.sql"])


### PR DESCRIPTION
## What
Adds an assertion in `scripts/migrate.py` that fails fast if two migration files share a numeric prefix, going forward.

## Why
`data/migrations/005_feedback.sql` and `data/migrations/005_verifications.sql` share a numeric prefix. Nothing is broken today: the `schema_migrations` ledger keys on filename, so both apply exactly once, and alphabetical order happens to be deterministic. But the numeric prefix is the ordering contract humans read - a future duplicate (e.g. `010_x.sql` / `010_y.sql`, where `y` depends on `x` but sorts first) would collide silently. Renaming the already-applied `005_*` files was ruled out: the ledger keys on filename, so a rename would re-run them.

## Changes
- `scripts/migrate.py`: added `assert_unique_numeric_prefixes()`, called from `main()` before any DB connection is opened. It groups migration filenames by their leading `NNN_` prefix and raises `AssertionError` (exit code 1) if any prefix has more than one file, except the grandfathered `005` pair, which is explicitly allowlisted with a comment explaining why.
- `tests/unit/test_migrate_prefixes.py`: table-driven unit tests covering the real `data/migrations/` contents, a rejected new duplicate, the grandfathered `005` pair, and non-matching filenames being ignored. No DB required.

## Testing
- `pytest tests/unit/test_migrate_prefixes.py -q` - 4 passed
- `pytest tests/ -m "not integration" -q` - 360 passed, 32 deselected (full non-integration suite, no new failures)
- `ruff check .` and `ruff format --check .` - clean

## Risks / Notes
- No schema or deploy-config changes. The check runs locally in `migrate.py` before `main()` connects to the database, so it also protects the Railway start hook and CI/deploy runs without any workflow changes.
- The `GRANDFATHERED_DUPLICATE_PREFIXES` set is explicitly commented to never gain new entries - any future duplicate prefix should be renumbered instead.

## Breaking Changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)