### PR TITLE
fix: null voted_at handled as warn-only anomaly, not a hard test failure (MON-232)

### DIFF
--- a/api/routers/votes.py
+++ b/api/routers/votes.py
@@ -19,8 +19,10 @@ router = APIRouter()
 def _encode_cursor(voted_at: Optional[datetime], vote_id: str) -> str:
     """Opaque keyset cursor over the list's sort key (voted_at, vote_id).
 
-    voted_at may be None — undated votes sort last (NULLS LAST) and still
-    need a cursor to page past them.
+    voted_at may be None - undated votes sort last (NULLS LAST) and still
+    need a cursor to page past them. stg_votes currently drops null-dated
+    votes before the mart (ADR-031), so this path is defense-in-depth, not
+    dead code: it only fires if that filter is ever relaxed.
     """
     ts = voted_at.isoformat() if voted_at is not None else ""
     raw = f"{ts}|{vote_id}"

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -810,6 +810,29 @@ A summary is regenerated when `objet_hash` changes.
 
 ---
 
+## ADR-031 - Null voted_at is a warn-only anomaly, not a hard test failure (MON-232)
+
+**Date:** 2026-08-07
+**Status:** Final
+
+**Decision:** `votes.voted_at` stays nullable at ingestion (per ADR from MON-13's remediation), and null-dated rows stay filtered out of `stg_votes` and everything downstream.
+The dbt source `not_null` test on `voted_at` (`transform/models/staging/sources.yml`) is downgraded to `severity: warn` instead of being dropped.
+
+**Reason:**
+Before this ADR, one upstream scrutin missing `dateScrutin` produced three contradictory outcomes at once: ingestion succeeded (by design, since MON-13 made the column nullable so a single bad record can't abort the whole `execute_batch`), the daily dbt test step failed hard and emailed a "stale data" alert that wasn't about staleness, and the vote itself never reached a mart or the API regardless of the test outcome.
+Dropping the test entirely would remove the only visibility into how often this quirk actually happens.
+Keeping it at `severity: warn` preserves that visibility in the dbt run output without blocking the daily pipeline or triggering a misleading failure email.
+The staging filter is unchanged: a vote with no date is not something the API, marts, or RAG corpus can meaningfully render, so it stays invisible past `stg_votes` by design, not by accident.
+
+**Impact:**
+- `api/routers/votes.py`'s `NULLS LAST` keyset-cursor handling over `mart_vote_summary` cannot currently be exercised, since the mart can never contain a null `voted_at` row under this contract.
+  It is kept as defense-in-depth rather than removed, since it only matters if the staging filter is ever relaxed, and the code cost of keeping it is small.
+- Any future change to relax the `stg_votes` filter (e.g. surfacing undated votes in the UI) must revisit this ADR, since the warn-only test and the "invisible by design" framing both assume the filter stays in place.
+
+**Trigger to revisit:** if the AN source starts omitting `dateScrutin` often enough that the warn becomes noise, or if a product decision surfaces undated votes to users instead of hiding them.
+
+---
+
 ## Rules for future development sessions
 
 1. Read this file before writing any code
@@ -826,3 +849,4 @@ A summary is regenerated when `objet_hash` changes.
 12. When in doubt: check what's actually deployed before writing new code
 13. Sustainability funding is donations-first via HelloAsso, with the existing `api_keys.rate_limit_multiplier` (ADR-029, MON-116/MON-98) as the paid-tier mechanism — do not build Stripe/webhook billing until a real paying commercial API customer exists
 14. Agenda ingestion is séance publique only, upserted into one `agenda_items` table and never deleted (ADR-030, MON-110) - an item is visible only when it was seen in the latest ingestion run and is not cancelled; never generate a summary for a stub `objet`
+15. Null `voted_at` is a tolerated upstream quirk, not an ingestion failure (ADR-031, MON-232) - the source test is `severity: warn`, `stg_votes` keeps filtering the row out, and undated votes stay invisible past staging by design

--- a/transform/models/staging/sources.yml
+++ b/transform/models/staging/sources.yml
@@ -43,8 +43,13 @@ sources:
               - not_null
               - unique
           - name: voted_at
+            description: >
+              Nullable by design (MON-13, ADR-031) - stg_votes drops null-dated
+              rows before the marts, so this test is a warn-only anomaly alert.
             tests:
-              - not_null
+              - not_null:
+                  config:
+                    severity: warn
           - name: result
             tests:
               - not_null

--- a/transform/models/staging/stg_votes.sql
+++ b/transform/models/staging/stg_votes.sql
@@ -30,6 +30,7 @@ renamed as (
 
     from source
     where vote_id is not null
+      -- Null voted_at is a tolerated upstream quirk (MON-13, ADR-031); rows are dropped here, not at ingestion
       and voted_at is not null
 )
 


### PR DESCRIPTION
## What
Resolves a three-way contradiction in how a null `votes.voted_at` is handled: tolerated at ingestion, hard-failed by the daily dbt source test, and silently dropped by staging.

## Why
MON-13's remediation made `voted_at` nullable so an AN scrutin missing `dateScrutin` can't abort the whole `execute_batch` ingestion transaction.
But the raw-source `not_null` test on `voted_at` still hard-fails the daily dbt test step whenever that happens, sending a "stale data" failure email that isn't actually about staleness, while `stg_votes.sql` filters the row out regardless, so the vote never reaches a mart or the API either way.
One upstream quirk was producing: successful ingestion + failing pipeline + invisible vote, all at once.

## Changes
- `transform/models/staging/sources.yml`: the `voted_at` source `not_null` test is downgraded to `severity: warn`, with a description documenting why (the row is filtered downstream regardless - this is an anomaly alert, not a data-freshness gate).
- `transform/models/staging/stg_votes.sql`: added a comment on the existing `voted_at is not null` filter clarifying it's intentional (MON-13), not a leftover.
- `api/routers/votes.py`: clarified the `NULLS LAST` keyset-cursor docstring - this path can't currently be exercised (the mart never contains a null `voted_at`), but it's kept as defense-in-depth rather than removed, since it only matters if the staging filter is ever relaxed.
- `docs/decisions.md`: added ADR-031 documenting the contract decided here, plus rule 15 in the "Rules for future development sessions" list.

## Acceptance criteria
The issue's fix asked to decide the contract once, either dropping the source test (accept invisibility) or keeping it at `severity: warn` (loud but non-blocking). This PR takes the second path: the test stays as an anomaly signal, downgraded so it stops reading as a stale-data failure, and the resulting invisibility is documented in ADR-031.

## Testing
- `python3 -m pytest tests/ -m "not integration" -q` - 365 passed (matches the CI-blocking selection).
- `python3 -m ruff check .` and `python3 -m ruff format --check .` - repo-wide, clean.
- Manually validated `transform/models/staging/sources.yml` parses as YAML.
- Could not run `dbt compile`/`dbt test` locally (broken local dbt install unrelated to this change) - CI's `ci.yml` runs dbt compile + dbt test against this diff and will catch any YAML/Jinja error.

## Risks / Notes
- No schema or data change - this only changes a dbt test severity and adds comments/docs. No migration, no deploy-config change.
- Reviewer should confirm the `severity: warn` framing (documented visibility, non-blocking) is the intended contract versus dropping the test entirely.

## Breaking Changes
None.