### PR TITLE
feat: link deputy and vote JSON-LD to the official AN pages (MON-267)

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ Next.js 15 (App Router) + Tailwind + Framer Motion, deployed on Vercel separatel
 |---|---|
 | `src/lib/api.ts` | Typed API client for all backend endpoints |
 | `src/lib/seo.ts` · `src/app/sitemap.ts` | Canonical site URL, metadata helpers, generated sitemap |
+| `src/lib/an.ts` | Official assemblee-nationale.fr URLs built from stored ids - the deputy profile link behind `Person.sameAs` and the dossier link shared by vote cards and `Event.about` (MON-267) |
 | `src/components/home/` | Landing-page scenes, live pulse panel, trust strip |
 | `src/components/HeroSearch.tsx` · `GlobalSearch.tsx` | Search entry points wired to the API |
 

--- a/frontend/__tests__/lib/an.test.ts
+++ b/frontend/__tests__/lib/an.test.ts
@@ -1,0 +1,33 @@
+import { anDeputyUrl, anDossierUrl } from '@/lib/an'
+
+describe('anDeputyUrl', () => {
+  it('builds the official profile URL from an acteur uid', () => {
+    expect(anDeputyUrl('PA842137')).toBe(
+      'https://www.assemblee-nationale.fr/dyn/deputes/PA842137'
+    )
+  })
+
+  it('returns null rather than a guessed URL for anything else', () => {
+    expect(anDeputyUrl(null)).toBeNull()
+    expect(anDeputyUrl(undefined)).toBeNull()
+    expect(anDeputyUrl('')).toBeNull()
+    expect(anDeputyUrl('842137')).toBeNull()
+    expect(anDeputyUrl('PA842137/../../admin')).toBeNull()
+    expect(anDeputyUrl("{'uid': 'PA842137'}")).toBeNull()
+  })
+})
+
+describe('anDossierUrl', () => {
+  it('builds the official dossier URL from a dossier ref', () => {
+    expect(anDossierUrl('DLR5L17N53980')).toBe(
+      'https://www.assemblee-nationale.fr/dyn/17/dossiers/DLR5L17N53980'
+    )
+  })
+
+  it('returns null for missing or corrupted refs (ADR-035)', () => {
+    expect(anDossierUrl(null)).toBeNull()
+    expect(anDossierUrl(undefined)).toBeNull()
+    expect(anDossierUrl('')).toBeNull()
+    expect(anDossierUrl("{'@xsi:type': 'DossierRef'}")).toBeNull()
+  })
+})

--- a/frontend/__tests__/lib/seo.test.ts
+++ b/frontend/__tests__/lib/seo.test.ts
@@ -104,6 +104,16 @@ describe('buildPersonJsonLd', () => {
     expect(data).not.toHaveProperty('memberOf')
     expect(data).not.toHaveProperty('image')
   })
