### PR TITLE
perf: build the frontend once per PR instead of twice (MON-252)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,13 +109,42 @@ jobs:
       - name: Build
         # Prerenders all SSG pages against the production API; src/lib/api.ts
         # already retries through the rate limiter, so this can take a few
-        # minutes on a cold cache.
+        # minutes on a cold cache. This is the *only* build in the workflow -
+        # playwright-smoke consumes its output rather than repeating it
+        # (MON-252), so a PR costs production one full-site prerender.
         run: npm run build
+
+      - name: Publish the build output for the smoke tier
+        uses: actions/upload-artifact@v4
+        with:
+          name: next-build
+          # .next/cache is the webpack/Next build cache - 637 MB of the 694 MB
+          # tree locally, and `next start` never reads it. Excluding it takes
+          # the artifact to ~55 MB. The `actions/cache` step above is what
+          # carries the cache between runs; this artifact only carries the
+          # built app between jobs.
+          path: |
+            frontend/.next
+            !frontend/.next/cache
+          # .next is a dotfile directory, and upload-artifact@v4 skips hidden
+          # paths unless told otherwise - without this the artifact is empty.
+          include-hidden-files: true
+          retention-days: 1
 
   playwright-smoke:
     # Renders real pages in a real browser so a `hidden md:flex` nav that's
     # actually still visible, or a mobile-width overflow, fails the PR
     # instead of shipping through jsdom-only tests (MON-241, MON-141/142).
+    #
+    # Depends on `frontend` for its build output rather than building again
+    # (MON-252). Both jobs used to run a full production prerender in
+    # parallel, so every PR pointed two concurrent full-site crawls at the
+    # production API - which caps anonymous callers at 30 req/min per IP
+    # (api/limiter.py) and already 429s under prerender load. The cost of
+    # this is wall-clock: the two jobs no longer overlap. The saving is one
+    # build's worth of CI minutes and, more importantly, half the prerender
+    # load on production.
+    needs: frontend
     runs-on: ubuntu-latest
     timeout-minutes: 20
     defaults:
@@ -137,10 +166,18 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
-      - name: Build
-        # Same production-API build as the frontend job above — the smoke
-        # tier exercises the built app, not the dev server.
-        run: npm run build
+      - name: Download the frontend build
+        # `npm run start` needs .next; node_modules comes from `npm ci` above
+        # and public/ from the checkout, so this is the only artifact needed.
+        uses: actions/download-artifact@v4
+        with:
+          name: next-build
+          path: frontend/.next
+
+      - name: Verify the build output arrived
+        # A silently empty or mis-rooted artifact would surface as a confusing
+        # `next start` failure several minutes later; fail here instead.
+        run: test -f .next/BUILD_ID && test -d .next/server && test -d .next/static
 
       - name: Run Playwright smoke tests
         run: npm run test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
           name: next-build
           # .next/cache is the webpack/Next build cache - 637 MB of the 694 MB
           # tree locally, and `next start` never reads it. Excluding it takes
-          # the artifact to ~55 MB. The `actions/cache` step above is what
+          # the artifact to ~57 MB. The `actions/cache` step above is what
           # carries the cache between runs; this artifact only carries the
           # built app between jobs.
           path: |
@@ -140,10 +140,13 @@ jobs:
     # (MON-252). Both jobs used to run a full production prerender in
     # parallel, so every PR pointed two concurrent full-site crawls at the
     # production API - which caps anonymous callers at 30 req/min per IP
-    # (api/limiter.py) and already 429s under prerender load. The cost of
-    # this is wall-clock: the two jobs no longer overlap. The saving is one
-    # build's worth of CI minutes and, more importantly, half the prerender
-    # load on production.
+    # (api/limiter.py) and already 429s under prerender load.
+    #
+    # Serialising the jobs does not cost wall-clock, because the build being
+    # removed was the *cold* one - this job never had the .next/cache restore
+    # the frontend job has. Measured across the two runs either side of the
+    # change: this job went 3m38s -> 1m7s, and the tier's wall-clock 3m38s ->
+    # 3m25s. Do not "restore parallelism" by adding a build back here.
     needs: frontend
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
## Problem

Since MON-241 added the `playwright-smoke` job, `ci.yml` ran `npm run build` **twice** on every pull request — once in `frontend`, once in `playwright-smoke`. Both are full production builds that prerender every SSG route against the **live production API**, and the two jobs ran in parallel, so each PR pointed **two concurrent full-site crawls** at an endpoint that caps anonymous callers at 30 req/min per IP (`api/limiter.py`) and already 429s under prerender load — on top of `check_quiz_votes.py --api <prod>` and the Playwright specs themselves, which also hit prod.

**This is not theoretical.** In the single session that produced this PR, the duplicate prerender cost:

- one `playwright-smoke` failure — `no link matching /votes/ (excluding ) found on /votes`, i.e. `/votes` rendered with zero vote links;
- one local `next build` failure — `Error occurred prerendering page "/votes"` / `Error: API error: 500`.

Both passed on retry with no code change, on branches that touched no frontend code.

Compounding it, the `.next/cache` restore step existed only in the `frontend` job, so the duplicate build was also the slower of the two and burned ~2x the CI minutes for the frontend tier.

