### PR TITLE
perf: sql_router reads mart_party_alignment, adds statement_timeout to RAG pools (MON-234)

### DIFF
--- a/rag/chain/retriever.py
+++ b/rag/chain/retriever.py
@@ -39,7 +39,18 @@ def _get_retriever_pool() -> psycopg2.pool.ThreadedConnectionPool:
     if _retriever_pool is None:
         with _retriever_pool_lock:
             if _retriever_pool is None:
-                _retriever_pool = psycopg2.pool.ThreadedConnectionPool(1, 3, dsn=DATABASE_URL)
+                try:
+                    _retriever_pool = psycopg2.pool.ThreadedConnectionPool(
+                        1, 3, dsn=DATABASE_URL, options="-c statement_timeout=5000"
+                    )
+                except psycopg2.OperationalError:
+                    # PgBouncer in transaction mode rejects startup options=;
+                    # see api/db.py init_pool for the same fallback.
+                    log.warning(
+                        "DB rejected startup options (statement_timeout) — initializing "
+                        "retriever pool without statement_timeout"
+                    )
+                    _retriever_pool = psycopg2.pool.ThreadedConnectionPool(1, 3, dsn=DATABASE_URL)
     return _retriever_pool
 
 

--- a/rag/chain/sql_router.py
+++ b/rag/chain/sql_router.py
@@ -33,7 +33,18 @@ def _get_pool() -> psycopg2.pool.ThreadedConnectionPool:
     if _pool is None:
         with _pool_lock:
             if _pool is None:
-                _pool = psycopg2.pool.ThreadedConnectionPool(1, 5, dsn=DATABASE_URL)
+                try:
+                    _pool = psycopg2.pool.ThreadedConnectionPool(
+                        1, 5, dsn=DATABASE_URL, options="-c statement_timeout=5000"
+                    )
+                except psycopg2.OperationalError:
+                    # PgBouncer in transaction mode rejects startup options=;
+                    # see api/db.py init_pool for the same fallback.
+                    log.warning(
+                        "DB rejected startup options (statement_timeout) — initializing "
+                        "sql_router pool without statement_timeout"
+                    )
+                    _pool = psycopg2.pool.ThreadedConnectionPool(1, 5, dsn=DATABASE_URL)
     return _pool
 
 
