### PR TITLE
perf: cache the /quiz/weekly pick per ISO week (MON-230)

### DIFF
--- a/api/routers/quiz.py
+++ b/api/routers/quiz.py
@@ -46,6 +46,7 @@ Denominator rules (consistent with ADR-019's presence framing):
 import logging
 import os
 import re
+import threading
 import uuid
 from collections import Counter, defaultdict
 from datetime import date, timedelta
@@ -473,6 +474,16 @@ def get_questions(request: Request) -> QuizQuestionsResponse:
     )
 
 
+# The pick is deliberately stable for a whole ISO week (see week_start), and the
+# candidate query's cutoff means the eligible row set never changes mid-week either
+# — so the resolved pick (including "none qualified") is cached per week_start,
+# skipping the 500-row scan on every request (MON-230). Same lock-guarded
+# read-then-recompute-then-store shape as the /health stats cache (api/main.py).
+_weekly_lock = threading.Lock()
+_weekly_cache_key: Optional[date] = None
+_weekly_cache_value: Optional[QuizWeeklyQuestion] = None
+
+
 @router.get(
     "/weekly",
     response_model=QuizWeeklyQuestion,
@@ -481,7 +492,18 @@ def get_questions(request: Request) -> QuizQuestionsResponse:
 )
 @limiter.limit(tiered_limit(30))
 def get_weekly(request: Request) -> QuizWeeklyQuestion:
+    global _weekly_cache_key, _weekly_cache_value
     cutoff = week_start(date.today())
+
+    with _weekly_lock:
+        if _weekly_cache_key == cutoff:
+            cached = _weekly_cache_value
+            if cached is None:
+                raise HTTPException(
+                    status_code=404, detail="Aucun scrutin qualifiant cette semaine."
+                )
+            return cached
+
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
@@ -498,20 +520,27 @@ def get_weekly(request: Request) -> QuizWeeklyQuestion:
             candidates = cur.fetchall()
 
     row = select_weekly_vote(candidates)
-    if row is None:
-        raise HTTPException(status_code=404, detail="Aucun scrutin qualifiant cette semaine.")
+    result = None
+    if row is not None:
+        voted_at = row["voted_at"]
+        result = QuizWeeklyQuestion(
+            vote_id=row["vote_id"],
+            question=build_weekly_question(row.get("summary_plain"), row["vote_title"]),
+            vote_title=row["vote_title"],
+            votes_for=row["votes_for"],
+            votes_against=row["votes_against"],
+            abstentions=row["abstentions"],
+            result=row["result"],
+            vote_date=voted_at.date().isoformat() if voted_at else None,
+        )
 
-    voted_at = row["voted_at"]
-    return QuizWeeklyQuestion(
-        vote_id=row["vote_id"],
-        question=build_weekly_question(row.get("summary_plain"), row["vote_title"]),
-        vote_title=row["vote_title"],
-        votes_for=row["votes_for"],
-        votes_against=row["votes_against"],
-        abstentions=row["abstentions"],
-        result=row["result"],
-        vote_date=voted_at.date().isoformat() if voted_at else None,
-    )
+    with _weekly_lock:
+        _weekly_cache_key = cutoff
+        _weekly_cache_value = result
+
+    if result is None:
+        raise HTTPException(status_code=404, detail="Aucun scrutin qualifiant cette semaine.")
+    return result
 
 
 def _normalized_department(body: QuizMatchRequest) -> Optional[str]:

--- a/tests/unit/test_quiz.py
+++ b/tests/unit/test_quiz.py
@@ -113,6 +113,19 @@ NOT_QUIZ_ID = "VTANR5L17V9999"
 assert NOT_QUIZ_ID not in {q["vote_id"] for q in QUIZ_QUESTIONS}
 
 
