### PR TITLE
fix: derive every absolute URL from a single SITE_URL constant (MON-254)

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,6 +1,12 @@
 # Public API base URL
 NEXT_PUBLIC_API_URL=https://monelu-production.up.railway.app
 
+# Public origin of the site (MON-254). Every absolute URL - metadataBase,
+# canonicals, OG urls, sitemap, robots, JSON-LD, OG card footers - derives from
+# src/lib/site.ts, which falls back to the Vercel domain when this is unset.
+# Read at build time (NEXT_PUBLIC_* is inlined), so changing it needs a rebuild.
+NEXT_PUBLIC_SITE_URL=https://mon-elu.vercel.app
+
 # Phase 6 — error tracking (MON-99). Leave blank to disable — the SDK no-ops
 # safely. Create a free project at https://sentry.io to get a DSN.
 NEXT_PUBLIC_SENTRY_DSN=

--- a/frontend/__tests__/lib/site.test.ts
+++ b/frontend/__tests__/lib/site.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { SITE_URL, SITE_HOST } from '@/lib/site'
+
+const SRC = join(__dirname, '..', '..', 'src')
+const ALLOWED = join(SRC, 'lib', 'site.ts')
+const LITERAL = 'mon-elu.vercel.app'
+
+function walk(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) return walk(full)
+    return /\.(ts|tsx)$/.test(entry.name) ? [full] : []
+  })
+}
+
+describe('site origin constants', () => {
+  it('derives SITE_HOST from SITE_URL without the scheme', () => {
+    expect(SITE_URL).toMatch(/^https?:\/\//)
+    expect(SITE_URL.endsWith('/')).toBe(false)
+    expect(SITE_HOST).toBe(SITE_URL.replace(/^https?:\/\//, ''))
+  })
+
+  // MON-254: ten files used to inline the domain, so a domain move left stale
+  // canonical, sitemap and OG URLs behind. src/lib/site.ts is the only place
+  // the literal may appear.
+  it('is the only place in src/ that spells the domain out', () => {
+    const offenders = walk(SRC).filter(
+      (file) => file !== ALLOWED && readFileSync(file, 'utf8').includes(LITERAL)
+    )
+    expect(offenders).toEqual([])
+  })
+})

--- a/frontend/src/app/chat/s/[id]/opengraph-image.tsx
+++ b/frontend/src/app/chat/s/[id]/opengraph-image.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from 'next/og'
+import { SITE_HOST } from '@/lib/site'
 
 export const runtime = 'edge'
 export const alt = 'Réponse MonÉlu — recherche sur les votes et les députés'
@@ -95,7 +96,7 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
             marginTop: 44,
           }}
         >
-          mon-elu.vercel.app/chat
+          {`${SITE_HOST}/chat`}
         </div>
       </div>
     ),

--- a/frontend/src/app/chat/s/[id]/page.tsx
+++ b/frontend/src/app/chat/s/[id]/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { api } from '@/lib/api'
 import { ChatAnswerCard } from '@/components/ChatAnswerCard'
+import { SITE_URL } from '@/lib/site'
 
 // Chat shares are immutable snapshots (ADR-024, mirrors ADR-022 for
 // verifications): this page reads the stored answer via GET /search/share/{id}
@@ -23,7 +24,7 @@ export async function generateMetadata({
   return {
     title,
     description,
-    openGraph: { title, description, url: `https://mon-elu.vercel.app/chat/s/${id}` },
+    openGraph: { title, description, url: `${SITE_URL}/chat/s/${id}` },
     twitter: { card: 'summary_large_image', title, description },
   }
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -16,6 +16,7 @@ import { MainFrame } from '@/components/MainFrame'
 import { JsonLd } from '@/components/JsonLd'
 import { ThemeProvider } from '@/components/ThemeProvider'
 import { buildWebsiteJsonLd } from '@/lib/seo'
+import { SITE_URL } from '@/lib/site'
 import { THEME_STORAGE_KEY } from '@/lib/theme'
 
 const serif = DM_Serif_Display({
@@ -42,7 +43,7 @@ const sans = DM_Sans({
 })
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://mon-elu.vercel.app'),
+  metadataBase: new URL(SITE_URL),
   title: 'MonÉlu — Suivez vos députés',
   description: "Données officielles de l'Assemblée Nationale. Suivez chaque vote de chaque député français.",
   manifest: '/manifest.json',
@@ -50,7 +51,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'MonÉlu — Suivez vos députés',
     description: "Données officielles de l'Assemblée Nationale",
-    url: 'https://mon-elu.vercel.app',
+    url: SITE_URL,
     siteName: 'MonÉlu',
     locale: 'fr_FR',
     type: 'website',

--- a/frontend/src/app/quiz/opengraph-image.tsx
+++ b/frontend/src/app/quiz/opengraph-image.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from 'next/og'
+import { SITE_HOST } from '@/lib/site'
 
 export const runtime = 'edge'
 export const alt = 'Quel député vote comme vous ? — MonÉlu'
@@ -72,7 +73,7 @@ export default function OGImage() {
             marginTop: 44,
           }}
         >
-          mon-elu.vercel.app/quiz — faites le test
+          {`${SITE_HOST}/quiz — faites le test`}
         </div>
       </div>
     ),

--- a/frontend/src/app/quiz/s/[id]/opengraph-image.tsx
+++ b/frontend/src/app/quiz/s/[id]/opengraph-image.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from 'next/og'
+import { SITE_HOST } from '@/lib/site'
 
 export const runtime = 'edge'
 export const alt = 'Quel député vote comme vous ? — MonÉlu'
@@ -103,7 +104,7 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
             marginTop: 44,
           }}
         >
