### PR TITLE
fix: drop dead IVFFLAT_PROBES, document FRONTEND_BASE_URL (MON-237)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,8 +33,10 @@ AIRFLOW_ADMIN_PASSWORD=
 MINIO_ROOT_USER=
 MINIO_ROOT_PASSWORD=
 
-# RAG retrieval — pgvector ivfflat probe count (optional, defaults set in rag/constants.py)
-IVFFLAT_PROBES=
+# Share URLs - base URL used to mint /chat/s/, /quiz/s/, and /verifier/v/ links
+# (api/routers/search.py, quiz.py, verify.py). Defaults to https://mon-elu.vercel.app
+# if unset - set explicitly in staging so share links don't point at prod.
+FRONTEND_BASE_URL=
 
 # dbt — required to generate transform/profiles.yml (scripts/create_dbt_profile.py),
 # used by CI and the deploy workflow against prod Supabase


### PR DESCRIPTION
## What
Removes the dead `IVFFLAT_PROBES` block from `.env.example` and documents `FRONTEND_BASE_URL`.

## Why
`IVFFLAT_PROBES` was documented as part of MON-42's env-var contract remediation, but the IVFFlat index it configured was dropped in migration 003 (ADR-008). `rag/constants.py` no longer reads it, and the file's comment pointed at defaults that no longer exist.

`FRONTEND_BASE_URL` drives every share URL the API mints (`api/routers/search.py`, `quiz.py`, `verify.py` - `/chat/s/`, `/quiz/s/`, `/verifier/v/`) but was absent from `.env.example`. It has a safe default (`https://mon-elu.vercel.app`), but a staging deploy that forgets to set it would silently mint prod-pointing share links.

Source: `deployment_config_diagnostic_2026-08-06.md`, Finding #1 (MON-237).

## Changes
- `.env.example`: deleted the `IVFFLAT_PROBES` line and its stale comment; added `FRONTEND_BASE_URL=` with a comment describing its default and role in share URLs.

## Testing
- `grep -rn "IVFFLAT_PROBES"` across the repo: no remaining references outside this diff.
- `grep -rn "FRONTEND_BASE_URL"` confirms the three routers (`search.py:19`, `quiz.py:70`, `verify.py:28`) that read it via `os.getenv(..., "https://mon-elu.vercel.app")`.
- No code paths changed; this is a documentation/config-contract fix only, so no test suite run was needed.

## Risks / Notes
- Pure documentation change - no runtime behavior changes.

## Breaking Changes
None.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KnjbQbpj3Hf9x9akzakybE