### PR TITLE
fix: repair stringified votes.dossier_id and guard against recurrence (MON-258)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ Important data quirks:
 - `nonVotant` ≠ `abstention`: present in chamber but did not vote vs. formally abstained
 - Yaël Braun-Pivet shows 100% presence — Présidente de l'AN, appears on every scrutin by design
 - Production DB holds votes from `2025-07-01` (Supabase free tier); local dev can hold the full legislature from `2024-07-07`
-- `votes.dossier_id` is sparse and partly corrupt (ADR-035, MON-242). The AN only began populating `objet.dossierLegislatif` on scrutins in **March 2026** - it is absent on every scrutin before that, so only ~75 dossiers in the legislature have a linkable scrutin at all. Separately, rows ingested between 2026-03 and commit `7e29131` (2026-07-13) store the Python `repr()` of the dict rather than its `dossierRef`, and the daily cron's 30-day `--since` window has not healed them. Never group votes by `dossier_id` to reconstruct a bill's history - see ADR-035.
+- `votes.dossier_id` is sparse, and the sparsity is upstream and permanent (ADR-035, MON-242). The AN only began populating `objet.dossierLegislatif` on scrutins in **March 2026** - it is absent on every scrutin before that, so only ~74 dossiers in the legislature have a linkable scrutin at all. Never group votes by `dossier_id` to reconstruct a bill's history - see ADR-035. The separate *corruption* (1 570 rows holding the Python `repr()` of the dict rather than its `dossierRef`, written before commit `7e29131` and left unhealed by the cron's 30-day `--since` window) is fixed: `scripts/backfill_dossier_ids.py` repaired them in prod on 2026-09-02, and `check_dossier_refs()` in `ingest_votes.py` now exits 1 if a future run writes non-conforming refs (MON-258).
 
 ---
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1135,7 +1135,7 @@ The epic's premise that this could reuse existing work does not hold.
 `rag/pipeline/chunk_law_summaries.py` produces per-vote **party-breakdown** chunks for the top 20 votes by turnout, keyed on `vote_id`.
 They are named `law_summary` but they are not per-dossier summaries and cannot seed a bill header.
 
-### 9. Production `votes.dossier_id` is currently corrupt and must be backfilled
+### 9. Production `votes.dossier_id` was corrupt and has been backfilled (resolved, MON-258)
 
 `scripts/ingest_votes.py` stored the Python `repr()` of the `dossierLegislatif` dict instead of its `dossierRef` until commit `7e29131` (2026-07-13, MON-89 review).
 The AN began tagging in March 2026.
@@ -1155,6 +1155,13 @@ On the order of 1 700 of the 2 606 usable tagged scrutins are affected, which is
 This is tracked as **MON-258**, filed separately from the MON-105 epic because it is corrupting live data today and its fix does not depend on anything else here.
 It blocks MON-243: `has_scrutins` computed against the corrupt column lands at roughly 8 dossiers instead of 75, and `GET /lois` returns near-empty parcours until it runs.
 It must re-extract `dossierRef` from the stored repr where possible, re-ingest with a wide `--since` where not, and add a guard so a non-conforming `dossier_id` cannot ship silently again.
+
+**Resolved 2026-09-02 (MON-258).**
+`scripts/backfill_dossier_ids.py` extracted the reference from all 1 570 corrupt rows with a narrow regex anchored on the `'dossierRef':` key - none needed re-ingestion.
+Production now holds 2 607 well-formed refs over 74 distinct dossiers, and a second run of the script changes zero rows.
+`check_dossier_refs()` in `ingest_votes.py` is the guard: `parse_vote` drops a reference that fails `^DLR[A-Za-z0-9]+$` rather than storing it, and the run exits 1 when more than `SKIP_RATE_THRESHOLD` of the dossier-carrying scrutins are malformed.
+Scrutins with no dossier at all are excluded from that ratio - an all-null run is normal history for anything before 2026-03, not a regression.
+What remains is the sparsity in §1, which is upstream and permanent.
 
 **Reason (summary):**
 

--- a/rag/experiments/verify_eval.py
+++ b/rag/experiments/verify_eval.py
@@ -29,7 +29,6 @@ Requires DATABASE_URL, OPENAI_API_KEY, GROQ_API_KEY. Costs a few cents at most
 verifications of the mixed-record claim).
 """
 
-import ast
 import os
 
 import mlflow
@@ -110,7 +109,9 @@ def _mixed_record_claim() -> dict | None:
         with conn.cursor() as cur:
             cur.execute(
                 """
