### PR TITLE
feat: mark up /methodologie and /a-propos as FAQPage JSON-LD (MON-268)

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ Next.js 15 (App Router) + Tailwind + Framer Motion, deployed on Vercel separatel
 | `src/lib/api.ts` | Typed API client for all backend endpoints |
 | `src/lib/seo.ts` · `src/app/sitemap.ts` | Canonical site URL, metadata helpers, generated sitemap |
 | `src/lib/an.ts` | Official assemblee-nationale.fr URLs built from stored ids - the deputy profile link behind `Person.sameAs` and the dossier link shared by vote cards and `Event.about` (MON-267) |
+| `src/lib/faq.ts` | Q&A copy for `/methodologie` and `/a-propos`, rendered as the visible text *and* published as `FAQPage` JSON-LD (MON-268) - edit the answers here, not in the pages; `__tests__/app/faq-jsonld.test.tsx` fails if the two diverge |
 | `src/components/home/` | Landing-page scenes, live pulse panel, trust strip |
 | `src/components/HeroSearch.tsx` · `GlobalSearch.tsx` | Search entry points wired to the API |
 

--- a/frontend/__tests__/app/faq-jsonld.test.tsx
+++ b/frontend/__tests__/app/faq-jsonld.test.tsx
@@ -1,0 +1,110 @@
+import { render } from '@testing-library/react'
+import MethodologiePage from '@/app/methodologie/page'
+import AProposPage from '@/app/a-propos/page'
+import { METHODOLOGIE_FAQ, A_PROPOS_FAQ, type FaqItem } from '@/lib/faq'
+import { buildFaqJsonLd } from '@/lib/seo'
+
+/**
+ * Schema.org requires both halves of an FAQ pair to be visible to the reader on
+ * the page carrying the markup. These tests are what make that a build-time
+ * guarantee instead of a review-time promise: they render the real page and
+ * fail the moment a copy edit moves the visible text away from what the
+ * JSON-LD claims (MON-268).
+ */
+
+/** Collapse nbsp, narrow spaces and whitespace runs so a comparison is about
+ *  wording rather than French typographic spacing. */
+function normalize(text: string): string {
+  return text.replace(/[   ]/g, ' ').replace(/\s+/g, ' ').trim()
+}
+
+/** Visible prose of one section, block by block, the way a reader reads it -
+ *  `textContent` alone would run the last word of a paragraph into the first
+ *  word of the next. */
+function visibleProse(container: HTMLElement, id: string): string {
+  const section = container.querySelector(`#${id}`)
+  if (!section) throw new Error(`No element with id "${id}" on the page`)
+  const blocks = Array.from(section.querySelectorAll('p, li')).map(el => el.textContent ?? '')
+  return normalize(blocks.join(' '))
+}
+
+function headingOf(container: HTMLElement, id: string): string {
+  const heading = container.querySelector(`#${id}`)?.querySelector('h2, h3')
+  return normalize(heading?.textContent ?? '')
+}
+
+function jsonLdBlocks(container: HTMLElement): Record<string, unknown>[] {
+  return Array.from(container.querySelectorAll('script[type="application/ld+json"]')).map(el =>
+    JSON.parse(el.textContent ?? '{}')
+  )
+}
+
+describe('buildFaqJsonLd', () => {
+  const items: FaqItem[] = [{ id: 'x', question: 'Pourquoi ?', answer: 'Parce que.' }]
+
+  it('builds an FAQPage whose mainEntity is Question/Answer pairs', () => {
+    const data = buildFaqJsonLd(items)
+    expect(data['@type']).toBe('FAQPage')
+    expect(data.inLanguage).toBe('fr')
+    expect(data.mainEntity).toEqual([
+      {
+        '@type': 'Question',
+        name: 'Pourquoi ?',
+        acceptedAnswer: { '@type': 'Answer', text: 'Parce que.' },
+      },
+    ])
+  })
+
+  it('carries every pair it is given, in order', () => {
+    const data = buildFaqJsonLd(METHODOLOGIE_FAQ)
+    expect(data.mainEntity).toHaveLength(METHODOLOGIE_FAQ.length)
+    expect((data.mainEntity as { name: string }[]).map(q => q.name)).toEqual(
+      METHODOLOGIE_FAQ.map(item => item.question)
+    )
+  })
+})
+
+describe('/methodologie FAQ markup', () => {
+  it('emits an FAQPage block', () => {
+    const { container } = render(<MethodologiePage />)
+    const faq = jsonLdBlocks(container).find(block => block['@type'] === 'FAQPage')
+    expect(faq).toBeDefined()
+    expect(faq!.mainEntity).toHaveLength(METHODOLOGIE_FAQ.length)
+  })
+
+  it.each(METHODOLOGIE_FAQ.map(item => [item.id, item] as const))(
+    '#%s shows its question as the section heading and its answer in the prose',
+    (_id, item) => {
+      const { container } = render(<MethodologiePage />)
+      expect(headingOf(container, item.id)).toBe(normalize(item.question))
+      expect(visibleProse(container, item.id)).toContain(normalize(item.answer))
+    }
+  )
+
+  it('keeps the anchors deep-linked from other pages', () => {
+    const { container } = render(<MethodologiePage />)
+    // Linked from deputy pages, vote pages, the hemicycle chart and the home
+    // page pulse panel - renaming a section must not break those.
+    for (const id of ['presence', 'limites', 'deputes-suivis']) {
+      expect(container.querySelector(`#${id}`)).not.toBeNull()
+    }
+  })
+})
+
+describe('/a-propos FAQ markup', () => {
+  it('emits an FAQPage block', () => {
+    const { container } = render(<AProposPage />)
+    const faq = jsonLdBlocks(container).find(block => block['@type'] === 'FAQPage')
+    expect(faq).toBeDefined()
+    expect(faq!.mainEntity).toHaveLength(A_PROPOS_FAQ.length)
+  })
+
+  it.each(A_PROPOS_FAQ.map(item => [item.id, item] as const))(
+    '#%s shows both its question and its answer',
+    (_id, item) => {
+      const { container } = render(<AProposPage />)
+      expect(headingOf(container, item.id)).toBe(normalize(item.question))
+      expect(visibleProse(container, item.id)).toContain(normalize(item.answer))
+    }
+  )
+})