## What changed

Recommended fix 1+2: build once, reuse the output.

- **`frontend` publishes its build output** as a `next-build` artifact after the existing `Build` step.
- **`playwright-smoke` gains `needs: frontend`**, downloads that artifact, and its own `Build` step is gone. `npm run start` needs only `.next` — `node_modules` comes from its own `npm ci` and `public/` from the checkout, both already present.

### Two details that would each have broken this silently

**`.next/cache` is excluded from the artifact.** It is 637 MB of the 694 MB tree locally, and `next start` never reads it; excluding it takes the artifact to **57 MB**. The `actions/cache` step still carries the cache between *runs* — this artifact only carries the built app between *jobs*. Uploading the whole tree would have worked but shipped 694 MB per PR.

**`include-hidden-files: true` is required.** `.next` is a dotfile directory, and `actions/upload-artifact@v4` skips hidden paths by default. Without it the artifact uploads **empty**, and the failure surfaces minutes later as a confusing `next start` error in a different job. A `Verify the build output arrived` step now asserts `BUILD_ID` / `server/` / `static/` immediately after the download, so a mis-rooted or empty artifact fails at the point of the mistake and says what is missing.

### The trade — measured, and better than expected

I expected serialising the jobs to cost wall-clock. It does not, because the build being removed was the *cold* one: `playwright-smoke` had no `.next/cache` restore, so its build cost more than the serialisation does.

Comparing the previous PR's run (33277214894) with this PR's (33338106874):

| | before | after |
|---|---|---|
| `frontend` | 1m21s | 2m16s (now includes the 57 MB upload) |
| `playwright-smoke` | 3m38s (cold build) | **1m7s** (no build) |
| frontend-tier wall-clock | 3m38s (parallel) | **3m25s** (serial) |
| CI minutes for the tier | 4m59s | **3m23s** |

So wall-clock is flat-to-slightly-better and CI minutes drop ~32%, on top of halving the prerender load on production — which was the actual defect. Two runs on different commits with different cache states is a measurement, not a benchmark, so treat the wall-clock figures as "no regression" rather than a guaranteed win; the halved prod load is structural and does not depend on timing.

I did not split the build into a third job to recover parallelism. It would work, but it changes the check names (`frontend` / `playwright-smoke`) that appear on every PR, and the numbers above show there is no parallelism left to recover.

## Acceptance criteria

| From the issue | How it is met |
|---|---|
| 1. `frontend` uploads `frontend/.next` (and `public`) as an artifact | Uploads `.next` minus `cache/`. `public/` is tracked in git (7 files) and comes from the checkout, so uploading it would be redundant |
| 2. `playwright-smoke` gains `needs: frontend`, downloads the artifact, drops its own `Build` | Done, plus a verify step so an empty/mis-rooted artifact fails immediately |
| 3. Fallback (keep jobs independent, add the cache restore, serialise) | Not needed — option 1+2 was taken, which removes the duplicate build entirely rather than just making it cheaper |
| Longer-term: point CI prerenders at a fixture/replay layer | **Not done** — see Deferred |

## Test plan

The real risk here is "does `next start` work from a `.next` tree with `cache/` stripped", so I simulated the round trip locally rather than reasoning about it:

1. Copied `.next` with `cache/` excluded into a fresh tree — the exact shape `upload-artifact` will ship (**57 MB**).
2. Moved the real `.next` aside and restored the copy in its place, simulating `download-artifact`.
3. Ran the new verify step's assertions against it — pass.
4. Ran `next start` from it and the **full smoke tier: 36 passed** in 19.9s.

That is the same configuration the `playwright-smoke` job will now use.

- `actionlint` clean apart from a pre-existing SC2046 on line 53 (the `detect-secrets-hook` step, untouched), confirmed to reproduce on master.
- **CI on this PR is itself the end-to-end test of the change** — the first run through the new job graph exercised the artifact upload/download path for real, and all 6 checks passed. `playwright-smoke` ran in **1m7s** against the downloaded artifact, versus 3m38s building its own.

## Deferred

**Pointing CI prerenders at a fixture/replay layer instead of production.** The issue flags this as "worth a separate decision", and it is: it changes what the frontend build actually validates (a fixture build no longer proves the app renders against real data shapes), so it belongs in an ADR rather than being slipped into a CI cleanup. This PR halves the load; it does not remove the dependency. If the smoke tier keeps flaking after this, that decision is the next step.

## Deploy / migration risk

CI-only. No application code, no schema, no deploy config — `deploy.yml` and `ingest_prod.yml` are untouched, so nothing about how master reaches production changes.

Two things to watch on this PR's own run:

1. **The artifact path.** If `upload-artifact` roots the entries differently than expected, the verify step fails fast with a clear message rather than a confusing `next start` error.
2. **`playwright-smoke` is now skipped when `frontend` fails**, where before it ran independently. That is the intended consequence of `needs:` — a failing build means there is nothing for the smoke tier to exercise — but it does mean a broken build no longer also reports smoke results.

Rollback is a straight revert of the workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjrfEA2HZoKnVzdiZV2HaL
