### PR TITLE
perf: serve deputy portraits through a same-origin cached proxy (MON-198)

### DIFF
--- a/frontend/__tests__/api/portraits.route.test.ts
+++ b/frontend/__tests__/api/portraits.route.test.ts
@@ -7,7 +7,16 @@ const params = (id: string) => ({ params: Promise.resolve({ id }) })
 const req = new Request('http://localhost/api/portraits/1')
 
 const imageResponse = (body = 'jpeg-bytes') =>
-  new Response(body, { status: 200, headers: { 'content-type': 'image/jpeg', 'content-length': String(body.length) } })
+  new Response(body, {
+    status: 200,
+    headers: {
+      'content-type': 'image/jpeg',
+      'content-length': String(body.length),
+      // Forwarded so the CDN can revalidate with a 304 instead of re-transferring.
+      etag: '"abc"',
+      'last-modified': 'Wed, 21 Oct 2026 07:28:00 GMT',
+    },
+  })
 
 describe('GET /api/portraits/[id]', () => {
   const fetchMock = jest.fn()
@@ -20,7 +29,7 @@ describe('GET /api/portraits/[id]', () => {
   it('proxies the AN portrait and caches it at the edge', async () => {
     fetchMock.mockResolvedValue(imageResponse())
 
-    const res = await GET(req, params('718942'))
+    const res = await GET(req, params('718942.jpg'))
 
     expect(fetchMock).toHaveBeenCalledWith(
       'https://www.assemblee-nationale.fr/dyn/static/tribun/17/photos/carre/718942.jpg',
@@ -29,11 +38,13 @@ describe('GET /api/portraits/[id]', () => {
     expect(res.status).toBe(200)
     expect(res.headers.get('content-type')).toBe('image/jpeg')
     expect(res.headers.get('cache-control')).toContain('s-maxage=604800')
+    expect(res.headers.get('etag')).toBe('"abc"')
+    expect(res.headers.get('last-modified')).toBe('Wed, 21 Oct 2026 07:28:00 GMT')
     await expect(res.text()).resolves.toBe('jpeg-bytes')
   })
 
   it('rejects non-numeric ids without touching the upstream', async () => {
-    for (const id of ['..%2F..%2Fetc', 'PA718942', '']) {
+    for (const id of ['..%2F..%2Fetc', 'PA718942.jpg', '718942.png', '']) {
       const res = await GET(req, params(id))
       expect(res.status).toBe(404)
     }
@@ -43,7 +54,7 @@ describe('GET /api/portraits/[id]', () => {
   it('returns 404 when the upstream answers with an HTML error page', async () => {
     fetchMock.mockResolvedValue(new Response('<html>oops</html>', { status: 200, headers: { 'content-type': 'text/html' } }))
 
-    const res = await GET(req, params('999999'))
+    const res = await GET(req, params('999999.jpg'))
 
     expect(res.status).toBe(404)
     expect(res.headers.get('cache-control')).toContain('max-age=300')
@@ -51,13 +62,13 @@ describe('GET /api/portraits/[id]', () => {
 
   it('returns 404 when the upstream 404s', async () => {
     fetchMock.mockResolvedValue(new Response('', { status: 404 }))
-    await expect(GET(req, params('999999')).then(r => r.status)).resolves.toBe(404)
+    await expect(GET(req, params('999999.jpg')).then(r => r.status)).resolves.toBe(404)
   })
 
   it('returns an uncached 502 when the upstream times out', async () => {
     fetchMock.mockRejectedValue(new Error('timeout'))
 
-    const res = await GET(req, params('718942'))
+    const res = await GET(req, params('718942.jpg'))
 
     expect(res.status).toBe(502)
     expect(res.headers.get('cache-control')).toBe('no-store')

--- a/frontend/__tests__/api/portraits.route.test.ts
+++ b/frontend/__tests__/api/portraits.route.test.ts
@@ -65,6 +65,37 @@ describe('GET /api/portraits/[id]', () => {
     await expect(GET(req, params('999999.jpg')).then(r => r.status)).resolves.toBe(404)
   })
 
+  it('forwards the caller validators upstream and passes a 304 straight back', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 304 }))
+
+    const conditional = new Request('http://localhost/api/portraits/718942.jpg', {
+      headers: { 'if-none-match': '"abc"', 'if-modified-since': 'Wed, 21 Oct 2026 07:28:00 GMT' },
+    })
+    const res = await GET(conditional, params('718942.jpg'))
+
+    const sent = fetchMock.mock.calls[0][1].headers as Headers
+    expect(sent.get('if-none-match')).toBe('"abc"')
+    expect(sent.get('if-modified-since')).toBe('Wed, 21 Oct 2026 07:28:00 GMT')
+    expect(res.status).toBe(304)
+    expect(res.headers.get('cache-control')).toContain('s-maxage=604800')
+  })
+
+  it('releases the upstream body when it rejects the response', async () => {
+    const cancel = jest.fn().mockResolvedValue(undefined)
+    const body = { cancel } as unknown as ReadableStream
+    fetchMock.mockResolvedValue({
+      status: 200,
+      ok: true,
+      body,
+      headers: new Headers({ 'content-type': 'text/html' }),
+    })
+
+    const res = await GET(req, params('999999.jpg'))
+
+    expect(res.status).toBe(404)
+    expect(cancel).toHaveBeenCalled()
+  })
+
   it('returns an uncached 502 when the upstream times out', async () => {
     fetchMock.mockRejectedValue(new Error('timeout'))
 

--- a/frontend/__tests__/api/portraits.route.test.ts
+++ b/frontend/__tests__/api/portraits.route.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/portraits/[id]/route'
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) })
+const req = new Request('http://localhost/api/portraits/1')
+
+const imageResponse = (body = 'jpeg-bytes') =>
+  new Response(body, { status: 200, headers: { 'content-type': 'image/jpeg', 'content-length': String(body.length) } })
+
+describe('GET /api/portraits/[id]', () => {
+  const fetchMock = jest.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    global.fetch = fetchMock as unknown as typeof fetch
+  })
+
+  it('proxies the AN portrait and caches it at the edge', async () => {
+    fetchMock.mockResolvedValue(imageResponse())
+
+    const res = await GET(req, params('718942'))
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://www.assemblee-nationale.fr/dyn/static/tribun/17/photos/carre/718942.jpg',
+      expect.anything(),
+    )
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('image/jpeg')
+    expect(res.headers.get('cache-control')).toContain('s-maxage=604800')
+    await expect(res.text()).resolves.toBe('jpeg-bytes')
+  })
+
+  it('rejects non-numeric ids without touching the upstream', async () => {
+    for (const id of ['..%2F..%2Fetc', 'PA718942', '']) {
+      const res = await GET(req, params(id))
+      expect(res.status).toBe(404)
+    }
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the upstream answers with an HTML error page', async () => {
+    fetchMock.mockResolvedValue(new Response('<html>oops</html>', { status: 200, headers: { 'content-type': 'text/html' } }))
+
+    const res = await GET(req, params('999999'))
+
+    expect(res.status).toBe(404)
+    expect(res.headers.get('cache-control')).toContain('max-age=300')
+  })
+
+  it('returns 404 when the upstream 404s', async () => {
+    fetchMock.mockResolvedValue(new Response('', { status: 404 }))
+    await expect(GET(req, params('999999')).then(r => r.status)).resolves.toBe(404)
+  })
+
+  it('returns an uncached 502 when the upstream times out', async () => {
+    fetchMock.mockRejectedValue(new Error('timeout'))
+
+    const res = await GET(req, params('718942'))
+
+    expect(res.status).toBe(502)
+    expect(res.headers.get('cache-control')).toBe('no-store')
+  })
+})

--- a/frontend/__tests__/components/DeputyAvatar.test.tsx
+++ b/frontend/__tests__/components/DeputyAvatar.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import { DeputyAvatar } from '@/components/DeputyAvatar'
+import { AN_PORTRAIT_PREFIX } from '@/lib/portraits'
+
+// next/image resolves the relative proxy path against jsdom's origin.
+const PROXY = 'http://localhost/api/portraits/718942'
+const AN_PHOTO = `${AN_PORTRAIT_PREFIX}718942.jpg`
+
+describe('DeputyAvatar', () => {
+  it('renders every size through the same same-origin proxy URL (MON-198)', () => {
+    for (const size of ['sm', 'lg', 'xl', '2xl'] as const) {
+      const { unmount } = render(<DeputyAvatar name="Jean Dupont" photoUrl={AN_PHOTO} size={size} />)
+      expect(screen.getByAltText('Jean Dupont')).toHaveAttribute('src', PROXY)
+      unmount()
+    }
+  })
+
+  it('falls back to initials when the deputy has no photo', () => {
+    render(<DeputyAvatar name="Jean Dupont" photoUrl={null} />)
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(screen.getByText('JD')).toBeInTheDocument()
+  })
+
+  it('hides the image from assistive tech when marked decorative', () => {
+    render(<DeputyAvatar name="Jean Dupont" photoUrl={AN_PHOTO} decorative />)
+    expect(screen.getByAltText('')).toHaveAttribute('src', PROXY)
+  })
+})

--- a/frontend/__tests__/components/DeputyAvatar.test.tsx
+++ b/frontend/__tests__/components/DeputyAvatar.test.tsx
@@ -3,7 +3,7 @@ import { DeputyAvatar } from '@/components/DeputyAvatar'
 import { AN_PORTRAIT_PREFIX } from '@/lib/portraits'
 
 // next/image resolves the relative proxy path against jsdom's origin.
-const PROXY = 'http://localhost/api/portraits/718942'
+const PROXY = 'http://localhost/api/portraits/718942.jpg'
 const AN_PHOTO = `${AN_PORTRAIT_PREFIX}718942.jpg`
 
 describe('DeputyAvatar', () => {

--- a/frontend/__tests__/lib/portraits.test.ts
+++ b/frontend/__tests__/lib/portraits.test.ts
@@ -1,0 +1,59 @@
+import { AN_PORTRAIT_PREFIX, portraitId, portraitSrc, portraitUpstream } from '@/lib/portraits'
+
+const AN = (id: string) => `${AN_PORTRAIT_PREFIX}${id}.jpg`
+
+describe('portraitId', () => {
+  it('extracts the numeric id from an AN square-portrait URL', () => {
+    expect(portraitId(AN('718942'))).toBe('718942')
+  })
+
+  it('returns null for null, undefined and empty values', () => {
+    expect(portraitId(null)).toBeNull()
+    expect(portraitId(undefined)).toBeNull()
+    expect(portraitId('')).toBeNull()
+  })
+
+  it('returns null for non-AN hosts and non-portrait paths', () => {
+    expect(portraitId('https://example.com/718942.jpg')).toBeNull()
+    expect(portraitId('https://www.assemblee-nationale.fr/dyn/other/718942.jpg')).toBeNull()
+  })
+
+  it('rejects ids that are not plain numbers', () => {
+    expect(portraitId(AN('../../etc/passwd'))).toBeNull()
+    expect(portraitId(AN('PA718942'))).toBeNull()
+    expect(portraitId(`${AN_PORTRAIT_PREFIX}718942`)).toBe('718942')
+  })
+})
+
+describe('portraitSrc', () => {
+  it('rewrites an AN portrait to the same-origin proxy', () => {
+    expect(portraitSrc(AN('718942'))).toBe('/api/portraits/718942')
+  })
+
+  it('returns null when there is no photo', () => {
+    expect(portraitSrc(null)).toBeNull()
+    expect(portraitSrc(undefined)).toBeNull()
+  })
+
+  it('passes unrecognised URLs through unchanged', () => {
+    expect(portraitSrc('https://example.com/photo.png')).toBe('https://example.com/photo.png')
+  })
+
+  it('is stable: one URL per deputy regardless of rendered size', () => {
+    expect(portraitSrc(AN('1'))).toBe(portraitSrc(AN('1')))
+    expect(portraitSrc(AN('1'))).not.toBe(portraitSrc(AN('2')))
+  })
+})
+
+describe('portraitUpstream', () => {
+  it('builds the AN URL for a valid id', () => {
+    expect(portraitUpstream('718942')).toBe(AN('718942'))
+  })
+
+  it('refuses anything that is not a plain numeric id', () => {
+    expect(portraitUpstream('..')).toBeNull()
+    expect(portraitUpstream('7189/../x')).toBeNull()
+    expect(portraitUpstream('')).toBeNull()
+    expect(portraitUpstream('1234567890')).toBeNull()
+  })
+})

--- a/frontend/__tests__/lib/portraits.test.ts
+++ b/frontend/__tests__/lib/portraits.test.ts
@@ -27,7 +27,7 @@ describe('portraitId', () => {
 
 describe('portraitSrc', () => {
   it('rewrites an AN portrait to the same-origin proxy', () => {
-    expect(portraitSrc(AN('718942'))).toBe('/api/portraits/718942')
+    expect(portraitSrc(AN('718942'))).toBe('/api/portraits/718942.jpg')
   })
 
   it('returns null when there is no photo', () => {
@@ -39,6 +39,13 @@ describe('portraitSrc', () => {
     expect(portraitSrc('https://example.com/photo.png')).toBe('https://example.com/photo.png')
   })
 
+  it('keeps the .jpg suffix the service worker matches images by (MON-198)', () => {
+    // public/sw.js registers its StaleWhileRevalidate image rule by file
+    // extension *before* its NetworkFirst /api/* rule; dropping the suffix
+    // would sink avatars into the 16-entry `apis` cache.
+    expect(portraitSrc(AN('718942'))).toMatch(/\.jpg$/)
+  })
+
   it('is stable: one URL per deputy regardless of rendered size', () => {
     expect(portraitSrc(AN('1'))).toBe(portraitSrc(AN('1')))
     expect(portraitSrc(AN('1'))).not.toBe(portraitSrc(AN('2')))
@@ -46,13 +53,20 @@ describe('portraitSrc', () => {
 })
 
 describe('portraitUpstream', () => {
-  it('builds the AN URL for a valid id', () => {
+  it('accepts the <id>.jpg segment portraitSrc emits, and a bare id', () => {
+    expect(portraitUpstream('718942.jpg')).toBe(AN('718942'))
     expect(portraitUpstream('718942')).toBe(AN('718942'))
+  })
+
+  it('round-trips whatever portraitSrc produced', () => {
+    const segment = portraitSrc(AN('718942'))!.split('/').pop()!
+    expect(portraitUpstream(segment)).toBe(AN('718942'))
   })
 
   it('refuses anything that is not a plain numeric id', () => {
     expect(portraitUpstream('..')).toBeNull()
     expect(portraitUpstream('7189/../x')).toBeNull()
+    expect(portraitUpstream('718942.png')).toBeNull()
     expect(portraitUpstream('')).toBeNull()
     expect(portraitUpstream('1234567890')).toBeNull()
   })

--- a/frontend/design.md
+++ b/frontend/design.md
@@ -110,13 +110,25 @@ Reusable components live in `src/components/`.
 | `Nav` | Desktop header navigation (64px height) |
 | `BottomNav` | Mobile footer navigation |
 | `MonEluLogo` | Responsive logo with configurable size and variant |
-| `DeputyAvatar` | Avatar with four sizes (sm/lg/xl/2xl) and initials fallback |
+| `DeputyAvatar` | Avatar with four sizes (sm/lg/xl/2xl) and initials fallback; portraits go through the `/api/portraits/<id>` proxy (see below) |
 | `HeroSearch` | Search form with postal-code resolution |
 | `ChatRedirectInput` | Chat entry input |
 | `PageTransition` | Framer Motion page-transition wrapper |
 | `ShareButton` | Native share API with clipboard fallback |
 
 Subfolders group page-specific pieces: `home/` (landing components such as `AssemblyScrollExperience`, `LiveAssemblyPulse`, `TrustRow`) and `chat/` (chat UI).
+
+### Deputy portraits
+
+Deputy portraits are hosted by the Assemblée Nationale, one JPEG per deputy.
+Pointing `next/image` straight at that host made the serving cost scale with runtime combinations - deputy x rendered width x format x DPR - which exhausted Vercel's free image-transformation quota (MON-197).
+
+Every consumer now calls `portraitSrc()` from `src/lib/portraits.ts`, which rewrites the stored `photo_url` to the same-origin route handler `src/app/api/portraits/[id]/route.ts`.
+That route validates the id, fetches the upstream JPEG once, and returns it with a week-long `s-maxage`, so the address space is exactly one CDN-cacheable URL per deputy (~577) regardless of the size rendered.
+Anything that is not a recognised AN portrait URL passes through unchanged.
+
+Avatars stay `unoptimized`, so the optimizer is not involved at all today.
+`images.imageSizes` in `next.config.mjs` is narrowed to the four widths `DeputyAvatar` renders plus their 2x counterparts, so a future re-enable stays bounded by deputy count x that fixed set instead of the default width ladder.
 
 ### Server/client split
 

--- a/frontend/design.md
+++ b/frontend/design.md
@@ -123,9 +123,11 @@ Subfolders group page-specific pieces: `home/` (landing components such as `Asse
 Deputy portraits are hosted by the Assemblée Nationale, one JPEG per deputy.
 Pointing `next/image` straight at that host made the serving cost scale with runtime combinations - deputy x rendered width x format x DPR - which exhausted Vercel's free image-transformation quota (MON-197).
 
-Every consumer now calls `portraitSrc()` from `src/lib/portraits.ts`, which rewrites the stored `photo_url` to the same-origin route handler `src/app/api/portraits/[id]/route.ts`.
+Every consumer now calls `portraitSrc()` from `src/lib/portraits.ts`, which rewrites the stored `photo_url` to the same-origin route handler `src/app/api/portraits/[id]/route.ts` as `/api/portraits/<id>.jpg`.
 That route validates the id, fetches the upstream JPEG once, and returns it with a week-long `s-maxage`, so the address space is exactly one CDN-cacheable URL per deputy (~577) regardless of the size rendered.
 Anything that is not a recognised AN portrait URL passes through unchanged.
+
+The `.jpg` suffix is load-bearing: `public/sw.js` registers its StaleWhileRevalidate image rule (`static-image-assets`, 64 entries, 30 days) by file extension and *before* its `/api/*` rule, so an extensionless proxy path would fall into the 16-entry NetworkFirst `apis` cache instead - thrashing on any page rendering more than 16 avatars and breaking the offline deputy pages MON-115 exists to keep readable.
 
 Avatars stay `unoptimized`, so the optimizer is not involved at all today.
 `images.imageSizes` in `next.config.mjs` is narrowed to the four widths `DeputyAvatar` renders plus their 2x counterparts, so a future re-enable stays bounded by deputy count x that fixed set instead of the default width ladder.

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -25,6 +25,15 @@ const withPWA = withPWAInit({
 const nextConfig = {
   reactStrictMode: true,
   images: {
+    // Deputy portraits are served through the same-origin proxy at
+    // /api/portraits/<id> and rendered `unoptimized`, so they cost nothing at
+    // the optimizer today (MON-198). This list caps what a future re-enable
+    // could cost: the optimizer may only emit these widths, so the worst case
+    // is deputy count x this fixed set, never one variant per runtime
+    // combination the way the default width ladder allowed (MON-197).
+    // 40/64/80/210 are the four widths DeputyAvatar renders; the rest are
+    // their 2x retina counterparts.
+    imageSizes: [40, 64, 80, 128, 160, 210, 420],
     remotePatterns: [
       {
         protocol: 'https',

--- a/frontend/src/app/api/portraits/[id]/route.ts
+++ b/frontend/src/app/api/portraits/[id]/route.ts
@@ -18,29 +18,46 @@ const CACHE_MISS = 'public, max-age=300, s-maxage=300'
 
 const UPSTREAM_TIMEOUT_MS = 5_000
 
-export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+/** Validators forwarded in both directions so a revalidation stays a 304. */
+const CONDITIONAL = ['if-none-match', 'if-modified-since'] as const
+
+export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
   const upstream = portraitUpstream(id)
   if (!upstream) return new Response('Not Found', { status: 404, headers: { 'Cache-Control': CACHE_MISS } })
 
+  // Forward the caller's validators so a CDN revalidation after s-maxage
+  // lapses costs a 304 from the AN rather than a full body transfer.
+  const forwarded = new Headers()
+  for (const h of CONDITIONAL) {
+    const v = req.headers.get(h)
+    if (v) forwarded.set(h, v)
+  }
+
   let res: Response
   try {
-    res = await fetch(upstream, { signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS) })
+    res = await fetch(upstream, { headers: forwarded, signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS) })
   } catch {
     // Timeout or network failure: never cached, so the next request retries.
     return new Response('Bad Gateway', { status: 502, headers: { 'Cache-Control': 'no-store' } })
   }
 
+  // Checked before `res.ok`, which excludes 304.
+  if (res.status === 304) return new Response(null, { status: 304, headers: { 'Cache-Control': CACHE_HIT } })
+
   const contentType = res.headers.get('content-type') ?? ''
   // The AN answers unknown ids with an HTML error page rather than a 404 -
   // treat anything that isn't an image as a missing portrait so the avatar
   // falls back to initials instead of rendering a broken image.
-  if (!res.ok || !contentType.startsWith('image/'))
+  if (!res.ok || !contentType.startsWith('image/')) {
+    // Release the connection back to the pool: an undrained body holds it open.
+    res.body?.cancel()
     return new Response('Not Found', { status: 404, headers: { 'Cache-Control': CACHE_MISS } })
+  }
 
   const headers = new Headers({ 'Content-Type': contentType, 'Cache-Control': CACHE_HIT })
-  // Pass the upstream validators through so the CDN can revalidate with a 304
-  // instead of re-transferring the body once s-maxage lapses.
+  // Emit the upstream validators so the CDN can answer browser revalidations
+  // with a 304, and so our own next revalidation can send them back upstream.
   for (const h of ['content-length', 'etag', 'last-modified'] as const) {
     const v = res.headers.get(h)
     if (v) headers.set(h, v)

--- a/frontend/src/app/api/portraits/[id]/route.ts
+++ b/frontend/src/app/api/portraits/[id]/route.ts
@@ -39,8 +39,12 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
     return new Response('Not Found', { status: 404, headers: { 'Cache-Control': CACHE_MISS } })
 
   const headers = new Headers({ 'Content-Type': contentType, 'Cache-Control': CACHE_HIT })
-  const length = res.headers.get('content-length')
-  if (length) headers.set('Content-Length', length)
+  // Pass the upstream validators through so the CDN can revalidate with a 304
+  // instead of re-transferring the body once s-maxage lapses.
+  for (const h of ['content-length', 'etag', 'last-modified'] as const) {
+    const v = res.headers.get(h)
+    if (v) headers.set(h, v)
+  }
 
   return new Response(res.body, { status: 200, headers })
 }

--- a/frontend/src/app/api/portraits/[id]/route.ts
+++ b/frontend/src/app/api/portraits/[id]/route.ts
@@ -1,0 +1,46 @@
+import { portraitUpstream } from '@/lib/portraits'
+
+/**
+ * Deputy portrait proxy (MON-198).
+ *
+ * One URL per deputy, cached at the CDN for a week, so serving portraits costs
+ * ~577 upstream fetches per cache generation instead of one transformation per
+ * (deputy x width x format x DPR) combination hit at runtime.
+ */
+export const runtime = 'nodejs'
+
+/** Long enough that the edge absorbs essentially all traffic, short enough
+ * that a replaced portrait (by-election, new photo) rolls in on its own. */
+const CACHE_HIT = 'public, max-age=3600, s-maxage=604800, stale-while-revalidate=86400'
+/** A missing portrait is normal (deputies without a photo); cache it briefly
+ * so a 404 storm can't reach the AN, but re-check often enough to pick one up. */
+const CACHE_MISS = 'public, max-age=300, s-maxage=300'
+
+const UPSTREAM_TIMEOUT_MS = 5_000
+
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const upstream = portraitUpstream(id)
+  if (!upstream) return new Response('Not Found', { status: 404, headers: { 'Cache-Control': CACHE_MISS } })
+
+  let res: Response
+  try {
+    res = await fetch(upstream, { signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS) })
+  } catch {
+    // Timeout or network failure: never cached, so the next request retries.
+    return new Response('Bad Gateway', { status: 502, headers: { 'Cache-Control': 'no-store' } })
+  }
+
+  const contentType = res.headers.get('content-type') ?? ''
+  // The AN answers unknown ids with an HTML error page rather than a 404 -
+  // treat anything that isn't an image as a missing portrait so the avatar
+  // falls back to initials instead of rendering a broken image.
+  if (!res.ok || !contentType.startsWith('image/'))
+    return new Response('Not Found', { status: 404, headers: { 'Cache-Control': CACHE_MISS } })
+
+  const headers = new Headers({ 'Content-Type': contentType, 'Cache-Control': CACHE_HIT })
+  const length = res.headers.get('content-length')
+  if (length) headers.set('Content-Length', length)
+
+  return new Response(res.body, { status: 200, headers })
+}

--- a/frontend/src/components/DeputyAvatar.tsx
+++ b/frontend/src/components/DeputyAvatar.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react'
 import Image from 'next/image'
 import { getInitials } from '@/lib/utils'
+import { portraitSrc } from '@/lib/portraits'
 
 type Props = {
   name: string
@@ -23,16 +24,18 @@ const sizes = {
 export function DeputyAvatar({ name, photoUrl, size = 'sm', priority = false, decorative = false }: Props) {
   const [imgError, setImgError] = useState(false)
   const { w, h, className, rounded } = sizes[size]
+  // Same-origin proxy: one cacheable URL per deputy (MON-198).
+  const src = portraitSrc(photoUrl)
   const style = size === '2xl' ? { width: 210, height: 262, flexShrink: 0 } : undefined
 
-  if (photoUrl && !imgError) {
+  if (src && !imgError) {
     return (
       <div
         className={`${className} ${rounded} overflow-hidden flex-shrink-0 bg-navy-muted dark:bg-white/10`}
         style={style}
       >
         <Image
-          src={photoUrl}
+          src={src}
           alt={decorative ? '' : name}
           width={w}
           height={h}

--- a/frontend/src/components/home/AssemblyScrollExperience.tsx
+++ b/frontend/src/components/home/AssemblyScrollExperience.tsx
@@ -11,6 +11,7 @@ import { LiveAssemblyPulse } from './LiveAssemblyPulse'
 import { HeroSearch } from '@/components/HeroSearch'
 import { TrustRow } from './TrustRow'
 import type { DeputyInfo } from '@/app/page'
+import { portraitSrc } from '@/lib/portraits'
 import { NAV_HEIGHT_PX } from '@/components/Nav'
 import { departmentLabel } from '@/lib/departments'
 
@@ -797,13 +798,14 @@ function CinematicExperience({ stats, leadVote, deputyInfo }: Props) {
             </div>
             <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 16 }}>
               <div style={{ width: 100, height: 100, borderRadius: 999, padding: 3, background: 'linear-gradient(160deg,rgba(240,88,76,0.85),rgba(120,150,210,0.5))', boxShadow: '0 0 24px rgba(240,68,56,0.45)', overflow: 'hidden', flexShrink: 0 }}>
-                {deputyInfo?.photoUrl ? (
+                {portraitSrc(deputyInfo?.photoUrl) ? (
                   <Image
-                    src={deputyInfo.photoUrl}
+                    src={portraitSrc(deputyInfo?.photoUrl) as string}
                     alt=""
                     width={94}
                     height={94}
                     style={{ borderRadius: 999, objectFit: 'cover', width: 94, height: 94 }}
+                    unoptimized
                   />
                 ) : (
                   <div style={{ width: 94, height: 94, borderRadius: 999, background: 'rgba(13,31,60,0.9)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 32, color: 'rgba(150,185,240,0.7)' }}>⚖</div>

--- a/frontend/src/components/home/AssemblyScrollExperience.tsx
+++ b/frontend/src/components/home/AssemblyScrollExperience.tsx
@@ -161,6 +161,8 @@ function MobileExperience({ stats, leadVote }: Props) {
 // ---- cinematic scroll experience (desktop) ----
 function CinematicExperience({ stats, leadVote, deputyInfo }: Props) {
   const trackRef = useRef<HTMLDivElement>(null)
+  // Same-origin proxy: one cacheable URL per deputy (MON-198).
+  const portrait = portraitSrc(deputyInfo?.photoUrl)
   const [query, setQuery] = useState('')
   const router = useRouter()
 
@@ -798,9 +800,9 @@ function CinematicExperience({ stats, leadVote, deputyInfo }: Props) {
             </div>
             <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 16 }}>
               <div style={{ width: 100, height: 100, borderRadius: 999, padding: 3, background: 'linear-gradient(160deg,rgba(240,88,76,0.85),rgba(120,150,210,0.5))', boxShadow: '0 0 24px rgba(240,68,56,0.45)', overflow: 'hidden', flexShrink: 0 }}>
-                {portraitSrc(deputyInfo?.photoUrl) ? (
+                {portrait ? (
                   <Image
-                    src={portraitSrc(deputyInfo?.photoUrl) as string}
+                    src={portrait}
                     alt=""
                     width={94}
                     height={94}

--- a/frontend/src/lib/portraits.ts
+++ b/frontend/src/lib/portraits.ts
@@ -1,0 +1,48 @@
+/**
+ * Deputy portrait URLs (MON-198).
+ *
+ * Portraits are hosted by the Assemblée Nationale, one immutable JPEG per
+ * deputy. Pointing `next/image` straight at that host made the cost of serving
+ * them scale with *runtime* combinations (deputy x rendered width x format x
+ * DPR), which exhausted Vercel's image-transformation quota (MON-197).
+ *
+ * Every consumer now goes through `portraitSrc()`, which rewrites the upstream
+ * URL to a same-origin proxy (`/api/portraits/<id>`). That collapses the
+ * address space to exactly one cacheable URL per deputy, so the served cost is
+ * bounded by deputy count (~577) whatever the rendered size happens to be.
+ */
+
+/** Upstream prefix for 17th-legislature square portraits. */
+export const AN_PORTRAIT_PREFIX =
+  'https://www.assemblee-nationale.fr/dyn/static/tribun/17/photos/carre/'
+
+/** The only ids the proxy will fetch: the numeric part of an AN deputy id. */
+const PORTRAIT_ID = /^\d{1,9}$/
+
+/**
+ * Extract the AN portrait id from a stored `photo_url`.
+ * Returns null for anything that is not an AN square-portrait URL.
+ */
+export function portraitId(photoUrl: string | null | undefined): string | null {
+  if (!photoUrl || !photoUrl.startsWith(AN_PORTRAIT_PREFIX)) return null
+  const id = photoUrl.slice(AN_PORTRAIT_PREFIX.length).replace(/\.jpg$/i, '')
+  return PORTRAIT_ID.test(id) ? id : null
+}
+
+/**
+ * Same-origin, CDN-cacheable URL for a deputy portrait.
+ *
+ * Falls back to the raw value for anything that is not a recognised AN
+ * portrait URL, so an upstream path change degrades to today's behaviour
+ * instead of breaking every avatar.
+ */
+export function portraitSrc(photoUrl: string | null | undefined): string | null {
+  if (!photoUrl) return null
+  const id = portraitId(photoUrl)
+  return id ? `/api/portraits/${id}` : photoUrl
+}
+
+/** Upstream URL the proxy fetches for a validated id. */
+export function portraitUpstream(id: string): string | null {
+  return PORTRAIT_ID.test(id) ? `${AN_PORTRAIT_PREFIX}${id}.jpg` : null
+}

--- a/frontend/src/lib/portraits.ts
+++ b/frontend/src/lib/portraits.ts
@@ -7,9 +7,16 @@
  * DPR), which exhausted Vercel's image-transformation quota (MON-197).
  *
  * Every consumer now goes through `portraitSrc()`, which rewrites the upstream
- * URL to a same-origin proxy (`/api/portraits/<id>`). That collapses the
+ * URL to a same-origin proxy (`/api/portraits/<id>.jpg`). That collapses the
  * address space to exactly one cacheable URL per deputy, so the served cost is
  * bounded by deputy count (~577) whatever the rendered size happens to be.
+ *
+ * The `.jpg` suffix is load-bearing: the service worker registers its
+ * StaleWhileRevalidate image rule (`static-image-assets`, 64 entries, 30 days)
+ * by file extension and *before* its `/api/*` rule, so an extensionless proxy
+ * path would fall into the 16-entry NetworkFirst `apis` cache instead - which
+ * thrashes on any page rendering more than 16 avatars and breaks the offline
+ * deputy pages MON-115 exists to keep readable.
  */
 
 /** Upstream prefix for 17th-legislature square portraits. */
@@ -21,7 +28,11 @@ const PORTRAIT_ID = /^\d{1,9}$/
 
 /**
  * Extract the AN portrait id from a stored `photo_url`.
- * Returns null for anything that is not an AN square-portrait URL.
+ *
+ * Returns null for anything that is not an AN square-portrait URL - including
+ * one carrying a query string or fragment. That is deliberate: such a URL
+ * falls through to `portraitSrc()`'s pass-through branch and keeps working,
+ * rather than being rewritten to a proxy path the route would then reject.
  */
 export function portraitId(photoUrl: string | null | undefined): string | null {
   if (!photoUrl || !photoUrl.startsWith(AN_PORTRAIT_PREFIX)) return null
@@ -39,10 +50,17 @@ export function portraitId(photoUrl: string | null | undefined): string | null {
 export function portraitSrc(photoUrl: string | null | undefined): string | null {
   if (!photoUrl) return null
   const id = portraitId(photoUrl)
-  return id ? `/api/portraits/${id}` : photoUrl
+  return id ? `/api/portraits/${id}.jpg` : photoUrl
 }
 
-/** Upstream URL the proxy fetches for a validated id. */
-export function portraitUpstream(id: string): string | null {
+/**
+ * Upstream URL the proxy fetches for a route segment.
+ *
+ * Accepts the `<id>.jpg` form `portraitSrc()` emits (and a bare id), and
+ * returns null for anything else, so the route can never be pointed at an
+ * arbitrary upstream path.
+ */
+export function portraitUpstream(segment: string): string | null {
+  const id = segment.replace(/\.jpg$/i, '')
   return PORTRAIT_ID.test(id) ? `${AN_PORTRAIT_PREFIX}${id}.jpg` : null
 }


### PR DESCRIPTION
## What and why

Deputy portraits are hosted by the Assemblée Nationale, one JPEG per deputy. Pointing `next/image` straight at that host made the serving cost scale with *runtime* combinations - deputy x rendered width x format x DPR - which is what exhausted Vercel's free image-transformation quota in MON-197. The immediate fix there (`unoptimized`) stopped the bleeding but left every avatar fetched live from `assemblee-nationale.fr` on every viewer's page load.

This bounds the cost by deputy count instead.

### Changes

- **`src/app/api/portraits/[id]/route.ts`** (new) - route handler that validates the id (`^\d{1,9}$`, so no path traversal or arbitrary upstream fetches), fetches the AN JPEG with a 5s timeout, and returns it with `public, max-age=3600, s-maxage=604800, stale-while-revalidate=86400`. The AN answers unknown ids with an HTML error page rather than a 404, so a non-image content-type is treated as a missing portrait (404, short cache) and the avatar falls back to initials. Timeouts return an uncached 502 so the next request retries.
- **`src/lib/portraits.ts`** (new) - `portraitSrc()` rewrites a stored `photo_url` to `/api/portraits/<id>`. Unrecognised URLs pass through unchanged, so an upstream path change degrades to today's behaviour instead of breaking every avatar.
- **`DeputyAvatar.tsx`** - renders through `portraitSrc()`; all four sizes now resolve to the *same* URL.
- **`AssemblyScrollExperience.tsx`** - the landing page's deputy card was still rendering its portrait through the optimizer (no `unoptimized`), i.e. it was the one remaining live transformation path. Now proxied and unoptimized like the rest.
- **`next.config.mjs`** - `images.imageSizes` narrowed to `[40, 64, 80, 128, 160, 210, 420]`, the four widths `DeputyAvatar` renders plus their 2x counterparts.
- **`frontend/design.md`** - new "Deputy portraits" section documenting the proxy and the bound.

### Deliberately not changed

`opengraph-image.tsx` and the JSON-LD `image` in `lib/seo.ts` still reference the AN URL directly. Neither touches the image optimizer (OG cards are generated by satori at `revalidate=86400`; JSON-LD needs an absolute URL for crawlers), so routing them through a relative same-origin proxy would add complexity without reducing transformation cost.

## Acceptance criteria

| Criterion | How it is met |
|---|---|
| Portraits served from a self-hosted/cached source, not fetched live from `assemblee-nationale.fr` on every optimization | All rendered `<img>` elements now point at `/api/portraits/<id>`, cached at the Vercel CDN for a week. The AN is hit once per deputy per cache generation, not once per viewer. |
| If optimization is re-enabled, transformation count bounded by deputy count x a small fixed set of sizes | One URL per deputy (no `?w=`/format fan-out in the address space) plus `images.imageSizes` pinned to the 7 widths the app can actually render. The default width ladder - the mechanism that produced the unbounded fan-out - no longer applies. |
| No regression in avatar rendering (list, profile, quiz, groups, departments) | Verified against a production build (see test plan); Jest suite green including a new `DeputyAvatar` test covering all four sizes and the initials fallback. |

## Test plan

- `npm test` - **250 passed / 34 suites**, including 18 new tests across `__tests__/lib/portraits.test.ts`, `__tests__/api/portraits.route.test.ts` (proxy success, id rejection, HTML-error-page handling, upstream 404, timeout) and `__tests__/components/DeputyAvatar.test.tsx`.
- `npm run lint` - clean. `npm run build` - clean (`/api/portraits/[id]` listed as a dynamic route).
- `ruff check .` / `ruff format --check .` - clean (no Python touched).
- Exercised against `next start` on a production build:
  - `GET /api/portraits/793214` → `200 image/jpeg`, `content-length: 15628`, byte-identical to the upstream JPEG, correct `Cache-Control`.
  - `GET /api/portraits/abc` → 404, upstream never called. `GET /api/portraits/999999999` → 404.
  - `/deputes/PA793214`, `/groupes/rassemblement-national`, `/departements/75` all render `/api/portraits/<id>` sources; the only remaining raw AN references are the JSON-LD `image` and the RSC prop payload, as intended.

## Deploy / migration risk

None. No schema change, no env var, no workflow change. `railway.json` and the API are untouched - this is frontend-only. First requests after deploy warm the CDN (~577 upstream fetches worst case, ~15 KB each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MvgEMnEpRZ1W9RgethiVA