### PR TITLE
feat: add Organization JSON-LD as the site's publisher node (MON-273)

### DIFF
--- a/frontend/__tests__/lib/seo.test.ts
+++ b/frontend/__tests__/lib/seo.test.ts
@@ -1,5 +1,7 @@
 import {
   SITE_URL,
+  ORGANIZATION_ID,
+  buildOrganizationJsonLd,
   buildWebsiteJsonLd,
   buildPersonJsonLd,
   buildVoteJsonLd,
@@ -32,12 +34,52 @@ const vote: Vote = {
   theme: null,
 }
 
+describe('buildOrganizationJsonLd', () => {
+  it('is an Organization carrying the shared @id', () => {
+    const data = buildOrganizationJsonLd()
+    expect(data['@type']).toBe('Organization')
+    expect(data['@id']).toBe(ORGANIZATION_ID)
+    expect(ORGANIZATION_ID).toBe(`${SITE_URL}/#organization`)
+  })
+
+  it('derives every absolute URL from SITE_URL so a domain move carries (MON-254)', () => {
+    const data = buildOrganizationJsonLd()
+    expect(data.url).toBe(SITE_URL)
+    expect(data.logo.url).toBe(`${SITE_URL}/icon-512.png`)
+    // Nothing may hardcode an origin: every http(s) URL in the block is either
+    // SITE_URL-derived or an explicit external sameAs entry.
+    const urls = JSON.stringify(data).match(/https?:\/\/[^"]+/g) ?? []
+    const allowed = new Set<string>([...data.sameAs, 'https://schema.org'])
+    for (const url of urls) {
+      if (allowed.has(url)) continue
+      expect(url.startsWith(SITE_URL)).toBe(true)
+    }
+  })
+
+  it('omits contactPoint and foundingDate rather than inventing them', () => {
+    const data = buildOrganizationJsonLd()
+    expect(data).not.toHaveProperty('contactPoint')
+    expect(data).not.toHaveProperty('foundingDate')
+  })
+
+  it('lists only origins the project controls in sameAs', () => {
+    const data = buildOrganizationJsonLd()
+    expect(data.sameAs).toEqual(['https://github.com/Walid-peach/MonElu'])
+  })
+})
+
 describe('buildWebsiteJsonLd', () => {
   it('includes a SearchAction targeting /chat', () => {
     const data = buildWebsiteJsonLd()
     expect(data['@type']).toBe('WebSite')
     expect(data.url).toBe(SITE_URL)
     expect(data.potentialAction.target.urlTemplate).toBe(`${SITE_URL}/chat?q={search_term_string}`)
+  })
+
+  it('references the Organization by @id instead of re-declaring it', () => {
+    const data = buildWebsiteJsonLd()
+    expect(data.publisher).toEqual({ '@id': ORGANIZATION_ID })
+    expect(data.publisher).not.toHaveProperty('name')
   })
 })
 

--- a/frontend/__tests__/lib/seo.test.ts
+++ b/frontend/__tests__/lib/seo.test.ts
@@ -1,5 +1,6 @@
 import {
   SITE_URL,
+  SITE_DESCRIPTION,
   ORGANIZATION_ID,
   buildOrganizationJsonLd,
   buildWebsiteJsonLd,
@@ -65,6 +66,12 @@ describe('buildOrganizationJsonLd', () => {
   it('lists only origins the project controls in sameAs', () => {
     const data = buildOrganizationJsonLd()
     expect(data.sameAs).toEqual(['https://github.com/Walid-peach/MonElu'])
+  })
+
+  it('describes the site with the same text as the page meta description', () => {
+    // The root layout feeds metadata.description from SITE_DESCRIPTION, so a
+    // crawler must never read one description in <meta> and another in JSON-LD.
+    expect(buildOrganizationJsonLd().description).toBe(SITE_DESCRIPTION)
   })
 })
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -15,7 +15,7 @@ import { HideOnEmbed } from '@/components/HideOnEmbed'
 import { MainFrame } from '@/components/MainFrame'
 import { JsonLd } from '@/components/JsonLd'
 import { ThemeProvider } from '@/components/ThemeProvider'
-import { buildWebsiteJsonLd } from '@/lib/seo'
+import { buildOrganizationJsonLd, buildWebsiteJsonLd } from '@/lib/seo'
 import { SITE_URL } from '@/lib/site'
 import { THEME_STORAGE_KEY } from '@/lib/theme'
 
@@ -78,7 +78,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           {`(function(){try{if(window.location.pathname==='/')return;var s=localStorage.getItem('${THEME_STORAGE_KEY}');var d=s==='dark'||(s!=='light'&&window.matchMedia('(prefers-color-scheme: dark)').matches);if(d)document.documentElement.classList.add('dark');}catch(e){}})();`}
         </Script>
         <ThemeProvider>
-          <JsonLd data={buildWebsiteJsonLd()} />
+          {/* Organization first: WebSite.publisher references it by @id (MON-273). */}
+          <JsonLd data={[buildOrganizationJsonLd(), buildWebsiteJsonLd()]} />
           <Suspense fallback={null}>
             <Nav />
           </Suspense>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -15,7 +15,7 @@ import { HideOnEmbed } from '@/components/HideOnEmbed'
 import { MainFrame } from '@/components/MainFrame'
 import { JsonLd } from '@/components/JsonLd'
 import { ThemeProvider } from '@/components/ThemeProvider'
-import { buildOrganizationJsonLd, buildWebsiteJsonLd } from '@/lib/seo'
+import { SITE_DESCRIPTION, buildOrganizationJsonLd, buildWebsiteJsonLd } from '@/lib/seo'
 import { SITE_URL } from '@/lib/site'
 import { THEME_STORAGE_KEY } from '@/lib/theme'
 
@@ -45,7 +45,9 @@ const sans = DM_Sans({
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: 'MonÉlu — Suivez vos députés',
-  description: "Données officielles de l'Assemblée Nationale. Suivez chaque vote de chaque député français.",
+  // Shared with Organization.description in the JSON-LD below (MON-273) so the
+  // meta description and the structured data cannot drift apart.
+  description: SITE_DESCRIPTION,
   manifest: '/manifest.json',
   appleWebApp: { capable: true, statusBarStyle: 'default', title: 'MonÉlu' },
   openGraph: {

--- a/frontend/src/lib/seo.ts
+++ b/frontend/src/lib/seo.ts
@@ -5,9 +5,17 @@ import { SITE_URL } from '@/lib/site'
 export { SITE_URL } from '@/lib/site'
 export const SITE_NAME = 'MonÉlu'
 
+/**
+ * The site's own description, in one place.
+ *
+ * Consumed by the root layout's `metadata.description` and by
+ * `Organization.description` below, so the `<meta name="description">` a
+ * crawler reads and the JSON-LD it parses on the same page cannot drift apart.
+ * The shorter OG/Twitter card variant in `layout.tsx` is deliberate — card
+ * descriptions are truncated by the platforms anyway.
+ */
 export const SITE_DESCRIPTION =
-  "Le dossier de vote complet de chaque député de l'Assemblée nationale (XVIIᵉ législature), " +
-  "à partir des données ouvertes officielles. Chaque vote, chaque député, en français clair."
+  "Données officielles de l'Assemblée Nationale. Suivez chaque vote de chaque député français."
 
 /**
  * Stable node id for the publisher (MON-273).

--- a/frontend/src/lib/seo.ts
+++ b/frontend/src/lib/seo.ts
@@ -5,7 +5,60 @@ import { SITE_URL } from '@/lib/site'
 export { SITE_URL } from '@/lib/site'
 export const SITE_NAME = 'MonÉlu'
 
+export const SITE_DESCRIPTION =
+  "Le dossier de vote complet de chaque député de l'Assemblée nationale (XVIIᵉ législature), " +
+  "à partir des données ouvertes officielles. Chaque vote, chaque député, en français clair."
+
+/**
+ * Stable node id for the publisher (MON-273).
+ *
+ * Emitted once sitewide by `buildOrganizationJsonLd()` in the root layout, then
+ * referenced by `@id` from every other block that needs a publisher — the
+ * `WebSite` below today, and `Dataset.publisher` (MON-262) / `ClaimReview.author`
+ * (MON-263) once those land. Referencing beats re-declaring: consumers merge the
+ * blocks into one graph, so the organization is described in exactly one place.
+ */
+export const ORGANIZATION_ID = `${SITE_URL}/#organization`
+
 export type BreadcrumbItem = { name: string; url: string }
+
+/**
+ * Publisher identity for the site (MON-273).
+ *
+ * `WebSite` describes the site; this describes who stands behind it. Without it
+ * nothing in the graph says who publishes MonÉlu, which weakens every other
+ * block — a dataset with no resolvable publisher, or a fact-check with no
+ * identifiable author, carries far less weight.
+ *
+ * Deliberately omitted rather than guessed:
+ * - `contactPoint` — waits on the /contact page (MON-272). The only address on
+ *   the site today is a personal inbox, which is not a publisher contact point.
+ * - `foundingDate` — no verifiable date to hand; an invented one is worse than
+ *   an absent field.
+ * `sameAs` lists only origins the project actually controls.
+ */
+export function buildOrganizationJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    '@id': ORGANIZATION_ID,
+    name: SITE_NAME,
+    url: SITE_URL,
+    description: SITE_DESCRIPTION,
+    logo: {
+      '@type': 'ImageObject',
+      url: `${SITE_URL}/icon-512.png`,
+      width: 512,
+      height: 512,
+    },
+    areaServed: {
+      '@type': 'Country',
+      name: 'France',
+    },
+    knowsLanguage: 'fr',
+    sameAs: ['https://github.com/Walid-peach/MonElu'],
+  }
+}
 
 export function buildWebsiteJsonLd() {
   return {
@@ -13,6 +66,8 @@ export function buildWebsiteJsonLd() {
     '@type': 'WebSite',
     name: SITE_NAME,
     url: SITE_URL,
+    inLanguage: 'fr',
+    publisher: { '@id': ORGANIZATION_ID },
     potentialAction: {
       '@type': 'SearchAction',
       target: {


### PR DESCRIPTION
## What and why

The site emitted exactly one JSON-LD block sitewide — `buildWebsiteJsonLd()`, of type `WebSite`. That describes the *site*; nothing said who *publishes* it. An external agent-readiness scan of the live site ([is-agentic.com](https://is-agentic.com/scan/mon-elu.vercel.app), 2026-08-27) reported this from the outside as two separate failures: "No Organization JSON-LD type detected" and "JSON-LD found (1 block) but no identity type".

This adds `buildOrganizationJsonLd()` with a stable `@id`, renders it from the root layout next to the existing `WebSite` block, and points `WebSite.publisher` at that `@id` instead of re-declaring the organization inline. Both nodes ship inside one `ld+json` array, which consumers merge into a single graph.

**The `@id` is the actual deliverable.** MON-273 was filed as the node two other issues need to attach to:

- `Dataset.publisher` (MON-262) — a dataset with no resolvable publisher is markedly weaker, and Google Dataset Search treats it as such.
- `ClaimReview.author` (MON-263) — a fact-check attributed to nobody carries no weight.

Both are `blocks:` relations on the Linear issue, and both now have `https://mon-elu.vercel.app/#organization` to reference.

## Acceptance criteria

| From the issue | How it is met |
|---|---|
| `buildOrganizationJsonLd()` in `frontend/src/lib/seo.ts` | `seo.ts:48` |
| Rendered in `layout.tsx` alongside `WebSite` | `layout.tsx:84`, one array-form `<JsonLd>` |
| `name`, `url`, `logo`, `description`, `areaServed`, `knowsLanguage` | all present; `logo` is an `ImageObject` reusing the existing `public/icon-512.png` (no new asset) |
| `logo` needs no new asset | confirmed — `public/icon-512.png`, 23 KB, already shipped |
| Reference the `@id` from `Dataset.publisher` / `ClaimReview.author` | `ORGANIZATION_ID` exported at `seo.ts:29` for MON-262 / MON-263; `WebSite.publisher` already consumes it |
| Do not point `contactPoint` at a personal inbox | omitted entirely — see below |
| `sameAs` only where the project controls the profile | one entry, the public GitHub repository |

### Deliberately omitted rather than guessed

- **`contactPoint`** — waits on the `/contact` page (MON-272). The only address on the site today is a personal Gmail repeated across five pages, which is not a publisher contact point.
- **`foundingDate`** — the issue suggested `"2026"`, but I had no verifiable source (the `git log --reverse` needed to establish it would not complete in this worktree, see below). An invented date in structured data is worse than an absent field, so it is left out. Trivial to add later.

## Commits

1. **`aa7f2f5`** — the `Organization` node, the `@id`, the `publisher` reference, and 5 unit tests.
2. **`bb0fa27`** — review fix (see below): collapse the site description to one source of truth, plus a test that keeps it that way.

## Review fix applied

The first commit introduced `SITE_DESCRIPTION` carrying a **newly authored** sentence, while `layout.tsx` already set `metadata.description` to different text. A crawler would have read an `Organization.description` contradicting the `<meta name="description">` on the same page — which undercuts the point of the change. `SITE_DESCRIPTION` (`seo.ts:17`) now holds the *existing* metadata text and `layout.tsx:50` feeds `metadata.description` from it, so the two cannot drift. **No user-visible string changed.** The shorter OG/Twitter card variant stays and is now commented as deliberate.

Verified in real build output, not just unit tests:

```
Organization.description:  Données officielles de l'Assemblée Nationale. Suivez chaque vote de chaque député français.
meta name=description:     Données officielles de l'Assemblée Nationale. Suivez chaque vote de chaque député français.
MATCH: True
```

## Test plan

- `frontend/__tests__/lib/seo.test.ts` — 6 new cases: the `@id` contract, that every absolute URL derives from `SITE_URL` (guards the MON-254 property), that `contactPoint`/`foundingDate` stay absent, that `sameAs` holds only the controlled origin, that `WebSite.publisher` references rather than re-declares, and that the JSON-LD description equals the meta description.
- `npm test -- --ci` → **35 suites, 262 tests, all passing**
- `npx tsc --noEmit` → clean · `npm run lint` → clean · `next build` → succeeds
- `ruff check .` / `ruff format --check .` → clean repo-wide (no Python touched, but CI gates the whole repo)

**Verified against real build output** — extracted the `ld+json` from `.next/server/app/index.html`:

```json
[
  { "@type": "Organization", "@id": "https://mon-elu.vercel.app/#organization",
    "name": "MonÉlu", "logo": { "@type": "ImageObject",
    "url": "https://mon-elu.vercel.app/icon-512.png", "width": 512, "height": 512 }, … },
  { "@type": "WebSite", "publisher": { "@id": "https://mon-elu.vercel.app/#organization" }, … }
]
```

Also confirmed the block ships on a non-home route (`/deputes/comparer`) since it comes from the root layout. `buildPersonJsonLd`'s nested `memberOf: {"@type":"Organization"}` is an anonymous node with no `@id`, so it cannot collide with the publisher node.

## Follow-ups, not blocking

- `@graph` instead of a bare two-node array — worth revisiting when MON-262/MON-263 add a third and fourth node.
- `frontend/src/lib/site.ts:14` does not strip a trailing slash from `NEXT_PUBLIC_SITE_URL`, so `https://example.com/` would yield `https://example.com//#organization`. **Pre-existing from MON-254**, affecting the existing `WebSite`/`Person`/`Vote` builders equally — worth a one-line normalisation before the domain actually moves.
- The layout wiring is not asserted in CI; nothing fails if `layout.tsx` stops rendering the block. The MON-241 Playwright tier is the natural home for that assertion.

## Deploy risk

None. Additive structured data in the root layout — no schema, no config, no API, no runtime behaviour. Worst case is a malformed block that crawlers ignore, and the emitted JSON is verified above.

## Known CI flake

The first run had `playwright-smoke` fail on `[desktop-dark] › /votes/[id] fits the viewport` with `no link matching /votes/ found on /votes`. Unrelated to this change — the identical test passed in the other three browser projects in the same run, and a `<script type="application/ld+json">` tag cannot remove `<a href="/votes/…">` links. It is the `/votes` prod-API flake where the `revalidate = 900` server fetch returns empty under load, which is the class of problem MON-252 was filed for.

## Note on the working tree

This branch was cut while another session held the repo (`git worktree add` + `git reset --hard` ran for ~5 minutes). Before that cleared, this worktree had `scripts/ingest_votes.py` truncated to **0 bytes** and a stale `CLAUDE.md`, both uncommitted and both since restored from `origin/master` — no commit here carries either. `git diff master...HEAD` is exactly the three files above. Worth investigating separately: `~/Desktop/MonElu` looks iCloud-synced, which fits both the truncation and the pathological git slowness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xwDcAWqDUxmkXWuccPhSb
