### PR TITLE
fix: bound share/feedback sources, surface DB size in /health (MON-225)

### DIFF
--- a/.github/workflows/ingest_prod.yml
+++ b/.github/workflows/ingest_prod.yml
@@ -142,7 +142,11 @@ jobs:
         # pg_database_size() reading (api/main.py). Polling the public prod
         # endpoint mirrors "Validate quiz vote_ids" above (ci.yml does the same
         # for check_quiz_votes.py) rather than opening a second DB connection here.
+        # continue-on-error: a transient /health hiccup is a monitoring gap,
+        # not an ingestion failure - it must not trip "Notify failure" below
+        # and send a false "ingestion failed" alert for a healthy run.
         id: db_size
+        continue-on-error: true
         run: |
           body=$(curl -sf https://monelu-production.up.railway.app/health)
           size_mb=$(echo "$body" | python3 -c "import json,sys; print(json.load(sys.stdin).get('db_size_mb', ''))")

--- a/.github/workflows/ingest_prod.yml
+++ b/.github/workflows/ingest_prod.yml
@@ -137,6 +137,44 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: python scripts/check_quiz_votes.py
 
+      - name: Check database size (MON-225)
+        # Supabase free tier caps the DB at 500 MB; /health surfaces the live
+        # pg_database_size() reading (api/main.py). Polling the public prod
+        # endpoint mirrors "Validate quiz vote_ids" above (ci.yml does the same
+        # for check_quiz_votes.py) rather than opening a second DB connection here.
+        id: db_size
+        run: |
+          body=$(curl -sf https://monelu-production.up.railway.app/health)
+          size_mb=$(echo "$body" | python3 -c "import json,sys; print(json.load(sys.stdin).get('db_size_mb', ''))")
+          warning=$(echo "$body" | python3 -c "import json,sys; print(json.load(sys.stdin).get('db_size_warning', ''))")
+          echo "Database size: ${size_mb} MB"
+          echo "size_mb=$size_mb" >> "$GITHUB_OUTPUT"
+          if [ "$warning" = "True" ]; then
+            echo "::warning::Database size is ${size_mb} MB, approaching the Supabase free-tier 500 MB cap."
+            echo "## ⚠️ Database size warning" >> "$GITHUB_STEP_SUMMARY"
+            echo "Database is ${size_mb} MB, approaching the Supabase free-tier 500 MB cap. Writes will start failing at 500 MB." >> "$GITHUB_STEP_SUMMARY"
+            echo "warning=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Email database size alert
+        if: steps.db_size.outputs.warning == 'true' && env.MAIL_SERVER != '' && env.NOTIFY_EMAIL_TO != ''
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: ${{ secrets.MAIL_SERVER }}
+          server_port: ${{ secrets.MAIL_PORT }}
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          subject: "MonÉlu: database size approaching free-tier cap"
+          to: ${{ secrets.NOTIFY_EMAIL_TO }}
+          from: MonÉlu CI <${{ secrets.MAIL_USERNAME }}>
+          body: |
+            The production database is ${{ steps.db_size.outputs.size_mb }} MB,
+            approaching the Supabase free-tier 500 MB cap. Writes will start
+            failing once that limit is hit, which takes down the ingestion
+            pipeline as well as user-facing writes (shares, feedback, verifications).
+
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
       - name: Notify success
         run: echo "Ingestion completed at $(date)"
 

--- a/api/main.py
+++ b/api/main.py
@@ -216,6 +216,8 @@ app.include_router(agenda.router, prefix="/agenda", tags=["Agenda"])
 # so /health reads one snapshot refreshed at most every 60s.
 # ---------------------------------------------------------------------------
 _STATS_TTL_SECONDS = 60.0
+# MON-225: Supabase free tier caps the DB at 500 MB; warn with headroom to act.
+_DB_SIZE_WARN_MB = 400
 _stats_lock = threading.Lock()
 _stats_cache: dict | None = None
 _stats_cached_at = 0.0
@@ -241,7 +243,8 @@ def _get_db_stats() -> dict:
                     (SELECT COUNT(*) FROM deputies)        AS deputies,
                     (SELECT COUNT(*) FROM votes)           AS votes,
                     (SELECT COUNT(*) FROM vote_positions)  AS positions,
-                    (SELECT MAX(voted_at) FROM votes)      AS last_vote
+                    (SELECT MAX(voted_at) FROM votes)      AS last_vote,
+                    pg_database_size(current_database())   AS db_size_bytes
                 """
             )
             row = cur.fetchone()
@@ -251,6 +254,8 @@ def _get_db_stats() -> dict:
                     "votes": row["votes"],
                     "positions": row["positions"],
                     "last_ingestion": row["last_vote"].isoformat() if row["last_vote"] else None,
+                    # MON-225: Supabase free tier caps the DB at 500 MB.
+                    "db_size_mb": round(row["db_size_bytes"] / (1024 * 1024), 1),
                 }
             )
         try:
@@ -312,6 +317,10 @@ def health() -> JSONResponse:
                 "deputies": stats["deputies"],
                 "votes": stats["votes"],
                 "positions": stats["positions"],
+                # MON-225: Supabase free tier caps the DB at 500 MB; the daily
+                # ingestion workflow polls this to alert before writes start failing.
+                "db_size_mb": stats["db_size_mb"],
+                "db_size_warning": stats["db_size_mb"] >= _DB_SIZE_WARN_MB,
             }
         )
     if services["dbt_marts"] == "ok":

--- a/api/routers/feedback.py
+++ b/api/routers/feedback.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 
 from api.db import get_conn
 from api.limiter import limiter, tiered_limit
+from api.routers.search import ShareSourceItem
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +17,7 @@ class ChatFeedbackRequest(BaseModel):
     vote: str = Field(..., pattern="^(up|down)$")
     question: str = Field(..., min_length=1, max_length=500)
     answer: str = Field(..., min_length=1, max_length=8000)
-    sources: list[dict] = Field(default_factory=list, max_length=10)
+    sources: list[ShareSourceItem] = Field(default_factory=list, max_length=10)
 
 
 class ErrorReportRequest(BaseModel):
@@ -43,7 +44,7 @@ def submit_chat_feedback(request: Request, body: ChatFeedbackRequest):
         "vote": body.vote,
         "question": body.question,
         "answer": body.answer,
-        "sources": body.sources,
+        "sources": [s.model_dump() for s in body.sources],
     }
     try:
         with get_conn() as conn:

--- a/api/routers/search.py
+++ b/api/routers/search.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import uuid
@@ -6,7 +7,7 @@ from typing import Literal
 import groq
 from fastapi import APIRouter, HTTPException, Request
 from psycopg2.extras import Json
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from api.db import get_conn
 from api.limiter import limiter, tiered_limit
@@ -94,10 +95,37 @@ def search(request: Request, body: SearchRequest):
         ) from None
 
 
+# MON-225: a share row is an anonymous public write with no per-field size
+# limit before this - the JSONB `sources` column could carry megabytes of
+# arbitrary content on a single request. Chunk content stays well under 500
+# tokens (rag/pipeline/chunker.py TOKEN_WARN_THRESHOLD) and metadata is a flat
+# dict of scalars (see chunker.py chunk_* functions), so these bounds are
+# generous relative to real payloads, not a guess.
+_METADATA_MAX_KEYS = 20
+_METADATA_MAX_BYTES = 2000
+
+
+class ShareSourceItem(BaseModel):
+    content: str = Field(..., max_length=4000)
+    metadata: dict = Field(default_factory=dict)
+    similarity: float | None = Field(None, ge=0, le=1)
+
+    @field_validator("metadata")
+    @classmethod
+    def _bound_metadata(cls, v: dict) -> dict:
+        if len(v) > _METADATA_MAX_KEYS:
+            raise ValueError(f"metadata may not have more than {_METADATA_MAX_KEYS} keys")
+        if any(isinstance(val, (dict, list)) for val in v.values()):
+            raise ValueError("metadata values must be scalars")
+        if len(json.dumps(v, ensure_ascii=False)) > _METADATA_MAX_BYTES:
+            raise ValueError(f"metadata must serialize to under {_METADATA_MAX_BYTES} bytes")
+        return v
+
+
 class ShareRequest(BaseModel):
     question: str = Field(..., min_length=1, max_length=500)
     answer: str = Field(..., min_length=1, max_length=8000)
-    sources: list[dict] = Field(default_factory=list, max_length=20)
+    sources: list[ShareSourceItem] = Field(default_factory=list, max_length=20)
     confidence: str | None = Field(None, max_length=50)
     data_source: str | None = Field(None, max_length=50)
     caveat: str | None = Field(None, max_length=500)
@@ -151,7 +179,7 @@ def share_answer(request: Request, body: ShareRequest):
                     (
                         body.question,
                         body.answer,
-                        Json(body.sources),
+                        Json([s.model_dump() for s in body.sources]),
                         body.confidence,
                         body.data_source,
                         body.caveat,

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -833,6 +833,26 @@ The staging filter is unchanged: a vote with no date is not something the API, m
 
 ---
 
+## ADR-032 - Snapshot table retention: purgeable past 12 months, purge job deferred until the size alert fires (MON-225)
+
+**Date:** 2026-08-11
+**Status:** Deferred - policy decided, automated purge not built
+
+**Decision:** `verifications`, `chat_shares`, `quiz_shares`, and `feedback` are immutable-by-design (never updated) but not immortal-by-design: rows older than 12 months are purgeable, since a share/verdict/feedback row's value is overwhelmingly in the weeks after it is created (viral share spikes, active triage), not a permanent archive obligation.
+`api_key_usage` is a rolling per-day-per-key counter, not a user-facing snapshot, so it is purgeable on a much shorter horizon (90 days) once it needs it - accounting only ever looks at the current billing period.
+No automated purge job is built in this change. `pg_database_size()` is now surfaced in `/health` (`db_size_mb`, `db_size_warning` at 400 MB) and polled by `ingest_prod.yml`, which emails an alert past that threshold - the purge job is built when that alert actually fires, not preemptively.
+
+**Reason:** These four tables accept anonymous public writes with no delete path, on a 500 MB Supabase free-tier database already dominated by `vote_positions` (~715k rows). Unbounded growth is a real risk (a scripted client could write ~14k rows/day/IP before the existing 10/min rate limit even engages), but at current traffic none of these tables are a meaningful fraction of the 500 MB budget - building a purge job now would be speculative engineering against a threat that hasn't materialized. Deciding the retention window now (rather than improvising it under pressure when the DB is actually full) is the part worth doing today; writing the `DELETE` job is not, per the project's usual "decide now, build on trigger" pattern (see ADR-002).
+A `DELETE`-based purge is also a real behavior change worth flagging explicitly: it breaks the "upsert-only, nothing is ever deleted" property these tables have had since launch, and it means old `/chat/s/<id>`, `/verifier/v/<id>`, and `/quiz/s/<id>` share links will eventually 404. That is an acceptable tradeoff for a 12-month horizon on links whose value is front-loaded, but it should not happen silently - the purge job's implementation should link back to this ADR when it's built.
+
+**Impact:**
+- `ChatShareRequest.sources` / `ChatFeedbackRequest.sources` now go through a bounded `ShareSourceItem` model (`api/routers/search.py`) instead of `list[dict]`: per-item `content` capped at 4000 chars, `metadata` capped at 20 keys / 2000 serialized bytes with scalar-only values, `similarity` bounded to `[0, 1]`. This closes the "megabytes of arbitrary JSONB in one request" gap independently of the retention question.
+- No migration, cron, or script is added by this ADR. A future purge job is a normal follow-up issue (`DELETE FROM <table> WHERE created_at < now() - interval '12 months'`, batched, run from a workflow step) - not urgent today.
+
+**Trigger to build the purge job:** `db_size_warning` in `/health` goes true (>= 400 MB) and the growth is attributable to these tables (check via `scripts/check_db_size.py`), or a scripted-abuse pattern is observed in `api_key_usage`/share row counts well before the size threshold.
+
+---
+
 ## Rules for future development sessions
 
 1. Read this file before writing any code
@@ -850,3 +870,4 @@ The staging filter is unchanged: a vote with no date is not something the API, m
 13. Sustainability funding is donations-first via HelloAsso, with the existing `api_keys.rate_limit_multiplier` (ADR-029, MON-116/MON-98) as the paid-tier mechanism — do not build Stripe/webhook billing until a real paying commercial API customer exists
 14. Agenda ingestion is séance publique only, upserted into one `agenda_items` table and never deleted (ADR-030, MON-110) - an item is visible only when it was seen in the latest ingestion run and is not cancelled; never generate a summary for a stub `objet`
 15. Null `voted_at` is a tolerated upstream quirk, not an ingestion failure (ADR-031, MON-232) - the source test is `severity: warn`, `stg_votes` keeps filtering the row out, and undated votes stay invisible past staging by design
+16. Snapshot tables (`verifications`, `chat_shares`, `quiz_shares`, `feedback`) are purgeable past 12 months and `api_key_usage` past 90 days, but no purge job exists yet (ADR-032, MON-225) - build it only once `/health`'s `db_size_warning` actually fires, not preemptively; do not add a `DELETE` job to these tables without linking back to this ADR

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -62,7 +62,13 @@ _POSITION = {
 
 def test_health_ok(client, mock_cursor):
     mock_cursor.fetchone.side_effect = [
-        {"deputies": 577, "votes": 821, "positions": 289_411, "last_vote": None},
+        {
+            "deputies": 577,
+            "votes": 821,
+            "positions": 289_411,
+            "last_vote": None,
+            "db_size_bytes": 150 * 1024 * 1024,
+        },
         {"count": 577},
         {"count": 821},
     ]
@@ -80,6 +86,31 @@ def test_health_ok(client, mock_cursor):
     assert data["deputies"] == 577
     assert data["votes"] == 821
     assert data["positions"] == 289_411
+    assert data["db_size_mb"] == 150.0
+    assert data["db_size_warning"] is False
+
+
+def test_health_db_size_warning_past_threshold(client, mock_cursor):
+    mock_cursor.fetchone.side_effect = [
+        {
+            "deputies": 577,
+            "votes": 821,
+            "positions": 289_411,
+            "last_vote": None,
+            "db_size_bytes": 420 * 1024 * 1024,
+        },
+        {"count": 577},
+        {"count": 821},
+    ]
+    with patch.dict(
+        "os.environ",
+        {"OPENAI_API_KEY": "sk-real", "GROQ_API_KEY": "gsk_real"},  # pragma: allowlist secret
+    ):
+        resp = client.get("/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["db_size_mb"] == 420.0
+    assert data["db_size_warning"] is True
 
 
 def test_health_db_unavailable(client):
@@ -535,7 +566,13 @@ def test_rate_limit_handler_includes_retry_after():
 def test_health_degraded_when_openai_key_is_placeholder(client, mock_cursor):
     """Health endpoint returns 207 and marks openai=degraded when key is a placeholder."""
     mock_cursor.fetchone.side_effect = [
-        {"deputies": 577, "votes": 821, "positions": 289_411, "last_vote": None},
+        {
+            "deputies": 577,
+            "votes": 821,
+            "positions": 289_411,
+            "last_vote": None,
+            "db_size_bytes": 150 * 1024 * 1024,
+        },
         {"count": 577},
         {"count": 821},
     ]

--- a/tests/unit/test_search_share.py
+++ b/tests/unit/test_search_share.py
@@ -25,6 +25,38 @@ def test_share_request_rejects_empty_answer():
         ShareRequest(question="Q", answer="", sources=[])
 
 
+def test_share_request_rejects_oversized_source_content():
+    with pytest.raises(ValidationError):
+        ShareRequest(question="Q", answer="A", sources=[{"content": "x" * 4001}])
+
+
+def test_share_request_rejects_nested_metadata():
+    with pytest.raises(ValidationError):
+        ShareRequest(
+            question="Q",
+            answer="A",
+            sources=[{"content": "c", "metadata": {"nested": {"a": 1}}}],
+        )
+
+
+def test_share_request_rejects_too_many_metadata_keys():
+    with pytest.raises(ValidationError):
+        ShareRequest(
+            question="Q",
+            answer="A",
+            sources=[{"content": "c", "metadata": {f"k{i}": i for i in range(21)}}],
+        )
+
+
+def test_share_request_rejects_oversized_metadata():
+    with pytest.raises(ValidationError):
+        ShareRequest(
+            question="Q",
+            answer="A",
+            sources=[{"content": "c", "metadata": {"blob": "x" * 2001}}],
+        )
+
+
 def test_share_answer_inserts_row_and_returns_share_url(client, mock_cursor):
     mock_cursor.fetchone.return_value = {
         "id": "11111111-1111-1111-1111-111111111111",


### PR DESCRIPTION
## What
Closes the three gaps in MON-225: unbounded `sources` payloads on the anonymous-write chat share/feedback endpoints, no DB size visibility, and no documented retention policy for the five user-writable snapshot tables.

## Why
`verifications`, `chat_shares`, `quiz_shares`, `feedback`, and `api_key_usage` accept anonymous public writes with no delete path, on a Supabase free tier capped at 500 MB (already dominated by ~715k `vote_positions` rows). Two concrete risks: `ChatShareRequest.sources` / `ChatFeedbackRequest.sources` were `list[dict]` with no per-field size limit, so a single request could carry megabytes of arbitrary JSONB; and the only size visibility was a manual-only diagnostic script (`scripts/check_db_size.py`), so the DB could hit its cap silently and take down the ingestion pipeline along with user-facing writes.

## Changes
- **`api/routers/search.py`**: new `ShareSourceItem` model bounds each share source's `content` (4000 chars), `metadata` (20 keys / 2000 serialized bytes, scalar values only), and `similarity` (`[0, 1]`) - replaces the previously-unbounded `list[dict]`.
- **`api/routers/feedback.py`**: `ChatFeedbackRequest.sources` reuses the same `ShareSourceItem` model, closing the identical gap on the `feedback` table.
- **`api/main.py`**: `/health` now surfaces `db_size_mb` (via `pg_database_size()`) and `db_size_warning` (true past 400 MB), cached in the existing 60s stats snapshot.
- **`.github/workflows/ingest_prod.yml`**: new step polls the public `/health` endpoint after each daily ingestion run and emails an alert (reusing the existing soft-failure email pattern) if `db_size_warning` is true.
- **`docs/decisions.md`**: ADR-032 documents the retention decision - snapshot tables purgeable past 12 months, `api_key_usage` past 90 days - and explicitly defers building the purge job until the size alert actually fires, rather than building it speculatively now.
- Test coverage for the new bounds (`tests/unit/test_search_share.py`) and the `/health` size fields (`tests/test_api.py`).

## Testing
- `ruff check .` / `ruff format --check .` - clean.
- `pytest tests/unit/test_search_share.py tests/unit/test_feedback.py tests/test_api.py -q` - 91 passed.
- `pytest tests/ -m "not integration"` (the CI gate) - ran the full 390-item selection; 389 passed, one pre-existing failure isolated to `tests/unit/test_verify_chain.py::test_valid_verdict_keeps_only_db_backed_citations` was actually a *hang* caused by this sandbox having no outbound network access (same root cause as a hang in `tests/test_rag.py`, both unrelated files this PR does not touch) - confirmed the rest of the suite around it passed cleanly.
- Verified the workflow YAML parses (`yaml.safe_load`).

## Risks / Notes
- The `ingest_prod.yml` size-check step polls the public prod `/health` endpoint rather than opening a second DB connection in the workflow, mirroring the existing `check_quiz_votes.py --api https://monelu-production.up.railway.app` pattern in `ci.yml`.
- No migration and no automated purge job in this PR - ADR-032 is a policy decision, not an implementation; the purge job is a follow-up once the size alert fires (see the ADR's "Trigger to build" section).
- `ShareSourceItem`'s bounds (4000 chars content, 20 keys / 2000 bytes metadata) are sized against real RAG chunk content (`TOKEN_WARN_THRESHOLD = 500` tokens in `rag/pipeline/chunker.py`) and metadata shape (flat scalar dicts), not arbitrary guesses.

## Breaking Changes
None for legitimate clients - the frontend already sends `content`/`metadata`/`similarity` matching `SourceItem`'s shape for every share/feedback request. A client sending oversized or nested-metadata payloads will now get a 422 instead of being persisted.