--- a/frontend/src/app/a-propos/page.tsx
+++ b/frontend/src/app/a-propos/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
+import { JsonLd } from '@/components/JsonLd'
+import { A_PROPOS_FAQ } from '@/lib/faq'
+import { buildFaqJsonLd } from '@/lib/seo'
 import { canonicalUrl } from '@/lib/site'
 
 export const metadata: Metadata = {
@@ -140,6 +143,7 @@ const apiFeatures = [
 export default function AProposPage() {
   return (
     <div style={{ background: 'var(--dp-page-bg)', minHeight: '100vh' }}>
+      <JsonLd data={buildFaqJsonLd(A_PROPOS_FAQ)} />
 
       {/* ====== HERO ====== */}
       <div style={{ padding: '72px 56px 64px', background: 'linear-gradient(180deg,var(--dp-card-bg) 0%,var(--dp-page-bg) 100%)', borderBottom: '1px solid var(--dp-border-subtle)' }}>
@@ -393,6 +397,35 @@ export default function AProposPage() {
               </div>
               <div style={{ color: '#9CA3AF' }}>{'}'}</div>
             </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ====== FAQ ====== */}
+      {/* Visible question/answer copy, and the source of this page's FAQPage
+          JSON-LD (MON-268) - schema.org requires both halves to be readable
+          here, so the markup and the section below cannot disagree. */}
+      <div style={{ padding: '80px 56px', borderBottom: '1px solid var(--dp-border-subtle)', background: 'var(--dp-page-bg)' }}>
+        <div style={{ maxWidth: '1180px', margin: '0 auto', display: 'grid', gridTemplateColumns: '280px 1fr', gap: '80px', alignItems: 'start' }}>
+          <div>
+            <div className="text-red-civic font-semibold text-xs tracking-[0.18em] uppercase mb-4">Questions fréquentes</div>
+            <div style={{ width: '40px', height: '3px', background: 'var(--dp-text)', borderRadius: '2px', marginBottom: '20px' }} />
+            <p style={{ fontSize: '15px', lineHeight: 1.7, color: 'var(--dp-text-secondary)', margin: 0 }}>
+              L&apos;essentiel sur la plateforme, ses sources et ses conditions de réutilisation.
+            </p>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '28px' }}>
+            {A_PROPOS_FAQ.map((item) => (
+              <div key={item.id} id={item.id} style={{ scrollMarginTop: '96px' }}>
+                <h3 className="font-newsreader" style={{ fontWeight: 600, fontSize: '20px', color: 'var(--dp-text)', margin: '0 0 10px', letterSpacing: '-0.01em' }}>
+                  {item.question}
+                </h3>
+                <p style={{ fontSize: '15.5px', lineHeight: 1.7, color: 'var(--dp-text-secondary)', margin: 0 }}>
+                  {item.answer}
+                </p>
+              </div>
+            ))}
           </div>
         </div>
       </div>

--- a/frontend/src/app/methodologie/page.tsx
+++ b/frontend/src/app/methodologie/page.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from 'next'
+import { JsonLd } from '@/components/JsonLd'
 import { LegalPageLayout, LegalSection } from '@/components/LegalPageLayout'
+import { METHODOLOGIE_FAQ } from '@/lib/faq'
+import { buildFaqJsonLd } from '@/lib/seo'
 import { canonicalUrl } from '@/lib/site'
 
 const REPO_BASE = 'https://github.com/Walid-peach/MonElu/blob/master'
@@ -16,9 +19,22 @@ const textStyle = { fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-se
 const linkStyle = { color: 'var(--dp-text)', fontWeight: 600 }
 const sourceLineStyle = { fontSize: '13.5px', color: 'var(--dp-text-secondary)', margin: '10px 0 0' }
 
+/**
+ * Section heading for a question marked up in the page's `FAQPage` JSON-LD
+ * (MON-268). Reading the title from the same array the markup is built from is
+ * what makes "the question text is visible on the page" true by construction
+ * rather than by review.
+ */
+function faqTitle(id: string): string {
+  const item = METHODOLOGIE_FAQ.find(entry => entry.id === id)
+  if (!item) throw new Error(`No FAQ entry for section "${id}"`)
+  return item.question
+}
+
 export default function MethodologiePage() {
   return (
     <LegalPageLayout eyebrow="Vérifiabilité" title="Méthodologie">
+      <JsonLd data={buildFaqJsonLd(METHODOLOGIE_FAQ)} />
       <LegalSection id="intro" title="Pourquoi cette page">
         <p style={textStyle}>
           Un chiffre affiché sans méthode n&apos;est qu&apos;une affirmation. Cette page décrit, en français
@@ -29,7 +45,7 @@ export default function MethodologiePage() {
         </p>
       </LegalSection>
 
-      <LegalSection id="presence" title="Taux de présence">
+      <LegalSection id="presence" title={faqTitle('presence')}>
         <p style={{ ...textStyle, marginBottom: '10px' }}>
           Le taux de présence d&apos;un député compte <strong>toute position enregistrée</strong> lors d&apos;un
           scrutin : pour, contre, abstention, <strong>et non-votant</strong>. Un député &laquo;&nbsp;non-votant&nbsp;&raquo;
@@ -60,7 +76,7 @@ export default function MethodologiePage() {
         </p>
       </LegalSection>
 
-      <LegalSection id="deputes-suivis" title="Pourquoi le nombre de députés varie">
+      <LegalSection id="deputes-suivis" title={faqTitle('deputes-suivis')}>
         <p style={textStyle}>
           L&apos;Assemblée nationale compte 577 sièges. Le compteur &laquo;&nbsp;députés suivis&nbsp;&raquo;
           affiché sur MonÉlu dénombre l&apos;ensemble des député·e·s ayant siégé au moins une fois depuis le
@@ -70,7 +86,7 @@ export default function MethodologiePage() {
         </p>
       </LegalSection>
 
-      <LegalSection id="alignement" title="Alignement de parti et votes dissidents">
+      <LegalSection id="alignement" title={faqTitle('alignement')}>
         <p style={{ ...textStyle, marginBottom: '10px' }}>
           Pour chaque scrutin, MonÉlu calcule la <strong>position majoritaire</strong> du groupe parlementaire du
           député (pour, contre ou abstention - les non-votants ne comptent pas dans ce calcul). Un vote du député
@@ -99,7 +115,7 @@ export default function MethodologiePage() {
         </p>
       </LegalSection>
 
-      <LegalSection id="quiz" title="Le quiz « Quel député vote comme vous ? »">
+      <LegalSection id="quiz" title={faqTitle('quiz')}>
         <p style={{ ...textStyle, marginBottom: '10px' }}>
           Le quiz compare vos réponses aux positions <strong>réellement enregistrées</strong> de chaque
           député sur les mêmes scrutins. Votre pourcentage d&apos;accord avec un député est simplement&nbsp;:
@@ -153,7 +169,7 @@ export default function MethodologiePage() {
         </p>
       </LegalSection>
 
-      <LegalSection id="adopte-rejete" title="Vote adopté ou rejeté">
+      <LegalSection id="adopte-rejete" title={faqTitle('adopte-rejete')}>
         <p style={textStyle}>
           Le résultat d&apos;un scrutin (adopté ou rejeté) n&apos;est jamais recalculé par MonÉlu : il est repris
           tel quel du champ officiel publié par l&apos;Assemblée nationale pour ce scrutin. La 17ᵉ législature
@@ -168,7 +184,7 @@ export default function MethodologiePage() {
         </p>
       </LegalSection>
 
-      <LegalSection id="horizon" title="Horizon des données et fréquence de mise à jour">
+      <LegalSection id="horizon" title={faqTitle('horizon')}>
         <p style={{ ...textStyle, marginBottom: '10px' }}>
           La base de production couvre les scrutins depuis le <strong>1er juillet 2025</strong> (limite de
           l&apos;offre gratuite de la base de données hébergée ; l&apos;historique complet depuis le début de la
@@ -181,7 +197,7 @@ export default function MethodologiePage() {
         </p>
       </LegalSection>
 
-      <LegalSection id="limites" title="Limites connues">
+      <LegalSection id="limites" title={faqTitle('limites')}>
         <ul style={{ fontSize: '15px', lineHeight: 1.85, color: 'var(--dp-text-secondary)', margin: 0, paddingLeft: '20px' }}>
           <li>
             <strong>Non-votant ≠ abstention</strong> : un non-votant était présent sans exprimer d&apos;opinion ;
@@ -205,7 +221,7 @@ export default function MethodologiePage() {
         </ul>
       </LegalSection>
 
-      <LegalSection id="code" title="Code source et traçabilité">
+      <LegalSection id="code" title={faqTitle('code')}>
         <p style={{ ...textStyle, marginBottom: '10px' }}>
           L&apos;intégralité du code de transformation des données (ingestion, agrégation, API) est publique. Le
           schéma de dépendances entre les modèles de données (lineage) est généré automatiquement à chaque

--- a/frontend/src/lib/faq.ts
+++ b/frontend/src/lib/faq.ts
@@ -1,0 +1,124 @@
+/**
+ * Question/answer pairs marked up as `FAQPage` JSON-LD (MON-268).
+ *
+ * Schema.org requires both the question and the answer to be visible to the
+ * reader on the page carrying the markup, so these arrays are the *source* of
+ * the visible text rather than a parallel copy of it:
+ *
+ * - `/methodologie` renders each `question` as its section heading, and the
+ *   `answer` is a verbatim flattening of the prose already in that section.
+ * - `/a-propos` renders both fields directly.
+ *
+ * `__tests__/app/faq-jsonld.test.tsx` renders both pages and fails if any
+ * question or answer here stops appearing in the visible text - which is what
+ * keeps a later copy edit from silently turning the markup into a lie.
+ */
+export type FaqItem = {
+  /** Section anchor on the page. Load-bearing on `/methodologie`: `#presence`,
+   *  `#limites` and `#deputes-suivis` are deep-linked from deputy pages, vote
+   *  pages and the hemicycle chart, so these ids must not change. */
+  id: string
+  question: string
+  answer: string
+}
+
+/**
+ * `/methodologie` - the definitions models get wrong about French parliamentary
+ * data. Answers are the section bodies, paragraph texts joined by a space.
+ *
+ * `intro` and `contact` are deliberately not here: the first is meta ("why this
+ * page exists") and the second would publish a personal address into structured
+ * data for no discovery benefit.
+ */
+export const METHODOLOGIE_FAQ: FaqItem[] = [
+  {
+    id: 'presence',
+    question: "Comment le taux de présence est-il calculé ?",
+    answer:
+      "Le taux de présence d'un député compte toute position enregistrée lors d'un scrutin : pour, contre, abstention, et non-votant. Un député « non-votant » était présent dans l'hémicycle sans exprimer de vote - c'est une particularité documentée des données de l'Assemblée, pas une absence. Le dénominateur n'est pas « tous les scrutins depuis juillet 2024 » mais uniquement les scrutins tenus pendant le mandat du député (entre sa date de début et sa date de fin de mandat, le cas échéant). Un député élu en cours de législature n'est donc pas pénalisé pour des votes antérieurs à son entrée en fonction. Ce calcul unique est la seule définition de la présence utilisée sur MonÉlu - l'API, l'assistant de recherche et les fiches députés s'y conforment tous. C'est pourquoi Yaël Braun-Pivet, Présidente de l'Assemblée nationale, affiche 100 % de présence : elle est recensée sur chaque scrutin par construction des données de l'AN.",
+  },
+  {
+    id: 'deputes-suivis',
+    question: "Pourquoi le nombre de députés suivis dépasse-t-il 577 ?",
+    answer:
+      "L'Assemblée nationale compte 577 sièges. Le compteur « députés suivis » affiché sur MonÉlu dénombre l'ensemble des député·e·s ayant siégé au moins une fois depuis le début de la XVIIᵉ législature (7 juillet 2024) - y compris celles et ceux remplacé·e·s en cours de mandat (décès, nomination au gouvernement, invalidation d'élection). Ce total est donc naturellement supérieur à 577.",
+  },
+  {
+    id: 'alignement',
+    question: "Qu'est-ce qu'un vote dissident ?",
+    answer:
+      "Pour chaque scrutin, MonÉlu calcule la position majoritaire du groupe parlementaire du député (pour, contre ou abstention - les non-votants ne comptent pas dans ce calcul). Un vote du député est dit « dissident » lorsque sa position diffère de celle-ci. Limite connue : l'historique complet du député est comparé à son groupe parlementaire actuel, même s'il en a changé en cours de mandat. Un député ayant changé de groupe verra donc ses votes antérieurs au changement évalués par rapport à son nouveau groupe, pas celui auquel il appartenait au moment du vote.",
+  },
+  {
+    id: 'quiz',
+    question: "Comment le quiz « Quel député vote comme vous ? » calcule-t-il votre accord ?",
+    answer:
+      "Le quiz compare vos réponses aux positions réellement enregistrées de chaque député sur les mêmes scrutins. Votre pourcentage d'accord avec un député est simplement : nombre de scrutins où vous avez voté pareil, divisé par le nombre de scrutins comparables. Seules les positions exprimées comptent (pour, contre, abstention) : un député non-votant ou absent sur un scrutin n'est ni d'accord ni en désaccord avec vous - ce scrutin est simplement retiré du dénominateur pour ce député.",
+  },
+  {
+    id: 'adopte-rejete',
+    question: "Qui décide qu'un vote est adopté ou rejeté ?",
+    answer:
+      "Le résultat d'un scrutin (adopté ou rejeté) n'est jamais recalculé par MonÉlu : il est repris tel quel du champ officiel publié par l'Assemblée nationale pour ce scrutin. La 17ᵉ législature n'ayant pas de majorité stable, les scrutins rejetés sont, à ce jour, plus nombreux que les scrutins adoptés.",
+  },
+  {
+    id: 'horizon',
+    question: "Quelle période couvrent les données, et à quelle fréquence sont-elles mises à jour ?",
+    answer:
+      "La base de production couvre les scrutins depuis le 1er juillet 2025 (limite de l'offre gratuite de la base de données hébergée ; l'historique complet depuis le début de la législature, le 7 juillet 2024, est disponible en environnement de développement). Les données sont actualisées automatiquement chaque jour ouvré à 6h UTC : ingestion des nouveaux scrutins et fiches de députés, reconstruction de l'index de recherche sémantique, puis recalcul des statistiques agrégées (présence, alignement, scorecards).",
+  },
+  {
+    id: 'limites',
+    question: "Quelles sont les limites connues des données ?",
+    answer:
+      "Non-votant ≠ abstention : un non-votant était présent sans exprimer d'opinion ; une abstention est une position exprimée. Les pourcentages pour/contre/abstention affichés se calculent uniquement sur les positions exprimées (non-votant exclu de ce calcul-là, mais inclus dans la présence). Parti actuel, pas parti historique : voir la limite décrite ci-dessus pour l'alignement de parti. 2 députés sur 577 n'ont pas de groupe parlementaire actif identifié dans les données source - cas limite documenté, non un bug d'ingestion.",
+  },
+  {
+    id: 'code',
+    question: "Le code source est-il public ?",
+    answer:
+      "L'intégralité du code de transformation des données (ingestion, agrégation, API) est publique. Le schéma de dépendances entre les modèles de données (lineage) est généré automatiquement à chaque modification",
+  },
+]
+
+/**
+ * `/a-propos` - what MonÉlu is, where the data comes from, who runs it, what it
+ * costs, how often it refreshes.
+ *
+ * Unlike `/methodologie`, this page had no question-shaped copy to mark up, so
+ * these pairs are rendered as a visible "Questions fréquentes" section. Every
+ * answer restates a fact stated elsewhere on the same page (hero, sources,
+ * freshness table, licence card, contact block).
+ */
+export const A_PROPOS_FAQ: FaqItem[] = [
+  {
+    id: 'faq-quoi',
+    question: "Qu'est-ce que MonÉlu ?",
+    answer:
+      "MonÉlu est une plateforme de transparence civique qui publie le dossier de vote complet de chaque député de l'Assemblée nationale française. Les flux bruts de l'Assemblée sont ingérés, transformés par un pipeline de données de production, puis restitués sous une forme lisible pour les citoyens, les journalistes, les chercheurs et les développeurs.",
+  },
+  {
+    id: 'faq-sources',
+    question: "D'où viennent les données ?",
+    answer:
+      "Toutes les informations affichées proviennent de sources publiques officielles : les flux XML de l'Assemblée nationale, le portail open data data.gouv.fr, Légifrance pour les textes officiels et le registre des représentants d'intérêts de la HATVP. MonÉlu ne produit aucune donnée : la plateforme les structure, les horodate et les rend traçables jusqu'au document d'origine.",
+  },
+  {
+    id: 'faq-qui',
+    question: "Qui est derrière la plateforme ?",
+    answer:
+      "MonÉlu est développée et maintenue par Walid Elkhoukh, data engineer et responsable de la plateforme. Le code source est public sur GitHub, ce qui rend un audit indépendant possible par n'importe qui.",
+  },
+  {
+    id: 'faq-gratuit',
+    question: "MonÉlu est-il gratuit ?",
+    answer:
+      "Oui. La consultation du site et l'accès à l'API REST documentée sont gratuits, sans abonnement ni création de compte. Les données redistribuées le sont sous licence ouverte Etalab 2.0 : la réutilisation est libre, l'attribution est requise.",
+  },
+  {
+    id: 'faq-frequence',
+    question: "À quelle fréquence les données sont-elles mises à jour ?",
+    answer:
+      "Le pipeline s'exécute automatiquement chaque jour ouvré à 06h00 UTC via GitHub Actions. Les votes en séance, les fiches de députés et le corpus de recherche sont actualisés quotidiennement, les textes de loi à J+1 et les données patrimoniales chaque semaine.",
+  },
+]

--- a/frontend/src/lib/faq.ts
+++ b/frontend/src/lib/faq.ts
@@ -86,9 +86,14 @@ export const METHODOLOGIE_FAQ: FaqItem[] = [
  * costs, how often it refreshes.
  *
  * Unlike `/methodologie`, this page had no question-shaped copy to mark up, so
- * these pairs are rendered as a visible "Questions fréquentes" section. Every
- * answer restates a fact stated elsewhere on the same page (hero, sources,
- * freshness table, licence card, contact block).
+ * these pairs are rendered as a visible "Questions fréquentes" section.
+ *
+ * The provenance and refresh answers describe what the pipeline *actually*
+ * does - the Assemblée nationale open data portal, ingested every weekday at
+ * 06:00 UTC - rather than mirroring this page's own "sources" cards, which
+ * additionally list data.gouv.fr, Légifrance and the HATVP registry as active
+ * feeds. No ingestion script reads any of those three (see `scripts/ingest_*.py`),
+ * and structured data is the last place an unverified provenance claim belongs.
  */
 export const A_PROPOS_FAQ: FaqItem[] = [
   {
@@ -101,7 +106,7 @@ export const A_PROPOS_FAQ: FaqItem[] = [
     id: 'faq-sources',
     question: "D'où viennent les données ?",
     answer:
-      "Toutes les informations affichées proviennent de sources publiques officielles : les flux XML de l'Assemblée nationale, le portail open data data.gouv.fr, Légifrance pour les textes officiels et le registre des représentants d'intérêts de la HATVP. MonÉlu ne produit aucune donnée : la plateforme les structure, les horodate et les rend traçables jusqu'au document d'origine.",
+      "Toutes les données proviennent du portail open data de l'Assemblée nationale : les exports officiels des scrutins, des positions de vote de chaque député, des fiches d'acteurs et de l'agenda des séances publiques. MonÉlu ne produit aucune donnée : la plateforme les structure, les horodate et les rend traçables jusqu'au scrutin d'origine.",
   },
   {
     id: 'faq-qui',
@@ -119,6 +124,6 @@ export const A_PROPOS_FAQ: FaqItem[] = [
     id: 'faq-frequence',
     question: "À quelle fréquence les données sont-elles mises à jour ?",
     answer:
-      "Le pipeline s'exécute automatiquement chaque jour ouvré à 06h00 UTC via GitHub Actions. Les votes en séance, les fiches de députés et le corpus de recherche sont actualisés quotidiennement, les textes de loi à J+1 et les données patrimoniales chaque semaine.",
+      "Le pipeline s'exécute automatiquement chaque jour ouvré à 06h00 UTC via GitHub Actions : les nouveaux scrutins, les fiches de députés, l'agenda des séances et le corpus de recherche sémantique sont réingérés, puis les statistiques agrégées (présence, alignement, scorecards) sont recalculées.",
   },
 ]

--- a/frontend/src/lib/seo.ts
+++ b/frontend/src/lib/seo.ts
@@ -1,5 +1,6 @@
 import { anDeputyUrl, anDossierUrl } from '@/lib/an'
 import type { Deputy, Vote, VoteDetail } from '@/lib/api'
+import type { FaqItem } from '@/lib/faq'
 import { departmentLabel } from '@/lib/departments'
 import { SITE_URL } from '@/lib/site'
 
@@ -97,6 +98,35 @@ export function buildBreadcrumbJsonLd(items: BreadcrumbItem[]) {
       position: index + 1,
       name: item.name,
       item: item.url,
+    })),
+  }
+}
+
+/**
+ * Question/answer pairs as `FAQPage` (MON-268).
+ *
+ * The pairs come from `@/lib/faq`, which is also what renders the visible
+ * question and answer on the page - schema.org requires both to be visible to
+ * the reader, and a builder fed by separate copy would drift out of that
+ * requirement the first time someone edited the page.
+ *
+ * Q&A is the shape LLM crawlers lift most reliably, which is the point: the
+ * definitions a model gets wrong about French parliamentary data (non-votant
+ * versus abstention, what presence counts, why the Présidente shows 100 %) are
+ * already written on `/methodologie` - this makes them extractable.
+ */
+export function buildFaqJsonLd(items: FaqItem[]) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    inLanguage: 'fr',
+    mainEntity: items.map(item => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.answer,
+      },
     })),
   }
 }


### PR DESCRIPTION
## What

Publishes `FAQPage` JSON-LD on `/methodologie` (8 pairs) and `/a-propos` (5 pairs), sourced from a new `frontend/src/lib/faq.ts` that is also what renders the visible question and answer text on those pages.

## Why

`/methodologie` already contains, in prose, the answers to the exact questions a model gets wrong about French parliamentary data: what the presence rate counts, why `nonVotant` is not an abstention, why Yaël Braun-Pivet shows 100 % presence, what period the data covers. Q&A is the shape LLM crawlers lift most reliably, so marking that prose up is the difference between a model absorbing MonÉlu's presence definition and guessing. No new explanatory content was needed on `/methodologie` - the words were already there.

## The constraint that shaped the design

Schema.org requires **both** the question and the answer to be visible to the reader on the page carrying the markup. That rules out a builder fed by separate copy: it would be a lie the first time someone edited a paragraph. So `faq.ts` is the *source* of the visible text, not a parallel copy of it, and a test renders the real pages to enforce that.

## Changes

- **New `frontend/src/lib/faq.ts`** - `METHODOLOGIE_FAQ` and `A_PROPOS_FAQ`, each item `{ id, question, answer }`.
- **`buildFaqJsonLd(items)`** in `seo.ts`, alongside the existing builders. Emits `FAQPage` / `Question` / `acceptedAnswer` -> `Answer`, `inLanguage: 'fr'`.
- **`/methodologie`** renders each question as its section heading via `faqTitle(id)` and keeps every existing paragraph as the answer. Eight noun-phrase headings became real questions:

  | Before | After |
  |---|---|
  | Taux de présence | Comment le taux de présence est-il calculé ? |
  | Pourquoi le nombre de députés varie | Pourquoi le nombre de députés suivis dépasse-t-il 577 ? |
  | Alignement de parti et votes dissidents | Qu'est-ce qu'un vote dissident ? |
  | Le quiz « Quel député vote comme vous ? » | Comment le quiz « Quel député vote comme vous ? » calcule-t-il votre accord ? |
  | Vote adopté ou rejeté | Qui décide qu'un vote est adopté ou rejeté ? |
  | Horizon des données et fréquence de mise à jour | Quelle période couvrent les données, et à quelle fréquence sont-elles mises à jour ? |
  | Limites connues | Quelles sont les limites connues des données ? |
  | Code source et traçabilité | Le code source est-il public ? |

  `#presence`, `#limites` and `#deputes-suivis` - deep-linked from deputy pages, vote pages, `HemicycleChart` and the home pulse panel - are unchanged, and a test asserts they still exist. `intro` and `contact` keep their headings and stay out of the markup: the first is meta, the second would publish a personal address into structured data for no discovery benefit.

- **`/a-propos`** had no question-shaped copy to mark up, so it gains a visible "Questions fréquentes" section (before Contact) rendered from `A_PROPOS_FAQ`, in the page's existing 280px + 1fr / red-civic-eyebrow idiom. Every answer restates a fact already stated elsewhere on the page: hero, sources block, freshness table, licence card, contact block.
- **`__tests__/app/faq-jsonld.test.tsx`** - the drift guard, see Testing.
- README frontend module table gains a row for `src/lib/faq.ts` with the editing rule.

## Acceptance criteria

| Criterion (from MON-268) | How it is met |
|---|---|
| 1. `buildFaqJsonLd(items: {question, answer}[])` in `frontend/src/lib/seo.ts` alongside the existing builders | Done, taking `FaqItem[]` from `@/lib/faq`. |
| 2. Render via the existing `JsonLd` component on `/methodologie`, sourcing pairs from the headings and bodies already on the page, markup matching visible text | Done. Answers are verbatim flattenings of the existing prose; questions *are* the rendered headings, read from the same array, so the match holds by construction rather than by review. |
| 3. Same for `/a-propos` | Done, via a visible FAQ section - the page had no Q&A shape, and invented questions with no visible counterpart would have been invalid markup. **Confirmed with you before implementing.** |
| 3b. Same for the `InfoTooltip` definitions (MON-81) | **Deferred.** Those tooltips sit on deputy/vote pages, which are not FAQ pages; emitting `FAQPage` across 577 deputy pages for a shared definition is the spammy-duplication case the spec warns about. The tooltips already deep-link to `/methodologie#presence` and `#limites`, which is now exactly where the marked-up answer lives. |
| 4. `HowTo`/`Article` on `/donnees` | **Deferred**, as the issue frames it ("Consider…, pairs with MON-262's `Dataset` markup on the same page"). Belongs in MON-262 so `/donnees` gets one coherent structured-data pass. |

## Testing

- **The drift guard is the real test.** `__tests__/app/faq-jsonld.test.tsx` renders both actual page components and, per pair, asserts the question equals the section's rendered heading and the answer appears in that section's visible prose (paragraphs and list items joined block by block, nbsp and whitespace normalised). 18 tests.
- **Verified the guard can fail**, rather than trusting a green run: mutating one word of one answer turns it red (`1 failed, 17 passed`), then reverts clean.
- `npm test` - 38 suites / 350 tests pass (18 new). `npm run lint`, `npx tsc --noEmit`, `npm run build` all clean.
- Parsed the JSON-LD back out of the prerendered HTML: `/methodologie` emits an `FAQPage` with 8 questions, `/a-propos` with 5, both `inLanguage: fr`, alongside the existing `Organization` and `WebSite` blocks.
- Loaded `/methodologie` from a production server and confirmed the ten rendered `<h2>`s read as a coherent FAQ.
- Screenshotted the new `/a-propos` section at 1280px; it matches the page's existing type and grid.

## Risks / Notes

- **Visible copy changes on two designed pages** - the eight `/methodologie` headings above, and a new section on `/a-propos`. Both options were confirmed with you before implementation, but they are the part of this PR worth actually looking at rather than skimming.
- No API, schema, deploy-config or dependency change. Frontend-only, statically prerendered.
- Pre-existing, untouched: `/a-propos` overflows horizontally at 390px (`scrollWidth` 1077). Measured identically on the current production build, so this PR neither causes nor worsens it, and `/a-propos` is not in the MON-241 smoke tier. Worth its own issue.
- Google restricts `FAQPage` *rich results* to authoritative government and health sites, so no SERP change is expected. The payoff here is extractability by crawlers and models, which is what the issue targets.

## Breaking Changes

None.
