### PR TITLE
docs: fix migrations blurb - 001_init.sql is not the full schema (MON-227)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,8 +139,8 @@ Assemblée Nationale Open Data (ZIPs)
 - Modeled an Airflow+Spark architecture never built, with no compute for the actual FastAPI app — archived rather than fixed (MON-46). See Phase 5 and decision 1 in the decisions log.
 - `networking`, `s3`, `rds` modules are the only parts worth salvaging if an AWS migration ever happens; `ec2` does not survive that design.
 
-**`data/migrations/001_init.sql`** — Full schema
-- Four tables: `deputies`, `votes`, `vote_positions`, `document_chunks`
+**`data/migrations/`** — 10 sequential migration files applied by `migrate.py`'s ledger; `001_init.sql` is the core four-table baseline
+- `001_init.sql`: `deputies`, `votes`, `vote_positions`, `document_chunks`
 - All `CREATE TABLE IF NOT EXISTS` — safe to re-run
 - `migrate.py` keeps a `schema_migrations` ledger: each file is applied once and skipped on later deploys
 


### PR DESCRIPTION
## What
Fixes the `data/migrations/001_init.sql` blurb in CLAUDE.md, which still described it as "the full schema."

## Why
`001_init.sql` is now the historical four-table baseline, not the whole picture. The schema has grown to 10 migration files (`001` through `009`, including two `005_` files: `005_feedback.sql` and `005_verifications.sql`) and 11 domain tables plus the `schema_migrations` ledger. A new contributor reading the old blurb would be sent to one file expecting the complete schema.

Source: `database_diagnostic_2026-08-05.md`, Finding #3 (MON-227).

Note: the issue's suggested wording said "9 sequential migration files," but the actual current count is 10 (two files share the `005_` prefix). This PR uses the accurate count.

## Acceptance criteria
- [x] Reword `data/migrations/001_init.sql` blurb so it no longer implies the whole schema lives in one file

## Changes
- `CLAUDE.md`: reworded the migrations blurb to `data/migrations/` — 10 sequential migration files applied by `migrate.py`'s ledger; `001_init.sql` is the core four-table baseline. Kept the four-table list attached to `001_init.sql` specifically.

## Testing
- Docs-only change; no code or schema touched.
- Verified file count and table names directly against `data/migrations/*.sql` and `scripts/migrate.py`.

## Risks / Notes
None. Documentation-only change with no runtime impact.

## Breaking Changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)