### PR TITLE
feat: add a Playwright smoke tier to CI for mobile-regression coverage (MON-241)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,47 @@ jobs:
         # minutes on a cold cache.
         run: npm run build
 
+  playwright-smoke:
+    # Renders real pages in a real browser so a `hidden md:flex` nav that's
+    # actually still visible, or a mobile-width overflow, fails the PR
+    # instead of shipping through jsdom-only tests (MON-241, MON-141/142).
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Build
+        # Same production-API build as the frontend job above — the smoke
+        # tier exercises the built app, not the dev server.
+        run: npm run build
+
+      - name: Run Playwright smoke tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 7
+
   dbt-data-health:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Assemblée Nationale Open Data (ZIPs)
 
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
-| `ci.yml` | Every PR to `master` | ruff lint + pytest (unit) + dbt compile + dbt test; posts dbt results as PR comment |
+| `ci.yml` | Every PR to `master` | ruff lint + pytest (unit) + dbt compile + dbt test + frontend lint/typecheck/jest/build + Playwright smoke tier (MON-241: no-horizontal-overflow and nav-visibility checks on `/`, `/deputes`, `/deputes/[id]`, `/votes`, `/votes/[id]`, `/chat`, `/quiz` at 390px/1280px, light/dark, against a `next build`); posts dbt results as PR comment |
 | `deploy.yml` | Merge to `master` | dbt deps → run → test against prod Supabase |
 | `ingest_prod.yml` | Daily 06:00 UTC, weekdays | Ingest new votes + deputies + rebuild RAG index |
 | `summarize_backfill.yml` | Daily 07:00 UTC | Retries vote summaries (`summary_plain IS NULL`) independent of `ingest_prod.yml`'s `--since` window — the actual retry backstop (MON-221) |

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -9,6 +9,12 @@
 # testing
 /coverage
 
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+
 # next.js
 /.next/
 /out/

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -6,12 +6,13 @@ import { test, expect, type Page } from '@playwright/test'
 // hardcodes a deputy or vote id that could later 404.
 const STATIC_ROUTES = ['/', '/deputes', '/votes', '/chat', '/quiz']
 
