### PR TITLE
chore: move rank-bm25 to requirements-dev.txt (MON-238)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ detect-secrets==1.5.0
 dbt-core>=1.9,<1.10
 dbt-postgres>=1.9,<1.10
 mlflow==3.11.1
+rank-bm25==0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,3 @@ groq>=0.11.0
 tiktoken==0.7.0
 pgvector==0.3.2
 numpy>=1.26.0
-rank-bm25==0.2.2


### PR DESCRIPTION
## What
Moves `rank-bm25==0.2.2` out of `requirements.txt` (the Railway prod image) into `requirements-dev.txt`.

## Why
`rank-bm25`'s only importer is `rag/chain/hybrid_retriever.py`, the BM25 hybrid retrieval experiment reverted in ADR-013. It's kept around only for `mlflow_eval`'s `phase_b_hybrid` comparison config, an eval-only path. Nothing on the live API request path imports it, so it doesn't belong in the deployed image. MON-39 established the pattern of keeping eval-only dependencies (mlflow, dbt, pytest) in `requirements-dev.txt`; this follows the same principle.

## Changes
- `requirements.txt`: removed `rank-bm25==0.2.2`.
- `requirements-dev.txt`: added `rank-bm25==0.2.2` next to `mlflow==3.11.1`.

## Testing
- `python -m pytest tests/ -m "not integration" -q` - 393 passed (CI's blocking gate; `requirements-dev.txt` is installed alongside `requirements.txt` in `ci.yml`, so `mlflow_eval`'s import of `hybrid_retriever` still resolves).
- `ruff check .` and `ruff format --check .` - clean.
- Confirmed `rank_bm25` has no other importers (`grep -rn "rank_bm25" .`).

## Risks / Notes
None. Purely a dependency-location move; `hybrid_retriever.py` and the eval config are unchanged and still work locally once `requirements-dev.txt` is installed (same as `mlflow` already requires).

## Breaking Changes
None.

Closes MON-238

https://claude.ai/code/session_01NQnoQFNkj83ds7Mhah68K5