-          mon-elu.vercel.app/quiz — faites le test
+          {`${SITE_HOST}/quiz — faites le test`}
         </div>
       </div>
     ),

--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -1,10 +1,11 @@
 import type { MetadataRoute } from 'next'
+import { SITE_URL } from '@/lib/site'
 
 export default function robots(): MetadataRoute.Robots {
   return {
     // /partager (share-target redirect) and /~offline (SW fallback) are
     // machine endpoints, not content pages.
     rules: { userAgent: '*', allow: '/', disallow: ['/partager', '/~offline'] },
-    sitemap: 'https://mon-elu.vercel.app/sitemap.xml',
+    sitemap: `${SITE_URL}/sitemap.xml`,
   }
 }

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -3,8 +3,8 @@ import { api, type Deputy, type Vote } from '@/lib/api'
 import { departmentCode } from '@/lib/departments'
 import { THEME_ENTRIES } from '@/lib/themes'
 import { GROUP_ENTRIES } from '@/lib/groups'
+import { SITE_URL } from '@/lib/site'
 
-const SITE_URL = 'https://mon-elu.vercel.app'
 const PAGE_SIZE = 200
 const OFFSET_CAP = 2000 // api.votes.list() rejects offset beyond this — see api/routers/votes.py
 

--- a/frontend/src/app/verifier/v/[id]/opengraph-image.tsx
+++ b/frontend/src/app/verifier/v/[id]/opengraph-image.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from 'next/og'
+import { SITE_HOST } from '@/lib/site'
 
 export const runtime = 'edge'
 export const alt = 'Vérification MonÉlu — verdict sur une affirmation'
@@ -117,7 +118,7 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
             ? `${citations} scrutin${citations > 1 ? 's' : ''} officiel${citations > 1 ? 's' : ''} cité${citations > 1 ? 's' : ''}`
             : 'Vérifié contre les scrutins officiels'}
           {horizon ? ` · données depuis le ${horizon}` : ''}
-          {' · mon-elu.vercel.app/verifier'}
+          {` · ${SITE_HOST}/verifier`}
         </div>
 
         <div

--- a/frontend/src/app/verifier/v/[id]/page.tsx
+++ b/frontend/src/app/verifier/v/[id]/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { api } from '@/lib/api'
 import { VerdictCard } from '@/components/VerdictCard'
+import { SITE_URL } from '@/lib/site'
 
 // Verdicts are immutable snapshots (ADR-022): this page reads the stored
 // verdict via GET /verify/{id} — it must never trigger a new verification.
@@ -31,7 +32,7 @@ export async function generateMetadata({
   return {
     title,
     description,
-    openGraph: { title, description, url: `https://mon-elu.vercel.app/verifier/v/${id}` },
+    openGraph: { title, description, url: `${SITE_URL}/verifier/v/${id}` },
     twitter: { card: 'summary_large_image', title, description },
   }
 }

--- a/frontend/src/app/votes/[id]/page.tsx
+++ b/frontend/src/app/votes/[id]/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
   return {
     title: `${result} - ${shortTitle} - MonÉlu`,
     description,
-    openGraph: { title: `${result} - ${shortTitle} - MonÉlu`, description, url: `https://mon-elu.vercel.app/votes/${id}` },
+    openGraph: { title: `${result} - ${shortTitle} - MonÉlu`, description, url: `${SITE_URL}/votes/${id}` },
     twitter: { card: 'summary_large_image', title: `${result} - ${shortTitle} - MonÉlu`, description },
   }
 }