+@pytest.fixture(autouse=True)
+def _reset_weekly_cache():
+    """The weekly pick is cached per ISO week (MON-230) — clear it so each
+    test's mocked candidates are actually read instead of a prior test's."""
+    import api.routers.quiz as quiz_module
+
+    quiz_module._weekly_cache_key = None
+    quiz_module._weekly_cache_value = None
+    yield
+    quiz_module._weekly_cache_key = None
+    quiz_module._weekly_cache_value = None
+
+
 def _weekly_row(
     vote_id=NOT_QUIZ_ID,
     vote_title="l'ensemble du projet de loi relatif à un sujet quelconque",
@@ -240,6 +253,33 @@ def test_get_weekly_never_returns_a_curated_quiz_question(client, mock_cursor):
     mock_cursor.fetchall.return_value = [_weekly_row(vote_id=QUIZ_QUESTIONS[0]["vote_id"])]
     resp = client.get("/quiz/weekly")
     assert resp.status_code == 404
+
+
+def test_get_weekly_caches_the_pick_for_the_week(client, mock_cursor):
+    """MON-230 — a second request within the same ISO week must not re-scan."""
+    mock_cursor.fetchall.return_value = [_weekly_row()]
+    first = client.get("/quiz/weekly")
+    assert first.status_code == 200
+    calls_after_first = mock_cursor.execute.call_count
+
+    # Even if the DB would now answer differently, the cached pick wins.
+    mock_cursor.fetchall.return_value = [_weekly_row(vote_id="VTANR5L17V8888", votes_for=999)]
+    second = client.get("/quiz/weekly")
+    assert second.status_code == 200
+    assert second.json() == first.json()
+    assert mock_cursor.execute.call_count == calls_after_first
+
+
+def test_get_weekly_caches_the_404_for_the_week(client, mock_cursor):
+    mock_cursor.fetchall.return_value = []
+    first = client.get("/quiz/weekly")
+    assert first.status_code == 404
+    calls_after_first = mock_cursor.execute.call_count
+
+    mock_cursor.fetchall.return_value = [_weekly_row()]
+    second = client.get("/quiz/weekly")
+    assert second.status_code == 404
+    assert mock_cursor.execute.call_count == calls_after_first
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Caches the `/quiz/weekly` pick per ISO week instead of scanning 500 candidate rows and re-running selection in Python on every request.

## Why

`GET /quiz/weekly` (`api/routers/quiz.py`) picks a scrutin for the week and the pick is deliberately stable for the whole week (the query cutoff already excludes votes from the current week, so the candidate row set never changes mid-week either). Despite that, every request re-fetched 500 rows and re-ran `select_weekly_vote` from scratch. Flagged as Finding #3 in `api_diagnostic_2026-08-05.md`, with the existing 60s stats cache in `api/main.py` cited as the pattern to follow.

## Changes

- `api/routers/quiz.py`: added a module-level cache (`_weekly_cache_key` / `_weekly_cache_value`, guarded by `_weekly_lock`) keyed on `week_start(date.today())`. `get_weekly` now checks the cache first; on a miss it runs the existing query + `select_weekly_vote`, builds the `QuizWeeklyQuestion` (or `None` if nothing qualifies), stores it under the week's key, and returns. Both the positive pick and the "no qualifying scrutin" (404) outcome are cached, since both are equally stable for the week.
- `tests/unit/test_quiz.py`: added an autouse fixture that resets the new cache before/after each test (the module-level cache otherwise leaks state between tests run in the same ISO week), plus two new tests asserting a second request within the same week reuses the cached result (both the 200 and 404 cases) without a second DB scan.

## Testing

- `pytest tests/unit/test_quiz.py -q` — 59 passed (57 existing + 2 new caching tests).
- `pytest tests/ -m "not integration" -q` — 371 passed (full CI-blocking selection).
- `ruff check .` and `ruff format --check .` — clean.

## Risks / Notes

- Cache is per-process, in-memory, unbounded growth risk: none — it holds at most one entry (single key, overwritten each new week), never accumulates.
- No cross-instance invalidation needed: Railway runs a single API process, and even under multiple instances, each would independently cache the same deterministic pick for the week.
- No schema, deploy config, or endpoint contract changes.

## Breaking Changes

None.