-async function firstDetailHref(page: Page, listPath: string, hrefPrefix: string) {
+async function firstDetailHref(page: Page, listPath: string, hrefPrefix: string, exclude: string[] = []) {
   await page.goto(listPath)
-  const link = page.locator(`a[href^="${hrefPrefix}"]`).first()
-  await link.waitFor({ state: 'attached' })
-  const href = await link.getAttribute('href')
-  if (!href) throw new Error(`no link matching ${hrefPrefix} found on ${listPath}`)
+  const links = page.locator(`a[href^="${hrefPrefix}"]`)
+  await links.first().waitFor({ state: 'attached' })
+  const hrefs = await links.evaluateAll(els => els.map(el => el.getAttribute('href')))
+  const href = hrefs.find((h): h is string => !!h && !exclude.includes(h))
+  if (!href) throw new Error(`no link matching ${hrefPrefix} (excluding ${exclude.join(', ')}) found on ${listPath}`)
   return href
 }
 
@@ -31,7 +32,12 @@ test.describe('smoke: no horizontal overflow', () => {
   }
 
   test('/deputes/[id] fits the viewport', async ({ page }) => {
-    const href = await firstDetailHref(page, '/deputes', '/deputes/')
+    // /deputes/comparer and /deputes/tableau are static routes that also
+    // match the `/deputes/` prefix and render before the deputy row list.
+    const href = await firstDetailHref(page, '/deputes', '/deputes/', [
+      '/deputes/comparer',
+      '/deputes/tableau',
+    ])
     await page.goto(href)
     await assertNoHorizontalOverflow(page)
   })

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect, type Page } from '@playwright/test'
+
+// Static pages plus one dynamic page per detail route. Detail ids are
+// resolved at runtime from the live listing page (frontend/src/lib/api.ts
+// hits production for both build and this server), so the suite never
+// hardcodes a deputy or vote id that could later 404.
+const STATIC_ROUTES = ['/', '/deputes', '/votes', '/chat', '/quiz']
+
+async function firstDetailHref(page: Page, listPath: string, hrefPrefix: string) {
+  await page.goto(listPath)
+  const link = page.locator(`a[href^="${hrefPrefix}"]`).first()
+  await link.waitFor({ state: 'attached' })
+  const href = await link.getAttribute('href')
+  if (!href) throw new Error(`no link matching ${hrefPrefix} found on ${listPath}`)
+  return href
+}
+
+async function assertNoHorizontalOverflow(page: Page) {
+  const viewport = page.viewportSize()
+  if (!viewport) throw new Error('no viewport configured for this project')
+  const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth)
+  expect(scrollWidth).toBeLessThanOrEqual(viewport.width)
+}
+
+test.describe('smoke: no horizontal overflow', () => {
+  for (const route of STATIC_ROUTES) {
+    test(`${route} fits the viewport`, async ({ page }) => {
+      await page.goto(route)
+      await assertNoHorizontalOverflow(page)
+    })
+  }
+
+  test('/deputes/[id] fits the viewport', async ({ page }) => {
+    const href = await firstDetailHref(page, '/deputes', '/deputes/')
+    await page.goto(href)
+    await assertNoHorizontalOverflow(page)
+  })
+
+  test('/votes/[id] fits the viewport', async ({ page }) => {
+    const href = await firstDetailHref(page, '/votes', '/votes/')
+    await page.goto(href)
+    await assertNoHorizontalOverflow(page)
+  })
+})
+
+test.describe('smoke: /votes row columns are not clipped', () => {
+  // MON-142: the date column rendered but title/theme/result were clipped
+  // by overflow:hidden on the row's parent — invisible to jsdom, which
+  // doesn't lay out grid columns or honor overflow clipping.
+  test('first row title and result badge are visible', async ({ page }) => {
+    await page.goto('/votes')
+    const firstRow = page.locator('a[href^="/votes/"]').first()
+    await firstRow.waitFor({ state: 'attached' })
+    await expect(firstRow.getByText(/^Scrutin n°/).first()).toBeVisible()
+    await expect(firstRow.getByText(/^Adopté$|^Rejeté$/).first()).toBeVisible()
+  })
+})
+
+test.describe('smoke: nav visibility follows the md breakpoint', () => {
+  // MON-141: the desktop nav is `hidden md:flex` — jsdom can't tell an
+  // inline display:flex apart from the Tailwind class losing the cascade,
+  // so this needs an actual computed-style check in a real browser.
+  test('exactly one of the desktop nav / mobile tab bar is visible', async ({ page }) => {
+    await page.goto('/')
+    const viewport = page.viewportSize()
+    if (!viewport) throw new Error('no viewport configured for this project')
+
+    const desktopNavToggle = page.getByRole('button', { name: 'Explorer' })
+    const mobileMenuButton = page.getByRole('button', { name: 'Ouvrir le menu' })
+
+    if (viewport.width < 768) {
+      await expect(mobileMenuButton).toBeVisible()
+      await expect(desktopNavToggle).toBeHidden()
+    } else {
+      await expect(desktopNavToggle).toBeVisible()
+      await expect(mobileMenuButton).toBeHidden()
+    }
+  })
+})

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
+        "@playwright/test": "^1.62.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -4466,6 +4467,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@prisma/instrumentation": {
@@ -12928,6 +12945,52 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.9",
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
+    "@playwright/test": "^1.62.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -10,6 +10,11 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
+  // Each test does 1-2 full navigations against the live production API
+  // (frontend/src/lib/api.ts has no client-side retry); the default 30s
+  // budget is tight for that over CI's network, especially with parallel
+  // workers sharing the same endpoint.
+  timeout: process.env.CI ? 60_000 : 30_000,
   reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
   use: {
     baseURL: 'http://localhost:3000',

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from '@playwright/test'
+
+// Smoke tier (MON-241): catches the defect class jsdom cannot see — a
+// display:flex nav that survives past its `hidden md:flex` breakpoint, or a
+// viewport-width overflow — by rendering real pages in a real browser at the
+// two viewports and both themes that shipped every regression in the
+// 2026-07-17 diagnostic (MON-141/142/143/144).
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'npm run start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    { name: 'mobile-light', use: { viewport: { width: 390, height: 844 }, colorScheme: 'light' } },
+    { name: 'mobile-dark', use: { viewport: { width: 390, height: 844 }, colorScheme: 'dark' } },
+    { name: 'desktop-light', use: { viewport: { width: 1280, height: 800 }, colorScheme: 'light' } },
+    { name: 'desktop-dark', use: { viewport: { width: 1280, height: 800 }, colorScheme: 'dark' } },
+  ],
+})

