### PR TITLE
chore: remove dead CANCELLED_ETATS constant and stale Airflow docstrings (MON-223)

### DIFF
--- a/scripts/ingest_agenda.py
+++ b/scripts/ingest_agenda.py
@@ -51,7 +51,6 @@ DATABASE_URL = os.getenv("DATABASE_URL")
 AGENDA_ZIP_PATH = "/static/openData/repository/17/vp/reunions/Agenda.json.zip"
 
 SEANCE_XSI_TYPE = "seance_type"
-CANCELLED_ETATS = {"Annulé", "Supprimé"}
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/ingest_positions.py
+++ b/scripts/ingest_positions.py
@@ -176,7 +176,7 @@ def main() -> None:
 
 
 def run(since: str | None = None, zip_path: str | None = None) -> None:
-    """Programmatic entry point for Airflow — skips argparse."""
+    """Programmatic entry point — skips argparse."""
     if not DATABASE_URL:
         raise EnvironmentError("DATABASE_URL is not set. Copy .env.example to .env and fill it in.")
     if since:

--- a/scripts/ingest_votes.py
+++ b/scripts/ingest_votes.py
@@ -194,11 +194,6 @@ def _upsert_records(records: list[dict]) -> None:
         conn.close()
 
 
-def fetch_all_votes(since: str | None = None) -> list[dict]:
-    """Alias for fetch_all_scrutins — DAG-friendly name."""
-    return fetch_all_scrutins(since=since)
-
-
 def upsert_votes(raw_items: list[dict]) -> int:
     """Parse raw scrutin dicts and upsert into votes table. Returns count written."""
     records = [r for item in raw_items if (r := parse_vote(item)) is not None]


### PR DESCRIPTION
## What
Removes a dead constant and two stale Airflow-era docstring references from the ingestion scripts.

## Why
`CANCELLED_ETATS` in `scripts/ingest_agenda.py` was never referenced anywhere - cancellation filtering happens at the API layer per ADR-030 (MON-212), not at ingestion, so the constant was misleading dead code.
Separately, `scripts/ingest_positions.py` and `scripts/ingest_votes.py` still carried Airflow/DAG references (a docstring and a "DAG-friendly" alias function) pointing at an architecture that was archived in MON-46. Both point maintainers at a dead architecture and needed cleanup before MON-212 lands real cancellation-filtering logic against different strings.

## Changes
- `scripts/ingest_agenda.py`: deleted the unused `CANCELLED_ETATS = {"Annulé", "Supprimé"}` constant.
- `scripts/ingest_positions.py`: reworded the `run()` docstring from "Programmatic entry point for Airflow" to "Programmatic entry point" (function itself is unaffected; it's just a normal callable now).
- `scripts/ingest_votes.py`: deleted the unused `fetch_all_votes` alias function ("DAG-friendly name" for `fetch_all_scrutins`) - confirmed unreferenced anywhere in the repo.

## Testing
- `ruff check .` and `ruff format --check .` (repo-wide) - all pass.
- `pytest tests/ -m "not integration"` - ran locally; connection retries observed against the shared venv's DB config (no local Postgres running in this worktree), consistent with known local-only friction. CI's pytest job is the authoritative gate for this change.
- Manual review: confirmed via repo-wide grep that `CANCELLED_ETATS` and `fetch_all_votes` had zero other references before deleting.

## Risks / Notes
- Pure dead-code removal and docstring wording - no behavior change, no deploy risk.

## Breaking Changes
None.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019pP8PGMCL2sXii6ZifU1j5