### PR TITLE
fix: give positions and agenda ingestion a parse-yield guard (MON-249)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "CLAUDE.md",
         "hashed_secret": "ffddd4c9867f24ed207b1da5b50693e6d85a7889",
         "is_verified": false,
-        "line_number": 179
+        "line_number": 185
       }
     ],
     "README.md": [
@@ -252,5 +252,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-26T21:57:12Z"
+  "generated_at": "2026-08-27T21:23:01Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,12 @@ Assemblée Nationale Open Data (ZIPs)
 
 **`scripts/`** — Data ingestion and maintenance
 - Scripts fetch ZIPs from the AN open data portal with exponential-backoff retry (5 attempts, 2 s base) and upsert via `ON CONFLICT ... DO UPDATE`
+- **Every parser must fail loudly on an upstream shape change** (MON-220, MON-249).
+`SKIP_RATE_THRESHOLD = 0.05` lives in `scripts/_http.py` and is shared by all four parsers - never re-declare it per script.
+`ingest_deputies.py` and `ingest_votes.py` exit 1 before upserting when more than 5% of records fail to parse.
+`ingest_positions.py` streams its batches, so `check_position_yield()` runs after the loop instead: it exits 1 when nothing was written while the votes table had rows to attach positions to, or when more than 5% of extracted positions name an unknown `deputy_id`.
+`ingest_agenda.py`'s `check_agenda_yield()` exits 1 when in-window séance publique ODJ points exist but none (or more than 5%) survive `parse_point`.
+A new parser without such a guard ships a skeleton dataset on a green run - the exact failure mode these guards exist to remove.
 - `migrate.py` doubles as the Railway start hook (runs before uvicorn in `railway.json`)
 - `run_ingestion_prod.py` orchestrates the full pipeline for production runs, including `ingest_agenda.py` (MON-210) as a non-critical step - an agenda-feed failure must not block core deputies/votes/positions ingestion
 - `create_dbt_profile.py` generates `transform/profiles.yml` from `DBT_*` env vars (used by CI and deploy workflows)

--- a/scripts/_http.py
+++ b/scripts/_http.py
@@ -20,6 +20,12 @@ log = logging.getLogger(__name__)
 MAX_RETRIES = 5
 BACKOFF_BASE = 2  # seconds
 
+# Abort an ingestion run when more than this share of records fail to parse — a
+# silent AN format change should fail loudly, not ship a skeleton dataset
+# (MON-220). Shared by all four parsers (deputies, votes, positions, agenda) so
+# the four guards can never drift apart (MON-249).
+SKIP_RATE_THRESHOLD = 0.05
+
 
 def download_with_retry(url: str, timeout: int = 60) -> bytes:
     """GET with exponential backoff on 429 / 5xx / network errors; returns raw bytes.

--- a/scripts/ingest_agenda.py
+++ b/scripts/ingest_agenda.py
@@ -186,6 +186,11 @@ def parse_reunions(reunions: list[dict], since: str | None = None) -> list[dict]
     skipped_type = 0
     skipped_date = 0
     points_seen = 0
+    # A séance whose sitting has already happened always has a published ODJ, so
+    # it is the signal that separates "the ODJ container was renamed" from "the
+    # window holds no sittings yet" — see check_agenda_yield (MON-249).
+    today = date.today().isoformat()
+    past_seance_in_window = 0
     for reunion in reunions:
         if reunion.get("@xsi:type") != SEANCE_XSI_TYPE:
             skipped_type += 1
@@ -194,26 +199,32 @@ def parse_reunions(reunions: list[dict], since: str | None = None) -> list[dict]
         if since and sitting_date and sitting_date < since:
             skipped_date += 1
             continue
+        if sitting_date and sitting_date < today:
+            past_seance_in_window += 1
         for point in _odj_points(reunion):
             points_seen += 1
             record = parse_point(reunion, point)
             if record is not None:
                 records.append(record)
 
-    unparsed = points_seen - len(records)
     log.info(
-        "Parsed %d/%d ODJ points from séance publique réunions "
+        "Parsed %d/%d ODJ points in window (%d of the séance publique réunions are past) "
         "(skipped %d non-séance réunions, %d before --since).",
         len(records),
         points_seen,
+        past_seance_in_window,
         skipped_type,
         skipped_date,
     )
-    check_agenda_yield(parsed=len(records), points_seen=points_seen, unparsed=unparsed)
+    check_agenda_yield(
+        parsed=len(records),
+        points_seen=points_seen,
+        past_seance_in_window=past_seance_in_window,
+    )
     return records
 
 
-def check_agenda_yield(parsed: int, points_seen: int, unparsed: int) -> None:
+def check_agenda_yield(parsed: int, points_seen: int, past_seance_in_window: int) -> None:
     """Exit 1 when in-window séance points exist but do not survive parsing (MON-249).
 
     An empty record list is a silent no-op downstream: ``upsert_agenda_items([])``
@@ -222,11 +233,28 @@ def check_agenda_yield(parsed: int, points_seen: int, unparsed: int) -> None:
     ``last_seen_at = (SELECT MAX(last_seen_at) ...)``. Nothing in the run log or
     the API says the feed stopped parsing.
 
-    ``points_seen`` counts only points from séance publique réunions inside the
-    ``--since`` window, so a recess (or a narrow window with no sittings) yields
-    ``points_seen == 0`` and is correctly not treated as a failure.
+    Three shapes are separated, because ``points_seen == 0`` alone is ambiguous:
+
+    * the ODJ *container* was reshaped — ``_odj_points`` walks
+      ``ODJ.pointsODJ.pointODJ``, so renaming any level of that path yields no
+      points at all for every réunion. Caught via ``past_seance_in_window``: a
+      sitting that has already happened always has a published ODJ, so past
+      sittings with zero points between them is unambiguously a feed change.
+    * no sittings to parse — a recess, or a window whose only séance is still
+      ahead with its ODJ unpublished. ``past_seance_in_window == 0``, and the
+      run is correctly left alone.
+    * the point *fields* were reshaped — points are found but ``parse_point``
+      rejects them. Caught by the parsed-vs-seen ratio below.
     """
     if points_seen == 0:
+        if past_seance_in_window > 0:
+            log.error(
+                "No ODJ points found at all across %d past séance publique réunions "
+                "in the window. A past sitting always has a published ODJ, so the "
+                "ODJ.pointsODJ.pointODJ path in the AN agenda export has changed.",
+                past_seance_in_window,
+            )
+            sys.exit(1)
         log.info("No in-window séance publique ODJ points in the feed — nothing to guard.")
         return
 
@@ -238,6 +266,7 @@ def check_agenda_yield(parsed: int, points_seen: int, unparsed: int) -> None:
         )
         sys.exit(1)
 
+    unparsed = points_seen - parsed
     skip_rate = unparsed / points_seen
     if skip_rate > SKIP_RATE_THRESHOLD:
         log.error(

--- a/scripts/ingest_agenda.py
+++ b/scripts/ingest_agenda.py
@@ -26,6 +26,7 @@ import io
 import json
 import logging
 import os
+import sys
 import zipfile
 from datetime import date, timedelta
 
@@ -33,9 +34,9 @@ import psycopg2.extras
 from dotenv import load_dotenv
 
 try:
-    from scripts._http import connect_with_retry, download_with_retry
+    from scripts._http import SKIP_RATE_THRESHOLD, connect_with_retry, download_with_retry
 except ImportError:  # running as a plain file: python scripts/ingest_agenda.py
-    from _http import connect_with_retry, download_with_retry
+    from _http import SKIP_RATE_THRESHOLD, connect_with_retry, download_with_retry
 
 load_dotenv()
 
@@ -172,7 +173,10 @@ def parse_point(reunion: dict, point: dict) -> dict | None:
             "objet_hash": hashlib.sha256(objet.encode("utf-8")).hexdigest() if objet else None,
         }
     except Exception as exc:
-        log.debug("Could not parse ODJ point %s — %s", point.get("uid"), exc)
+        # WARNING, not DEBUG: basicConfig(level=INFO) never emitted the debug
+        # line, so a feed reshape produced zero records with no visible signal
+        # anywhere in the run log (MON-249).
+        log.warning("Could not parse ODJ point %s — %s", point.get("uid"), exc)
         return None
 
 
@@ -181,6 +185,7 @@ def parse_reunions(reunions: list[dict], since: str | None = None) -> list[dict]
     records: list[dict] = []
     skipped_type = 0
     skipped_date = 0
+    points_seen = 0
     for reunion in reunions:
         if reunion.get("@xsi:type") != SEANCE_XSI_TYPE:
             skipped_type += 1
@@ -190,18 +195,59 @@ def parse_reunions(reunions: list[dict], since: str | None = None) -> list[dict]
             skipped_date += 1
             continue
         for point in _odj_points(reunion):
+            points_seen += 1
             record = parse_point(reunion, point)
             if record is not None:
                 records.append(record)
 
+    unparsed = points_seen - len(records)
     log.info(
-        "Parsed %d ODJ points from séance publique réunions "
+        "Parsed %d/%d ODJ points from séance publique réunions "
         "(skipped %d non-séance réunions, %d before --since).",
         len(records),
+        points_seen,
         skipped_type,
         skipped_date,
     )
+    check_agenda_yield(parsed=len(records), points_seen=points_seen, unparsed=unparsed)
     return records
+
+
+def check_agenda_yield(parsed: int, points_seen: int, unparsed: int) -> None:
+    """Exit 1 when in-window séance points exist but do not survive parsing (MON-249).
+
+    An empty record list is a silent no-op downstream: ``upsert_agenda_items([])``
+    writes nothing, ``last_seen_at`` never advances, and ``GET /agenda`` keeps
+    serving the previous run's rows forever because its visibility filter is
+    ``last_seen_at = (SELECT MAX(last_seen_at) ...)``. Nothing in the run log or
+    the API says the feed stopped parsing.
+
+    ``points_seen`` counts only points from séance publique réunions inside the
+    ``--since`` window, so a recess (or a narrow window with no sittings) yields
+    ``points_seen == 0`` and is correctly not treated as a failure.
+    """
+    if points_seen == 0:
+        log.info("No in-window séance publique ODJ points in the feed — nothing to guard.")
+        return
+
+    if parsed == 0:
+        log.error(
+            "All %d in-window séance publique ODJ points failed to parse. "
+            "Check the AN agenda export for format changes.",
+            points_seen,
+        )
+        sys.exit(1)
+
+    skip_rate = unparsed / points_seen
+    if skip_rate > SKIP_RATE_THRESHOLD:
+        log.error(
+            "High parse failure rate: %d/%d ODJ points skipped (%.0f%%). "
+            "Check the AN agenda export for format changes.",
+            unparsed,
+            points_seen,
+            skip_rate * 100,
+        )
+        sys.exit(1)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/ingest_deputies.py
+++ b/scripts/ingest_deputies.py
@@ -26,9 +26,9 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from api.departments_data import DEPT_NAMES  # noqa: E402
 
 try:
-    from scripts._http import download_with_retry
+    from scripts._http import SKIP_RATE_THRESHOLD, download_with_retry
 except ImportError:  # running as a plain file: python scripts/ingest_deputies.py
-    from _http import download_with_retry
+    from _http import SKIP_RATE_THRESHOLD, download_with_retry
 
 load_dotenv()
 
@@ -40,10 +40,6 @@ log = logging.getLogger(__name__)
 
 AN_API_BASE_URL = os.getenv("AN_API_BASE_URL", "https://data.assemblee-nationale.fr")
 DATABASE_URL = os.getenv("DATABASE_URL")
-
-# Abort the run if more than this share of records fail to parse — a silent
-# AN format change should fail loudly, not ship a skeleton dataset (MON-220).
-SKIP_RATE_THRESHOLD = 0.05
 
 # Static export — one ZIP, one JSON file per deputy
 DEPUTIES_ZIP_PATH = (

--- a/scripts/ingest_positions.py
+++ b/scripts/ingest_positions.py
@@ -15,15 +15,16 @@ import io
 import json
 import logging
 import os
+import sys
 import zipfile
 
 import psycopg2.extras
 from dotenv import load_dotenv
 
 try:
-    from scripts._http import connect_with_retry, download_with_retry
+    from scripts._http import SKIP_RATE_THRESHOLD, connect_with_retry, download_with_retry
 except ImportError:  # running as a plain file: python scripts/ingest_positions.py
-    from _http import connect_with_retry, download_with_retry
+    from _http import SKIP_RATE_THRESHOLD, connect_with_retry, download_with_retry
 
 load_dotenv()
 
@@ -143,6 +144,61 @@ def upsert_positions(records: list[dict]) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Parse-yield guard (MON-249)
+# ---------------------------------------------------------------------------
+
+
+def check_position_yield(
+    written: int,
+    skipped_unknown_deputy: int,
+    known_votes_count: int,
+    matched_scrutins: int,
+) -> None:
+    """Exit 1 when the run's output is inconsistent with its input (MON-249).
+
+    ``extract_positions`` walks ``ventilationVotes.organe.groupes.groupe[]``. If
+    the AN reshapes that tree every call returns ``[]``, and without this guard
+    the script logs "0 positions written" and exits 0 — the orchestrator then
+    treats a total ingestion failure as a green run.
+
+    Two failure shapes are caught:
+
+    * nothing written at all while the votes table had rows to attach positions
+      to — either the tree-walk broke or the scrutin files vanished from the ZIP;
+    * more than ``SKIP_RATE_THRESHOLD`` of the extracted positions pointing at
+      deputy ids the deputies table does not know, which means the acteurRef
+      shape (or the deputies ingestion that ran just before) changed.
+
+    Unlike the deputies/votes guards this runs *after* the upserts: positions are
+    streamed in 2 000-row batches, so buffering the whole 715k-row set just to
+    validate it up front is not an option. The non-zero exit is what makes the
+    orchestrator fail the run — partial rows are harmless because the upsert is
+    idempotent and the next run overwrites them.
+    """
+    if known_votes_count > 0 and written == 0:
+        log.error(
+            "No positions written for %d known votes (%d scrutin files matched). "
+            "Check ventilationVotes in the AN scrutins export for format changes.",
+            known_votes_count,
+            matched_scrutins,
+        )
+        sys.exit(1)
+
+    considered = written + skipped_unknown_deputy
+    skip_rate = skipped_unknown_deputy / considered if considered else 0.0
+    if skip_rate > SKIP_RATE_THRESHOLD:
+        log.error(
+            "High unknown-deputy rate: %d/%d extracted positions reference a "
+            "deputy_id absent from the deputies table (%.0f%%). "
+            "Check the acteurRef format in the AN scrutins export.",
+            skipped_unknown_deputy,
+            considered,
+            skip_rate * 100,
+        )
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
@@ -209,7 +265,13 @@ def run(since: str | None = None, zip_path: str | None = None) -> None:
 
     log.info("=== Starting position ingestion ===")
     total_written = 0
-    total_skipped = 0
+    # Split counters: a single total_skipped conflated three unrelated causes,
+    # which made a broken tree-walk indistinguishable from an out-of-window
+    # scrutin (MON-249). Only skipped_unknown_deputy signals a format change.
+    skipped_window = 0
+    skipped_unknown_vote = 0
+    skipped_unknown_deputy = 0
+    matched_scrutins = 0
     batch: list[dict] = []
 
     with zipfile.ZipFile(io.BytesIO(raw)) as zf:
@@ -226,20 +288,21 @@ def run(since: str | None = None, zip_path: str | None = None) -> None:
             if since:
                 date_raw = (scrutin.get("dateScrutin") or "")[:10]
                 if date_raw and date_raw < since:
-                    total_skipped += 1
+                    skipped_window += 1
                     continue
 
             vote_id = scrutin.get("uid") or ""
             if vote_id not in known_votes:
-                total_skipped += 1
+                skipped_unknown_vote += 1
                 continue
 
+            matched_scrutins += 1
             positions = extract_positions(scrutin)
             for pos in positions:
                 if pos["deputy_id"] in known_deputies:
                     batch.append(pos)
                 else:
-                    total_skipped += 1
+                    skipped_unknown_deputy += 1
 
             if len(batch) >= 2000:
                 upsert_positions(batch)
@@ -251,7 +314,21 @@ def run(since: str | None = None, zip_path: str | None = None) -> None:
         upsert_positions(batch)
         total_written += len(batch)
 
-    log.info("Upsert complete — %d positions written, %d skipped.", total_written, total_skipped)
+    log.info(
+        "Upsert complete — %d positions written from %d matched scrutins "
+        "(skipped %d out-of-window, %d unknown vote_id, %d unknown deputy_id).",
+        total_written,
+        matched_scrutins,
+        skipped_window,
+        skipped_unknown_vote,
+        skipped_unknown_deputy,
+    )
+    check_position_yield(
+        written=total_written,
+        skipped_unknown_deputy=skipped_unknown_deputy,
+        known_votes_count=len(known_votes),
+        matched_scrutins=matched_scrutins,
+    )
     log.info("=== Position ingestion finished ===")
 
 

--- a/scripts/ingest_votes.py
+++ b/scripts/ingest_votes.py
@@ -25,9 +25,9 @@ import psycopg2.extras
 from dotenv import load_dotenv
 
 try:
-    from scripts._http import download_with_retry
+    from scripts._http import SKIP_RATE_THRESHOLD, download_with_retry
 except ImportError:  # running as a plain file: python scripts/ingest_votes.py
-    from _http import download_with_retry
+    from _http import SKIP_RATE_THRESHOLD, download_with_retry
 
 load_dotenv()
 
@@ -41,10 +41,6 @@ AN_BASE_URL = os.getenv("AN_API_BASE_URL", "https://data.assemblee-nationale.fr"
 DATABASE_URL = os.getenv("DATABASE_URL")
 
 SCRUTINS_ZIP_PATH = "/static/openData/repository/17/loi/scrutins/Scrutins.json.zip"
-
-# Abort the run if more than this share of records fail to parse — a silent
-# AN format change should fail loudly, not ship a skeleton dataset (MON-220).
-SKIP_RATE_THRESHOLD = 0.05
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/run_ingestion_prod.py
+++ b/scripts/run_ingestion_prod.py
@@ -171,6 +171,14 @@ def main() -> None:
             # Non-critical: the agenda export is a separate feed (MON-210,
             # ADR-030) from the scrutins/deputies ZIPs above, so a failure here
             # must not block core votes/deputies/positions ingestion.
+            #
+            # Deliberately still non-critical now that the step can exit 1 on a
+            # feed reshape (MON-249): a hard exit is not silent here — run_step
+            # emits an ::error:: annotation, the step name lands in the
+            # soft_failures GITHUB_OUTPUT, and ingest_prod.yml turns that into a
+            # step-summary warning plus a notification email. Promoting agenda to
+            # critical would let an upstream agenda-only change block the votes
+            # and positions ingestion that ADR-030 explicitly separated it from.
             t_agenda = run_step(
                 "Agenda", "ingest_agenda.py", ["--since", args.since], critical=False
             )

--- a/tests/unit/test_ingest_skip_rate_guard.py
+++ b/tests/unit/test_ingest_skip_rate_guard.py
@@ -11,6 +11,7 @@ and all four share SKIP_RATE_THRESHOLD from scripts._http.
 import io
 import json
 import zipfile
+from datetime import date, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -109,20 +110,28 @@ class TestIngestPositionsYieldGuard:
 class TestIngestAgendaYieldGuard:
     def test_all_points_unparsed_exits(self):
         with pytest.raises(SystemExit) as exc_info:
-            check_agenda_yield(parsed=0, points_seen=40, unparsed=40)
+            check_agenda_yield(parsed=0, points_seen=40, past_seance_in_window=5)
         assert exc_info.value.code == 1
 
     def test_high_unparsed_rate_exits(self):
         with pytest.raises(SystemExit) as exc_info:
-            check_agenda_yield(parsed=90, points_seen=100, unparsed=10)
+            check_agenda_yield(parsed=90, points_seen=100, past_seance_in_window=12)
         assert exc_info.value.code == 1
 
     def test_low_unparsed_rate_passes(self):
-        check_agenda_yield(parsed=99, points_seen=100, unparsed=1)
+        check_agenda_yield(parsed=99, points_seen=100, past_seance_in_window=12)
 
     def test_no_points_in_window_is_not_a_failure(self):
-        # Recess, or a --since window with no séance publique sittings.
-        check_agenda_yield(parsed=0, points_seen=0, unparsed=0)
+        # Recess, or a --since window whose only séance is still ahead with no
+        # ODJ published yet — no past sitting to contradict the empty result.
+        check_agenda_yield(parsed=0, points_seen=0, past_seance_in_window=0)
+
+    def test_no_points_despite_past_sittings_exits(self):
+        # The ODJ container itself was renamed: _odj_points returns [] for every
+        # réunion, so points_seen is 0 even though past sittings are in window.
+        with pytest.raises(SystemExit) as exc_info:
+            check_agenda_yield(parsed=0, points_seen=0, past_seance_in_window=8)
+        assert exc_info.value.code == 1
 
     def test_parse_reunions_exits_when_every_point_fails_to_parse(self):
         # A séance réunion whose ODJ points no longer carry a uid — the exact
@@ -141,6 +150,32 @@ class TestIngestAgendaYieldGuard:
 
     def test_parse_reunions_does_not_exit_when_only_commissions_are_present(self):
         reunions = [{"@xsi:type": "commission_type", "uid": "RU2"}]
+        assert parse_reunions(reunions) == []
+
+    def test_parse_reunions_exits_when_the_odj_container_is_renamed(self):
+        # _odj_points walks ODJ.pointsODJ.pointODJ; renaming any level of that
+        # path yields no points at all, which the parsed-vs-seen ratio cannot
+        # see. Past sittings in the window are what make it detectable (MON-249).
+        past = (date.today() - timedelta(days=7)).isoformat()
+        reunions = [
+            {
+                "@xsi:type": "seance_type",
+                "uid": f"RU{i}",
+                "timeStampDebut": f"{past}T09:00:00",
+                "ODJ": {"pointsODJRenamed": {"pointODJ": [{"uid": f"P{i}"}]}},
+            }
+            for i in range(3)
+        ]
+        with pytest.raises(SystemExit) as exc_info:
+            parse_reunions(reunions)
+        assert exc_info.value.code == 1
+
+    def test_parse_reunions_tolerates_a_future_sitting_with_no_odj_yet(self):
+        # First sitting back after a recess, ODJ not published — must not exit.
+        future = (date.today() + timedelta(days=7)).isoformat()
+        reunions = [
+            {"@xsi:type": "seance_type", "uid": "RU1", "timeStampDebut": f"{future}T09:00:00"}
+        ]
         assert parse_reunions(reunions) == []
 
 

--- a/tests/unit/test_ingest_skip_rate_guard.py
+++ b/tests/unit/test_ingest_skip_rate_guard.py
@@ -1,14 +1,25 @@
 """
-Tests for the parse-failure skip-rate guard in ingest_deputies.py and
-ingest_votes.py (MON-220): a high parse-skip rate must exit 1 instead of
-silently upserting a skeleton dataset with fresh ingested_at stamps.
+Tests for the parse-failure guards in the four ingestion parsers: a shape
+change upstream must exit 1 instead of silently shipping a skeleton dataset
+with fresh ingested_at stamps.
+
+ingest_deputies / ingest_votes carry the original skip-rate guard (MON-220);
+ingest_positions and ingest_agenda carry the yield guards added in MON-249,
+and all four share SKIP_RATE_THRESHOLD from scripts._http.
 """
 
-from unittest.mock import patch
+import io
+import json
+import zipfile
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from scripts import ingest_positions
+from scripts._http import SKIP_RATE_THRESHOLD
+from scripts.ingest_agenda import check_agenda_yield, parse_reunions
 from scripts.ingest_deputies import upsert_deputies
+from scripts.ingest_positions import check_position_yield
 from scripts.ingest_votes import upsert_votes
 
 
@@ -53,3 +64,146 @@ class TestIngestVotesSkipRateGuard:
             count = upsert_votes(raw_items)
         assert count == 20
         mock_upsert.assert_called_once()
+
+
+class TestSharedThreshold:
+    """All four parsers must move together — MON-249 folded the duplicated
+    constant into scripts/_http.py so a future retune cannot drift."""
+
+    def test_every_parser_uses_the_shared_constant(self):
+        from scripts import ingest_agenda, ingest_deputies, ingest_positions, ingest_votes
+
+        for module in (ingest_deputies, ingest_votes, ingest_positions, ingest_agenda):
+            assert module.SKIP_RATE_THRESHOLD is SKIP_RATE_THRESHOLD
+
+
+class TestIngestPositionsYieldGuard:
+    def test_zero_written_with_known_votes_exits(self):
+        # The ventilationVotes reshape: every extract_positions call returns [].
+        with pytest.raises(SystemExit) as exc_info:
+            check_position_yield(
+                written=0, skipped_unknown_deputy=0, known_votes_count=120, matched_scrutins=120
+            )
+        assert exc_info.value.code == 1
+
+    def test_zero_written_with_no_known_votes_is_fine(self):
+        # Recess: the --since window holds no votes, so there is nothing to write.
+        check_position_yield(
+            written=0, skipped_unknown_deputy=0, known_votes_count=0, matched_scrutins=0
+        )
+
+    def test_high_unknown_deputy_rate_exits(self):
+        with pytest.raises(SystemExit) as exc_info:
+            check_position_yield(
+                written=900, skipped_unknown_deputy=100, known_votes_count=2, matched_scrutins=2
+            )
+        assert exc_info.value.code == 1
+
+    def test_low_unknown_deputy_rate_passes(self):
+        # A handful of unknown acteurRefs (a deputy sworn in mid-window) is normal.
+        check_position_yield(
+            written=1000, skipped_unknown_deputy=10, known_votes_count=2, matched_scrutins=2
+        )
+
+
+class TestIngestAgendaYieldGuard:
+    def test_all_points_unparsed_exits(self):
+        with pytest.raises(SystemExit) as exc_info:
+            check_agenda_yield(parsed=0, points_seen=40, unparsed=40)
+        assert exc_info.value.code == 1
+
+    def test_high_unparsed_rate_exits(self):
+        with pytest.raises(SystemExit) as exc_info:
+            check_agenda_yield(parsed=90, points_seen=100, unparsed=10)
+        assert exc_info.value.code == 1
+
+    def test_low_unparsed_rate_passes(self):
+        check_agenda_yield(parsed=99, points_seen=100, unparsed=1)
+
+    def test_no_points_in_window_is_not_a_failure(self):
+        # Recess, or a --since window with no séance publique sittings.
+        check_agenda_yield(parsed=0, points_seen=0, unparsed=0)
+
+    def test_parse_reunions_exits_when_every_point_fails_to_parse(self):
+        # A séance réunion whose ODJ points no longer carry a uid — the exact
+        # shape a feed reshape produces (MON-249).
+        reunions = [
+            {
+                "@xsi:type": "seance_type",
+                "uid": "RU1",
+                "timeStampDebut": "2026-01-15T09:00:00",
+                "ODJ": {"pointsODJ": {"pointODJ": [{"objet": "Sans uid"}, {"objet": "Non plus"}]}},
+            }
+        ]
+        with pytest.raises(SystemExit) as exc_info:
+            parse_reunions(reunions)
+        assert exc_info.value.code == 1
+
+    def test_parse_reunions_does_not_exit_when_only_commissions_are_present(self):
+        reunions = [{"@xsi:type": "commission_type", "uid": "RU2"}]
+        assert parse_reunions(reunions) == []
+
+
+def _scrutins_zip(scrutins: list[dict]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for scrutin in scrutins:
+            zf.writestr(f"json/{scrutin['uid']}.json", json.dumps({"scrutin": scrutin}))
+    return buf.getvalue()
+
+
+def _known_ids_conn(vote_ids: list[str], deputy_ids: list[str]) -> MagicMock:
+    cur = MagicMock()
+    cur.fetchall.side_effect = [[(v,) for v in vote_ids], [(d,) for d in deputy_ids]]
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cur
+    return conn
+
+
+class TestIngestPositionsRunWiring:
+    """End-to-end over run()'s loop: the split counters must actually reach the
+    guard, which a pure check_position_yield() test cannot prove."""
+
+    def _run(self, scrutins, vote_ids, deputy_ids):
+        conn = _known_ids_conn(vote_ids, deputy_ids)
+        with (
+            patch.object(
+                ingest_positions, "fetch_scrutin_zip", return_value=_scrutins_zip(scrutins)
+            ),
+            patch.object(ingest_positions, "connect_with_retry", return_value=conn),
+            patch.object(ingest_positions, "upsert_positions") as mock_upsert,
+            patch.object(ingest_positions, "DATABASE_URL", "postgresql://test"),
+        ):
+            ingest_positions.run()
+        return mock_upsert
+
+    def test_reshaped_ventilation_votes_exits_1(self):
+        # ventilationVotes renamed upstream: extract_positions returns [] for every
+        # scrutin, so the run writes nothing and must fail loudly (MON-249).
+        scrutins = [{"uid": "VTANR5L17V1", "ventilationVotesRenamed": {}}]
+        with pytest.raises(SystemExit) as exc_info:
+            self._run(scrutins, vote_ids=["VTANR5L17V1"], deputy_ids=["PA1"])
+        assert exc_info.value.code == 1
+
+    def test_healthy_feed_writes_and_exits_cleanly(self):
+        scrutins = [
+            {
+                "uid": "VTANR5L17V1",
+                "ventilationVotes": {
+                    "organe": {
+                        "groupes": {
+                            "groupe": {
+                                "vote": {
+                                    "decompteNominatif": {
+                                        "pours": {"votant": [{"acteurRef": "PA1"}]},
+                                        "contres": {"votant": [{"acteurRef": "PA2"}]},
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+            }
+        ]
+        mock_upsert = self._run(scrutins, vote_ids=["VTANR5L17V1"], deputy_ids=["PA1", "PA2"])
+        assert [r["deputy_id"] for r in mock_upsert.call_args[0][0]] == ["PA1", "PA2"]


### PR DESCRIPTION
## Problem

[MON-220](https://linear.app/monelu/issue/MON-220) added a 5% parse-skip guard so a silent AN format change fails loudly instead of shipping a skeleton dataset. It only landed in two of the four parsers.

**`ingest_positions.py`** - the critical step feeding the 715k-row `vote_positions` table and every scorecard downstream. `total_skipped` conflated three unrelated causes (out-of-window scrutins, unknown `vote_id`, unknown `deputy_id`) into one counter, and nothing compared written-vs-expected. If the AN reshapes `ventilationVotes`, `extract_positions` returns `[]` for every scrutin, the log reads "0 positions written", and the script exits 0. The orchestrator treats that as success.

**`ingest_agenda.py`** - `parse_point` wrapped the whole flatten in `except Exception` and logged at `log.debug`, which `basicConfig(level=INFO)` never emits. No counter, no guard. A shape change produces `records == []`, `upsert_agenda_items([])` writes nothing, `last_seen_at` never advances - and `api/routers/agenda.py`'s `last_seen_at = (SELECT MAX(last_seen_at) ...)` filter then serves the *previous* run's rows indefinitely with no signal anywhere.

## What changed

**Shared threshold.** `SKIP_RATE_THRESHOLD = 0.05` moves from two duplicated declarations into `scripts/_http.py`. All four parsers import the one value, so a future retune cannot leave them out of step. A test asserts the four modules resolve to the same object.

**`ingest_positions.py`.** `total_skipped` splits into `skipped_window` / `skipped_unknown_vote` / `skipped_unknown_deputy`, plus a `matched_scrutins` counter, and the completion log reports all four. New `check_position_yield()` exits 1 when:

- nothing was written while the votes table had rows to attach positions to (the tree-walk broke, or the scrutin files left the ZIP), or
- more than 5% of extracted positions name a `deputy_id` the deputies table does not know (the `acteurRef` shape changed).

Unlike the deputies/votes guards, this runs *after* the upserts rather than before: positions stream in 2 000-row batches, so buffering the whole 715k-row set just to validate it up front is not an option. The non-zero exit is what fails the orchestrated run, and the upsert is idempotent, so any partially written rows are overwritten by the next run.

**`ingest_agenda.py`.** `parse_point` failures now log at WARNING (visible under `level=INFO`) and are counted. New `check_agenda_yield()` separates three shapes, because "no records" alone is ambiguous:

- **the point fields were reshaped** - points are found but `parse_point` rejects them: exit 1 when none, or fewer than 95%, survive.
- **the ODJ container was reshaped** - `_odj_points` walks `ODJ.pointsODJ.pointODJ`, so renaming any level of that path yields no points at all and the parsed-vs-seen ratio cannot see it. A sitting that has already happened always has a published ODJ, so the guard exits 1 when past in-window séance réunions exist while no points were found anywhere.
- **nothing to parse** - a recess, or a window whose only séance is still ahead with its ODJ unpublished. No past sitting contradicts the empty result, so the run is left alone.

That third case is why the issue's literal "exit 1 on 0 records from a non-empty ZIP" rule could not be implemented as written: the feed is in a recess right now (latest prod vote `2026-07-21`), so it would fail the daily cron today.

**`run_ingestion_prod.py`.** The agenda step stays `critical=False` and the comment now records why, since it can now exit 1 deliberately: a hard exit is not silent here - `run_step` emits an `::error::` annotation, the step name lands in the `soft_failures` GITHUB_OUTPUT, and `ingest_prod.yml` turns that into a step-summary warning plus a notification email. Promoting agenda to critical would let an agenda-only upstream change block the votes and positions ingestion that ADR-030 explicitly separated it from. This is the deliberate answer to the issue's item 3, not an omission.

**`CLAUDE.md`.** Records the invariant: every parser must fail loudly on an upstream shape change, the threshold lives in `_http.py`, and what each of the four guards checks.

## Acceptance criteria

| From the issue | How it is met |
|---|---|
| 1. Split `total_skipped` into three counters | `skipped_window` / `skipped_unknown_vote` / `skipped_unknown_deputy` (+ `matched_scrutins`), all reported in the completion log |
| 1. Exit 1 when `total_written == 0` while `known_votes` is non-empty | First branch of `check_position_yield()` |
| 1. Exit 1 on unknown-deputy skip rate > threshold | Second branch, denominator `written + skipped_unknown_deputy` as specified |
| 1. Move the threshold to a shared module | `scripts/_http.py`; all four parsers import it, enforced by `TestSharedThreshold` |
| 2. Count agenda parse failures, log at WARNING | `points_seen` / `unparsed` in `parse_reunions`; `parse_point` now logs at WARNING |
| 2. Same 5% guard over points-seen vs records-built | `check_agenda_yield()` skip-rate branch |
| 2. Exit 1 on 0 records from a non-empty feed | Two branches: `parsed == 0 and points_seen > 0` for a point-field reshape, and `points_seen == 0 and past_seance_in_window > 0` for a reshape of the ODJ container itself. Both scoped so a recess is not a false positive |
| 3. Decide on `critical=False` for the agenda step | Kept, per ADR-030; rationale documented inline - a hard exit already produces an `::error::` annotation, a soft-failure output and a notification email |

## Test plan

- `pytest tests/ -m "not integration"` - **426 passed** (up from 421; 18 new cases in `tests/unit/test_ingest_skip_rate_guard.py`).
- New coverage: both `check_position_yield` branches and their pass-through cases (including recess: 0 written with 0 known votes is fine); all four `check_agenda_yield` branches; `parse_reunions` exiting when every in-window point fails to parse, and *not* exiting on a commission-only feed.
- New `TestIngestPositionsRunWiring` drives `run()` end-to-end over a synthetic scrutins ZIP with a renamed `ventilationVotes` key - proving the split counters actually reach the guard, which a pure-function test cannot. The healthy-feed case asserts the extracted rows still reach `upsert_positions`.
- Exercised through the real code path, not just the guard in isolation: a ZIP whose points lost their uid exits **1**; a ZIP whose ODJ *container* is renamed with three past sittings exits **1** on the new branch; a ZIP holding only a future sitting with no ODJ exits **0**; a commission-only ZIP exits **0**.
- Checked against production before trusting the positions guard: **0 of 5 561 votes** have zero rows in `vote_positions`, so `written == 0` cannot false-positive on a legitimately position-less scrutin.
- `ruff check .` and `ruff format --check .` clean repo-wide.

## Review fixes applied

Two Should Fix findings from the review on this PR, both on `check_agenda_yield`:

1. **Blind to an ODJ-container reshape** - the guard only fired when point-level fields changed, so renaming `ODJ.pointsODJ.pointODJ` produced `points_seen == 0` and took the "nothing to guard" early return. Closed with the past-sitting rule described above.
2. **Redundant `unparsed` parameter** - always `points_seen - parsed`, but nothing enforced it, so an inconsistent triple could silently change which branch fired. Derived inside the function now.

## Deploy / migration risk

None. No schema change, no workflow trigger change, no deploy-config change. The behavioral change is confined to exit codes on runs that are already broken today - a healthy run's logs gain the split counters and are otherwise unchanged.

The one thing to watch: the first cron run after merge would fail loudly if positions or agenda ingestion is *already* silently broken in production. That is the intended outcome, but it means a red run right after merge is a real finding to investigate, not a regression from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjrfEA2HZoKnVzdiZV2HaL