--- a/frontend/src/app/votes/[id]/VoteDetailClient.tsx
+++ b/frontend/src/app/votes/[id]/VoteDetailClient.tsx
@@ -317,8 +317,8 @@ export function VoteDetailClient(props: Props) {
       </div>
 
       {/* ── Body ── */}
-      <div style={{ padding: '52px 56px 80px' }}>
-        <div style={{ maxWidth: 1180, margin: '0 auto', display: 'flex', gap: 56, alignItems: 'flex-start' }}>
+      <div className="px-5 py-10 sm:px-14 sm:py-[52px] sm:pb-20">
+        <div className="flex flex-col xl:flex-row xl:items-start" style={{ maxWidth: 1180, margin: '0 auto', gap: 56 }}>
 
           {/* Main column */}
           <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 52 }}>
@@ -490,7 +490,10 @@ export function VoteDetailClient(props: Props) {
           </div>
 
           {/* Sidebar */}
-          <div style={{ width: 300, flexShrink: 0, display: 'flex', flexDirection: 'column', gap: 24, position: 'sticky', top: 120 }}>
+          <div
+            className="w-full xl:w-[300px] xl:sticky"
+            style={{ flexShrink: 0, display: 'flex', flexDirection: 'column', gap: 24, top: 120 }}
+          >
 
             {/* Related votes */}
             {related.length > 0 && (


### PR DESCRIPTION
## What
Adds a Playwright smoke tier to CI: a new `playwright-smoke` job in `ci.yml` that renders `/`, `/deputes`, `/deputes/[id]`, `/votes`, `/votes/[id]`, `/chat`, and `/quiz` in a real Chromium browser at 390px and 1280px, light and dark, against a `next build`, and asserts no horizontal overflow, correct nav visibility across the `md` breakpoint, and unclipped `/votes` row columns.

## Why
Every mobile regression found in the 2026-07-17 frontend diagnostic (MON-141 Urgent, MON-142/143/144 High — all viewport layout breakage) shipped through a green CI: jsdom component tests can't see an inline `display:flex` defeating `hidden md:flex`, a viewport overflow, or a clipped column, because jsdom doesn't compute layout or CSS cascade the way a real browser does. This converts that defect class from "found by the next diagnostic" to "blocked at PR" (MON-241).

## Changes
- `frontend/playwright.config.ts` — new config: 4 projects (`mobile-light`, `mobile-dark`, `desktop-light`, `desktop-dark`) at 390×844 / 1280×800, `webServer` boots `next start` against the built app.
- `frontend/e2e/smoke.spec.ts` — new smoke suite:
  - No-horizontal-overflow assertion on the 5 static routes plus one dynamic `/deputes/[id]` and `/votes/[id]` each, with the detail id resolved at runtime from the live listing page (no hardcoded id that could 404 later).
  - Nav-visibility assertion: exactly one of the desktop nav (`Explorer` toggle) / mobile tab bar (`Ouvrir le menu` button) is visible per viewport — this is the exact MON-141 defect class (an inline style defeating a Tailwind `hidden md:flex`), which jsdom cannot detect but a real browser can.
  - `/votes` row-clipping assertion (MON-142 defect class): first row's title and result badge are visible.
- `.github/workflows/ci.yml` — new independent `playwright-smoke` job (checkout → npm ci → install Chromium → `npm run build` → `npm run test:e2e`), uploads the HTML report as an artifact on failure. Mirrors the existing `frontend` job's checkout/build pattern; no `needs:` dependency, consistent with how the other jobs in this file are structured.
- `frontend/package.json` — adds `@playwright/test` devDependency and a `test:e2e` script.
- `frontend/.gitignore` — ignores Playwright's local output dirs (`test-results/`, `playwright-report/`, `blob-report/`, `playwright/.cache/`).
- `frontend/src/app/votes/[id]/VoteDetailClient.tsx` — **bug fix surfaced by writing the tier**: the body's main-column/sidebar flex row used `alignItems: 'flex-start'`, written for the desktop side-by-side layout. That inline style has no breakpoint, so on mobile (where the row needed to stack to a column to avoid a fixed 300px sidebar column) it flipped cross-axis alignment to horizontal and shrank the main column to its widest child's content width (a 610px+ fixed-column grid further down the page) instead of stretching to the viewport — a genuine, reproducible 390px→742px overflow on every vote detail page, previously undetected. Fixed by scoping the row direction (`flex flex-col xl:flex-row`) and the alignment (`xl:items-start`) to the same `xl` breakpoint the file already uses elsewhere, and making the sidebar full-width/non-sticky below `xl`.
- `CLAUDE.md` — updated the `ci.yml` workflow-table row to describe the new job.

## Testing
- `venv/bin/python -m pytest tests/ -m "not integration" -q` — unrelated to this change, not re-run (Python-only suite, no Python files touched).
- `cd frontend && npm run lint` — clean.
- `cd frontend && npx tsc --noEmit` — clean (covers `playwright.config.ts` and `e2e/smoke.spec.ts` too, since `tsconfig.json`'s `include` picks up all `.ts`/`.tsx`).
- `cd frontend && npm test -- --ci` — 232 tests, 31 suites, all pass.
- `cd frontend && npm run build && npx playwright test` — 36/36 pass (9 tests × 4 projects) against the production API, matching the existing `frontend` CI job's build behavior.
- Regression-proofed the tier itself: reintroduced the exact MON-141 bug (`style={{ display: 'flex' }}` alongside `hidden md:flex`) and confirmed the nav-visibility test fails at both mobile projects; reverted and reconfirmed green.
- Found and fixed a real, previously-undiscovered overflow on `/votes/[id]` at 390px (see Changes above) — reran the full matrix twice (`--repeat-each=2`, 72/72) after the fix to confirm it isn't flaky.

## Risks / Notes
- The new job builds the frontend a second time (independent of the existing `frontend` job), adding a few minutes to CI wall time — no `needs:`/artifact-sharing was introduced to keep it consistent with how every other job in `ci.yml` is already structured (fully independent, no inter-job dependencies).
- Detail-route ids (`/deputes/[id]`, `/votes/[id]`) are resolved at runtime from the live listing page against production data, so the suite can't go stale from a hardcoded id, but it does mean the job's outcome depends on prod being reachable — same dependency the existing `frontend` build job already has.
- Scope: this PR only fixes the one overflow the new tier surfaced. It does not attempt a broader mobile-responsiveness audit of the vote detail page (e.g., the fixed-pixel-column group-votes table is still clipped, not overflowing, on narrow viewports — cosmetic, out of scope here, and not a page-level overflow the smoke tier checks for).

## Breaking Changes
None.