@@ -416,30 +427,18 @@ SQL_QUERIES = {
         ORDER BY count DESC
     """,
     "party_alignment": """
+        -- per-deputy aligned_votes/total_votes rolled up to party level;
+        -- reads the mart instead of re-deriving the majority via a live
+        -- 715k-row self-join (MON-118 materialized it for this reason)
         SELECT
-            d.party,
+            party,
             ROUND(
-                COUNT(*) FILTER (WHERE vp.position = majority.majority_pos)::numeric
-                / NULLIF(COUNT(*), 0) * 100, 1
+                SUM(aligned_votes)::numeric / NULLIF(SUM(total_votes), 0) * 100, 1
             ) as alignment_pct,
-            COUNT(*) as total_votes
-        FROM vote_positions vp
-        JOIN deputies d ON vp.deputy_id = d.deputy_id
-        JOIN (
-            SELECT
-                vp2.vote_id,
-                d2.party,
-                MODE() WITHIN GROUP (ORDER BY vp2.position) as majority_pos
-            FROM vote_positions vp2
-            JOIN deputies d2 ON vp2.deputy_id = d2.deputy_id
-            WHERE vp2.position IN ('pour','contre','abstention')
-              AND d2.party IS NOT NULL
-            GROUP BY vp2.vote_id, d2.party
-        ) majority ON vp.vote_id = majority.vote_id
-            AND d.party = majority.party
-        WHERE d.party IS NOT NULL
-          AND vp.position IN ('pour','contre','abstention')
-        GROUP BY d.party
+            SUM(total_votes) as total_votes
+        FROM analytics_marts.mart_party_alignment
+        WHERE party IS NOT NULL
+        GROUP BY party
         ORDER BY alignment_pct DESC
         LIMIT 12
     """,

--- a/tests/integration/test_alignment.py
+++ b/tests/integration/test_alignment.py
@@ -10,6 +10,8 @@ transform/models/intermediate/int_party_vote_majority.sql.
 
 import pytest
 
+from rag.chain.sql_router import SQL_QUERIES
+
 _ALIGNMENT_SQL = """
 SELECT
     deputy_id,
@@ -105,3 +107,18 @@ def test_dissident_votes_respects_limit(db_conn):
         rows = cur.fetchall()
 
     assert len(rows) == 2
+
+
+@pytest.mark.integration
+def test_party_alignment_reads_mart(db_conn):
+    """rag.chain.sql_router's party_alignment intent (MON-234) must read
+    analytics_marts.mart_party_alignment, not re-derive it via a live join."""
+    with db_conn.cursor() as cur:
+        cur.execute(SQL_QUERIES["party_alignment"])
+        rows = cur.fetchall()
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["party"] == "Rassemblement National"
+    assert row["total_votes"] == 25
+    assert float(row["alignment_pct"]) == 80.0


### PR DESCRIPTION
## What
`rag/chain/sql_router.py`'s `party_alignment` intent stops re-deriving the per-(party, vote) majority from a live 715k-row self-join with `MODE() WITHIN GROUP` on every matching question, and reads `analytics_marts.mart_party_alignment` instead. Also adds `statement_timeout=5000` to the sql_router and retriever connection pools.

## Why
MON-118 materialized `int_party_vote_majority` / `mart_party_alignment` specifically because this join was too slow per-request for `api/routers/deputies.py`'s dissident-votes query. `sql_router.py`'s `party_alignment` intent (and `deputy_dissidents`, which already reads the mart correctly) kept its own live copy of the same computation, paying the cost MON-118 was meant to eliminate. Separately, the sql_router and retriever pools were plain `ThreadedConnectionPool`s without the `statement_timeout` the API pool (`api/db.py`) sets, so a pathological query could hold a pooled RAG connection indefinitely.

## Changes
- `rag/chain/sql_router.py`: `SQL_QUERIES["party_alignment"]` now aggregates `mart_party_alignment`'s per-deputy `aligned_votes`/`total_votes` up to party level (`SUM(aligned_votes)/SUM(total_votes)`), instead of the live self-join. Mathematically equivalent to the old query - the mart's `deputy_alignment` CTE (`transform/models/marts/mart_party_alignment.sql`) uses the same join conditions (`vote_id`, `party`) and the same denominator (positions in `pour`/`contre`/`abstention`), so summing per-deputy `aligned_votes`/`total_votes` reproduces the original per-party `COUNT(*) FILTER(...)/COUNT(*)`.
- `rag/chain/sql_router.py` / `rag/chain/retriever.py`: `_get_pool()` / `_get_retriever_pool()` now pass `options="-c statement_timeout=5000"`, with the same PgBouncer-transaction-mode fallback `api/db.py`'s `init_pool()` already uses (`except psycopg2.OperationalError` retries without `options=`).
- `tests/integration/test_alignment.py`: added `test_party_alignment_reads_mart`, which runs the new `party_alignment` SQL against the existing seeded fixture (`PA001`, Rassemblement National, 25 total / 20 aligned) and asserts `alignment_pct == 80.0`.

## Testing
- `python3 -m pytest tests/ -m "not integration" -q` - 369 passed (matches the CI-blocking selection).
- `python3 -m ruff check .` and `python3 -m ruff format --check .` - repo-wide, clean.
- Could not run the integration suite locally (Docker not running in this environment) - CI's `ci.yml` runs `pytest tests/integration/ -m integration` against a real Postgres service and will exercise the new `test_party_alignment_reads_mart` test.
- Manually verified the new query is a mathematically equivalent rewrite of the old self-join by tracing both against `mart_party_alignment.sql`'s join conditions and denominator.

## Risks / Notes
- No schema or migration change. `deputy_dissidents` already read the mart with the same implicit "any exception → return [] → fall back to RAG" behavior in `run_sql_query`, which this PR relies on for `party_alignment` too (no mart-absent fallback needed beyond what already exists).
- `statement_timeout=5000` matches the API pool's existing value; if a legitimate RAG query is found to exceed 5s under real load, that's a follow-up, not a regression introduced here.

## Breaking Changes
None.