-                SELECT d.full_name, v.dossier_id
+                SELECT
+                    d.full_name,
+                    (array_agg(v.vote_title ORDER BY v.total_voters DESC))[1] AS bill_title
                 FROM vote_positions vp
                 JOIN deputies d ON d.deputy_id = vp.deputy_id
                 JOIN votes v ON v.vote_id = vp.vote_id
@@ -127,17 +128,16 @@ def _mixed_record_claim() -> dict | None:
             row = cur.fetchone()
     if not row:
         return None
-    full_name, dossier_id = row
-    # dossier_id is stored as the repr of the AN dict, e.g. "{'libelle': ...}".
-    try:
-        libelle = ast.literal_eval(dossier_id).get("libelle")
-    except (ValueError, SyntaxError):
-        libelle = None
-    if not libelle:
+    full_name, bill_title = row
+    # The bill label is the title of the dossier's best-attended scrutin - the
+    # vote on the whole text rather than on an amendment. It used to be read out
+    # of dossier_id, which held the repr of the AN dict; that corruption is fixed
+    # and dossier_id now holds the bare ref only (MON-258).
+    if not bill_title:
         return None
     return {
         "label": "mixed record (pour on some scrutins, contre on others)",
-        "claim": f"{full_name} a voté pour : {libelle}",
+        "claim": f"{full_name} a voté pour : {bill_title}",
         "expected": {"trompeur"},
         "expect_citation": None,
     }