--- a/frontend/src/lib/seo.ts
+++ b/frontend/src/lib/seo.ts
@@ -1,7 +1,8 @@
 import type { Deputy, Vote } from '@/lib/api'
 import { departmentLabel } from '@/lib/departments'
+import { SITE_URL } from '@/lib/site'
 
-export const SITE_URL = 'https://mon-elu.vercel.app'
+export { SITE_URL } from '@/lib/site'
 export const SITE_NAME = 'MonÉlu'
 
 export type BreadcrumbItem = { name: string; url: string }

--- a/frontend/src/lib/site.ts
+++ b/frontend/src/lib/site.ts
@@ -1,0 +1,17 @@
+/**
+ * Single source of truth for the public origin of the site.
+ *
+ * Everything that emits an absolute URL (metadataBase, canonicals, OG urls,
+ * sitemap, robots, JSON-LD, OG card footers) must derive from here so a domain
+ * move is a one-line change plus an env var - see MON-254.
+ *
+ * `NEXT_PUBLIC_*` is inlined by Next at build time, so a domain change takes a
+ * rebuild - which is what a Vercel env-var change triggers anyway.
+ *
+ * Kept in its own module rather than in `seo.ts` so the edge-runtime
+ * `opengraph-image` routes can import it without pulling in the department map.
+ */
+export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://mon-elu.vercel.app'
+
+/** Host only, for display in OG card footers (e.g. `mon-elu.vercel.app`). */
+export const SITE_HOST = SITE_URL.replace(/^https?:\/\//, '').replace(/\/$/, '')


### PR DESCRIPTION
## Why

`frontend/src/lib/seo.ts` already defined `SITE_URL`, but ten files inlined `https://mon-elu.vercel.app` instead of importing it. A domain move would have left stale canonical, sitemap, robots and OG URLs behind — `metadataBase` (every relative canonical site-wide) and `sitemap.ts` being the load-bearing ones, i.e. an SEO regression rather than a cosmetic one.

## What changed

- **New `frontend/src/lib/site.ts`** — the single source of truth:
  - `SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://mon-elu.vercel.app'` (same default, now settable per environment)
  - `SITE_HOST` — the host without the scheme, for the text rendered in OG card footers
  - Kept in its own module rather than inside `seo.ts` so the four edge-runtime `opengraph-image` routes can import it without pulling in the department map that `seo.ts` depends on.
- `seo.ts` re-exports `SITE_URL`, so every existing `import { SITE_URL } from '@/lib/seo'` keeps working.
- All ten literals replaced (`layout.tsx` ×2, `sitemap.ts` — duplicate const deleted, `robots.ts`, `votes/[id]/page.tsx`, `chat/s/[id]/page.tsx`, `verifier/v/[id]/page.tsx`, and the four OG image footers).
- `frontend/.env.example` documents `NEXT_PUBLIC_SITE_URL` and the build-time inlining semantics.
- **New `frontend/__tests__/lib/site.test.ts`** — walks `src/` and fails if the literal domain reappears in any `.ts`/`.tsx` outside `site.ts`; also asserts `SITE_HOST` stays derived from `SITE_URL`.

## Acceptance criteria

| Recommended fix | How it is met |
| -- | -- |
| 1. `SITE_URL` reads `NEXT_PUBLIC_SITE_URL` with the current value as fallback | `src/lib/site.ts` (moved out of `seo.ts`, re-exported from it) |
| 2. Replace all ten literals with the shared constant; delete `sitemap.ts`'s duplicate const | Done — `grep -rn mon-elu.vercel.app src/` now matches only `site.ts` |
| 3. Add an assertion that fails if the literal reappears outside the constant's home | `__tests__/lib/site.test.ts` |

## Test plan

- `npm run lint` — clean; `npm test` — 36 suites / 258 tests pass (2 new).
- `npm run build` — green (a first run failed prerendering `/sitemap.xml` with `API error: 500`; the prod API was returning 429 at that moment — the known rate-limit flake — and the retry built clean).
- Real end-to-end check: rebuilt with `NEXT_PUBLIC_SITE_URL=https://monelu.fr` and served it — `/robots.txt` → `Sitemap: https://monelu.fr/sitemap.xml`, `/sitemap.xml` first `<loc>` → `https://monelu.fr`, home page head → `og:url` and `og:image` on `https://monelu.fr`. Unset, everything renders the current domain unchanged.

## Deploy notes

No migration, no API change. Behaviour is byte-identical while `NEXT_PUBLIC_SITE_URL` is unset. Because `NEXT_PUBLIC_*` is inlined at build time, setting it on Vercel takes effect on the next build — which a Vercel env-var change triggers anyway.
