### PR TITLE
fix: add timeout and concurrency to dbt_docs.yml, concurrency to summarize_backfill.yml (MON-236)

### DIFF
--- a/.github/workflows/dbt_docs.yml
+++ b/.github/workflows/dbt_docs.yml
@@ -6,9 +6,14 @@ on:
     paths:
       - 'transform/**'
 
+concurrency:
+  group: dbt-docs
+  cancel-in-progress: false
+
 jobs:
   dbt-docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:

--- a/.github/workflows/summarize_backfill.yml
+++ b/.github/workflows/summarize_backfill.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 7 * * *'   # 07:00 UTC daily — one hour after Groq TPD reset at midnight UTC
   workflow_dispatch:        # Manual trigger
 
+concurrency:
+  group: summaries
+  cancel-in-progress: false
+
 jobs:
   backfill:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What
Adds a `timeout-minutes` and a `concurrency` group to `dbt_docs.yml`, and a `concurrency` group to `summarize_backfill.yml`.

## Why
MON-36's remediation added timeouts and concurrency groups "on all jobs", but `dbt_docs.yml` had neither.
A hung `dbt docs generate` against prod could run for GitHub's 6-hour default job limit, and two rapid merges touching `transform/` could race their `gh-pages` pushes.

`summarize_backfill.yml` had a timeout but no concurrency group.
Its 07:00 UTC run could overlap a slow 06:00 ingest run's own summaries step, double-spending Groq quota on the same NULL-summary votes.
This is harmless data-wise (upsert-only, idempotent) but burns the daily token budget the 07:00 run exists to use.

## Changes
- `dbt_docs.yml`: added `timeout-minutes: 15` on the `dbt-docs` job, and a `concurrency: {group: dbt-docs, cancel-in-progress: false}` block, matching the pattern used in `deploy.yml` and `ingest_prod.yml`.
- `summarize_backfill.yml`: added a `concurrency: {group: summaries, cancel-in-progress: false}` block. The existing `timeout-minutes: 30` on the job was already present and untouched.

## Testing
- Validated both YAML files parse correctly with `python3 -c "import yaml; yaml.safe_load(...)"`.
- No Python or frontend code changed — `pytest`/`ruff`/`npm` suites are not applicable to this diff.
- Pre-commit hooks (yaml check, trailing whitespace, etc.) passed on commit.

## Risks / Notes
- `cancel-in-progress: false` on both groups means overlapping runs queue rather than cancel — a hung `dbt-docs` run now self-terminates within 15 minutes instead of blocking a queued run for 6 hours.
- The `summaries` concurrency group only dedupes overlapping `summarize_backfill.yml` runs against each other; it does not share a lock with `ingest_prod.yml`'s own summaries step (per the issue, sharing the ingest advisory-lock pattern was an alternative fix, not required by the acceptance criteria).

## Breaking Changes
None.
