### PR TITLE
fix: correct department code and preposition in deputy_by_department formatter (MON-235)

### DIFF
--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -16,6 +16,7 @@ import psycopg2.pool
 from dotenv import load_dotenv
 
 from rag.constants import NOTABLE_DEPUTY_NAMES
+from rag.pipeline.chunker import dept_preposition
 
 load_dotenv()
 
@@ -90,6 +91,10 @@ CODE_TO_DEPT_NAME: dict[str, str] = {
     "94": "Val-de-Marne",
     "95": "Val-d'Oise",
 }
+
+# deputies.department stores the full name (update_party.py writes it), not the code —
+# invert CODE_TO_DEPT_NAME to recover the code for display.
+DEPT_NAME_TO_CODE_DISPLAY: dict[str, str] = {name: code for code, name in CODE_TO_DEPT_NAME.items()}
 
 
 def normalize_text(text: str) -> str:
@@ -449,6 +454,19 @@ def _fmt_vote_line(r: dict) -> str:
     )
 
 
+def _fmt_deputy_by_department(rows: list[dict]) -> str:
+    if not rows:
+        return "Aucun député trouvé pour ce département."
+    dept_name = rows[0]["department"]
+    code = DEPT_NAME_TO_CODE_DISPLAY.get(dept_name)
+    prep = dept_preposition(dept_name)
+    sep = "" if prep.endswith("'") else " "
+    dept_suffix = f" (département {code})" if code else ""
+    return f"{len(rows)} député(s) {prep}{sep}{dept_name}{dept_suffix} :\n" + "\n".join(
+        f"- {r['full_name']} ({r['party'] or 'parti non renseigné'})" for r in rows
+    )
+
+
 FORMATTERS = {
     "deputy_top_presence": lambda rows: (
         "Députés en exercice avec le meilleur taux de présence "
@@ -544,16 +562,7 @@ FORMATTERS = {
             for r in rows
         )
     ),
-    "deputy_by_department": lambda rows: (
-        (
-            f"{len(rows)} député(s) dans les "
-            f"{CODE_TO_DEPT_NAME.get(rows[0]['department'], rows[0]['department'])} "
-            f"(département {rows[0]['department']}) :\n"
-            + "\n".join(f"- {r['full_name']} ({r['party'] or 'parti non renseigné'})" for r in rows)
-        )
-        if rows
-        else "Aucun député trouvé pour ce département."
-    ),
+    "deputy_by_department": _fmt_deputy_by_department,
     "deputy_total_count": lambda rows: (
         f"MonÉlu suit {rows[0]['active']} députés en exercice "
         f"({rows[0]['total']} au total sur la 17e législature, "

--- a/tests/unit/test_sql_router_intents.py
+++ b/tests/unit/test_sql_router_intents.py
@@ -234,3 +234,24 @@ def test_every_new_formatter_renders_its_row_shape():
     for intent, rows in _SAMPLE_ROWS.items():
         out = FORMATTERS[intent](rows)
         assert isinstance(out, str) and out, intent
+
+
+def test_deputy_by_department_shows_code_and_correct_preposition():
+    from rag.chain.sql_router import FORMATTERS
+
+    rows = [{"full_name": "A B", "party": "P", "department": "Yvelines"}]
+    out = FORMATTERS["deputy_by_department"](rows)
+    assert "(département 78)" in out
+    assert "des Yvelines" in out
+
+    rows = [{"full_name": "A B", "party": "P", "department": "Paris"}]
+    out = FORMATTERS["deputy_by_department"](rows)
+    assert "(département 75)" in out
+    assert "de Paris" in out
+    assert "les Paris" not in out
+
+
+def test_deputy_by_department_empty():
+    from rag.chain.sql_router import FORMATTERS
+
+    assert FORMATTERS["deputy_by_department"]([]) == "Aucun député trouvé pour ce département."


### PR DESCRIPTION
## What
Fixes the `deputy_by_department` SQL-router answer formatter so it shows the department's numeric code and uses grammatically correct French prepositions instead of always saying "dans les".

## Why
`deputies.department` stores the full department name (e.g. "Yvelines"), not the code — `scripts/update_party.py` writes the expanded name at insert time. The formatter was looking that name up in `CODE_TO_DEPT_NAME`, which is keyed by numeric code, so the lookup always missed and fell back to the name itself. The result was answers like "dans les Yvelines (département Yvelines)" instead of "(département 78)", and "dans les" is wrong for most departments ("dans les Paris" instead of "de Paris"). Purely cosmetic — the underlying data was always correct.

## Changes
- Added `DEPT_NAME_TO_CODE_DISPLAY` in `rag/chain/sql_router.py`, inverting `CODE_TO_DEPT_NAME` to recover the numeric code from the stored full name.
- Imported and reused `dept_preposition()` from `rag/pipeline/chunker.py` (the same helper the chunker already uses for department phrasing) instead of hardcoding "dans les".
- Extracted the `deputy_by_department` formatter out of the `FORMATTERS` lambda dict into a named `_fmt_deputy_by_department()` function, matching the existing `_fmt_vote_line()` pattern, since the logic no longer fit cleanly as a one-line lambda.
- Added regression tests in `tests/unit/test_sql_router_intents.py` covering the department code display and preposition correctness (`des Yvelines`, `de Paris`, not `les Paris`), plus the empty-rows case.

## Testing
- `ruff check .` and `ruff format --check .` — pass.
- `pytest tests/ -m "not integration" -q` — 367 passed.
- `pytest tests/unit/test_sql_router_intents.py tests/unit/test_chunker.py -q` — 31 passed.
- Manually exercised `_fmt_deputy_by_department` with sample rows for Yvelines, Paris, and Val-d'Oise to confirm correct code and preposition output.

## Risks / Notes
Formatter-only change; no schema, query, or deploy-config changes. No migration risk.

## Breaking Changes
None.