+
+  it('links the deputy to their official AN profile via sameAs (MON-267)', () => {
+    const data = buildPersonJsonLd(deputy)
+    expect(data.sameAs).toEqual(['https://www.assemblee-nationale.fr/dyn/deputes/PA123'])
+  })
+
+  it('omits sameAs rather than guessing a URL from an unrecognised id', () => {
+    const data = buildPersonJsonLd({ ...deputy, deputy_id: "{'uid': 'PA123'}" })
+    expect(data).not.toHaveProperty('sameAs')
+  })
 })
 
 describe('buildVoteJsonLd', () => {
@@ -118,6 +128,22 @@ describe('buildVoteJsonLd', () => {
   it('omits description when summary_plain is missing', () => {
     const data = buildVoteJsonLd({ ...vote, summary_plain: null })
     expect(data).not.toHaveProperty('description')
+  })
+
+  it('points at the official dossier when dossier_id is present (MON-267)', () => {
+    const data = buildVoteJsonLd({ ...vote, dossier_id: 'DLR5L17N53980' })
+    expect(data.about).toEqual({
+      '@type': 'Legislation',
+      url: 'https://www.assemblee-nationale.fr/dyn/17/dossiers/DLR5L17N53980',
+    })
+  })
+
+  it('omits about when dossier_id is missing or corrupted', () => {
+    expect(buildVoteJsonLd(vote)).not.toHaveProperty('about')
+    // The stringified-dict shape some legacy rows carry (ADR-035).
+    expect(
+      buildVoteJsonLd({ ...vote, dossier_id: "{'@xsi:type': 'DossierRef'}" })
+    ).not.toHaveProperty('about')
   })
 })
 

--- a/frontend/src/app/votes/[id]/VoteDetailClient.tsx
+++ b/frontend/src/app/votes/[id]/VoteDetailClient.tsx
@@ -9,6 +9,7 @@ import { getInitials, partyHex } from '@/lib/utils'
 import { groupSlug } from '@/lib/groups'
 import { resolvePostalCode } from '@/lib/postal'
 import { csvUrl } from '@/lib/api'
+import { anDossierUrl } from '@/lib/an'
 import { HemicycleChart } from '@/components/HemicycleChart'
 import type { HemicycleDeputy } from '@/lib/hemicycle'
 
@@ -138,13 +139,9 @@ export function VoteDetailClient(props: Props) {
 
   const adopted = result === 'adopté'
   const headline = summary || voteTitle
-  // Some legacy rows still have a stringified-dict dossier_id from a past
-  // ingestion bug (MON-89) — only link when it looks like a real AN ref
-  // (e.g. "DLR5L17N53980"), so a corrupted value silently shows no link
-  // instead of a broken one.
-  const dossierUrl = dossierId && /^[A-Za-z0-9-]+$/.test(dossierId)
-    ? `https://www.assemblee-nationale.fr/dyn/17/dossiers/${dossierId}`
-    : null
+  // Shared with the vote's JSON-LD (MON-267): the link a reader clicks and the
+  // `Event.about` a crawler reads must be the same URL, guard included.
+  const dossierUrl = anDossierUrl(dossierId)
 
   return (
     <div style={{ background: 'var(--dp-page-bg)', minHeight: '100vh' }}>

--- a/frontend/src/lib/an.ts
+++ b/frontend/src/lib/an.ts
@@ -1,0 +1,42 @@
+/**
+ * URLs on the Assemblée nationale's own site (MON-267).
+ *
+ * Single definition of the two official URLs MonÉlu constructs from ids it
+ * already stores. Both are consumed twice - once as a link a reader clicks,
+ * once as an entity-reconciliation signal in JSON-LD (`Person.sameAs`,
+ * `Event.about`) - and a drift between those two would publish a URL the site
+ * itself does not use.
+ *
+ * Both guard on shape and return null rather than a guessed URL: a stored id
+ * that does not look like an AN reference silently produces no link instead of
+ * a broken one.
+ */
+
+/** AN acteur uid, e.g. `PA842137`. */
+const ACTEUR_UID = /^PA\d{1,9}$/
+
+/** AN dossier ref, e.g. `DLR5L17N53980`. */
+const DOSSIER_REF = /^[A-Za-z0-9-]+$/
+
+/**
+ * Official profile page of a deputy on assemblee-nationale.fr.
+ *
+ * Guarded the way `portraitId()` guards: rows ingested before the uid shape was
+ * settled, or any future upstream change, yield null.
+ */
+export function anDeputyUrl(deputyId: string | null | undefined): string | null {
+  if (!deputyId || !ACTEUR_UID.test(deputyId)) return null
+  return `https://www.assemblee-nationale.fr/dyn/deputes/${deputyId}`
+}
+
+/**
+ * Official dossier législatif page.
+ *
+ * Some legacy rows still carry a stringified-dict `dossier_id` from a past
+ * ingestion bug (MON-89, ADR-035), which is why the shape check is not
+ * optional here.
+ */
+export function anDossierUrl(dossierId: string | null | undefined): string | null {
+  if (!dossierId || !DOSSIER_REF.test(dossierId)) return null
+  return `https://www.assemblee-nationale.fr/dyn/17/dossiers/${dossierId}`
+}

--- a/frontend/src/lib/seo.ts
+++ b/frontend/src/lib/seo.ts
@@ -1,4 +1,5 @@
-import type { Deputy, Vote } from '@/lib/api'
+import { anDeputyUrl, anDossierUrl } from '@/lib/an'
+import type { Deputy, Vote, VoteDetail } from '@/lib/api'
 import { departmentLabel } from '@/lib/departments'
 import { SITE_URL } from '@/lib/site'
 
@@ -100,7 +101,20 @@ export function buildBreadcrumbJsonLd(items: BreadcrumbItem[]) {
   }
 }
 
+/**
+ * A deputy as an entity, not just a page (MON-267).
+ *
+ * `sameAs` is what lets a consumer confirm that this "Marie Dupont" is the same
+ * person as the one on the Assemblée nationale's own site - without it the 577
+ * deputy pages float unattached to the entity graph. The AN profile URL is
+ * derived from `deputy_id`, which is the AN acteur uid, so it needs no new data.
+ *
+ * Wikidata deliberately absent: it is the second-strongest link available, but
+ * it needs a one-off reconciliation and a `wikidata_id` column, scoped
+ * separately rather than guessed from a name match.
+ */
 export function buildPersonJsonLd(deputy: Deputy) {
+  const officialUrl = anDeputyUrl(deputy.deputy_id)
   return {
     '@context': 'https://schema.org',
     '@type': 'Person',
@@ -109,6 +123,7 @@ export function buildPersonJsonLd(deputy: Deputy) {
     familyName: deputy.last_name,
     jobTitle: 'Député',
     url: `${SITE_URL}/deputes/${deputy.deputy_id}`,
+    ...(officialUrl ? { sameAs: [officialUrl] } : {}),
     ...(deputy.photo_url ? { image: deputy.photo_url } : {}),
     ...(deputy.party ? { memberOf: { '@type': 'Organization', name: deputy.party } } : {}),
     workLocation: {
@@ -124,7 +139,23 @@ export function buildPersonJsonLd(deputy: Deputy) {
   }
 }
 
-export function buildVoteJsonLd(vote: Vote) {
+/**
+ * A scrutin as an `Event` (MON-267).
+ *
+ * The event type carries the sitting - when it happened, where, who convened
+ * it. What the vote is *about* is the legislative text, so when the scrutin
+ * carries a usable `dossier_id` the block also points at the official dossier
+ * page, linking the vote into the same entity graph the deputy pages join
+ * through `Person.sameAs`.
+ *
+ * The `Legislation` node carries a url and no name on purpose: `vote_title` is
+ * the scrutin's own wording ("l'ensemble du projet de loi…", "amendement
+ * n°45"), not the name of the text, and naming the entity wrongly is worse than
+ * leaving a consumer to resolve it from the url. Most scrutins have no
+ * `dossier_id` at all (ADR-035), so `about` is absent far more often than not.
+ */
+export function buildVoteJsonLd(vote: Vote | VoteDetail) {
+  const dossierUrl = anDossierUrl('dossier_id' in vote ? vote.dossier_id : null)
   return {
     '@context': 'https://schema.org',
     '@type': 'Event',
@@ -147,6 +178,7 @@ export function buildVoteJsonLd(vote: Vote) {
       name: 'Assemblée nationale',
     },
     ...(vote.summary_plain ? { description: vote.summary_plain } : {}),
+    ...(dossierUrl ? { about: { '@type': 'Legislation', url: dossierUrl } } : {}),
     url: `${SITE_URL}/votes/${vote.vote_id}`,
   }
 }


### PR DESCRIPTION
## What

Adds `sameAs` to the `Person` JSON-LD on all 577 deputy pages, pointing at the deputy's official Assemblée nationale profile, and adds an `about` → `Legislation` node to the vote `Event` JSON-LD pointing at the official dossier when the scrutin has a usable `dossier_id`.

## Why

`sameAs` is the single strongest entity-reconciliation signal in structured data - it is how a search engine or an LLM confirms that MonÉlu's "Marie Dupont" is the same person as the one on the AN's own site. Without it the 577 deputy pages float unattached to the entity graph, and a model asked "how did deputy X vote on Y" has no evidence that MonÉlu's X is the X it means. Deputies are the entity people ask LLMs about by name, so this is the cheapest available improvement to whether MonÉlu is the source that gets cited.

Neither link needs new data: `deputies.deputy_id` is the AN acteur uid, and `votes.dossier_id` is the dossier ref the vote page already links to.

## Changes

- **New `frontend/src/lib/an.ts`** - single definition of the two official assemblee-nationale.fr URLs the site constructs from stored ids. Both guard on shape and return `null` rather than a guessed URL, the way `portraitId()` guards.
- **`buildPersonJsonLd`** emits `sameAs: [<official AN profile>]`, omitted entirely when `deputy_id` does not match the acteur-uid shape.
- **`buildVoteJsonLd`** emits `about: { '@type': 'Legislation', url }` when the scrutin carries a usable `dossier_id`. Signature widened to `Vote | VoteDetail`, since `dossier_id` lives on `VoteDetail`.
  - **Url only, no `name`, on purpose**: `vote_title` is the scrutin's own wording (a real example from the build: `"l'amendement n° 879 de M. David Magnier à l'article 8 bis du projet de loi relatif à la protection des enfants"`), not the name of the legislative text. Naming the entity wrongly is worse than leaving a consumer to resolve it from the url.
- **`VoteDetailClient`** now builds its reader-facing dossier link through the same helper instead of its own inline regex + template, so the link a reader clicks and the URL a crawler reads cannot drift apart.
- Tests for both helpers and both JSON-LD builders, including the corrupted stringified-dict `dossier_id` shape some legacy rows carry (ADR-035).
- README frontend module table gains a row for `src/lib/an.ts`.

## Acceptance criteria

| Criterion (from MON-267) | How it is met |
|---|---|
| 1. `sameAs` on `buildPersonJsonLd`, starting with the official AN profile URL derived from `deputy_id`, guarded like `portraitId()` - no `sameAs` rather than a guessed URL | `anDeputyUrl()` in `an.ts` guards on `/^PA\d{1,9}$/`; `buildPersonJsonLd` spreads `sameAs` in only when it resolves. Verified live: `/deputes/PA841729` renders `"sameAs":["https://www.assemblee-nationale.fr/dyn/deputes/PA841729"]`, and that URL returns 200. |
| 2. Wikidata as a second entry | **Deferred, as the issue scopes it** ("worth scoping separately if the AN link ships first") - it needs a one-off SPARQL reconciliation and a nullable `wikidata_id` column. The omission is documented in the `buildPersonJsonLd` docstring so it is not mistaken for an oversight. |
| 3. `about: { '@type': 'Legislation', … url: <AN dossier URL> }` on `buildVoteJsonLd` when `vote.dossier_id` is present, reusing the dossier URL construction | Done, via `anDossierUrl()`. The reuse goes further than the issue asked: `VoteDetailClient`'s own copy of that construction now calls the same helper. `name` deliberately omitted - see Changes. |
| Assertions live in `frontend/__tests__/lib/seo.test.ts` | 4 new cases there, plus a dedicated `__tests__/lib/an.test.ts` for the guards. |

## Testing

- `npm test` - 37 suites / 332 tests pass (6 new).
- `npm run lint` clean, `npx tsc --noEmit` clean, `npm run build` succeeds.
- `ruff check .` and `ruff format --check .` clean repo-wide (no Python touched).
- **Verified on real data, not just fixtures**: grepped the prerendered vote pages out of `.next/server/app/votes/` - real scrutins emit `"about":{"@type":"Legislation","url":".../dyn/17/dossiers/DLR5L17N54372"}`, and scrutins without a dossier emit no `about`.
- Started the production server and curled `/deputes/PA841729` to confirm the rendered `sameAs`.
- Both constructed URL shapes return HTTP 200 against the live AN site.

## Risks / Notes

- Frontend-only, no schema or deploy-config change. Worst case for a malformed id is an absent field, never a broken link.
- The vote `about` node will be absent on the large majority of scrutins: per ADR-035, only ~75 dossiers in the legislature have a linkable scrutin at all, and some pre-`7e29131` rows still store a stringified dict. Both cases are handled by the guard.
- Follow-up worth filing: the Wikidata `sameAs` entry (criterion 2).

## Breaking Changes

None.
