### PR TITLE
fix: base mart_deputy_scorecard.updated_at on deputies ingest, not vote_positions (MON-231)

### DIFF
--- a/transform/models/marts/mart_deputy_scorecard.sql
+++ b/transform/models/marts/mart_deputy_scorecard.sql
@@ -10,8 +10,13 @@ votes as (
     select * from {{ ref('stg_votes') }}
 ),
 
+-- Deputies are re-upserted on every successful ingestion run, recess or not
+-- (see transform/models/staging/sources.yml), so their ingested_at is the
+-- cron-death detector. stg_vote_positions.ingested_at only advances when a
+-- new vote falls inside the cron's --since window, which legitimately
+-- stalls for 30+ days during a parliamentary recess (MON-231).
 last_ingested as (
-    select max(ingested_at) as ingested_at from {{ ref('stg_vote_positions') }}
+    select max(ingested_at) as ingested_at from {{ ref('stg_deputies') }}
 ),
 
 -- Presence denominator: only votes held during the deputy's mandate window.
@@ -154,7 +159,9 @@ final as (
             else 0
         end                                                  as voting_days_rate,
 
-        -- metadata: reflects last ingest, not query time — makes recency test meaningful
+        -- metadata: last deputies ingest, not query time or vote-positions
+        -- ingest (see last_ingested above) - makes the recency test meaningful
+        -- year-round, including during a recess (MON-231)
         l.ingested_at                                        as updated_at
 
     from deputies d


### PR DESCRIPTION
## What
Bases `mart_deputy_scorecard.updated_at` on the deputies source's `ingested_at` instead of `stg_vote_positions.ingested_at`.

## Why
`mart_deputy_scorecard.updated_at` was `max(stg_vote_positions.ingested_at)`.
Daily ingestion only re-stamps `ingested_at` for positions of votes inside the cron's 30-day `--since` window, so once the most recent vote is older than 30 days (a long summer recess), `updated_at` stalls.

The source freshness config (`transform/models/staging/sources.yml`) was deliberately widened to `error_after: 30 day` on `votes` and `vote_positions` for exactly this reason, with the comment "avoids August false alarms" - but the `dbt_utils.recency` test on the mart (`transform/models/marts/schema.yml`) still demands `<= 4 days`, contradicting that tolerance.

`deploy.yml`'s `dbt test` step is `continue-on-error: true` and `ci.yml`'s dbt-data-health job is non-blocking by design, so this was not turning workflows red - but during a recess every PR got a "❌ failed" data-health comment and every deploy logged a failed test step, recurring false alarms that erode the signal those surfaces exist to carry.

## Changes
- `transform/models/marts/mart_deputy_scorecard.sql`: the `last_ingested` CTE now selects `max(ingested_at)` from `stg_deputies` instead of `stg_vote_positions`. Deputies are re-upserted on every successful ingestion run regardless of recess (per the comment already on the `deputies` source in `sources.yml`), making their `ingested_at` the correct cron-death detector - the same role it already plays for source freshness. Updated the inline comments to explain the choice and reference MON-231.

The recency test itself (`interval: 4` in `transform/models/marts/schema.yml`) is left as-is: it now matches the deputies source's own `warn_after: 4 day` tolerance, so it stays meaningful year-round instead of only outside recess windows.

## Testing
- Static validation: `schema.yml` parses as valid YAML.
- No Python files changed, so `pytest`/`ruff` are unaffected by this branch.
- Could not run `dbt compile`/`dbt test` locally (no local Postgres running via Docker; running against prod Supabase requires the `DBT_*` secrets that only CI has). CI's `dbt-data-health` job (`ci.yml`) will compile and test this model against prod data automatically - the change is a single-column source swap in one CTE, so compile risk is low.

## Risks / Notes
- No schema/data change - `updated_at`'s value changes (now reflects deputy ingest recency, not vote-position ingest recency), but its type and column position are unchanged.
- `mart_vote_summary` and `mart_party_alignment` have their own `last_ingested` CTEs based on `stg_votes`/`stg_vote_positions` respectively, but neither has a `dbt_utils.recency` schema test, so they are out of scope for this false-alarm issue.
- Reviewer should confirm the next CI run's dbt-data-health comment no longer fails purely on staleness (best verified once actually in a recess window, or by reasoning about the query change).

## Breaking Changes
None.