--- a/scripts/backfill_dossier_ids.py
+++ b/scripts/backfill_dossier_ids.py
@@ -1,0 +1,125 @@
+"""
+scripts/backfill_dossier_ids.py
+
+Repairs votes.dossier_id rows that hold the Python repr() of the AN
+``objet.dossierLegislatif`` dict instead of its ``dossierRef`` (MON-258).
+
+Why this exists: until commit 7e29131 (2026-07-13) ingest_votes.py stringified
+the whole ``{libelle, dossierRef}`` dict. The parser is fixed, but the upsert
+only heals rows that fall inside the ingestion ``--since`` window, and the daily
+cron uses 30 days - so every scrutin ingested between 2026-01 and 2026-06 kept
+its corrupt value. The frontend (``frontend/src/lib/an.ts``) validates the value
+before building the dossier URL, so the "Voir le dossier officiel" link was
+silently absent on ~1 570 votes rather than visibly broken.
+
+The stored text is parsed with a narrow regex, never ``eval``/``ast.literal_eval``:
+the only thing wanted out of it is the reference, and it is stored data whose
+shape is dictated upstream.
+
+Rows whose text carries no extractable reference are reported, not guessed at -
+re-ingest them with a wide window instead:
+
+    python scripts/ingest_votes.py --since 2026-01-01
+
+Idempotent: it only ever touches rows failing ``^DLR[A-Za-z0-9]+$``, so a second
+run finds nothing to do.
+
+Usage:
+    python -m scripts.backfill_dossier_ids            # report only
+    python -m scripts.backfill_dossier_ids --apply    # write the repairs
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+
+import psycopg2
+from dotenv import load_dotenv
+from psycopg2.extras import execute_batch
+
+load_dotenv()
+
+# The reference as it appears inside the stringified dict. Anchored on the key
+# so a libelle that happens to contain "DLR…" cannot be mistaken for the ref.
+EMBEDDED_REF_RE = re.compile(r"'dossierRef':\s*'(DLR[A-Za-z0-9]+)'")
+
+SELECT_CORRUPT_SQL = """
+SELECT vote_id, dossier_id
+FROM votes
+WHERE dossier_id IS NOT NULL
+  AND dossier_id !~ '^DLR[A-Za-z0-9]+$'
+ORDER BY vote_id
+"""
+
+UPDATE_SQL = "UPDATE votes SET dossier_id = %s WHERE vote_id = %s"
+
+
+def extract_embedded_ref(stored: str) -> str | None:
+    """Pull the dossier reference out of a stringified dossierLegislatif dict."""
+    match = EMBEDDED_REF_RE.search(stored)
+    return match.group(1) if match else None
+
+
+def compute_repairs(
+    rows: list[tuple[str, str]],
+) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    """Split corrupt rows into (repairable as (vote_id, ref), unrepairable)."""
+    repairs: list[tuple[str, str]] = []
+    unrepairable: list[tuple[str, str]] = []
+    for vote_id, stored in rows:
+        ref = extract_embedded_ref(stored)
+        if ref:
+            repairs.append((vote_id, ref))
+        else:
+            unrepairable.append((vote_id, stored))
+    return repairs, unrepairable
+
+
+def backfill(apply: bool) -> None:
+    conn = psycopg2.connect(os.environ["DATABASE_URL"])
+    try:
+        with conn.cursor() as cur:
+            cur.execute(SELECT_CORRUPT_SQL)
+            rows = cur.fetchall()
+
+        repairs, unrepairable = compute_repairs(rows)
+
+        print(f"Corrupt dossier_id rows : {len(rows)}")
+        print(f"Repairable by extraction: {len(repairs)}")
+        print(f"Unrepairable            : {len(unrepairable)}\n")
+        for vote_id, ref in repairs[:10]:
+            print(f"  {vote_id} → {ref}")
+        if len(repairs) > 10:
+            print(f"  … and {len(repairs) - 10} more")
+        for vote_id, stored in unrepairable:
+            print(f"  UNREPAIRABLE {vote_id}: {stored[:120]!r}")
+        if unrepairable:
+            print(
+                "\nRe-ingest the unrepairable rows: "
+                "python scripts/ingest_votes.py --since 2026-01-01"
+            )
+
+        if apply and repairs:
+            with conn.cursor() as cur:
+                execute_batch(
+                    cur,
+                    UPDATE_SQL,
+                    [(ref, vote_id) for vote_id, ref in repairs],
+                    page_size=500,
+                )
+            conn.commit()
+            print(f"\nCommitted {len(repairs)} repairs.")
+            print("Re-run `dbt run` so marts pick up the refs, and revalidate the CDN cache.")
+        elif not apply:
+            print("\nDry run - re-run with --apply to write.")
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Repair stringified votes.dossier_id values.")
+    parser.add_argument("--apply", action="store_true", help="write repairs (default: dry run)")
+    args = parser.parse_args()
+    backfill(apply=args.apply)

--- a/scripts/ingest_votes.py
+++ b/scripts/ingest_votes.py
@@ -16,6 +16,7 @@ import io
 import json
 import logging
 import os
+import re
 import sys
 import zipfile
 from datetime import date, timedelta
@@ -41,6 +42,11 @@ AN_BASE_URL = os.getenv("AN_API_BASE_URL", "https://data.assemblee-nationale.fr"
 DATABASE_URL = os.getenv("DATABASE_URL")
 
 SCRUTINS_ZIP_PATH = "/static/openData/repository/17/loi/scrutins/Scrutins.json.zip"
+
+# Shape of an AN dossier législatif reference, e.g. "DLR5L17N52985". Mirrored by
+# frontend/src/lib/an.ts::DOSSIER_REF, which refuses to build the "Voir le dossier
+# officiel" link for anything else (MON-258).
+DOSSIER_REF_RE = re.compile(r"^DLR[A-Za-z0-9]+$")
 
 
 # ---------------------------------------------------------------------------
@@ -97,6 +103,29 @@ def _to_int(val) -> int | None:
         return None
 
 
+def extract_dossier_ref(item: dict) -> str | None:
+    """Dossier reference carried by a scrutin, exactly as published.
+
+    Returned unvalidated on purpose: ``parse_vote`` drops a non-conforming value
+    and ``check_dossier_refs`` reports it, so the two callers see the same raw
+    string rather than one silently repairing what the other is meant to detect.
+    """
+    dossier_ref = item.get("dossierRef") or None
+    if isinstance(dossier_ref, dict):
+        dossier_ref = dossier_ref.get("#text") or dossier_ref.get("ref")
+    # Also check objet.dossierLegislatif - the only populated location since 2026-03.
+    if not dossier_ref:
+        obj = item.get("objet") or {}
+        dossier_ref = obj.get("dossierLegislatif") or None
+        if isinstance(dossier_ref, dict):
+            dossier_ref = dossier_ref.get("dossierRef") or dossier_ref.get("#text")
+    return str(dossier_ref) if dossier_ref else None
+
+
+def is_dossier_ref(value: str | None) -> bool:
+    return bool(value) and DOSSIER_REF_RE.match(value) is not None
+
+
 def parse_vote(item: dict) -> dict | None:
     try:
         uid = item.get("uid") or ""
@@ -124,15 +153,7 @@ def parse_vote(item: dict) -> dict | None:
         abstentions = _to_int(decompte.get("abstentions"))
         total_voters = _to_int(syn.get("nombreVotants"))
 
-        dossier_ref = item.get("dossierRef") or None
-        if isinstance(dossier_ref, dict):
-            dossier_ref = dossier_ref.get("#text") or dossier_ref.get("ref")
-        # Also check objet.dossierLegislatif
-        if not dossier_ref:
-            obj = item.get("objet") or {}
-            dossier_ref = obj.get("dossierLegislatif") or None
-            if isinstance(dossier_ref, dict):
-                dossier_ref = dossier_ref.get("dossierRef") or dossier_ref.get("#text")
+        dossier_ref = extract_dossier_ref(item)
 
         return {
             "vote_id": uid,
@@ -144,7 +165,7 @@ def parse_vote(item: dict) -> dict | None:
             "votes_against": votes_against,
             "abstentions": abstentions,
             "total_voters": total_voters,
-            "dossier_id": str(dossier_ref) if dossier_ref else None,
+            "dossier_id": dossier_ref if is_dossier_ref(dossier_ref) else None,
         }
     except Exception as exc:
         log.debug("Could not parse scrutin %s — %s", item.get("uid"), exc)
@@ -190,6 +211,52 @@ def _upsert_records(records: list[dict]) -> None:
         conn.close()
 
 
+def check_dossier_refs(raw_items: list[dict]) -> None:
+    """Exit 1 when the dossier reference stops looking like a dossier reference.
+
+    ``objet.dossierLegislatif`` is a ``{libelle, dossierRef}`` dict, and until
+    commit 7e29131 the parser stringified the whole dict instead of reading
+    ``dossierRef``. Nothing failed: the corrupt value was upserted, the frontend
+    regex in ``an.ts`` rejected it, and the "Voir le dossier officiel" link was
+    simply not rendered on 1 570 production votes for four months (MON-258).
+
+    A shape change on that subtree fails the same silent way, so the check is on
+    the *share* of dossier-carrying scrutins whose reference is malformed rather
+    than on the parse succeeding at all. Scrutins with no dossier are not counted:
+    the AN published none before 2026-03 (ADR-035), so an all-null run is normal
+    history, not a regression.
+    """
+    seen = 0
+    malformed: list[tuple[str, str]] = []
+    for item in raw_items:
+        raw = extract_dossier_ref(item)
+        if raw is None:
+            continue
+        seen += 1
+        if not is_dossier_ref(raw):
+            malformed.append((str(item.get("uid") or "?"), raw))
+
+    if not malformed:
+        log.info(
+            "Dossier references: %d/%d scrutins carry one, all well-formed.", seen, len(raw_items)
+        )
+        return
+
+    rate = len(malformed) / seen
+    log.error(
+        "Malformed dossier references: %d/%d (%.0f%%). First offenders: %s",
+        len(malformed),
+        seen,
+        rate * 100,
+        "; ".join(f"{uid}={raw[:80]!r}" for uid, raw in malformed[:3]),
+    )
+    if rate > SKIP_RATE_THRESHOLD:
+        # Abort before upserting: these rows would be written with a NULL
+        # dossier_id, which reads downstream as "this scrutin has no bill"
+        # rather than as a broken feed.
+        sys.exit(1)
+
+
 def upsert_votes(raw_items: list[dict]) -> int:
     """Parse raw scrutin dicts and upsert into votes table. Returns count written."""
     records = [r for item in raw_items if (r := parse_vote(item)) is not None]
@@ -208,6 +275,7 @@ def upsert_votes(raw_items: list[dict]) -> int:
         # stamp them with a fresh ingested_at, masking the failure from dbt
         # source freshness checks (MON-220).
         sys.exit(1)
+    check_dossier_refs(raw_items)
     _upsert_records(records)
     return len(records)
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -11,8 +11,9 @@ from pathlib import Path
 import pytest
 
 from rag.chain.sql_router import detect_department, detect_intent, normalize_text
+from scripts.backfill_dossier_ids import compute_repairs, extract_embedded_ref
 from scripts.ingest_positions import _votants, extract_positions
-from scripts.ingest_votes import _to_int, parse_vote
+from scripts.ingest_votes import _to_int, check_dossier_refs, parse_vote
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -103,6 +104,95 @@ def test_parse_vote_dossier_legislatif_dict_extracts_ref():
     result = parse_vote(item)
     assert result is not None
     assert result["dossier_id"] == "DLR5L17N53980"
+
+
+def _scrutin_with_dossier(uid: str, dossier) -> dict:
+    """Minimal well-formed scrutin carrying an arbitrary dossierLegislatif value."""
+    return {
+        "uid": uid,
+        "dateScrutin": "2026-04-01",
+        "titre": "Amendement",
+        "sort": {"code": "rejeté"},
+        "syntheseVote": {
+            "nombreVotants": "100",
+            "decompte": {"pour": "40", "contre": "60", "abstentions": "0"},
+        },
+        "typeVote": {"codeTypeVote": "SFS"},
+        "objet": {"dossierLegislatif": dossier},
+    }
+
+
+def test_parse_vote_drops_a_stringified_dossier_dict():
+    """A dossierLegislatif that arrives already stringified must never reach the
+    DB: a NULL is recoverable by re-ingestion, a corrupt string is not, and the
+    frontend rejects it either way (MON-258)."""
+    item = _scrutin_with_dossier(
+        "VTANR5L17V5280",
+        "{'libelle': 'L’intérêt des enfants', 'dossierRef': 'DLR5L17N51655'}",
+    )
+    result = parse_vote(item)
+    assert result is not None
+    assert result["dossier_id"] is None
+
+
+def test_check_dossier_refs_exits_on_malformed_majority():
+    """The guard aborts the run rather than upserting NULLs that read downstream
+    as 'this scrutin has no bill' (MON-258)."""
+    corrupt = "{'libelle': 'X', 'dossierRef': 'DLR5L17N51655'}"
+    items = [_scrutin_with_dossier(f"VT{i}", corrupt) for i in range(10)]
+    with pytest.raises(SystemExit) as exc:
+        check_dossier_refs(items)
+    assert exc.value.code == 1
+
+
+def test_check_dossier_refs_passes_on_well_formed_and_on_dossierless_runs():
+    """Scrutins with no dossier at all are normal history (none before 2026-03),
+    so an all-null run must not trip the guard."""
+    check_dossier_refs(
+        [_scrutin_with_dossier("VT1", {"libelle": "X", "dossierRef": "DLR5L17N53980"})]
+    )
+    check_dossier_refs([{"uid": "VT2", "dateScrutin": "2025-01-01", "titre": "X"}])
+    check_dossier_refs([])
+
+
+# ---------------------------------------------------------------------------
+# MON-258 - backfill of already-corrupt rows
+# ---------------------------------------------------------------------------
+
+
+def test_extract_embedded_ref_reads_the_ref_out_of_a_stored_repr():
+    stored = "{'libelle': 'L’intérêt des enfants', 'dossierRef': 'DLR5L17N51655'}"
+    assert extract_embedded_ref(stored) == "DLR5L17N51655"
+
+
+def test_extract_embedded_ref_handles_a_libelle_with_embedded_quotes():
+    stored = (
+        "{'libelle': \"Création du cadre d'emploi des personnels de santé\", "
+        "'dossierRef': 'DLR5L17N51346'}"
+    )
+    assert extract_embedded_ref(stored) == "DLR5L17N51346"
+
+
+def test_extract_embedded_ref_ignores_a_ref_shaped_libelle():
+    """Only the value keyed by dossierRef counts - a libelle mentioning a ref
+    must not be promoted into dossier_id."""
+    stored = "{'libelle': 'Rapport sur DLR5L17N99999', 'dossierRef': 'DLR5L17N51655'}"
+    assert extract_embedded_ref(stored) == "DLR5L17N51655"
+
+
+def test_extract_embedded_ref_returns_none_when_nothing_is_recoverable():
+    assert extract_embedded_ref("{'libelle': 'X'}") is None
+
+
+def test_compute_repairs_splits_recoverable_from_unrepairable():
+    repairs, unrepairable = compute_repairs(
+        [
+            ("VT1", "{'libelle': 'A', 'dossierRef': 'DLR5L17N1'}"),
+            ("VT2", "{'libelle': 'B'}"),
+        ]
+    )
+    assert repairs == [("VT1", "DLR5L17N1")]
+    assert unrepairable == [("VT2", "{'libelle': 'B'}")]
 
 
 def test_parse_vote_missing_uid_returns_none():


### PR DESCRIPTION
## Why

`votes.dossier_id` held the Python `repr()` of the AN `objet.dossierLegislatif` dict instead of its `dossierRef` on **1 570 production rows**:

```
"{'libelle': 'Projet de loi relatif à la lutte contre les fraudes sociales et fiscales', 'dossierRef': 'DLR5L17N52985'}"
```

The parser itself was fixed in `7e29131` (2026-07-13, MON-89 review), but the upsert only heals rows inside the ingestion `--since` window and the daily cron uses 30 days, so every scrutin ingested between 2026-01-29 and 2026-06-11 kept its corrupt value.

Nobody noticed because `frontend/src/lib/an.ts` validates the ref before building the dossier URL - a corrupt value fails the regex and the "Voir le dossier officiel" link is simply not rendered. The page looks fine; the affordance was silently missing on the majority of votes that should have one, and MON-243 / MON-105 cannot build bill timelines without it.

## What changed

**`scripts/backfill_dossier_ids.py`** (new) - one-shot, idempotent repair following the `backfill_party_labels.py` precedent: dry-run by default, `--apply` to write.
It extracts the reference with a narrow regex anchored on the `'dossierRef':` key rather than `eval`/`ast.literal_eval` on stored text, and *reports* anything it cannot recover instead of guessing (re-ingest those with a wide `--since`). In practice all 1 570 rows were recoverable.

**`scripts/ingest_votes.py`** - the guard, in the style of MON-220/MON-249:
- `extract_dossier_ref()` is now a named helper returning the reference *unvalidated*, so the writer and the checker see the same raw string.
- `parse_vote()` drops a reference failing `^DLR[A-Za-z0-9]+$` instead of storing it. A NULL is recoverable by re-ingestion; a corrupt string is not, and the frontend rejects both.
- `check_dossier_refs()` runs before the upsert and exits 1 when more than `SKIP_RATE_THRESHOLD` (the shared 5% from `_http.py`) of the *dossier-carrying* scrutins are malformed. Scrutins with no dossier are excluded from that ratio on purpose: the AN published none before 2026-03 (ADR-035 §1), so an all-null run is normal history, not a regression.

**Docs** - CLAUDE.md's data-quirk line and ADR-035 §9 now record the corruption as resolved, leaving only the March-2026 sparsity, which is upstream and permanent.

## Acceptance criteria

| Criterion | Status |
|---|---|
| Zero prod rows with a non-null `dossier_id` failing `^DLR[A-Za-z0-9]+$` | Done - `NON-conforming: 0` (was 1 570) |
| `GET /votes/VTANR5L17V5994` returns `DLR5L17N52985` | **Pending `dbt run`** - see below |
| Usable refs rise to ~2 600, distinct dossiers to ~75 | Done - 2 607 refs over 74 distinct dossiers |
| Backfill is idempotent | Done - second run reports `Corrupt dossier_id rows : 0` |
| Regression guard, with a unit test on dict-shaped input | Done - `check_dossier_refs()` + 8 new tests |
| Link renders on a previously-corrupt vote, no frontend change | Done once the mart refreshes - `an.ts` is untouched |
| `ruff check .` and `pytest tests/` pass | Lint clean repo-wide; tests in CI |
| CLAUDE.md `dossier_id` quirk line updated | Done, plus ADR-035 §9 |

### The one criterion not yet observable in the API

`GET /votes/{id}` reads `analytics_marts.mart_vote_summary`, not `votes`. The mart is a full-refresh dbt **table**, so it still carries the 1 570 stale values until the next `dbt run`. The source table is correct now:

```
votes table:            DLR5L17N52985
mart_vote_summary:      {'libelle': ..., 'dossierRef': 'DLR5L17N52985'}   <- stale
```

That resolves on its own via either `deploy.yml` (on merge to master) or `ingest_prod.yml` (daily, 06:00 UTC) - no action needed, but the endpoint will keep returning the old string until one of them runs. I deliberately did not run `dbt run` against prod by hand: rebuilding a mart table outside the pipeline briefly drops it, which is a bigger production risk than the targeted `UPDATE` this issue asked for.

## Test plan

- 8 new tests in `tests/test_parsers.py`: dict-shaped and already-stringified `dossierLegislatif`, the guard exiting 1 on a malformed majority, the guard staying quiet on well-formed and on dossier-less runs, ref extraction across quote variants, a ref-shaped `libelle` not being mistaken for the ref, and the repairable/unrepairable split.
- Backfill exercised for real against prod: dry run (1 570 repairable, 0 unrepairable) -> `--apply` (1 570 committed) -> second dry run (0 rows).
- `ruff check .` and `ruff format --check .` clean over the whole repo.

## Deploy notes

No schema change, no migration, no config change. The prod data fix is already applied. Merging triggers the `dbt run` that propagates it to the marts.

## Out of scope

The 30-day cron `--since` window that let this sit for four months is noted in CLAUDE.md decision 8 and left alone, per the issue.

Closes MON-258.
