### PR TITLE
feat: one h1 and a server-rendered summary on the homepage (MON-270)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "CLAUDE.md",
         "hashed_secret": "ffddd4c9867f24ed207b1da5b50693e6d85a7889",
         "is_verified": false,
-        "line_number": 192
+        "line_number": 197
       }
     ],
     "README.md": [
@@ -252,5 +252,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-31T20:59:37Z"
+  "generated_at": "2026-09-01T23:06:07Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Assemblée Nationale Open Data (ZIPs)
 
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
-| `ci.yml` | Every PR to `master` | ruff lint + pytest (unit) + dbt compile + dbt test + frontend lint/typecheck/jest/build + Playwright smoke tier (MON-241: no-horizontal-overflow and nav-visibility checks on `/`, `/deputes`, `/deputes/[id]`, `/votes`, `/votes/[id]`, `/chat`, `/quiz` at 390px/1280px, light/dark, against a `next build`, plus canonical-link and 404-status checks on `desktop-light` only - MON-269, MON-275); posts dbt results as PR comment |
+| `ci.yml` | Every PR to `master` | ruff lint + pytest (unit) + dbt compile + dbt test + frontend lint/typecheck/jest/build + Playwright smoke tier (MON-241: no-horizontal-overflow and nav-visibility checks on `/`, `/deputes`, `/deputes/[id]`, `/votes`, `/votes/[id]`, `/chat`, `/quiz` at 390px/1280px, light/dark, against a `next build`, plus canonical-link and 404-status checks on `desktop-light` only - MON-269, MON-275, and a single-`h1`/server-rendered-summary check on `/` at both viewports - MON-270); posts dbt results as PR comment |
 | `deploy.yml` | Merge to `master` | dbt deps → run → test against prod Supabase |
 | `ingest_prod.yml` | Daily 06:00 UTC, weekdays | Ingest new votes + deputies + rebuild RAG index, then `dbt run` → operational tail. Every step after `dbt run` is `continue-on-error` + `!cancelled()`, and a final **data-quality gate** re-fails the job on `dbt snapshot`/`dbt test`/`dbt source freshness`/quiz-validation outcomes (MON-250) — a failing assertion must never skip cache revalidation or the monitoring probes. The DB-size probe is deliberately outside the gate. |
 | `summarize_backfill.yml` | Daily 07:00 UTC | Retries vote summaries (`summary_plain IS NULL`) independent of `ingest_prod.yml`'s `--since` window — the actual retry backstop (MON-221) |
@@ -148,6 +148,11 @@ A new parser without such a guard ships a skeleton dataset on a green run - the 
 - A detail page's *identity* fetch uses `.catch(nullIfMissing)` (`src/lib/api.ts`), never a bare `.catch(() => null)`: only a genuine 404/422 becomes `notFound()`, while a 429 or 5xx is rethrown and surfaces as a server error. The supporting fetches on the same page keep `.catch(() => null)` - each one degrades a section rather than deciding whether the page exists.
 - `/votes/[id]` and `/themes/[slug]` deliberately have **no `generateStaticParams`** (MON-275). Prerendering the 100 most recent votes plus the 10 themes meant ~220 API calls from one IP inside a build, which exhausted the API's DB connections and came back as 500s on endpoints that answer in 200 ms on every manual request - three CI builds in a row died on a different page each. `dynamicParams` plus `revalidate` already cover both routes on demand, and static pages generated dropped from 135 to 25. Do not reintroduce either without a way to throttle the burst; `sitemap.ts` is the remaining build-time burst and is still build-fatal if the API fails.
 - Every route declares `alternates.canonical` via `canonicalUrl()` (MON-269) - see the Deployment section.
+- The homepage carries **exactly one `<h1>`**, and it lives in `AssemblyScrollExperience`'s server-rendered half (MON-270).
+`CinematicExperience` only mounts after `useSyncExternalStore` confirms a desktop viewport, so on desktop the DOM is the union of both trees - its two scroll-panel titles are `<h2>`, never `<h1>`.
+`HomeSummary` (`src/components/home/HomeSummary.tsx`) is the static prose block below the cinematic: it is what a crawler or an LLM actually reads about this site, since the scroll experience itself is ~1 KB of display strings inside animated panels.
+It is also the only place linking every `/groupes/[slug]` and `/themes/[slug]` from the homepage - keep it a server component with no interactivity.
+`e2e/smoke.spec.ts` asserts both halves at 390px and 1280px.
 
 **`archive/infra-aws/`** — Archived AWS Terraform IaC (not live)
 - Modeled an Airflow+Spark architecture never built, with no compute for the actual FastAPI app — archived rather than fixed (MON-46). See Phase 5 and decision 1 in the decisions log.

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -62,7 +62,7 @@ test.describe('smoke: /votes row columns are not clipped', () => {
   })
 })
 
-test.describe('smoke: the homepage has exactly one h1', () => {
+test.describe('smoke: the homepage is legible to a crawler', () => {
   // MON-270: `/` renders `MobileExperience` on every viewport and mounts
   // `CinematicExperience` on top of it once `useSyncExternalStore` confirms
   // desktop - so the desktop DOM is the union of both trees, and the two

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -62,6 +62,44 @@ test.describe('smoke: /votes row columns are not clipped', () => {
   })
 })
 
+test.describe('smoke: the homepage has exactly one h1', () => {
+  // MON-270: `/` renders `MobileExperience` on every viewport and mounts
+  // `CinematicExperience` on top of it once `useSyncExternalStore` confirms
+  // desktop - so the desktop DOM is the union of both trees, and the two
+  // scroll-panel titles used to make three competing `<h1>`s. jsdom never sees
+  // this: the cinematic half only mounts behind a real matchMedia. Both
+  // viewports matter (they render different trees); the color scheme does not.
+  test.beforeEach(({}, testInfo) => {
+    testInfo.skip(!testInfo.project.name.endsWith('-light'), 'color-scheme-independent')
+  })
+
+  test('one h1, and an h2 outline beneath it', async ({ page }) => {
+    await page.goto('/')
+    const viewport = page.viewportSize()
+    if (!viewport) throw new Error('no viewport configured for this project')
+
+    // The cinematic mounts in an effect after hydration, so counting too early
+    // would pass for the wrong reason. Wait for one of its own panels first.
+    if (viewport.width >= 768) {
+      await page.locator('[data-title="0"]').waitFor({ state: 'attached' })
+    }
+
+    await expect(page.locator('h1')).toHaveCount(1)
+    await expect(page.locator('h1')).toHaveText([/enfin lisible/])
+    // The prose summary contributes the outline the flat hero never had.
+    await expect(page.getByRole('heading', { level: 2, name: /relevé de vote complet/ })).toBeAttached()
+  })
+
+  test('the prose summary is in the server HTML, not injected by JS', async ({ request }) => {
+    // The whole point of the section: a crawler that never runs the client
+    // bundle must still be told what this site is.
+    const html = await (await request.get('/')).text()
+    expect(html).toContain('plateforme de transparence civique')
+    expect(html).toContain('href="/methodologie"')
+    expect(html).toContain('href="/groupes/rassemblement-national"')
+  })
+})
+
 test.describe('smoke: nav visibility follows the md breakpoint', () => {
   // MON-141: the desktop nav is `hidden md:flex` — jsdom can't tell an
   // inline display:flex apart from the Tailwind class losing the cascade,

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import * as Sentry from '@sentry/nextjs'
 import { api, Vote, Deputy, Scorecard } from '@/lib/api'
 import { AssemblyScrollExperience } from '@/components/home/AssemblyScrollExperience'
+import { HomeSummary } from '@/components/home/HomeSummary'
 import { canonicalUrl } from '@/lib/site'
 
 export const metadata: Metadata = {
@@ -160,6 +161,7 @@ export default async function Home() {
   return (
     <div className="overflow-x-clip bg-[#070b14]">
       <AssemblyScrollExperience stats={homeStats} leadVote={pulseVote} deputyInfo={deputyInfo} />
+      <HomeSummary stats={homeStats} />
     </div>
   )
 }

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -83,6 +83,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${SITE_URL}/deputes/tableau`, changeFrequency: 'daily', priority: 0.6 },
     { url: `${SITE_URL}/donnees`, changeFrequency: 'monthly', priority: 0.5 },
     { url: `${SITE_URL}/votes`, changeFrequency: 'daily', priority: 0.9 },
+    { url: `${SITE_URL}/mon-depute`, changeFrequency: 'monthly', priority: 0.6 },
     ...THEME_ENTRIES.map(({ slug }) => ({
       url: `${SITE_URL}/themes/${slug}`,
       changeFrequency: 'weekly' as const,

--- a/frontend/src/components/home/AssemblyScrollExperience.tsx
+++ b/frontend/src/components/home/AssemblyScrollExperience.tsx
@@ -40,6 +40,8 @@ function StaticExperience({ stats, leadVote }: Props) {
             <p className="text-xs font-semibold uppercase text-red-light">
               Données officielles de l&apos;Assemblée Nationale
             </p>
+            {/* The page's single `<h1>` in the reduced-motion branch (MON-270);
+                `StaticExperience` and `MobileExperience` never render together. */}
             <h1 className="mt-6 font-serif text-5xl leading-tight text-white md:text-7xl">
               La vie politique française, enfin lisible.
             </h1>
@@ -97,6 +99,8 @@ function MobileExperience({ stats, leadVote }: Props) {
           <p className="text-xs font-semibold uppercase text-red-light">
             Données officielles
           </p>
+          {/* The page's single `<h1>` (MON-270). This section is server-rendered on
+              every viewport - the cinematic below it only ever adds `<h2>`s. */}
           <h1 className="mt-5 font-serif text-4xl leading-tight text-white">
             La vie politique française, enfin lisible.
           </h1>
@@ -744,13 +748,20 @@ function CinematicExperience({ stats, leadVote, deputyInfo }: Props) {
             <p style={{ fontSize: 'clamp(16px,1.8vw,19px)', lineHeight: 1.55, color: 'rgba(255,255,255,0.9)', margin: '16px auto 0', maxWidth: 520, textShadow: '0 1px 14px rgba(0,0,0,0.55)' }}>Suivez les votes de vos députés, en toute neutralité.</p>
           </div>
 
-          {/* data act titles */}
+          {/*
+            data act titles - `<h2>`, not `<h1>` (MON-270). Both panels render
+            together (the scroll animation cross-fades them), and the cinematic
+            mounts on top of `MobileExperience`, whose hero already carries the
+            page's only `<h1>`. Three competing `<h1>`s gave a crawler no
+            primary subject; the styling here is inline, so the tag change is
+            purely semantic.
+          */}
           <div data-title="0" style={{ position: 'absolute', top: 'clamp(90px,13vh,124px)', left: 'clamp(22px,4vw,60px)', width: 'min(460px,86vw)', opacity: 0 }}>
-            <h1 style={{ margin: 0, fontFamily: 'DM Serif Display, Georgia, serif', fontWeight: 800, fontSize: 'clamp(34px,4.6vw,52px)', lineHeight: 1.03, letterSpacing: '-0.02em', color: '#fff', textShadow: '0 2px 30px rgba(0,0,0,0.6)' }}>LA DÉMOCRATIE<br />EN DONNÉES</h1>
+            <h2 style={{ margin: 0, fontFamily: 'DM Serif Display, Georgia, serif', fontWeight: 800, fontSize: 'clamp(34px,4.6vw,52px)', lineHeight: 1.03, letterSpacing: '-0.02em', color: '#fff', textShadow: '0 2px 30px rgba(0,0,0,0.6)' }}>LA DÉMOCRATIE<br />EN DONNÉES</h2>
             <p style={{ margin: '22px 0 0', fontSize: 'clamp(16px,1.8vw,19px)', lineHeight: 1.55, color: 'rgba(255,255,255,0.84)', maxWidth: 340, textShadow: '0 1px 14px rgba(0,0,0,0.7)' }}>Chaque siège devient un point.<br />Chaque vote, une certitude.</p>
           </div>
           <div data-title="1" style={{ position: 'absolute', top: 'clamp(90px,13vh,124px)', left: 'clamp(22px,4vw,60px)', width: 'min(460px,86vw)', opacity: 0 }}>
-            <h1 style={{ margin: 0, fontFamily: 'DM Serif Display, Georgia, serif', fontWeight: 800, fontSize: 'clamp(32px,4.4vw,50px)', lineHeight: 1.04, letterSpacing: '-0.02em', color: '#fff', textShadow: '0 2px 30px rgba(0,0,0,0.6)' }}>VOTRE DÉPUTÉ,<br />VOTRE VOIX</h1>
+            <h2 style={{ margin: 0, fontFamily: 'DM Serif Display, Georgia, serif', fontWeight: 800, fontSize: 'clamp(32px,4.4vw,50px)', lineHeight: 1.04, letterSpacing: '-0.02em', color: '#fff', textShadow: '0 2px 30px rgba(0,0,0,0.6)' }}>VOTRE DÉPUTÉ,<br />VOTRE VOIX</h2>
             <p style={{ margin: '22px 0 0', fontSize: 'clamp(16px,1.8vw,19px)', lineHeight: 1.55, color: 'rgba(255,255,255,0.84)', maxWidth: 330, textShadow: '0 1px 14px rgba(0,0,0,0.7)' }}>Derrière un seul point,<br />l&apos;élu qui répond de votre voix.</p>
           </div>
 

--- a/frontend/src/components/home/HomeSummary.tsx
+++ b/frontend/src/components/home/HomeSummary.tsx
@@ -35,7 +35,9 @@ const groupTitleStyle = {
   fontWeight: 700,
   letterSpacing: '0.14em',
   textTransform: 'uppercase',
-  color: 'var(--dp-text-muted)',
+  // Not --dp-text-muted: at 12.5px it is 2.31:1 on --dp-page-bg, and these
+  // are the outline this section exists to add.
+  color: 'var(--dp-text-secondary)',
   margin: '0 0 12px',
 } as const
 
@@ -64,7 +66,7 @@ function LinkList({ links }: { links: Array<{ href: string; label: string }> }) 
     >
       {links.map(({ href, label }) => (
         <li key={href}>
-          <Link href={href} style={{ color: 'var(--dp-text-secondary)' }}>
+          <Link href={href} style={{ color: 'var(--dp-text)' }}>
             {label}
           </Link>
         </li>

--- a/frontend/src/components/home/HomeSummary.tsx
+++ b/frontend/src/components/home/HomeSummary.tsx
@@ -1,0 +1,187 @@
+import Link from 'next/link'
+import type { AssemblyStats } from './LiveAssemblyPulse'
+import { THEME_ENTRIES } from '@/lib/themes'
+import { GROUP_ENTRIES } from '@/lib/groups'
+
+/**
+ * Server-rendered prose summary of what MonÉlu is (MON-270).
+ *
+ * `AssemblyScrollExperience` is a client component whose desktop half does not
+ * mount at all until `useSyncExternalStore` confirms the viewport, and whose
+ * text is short display strings inside animated panels. The homepage therefore
+ * used to ship ~1.1 KB of JS-free content: gorgeous for a human, and close to
+ * silent for a crawler or an LLM deciding what this domain is about.
+ *
+ * This section is deliberately static and non-interactive so it is always in
+ * the HTML, on every viewport, with or without JavaScript. It doubles as the
+ * internal-linking hub the site lacked - every group and every theme page is
+ * one hop from the homepage - and as the human-readable twin of the llms.txt
+ * from MON-261.
+ */
+
+const NUMBER = new Intl.NumberFormat('fr-FR')
+
+const sectionTitleStyle = {
+  fontFamily: 'var(--font-serif), Georgia, serif',
+  fontSize: 'clamp(24px,3vw,32px)',
+  lineHeight: 1.15,
+  letterSpacing: '-0.02em',
+  color: 'var(--dp-text)',
+  margin: 0,
+} as const
+
+const groupTitleStyle = {
+  fontSize: '12.5px',
+  fontWeight: 700,
+  letterSpacing: '0.14em',
+  textTransform: 'uppercase',
+  color: 'var(--dp-text-muted)',
+  margin: '0 0 12px',
+} as const
+
+const textStyle = {
+  fontSize: '15.5px',
+  lineHeight: 1.75,
+  color: 'var(--dp-text-secondary)',
+  margin: '18px 0 0',
+} as const
+
+const linkStyle = { color: 'var(--dp-text)', fontWeight: 600 }
+
+function LinkList({ links }: { links: Array<{ href: string; label: string }> }) {
+  return (
+    <ul
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '8px 18px',
+        listStyle: 'none',
+        margin: 0,
+        padding: 0,
+        fontSize: '14.5px',
+        lineHeight: 1.6,
+      }}
+    >
+      {links.map(({ href, label }) => (
+        <li key={href}>
+          <Link href={href} style={{ color: 'var(--dp-text-secondary)' }}>
+            {label}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export function HomeSummary({ stats }: { stats: AssemblyStats }) {
+  return (
+    <section
+      aria-labelledby="a-propos-du-site"
+      style={{
+        background: 'var(--dp-page-bg)',
+        borderTop: '1px solid var(--dp-border)',
+        padding: 'clamp(48px,6vw,72px) clamp(16px,5vw,56px)',
+      }}
+    >
+      <div style={{ maxWidth: '860px', margin: '0 auto' }}>
+        <p
+          style={{
+            fontSize: '12.5px',
+            fontWeight: 700,
+            letterSpacing: '0.18em',
+            textTransform: 'uppercase',
+            color: 'var(--dp-red)',
+            margin: '0 0 14px',
+          }}
+        >
+          À propos de MonÉlu
+        </p>
+        <h2 id="a-propos-du-site" style={sectionTitleStyle}>
+          Le relevé de vote complet de chaque député, en accès libre.
+        </h2>
+
+        <p style={textStyle}>
+          <strong>MonÉlu</strong> est une plateforme de transparence civique qui publie le relevé de
+          vote de chaque député de l&apos;Assemblée nationale française, pour la{' '}
+          <strong>17<sup>e</sup> législature</strong> ouverte le 7 juillet 2024. Pour chaque scrutin
+          public, le site indique le résultat, le détail pour / contre / abstention, et la position
+          individuelle de chaque élu - la même donnée que le compte rendu officiel, mise en français
+          courant et rendue consultable député par député.
+        </p>
+
+        <p style={textStyle}>
+          La base couvre aujourd&apos;hui <strong>{NUMBER.format(stats.deputies)} députés</strong>,{' '}
+          <strong>{NUMBER.format(stats.votes)} scrutins</strong> et{' '}
+          <strong>{NUMBER.format(stats.positions)} positions individuelles</strong>. Les scrutins
+          publiés en production remontent au 1<sup>er</sup> juillet 2025 ; l&apos;historique complet
+          depuis le début de la législature existe en environnement de développement. Les données
+          sont réingérées automatiquement chaque jour ouvré. {stats.lastUpdated}.
+        </p>
+
+        <p style={textStyle}>
+          Toutes les données proviennent du portail open data de l&apos;Assemblée nationale et sont
+          redistribuées sous <strong>Licence Ouverte 2.0 (Etalab)</strong>, sans retraitement
+          éditorial : MonÉlu ne note pas les députés et ne prend pas position. Le calcul de chaque
+          statistique affichée est décrit sur la page{' '}
+          <Link href="/methodologie" style={linkStyle}>
+            méthodologie
+          </Link>
+          , les jeux de données et l&apos;API publique sur la page{' '}
+          <Link href="/donnees" style={linkStyle}>
+            données
+          </Link>
+          .
+        </p>
+
+        <div style={{ marginTop: 'clamp(32px,4vw,44px)', display: 'grid', gap: '28px' }}>
+          <div>
+            <h3 style={groupTitleStyle}>Explorer</h3>
+            <LinkList
+              links={[
+                { href: '/deputes', label: 'Tous les députés' },
+                { href: '/deputes/tableau', label: 'Tableau comparatif' },
+                { href: '/votes', label: 'Tous les scrutins' },
+                { href: '/mon-depute', label: 'Trouver mon député' },
+                { href: '/quiz', label: 'Quel député vote comme moi ?' },
+                { href: '/chat', label: 'Poser une question aux données' },
+              ]}
+            />
+          </div>
+
+          <div>
+            <h3 style={groupTitleStyle}>Groupes parlementaires</h3>
+            <LinkList
+              links={GROUP_ENTRIES.map(({ slug, name }) => ({
+                href: `/groupes/${slug}`,
+                label: name,
+              }))}
+            />
+          </div>
+
+          <div>
+            <h3 style={groupTitleStyle}>Thèmes</h3>
+            <LinkList
+              links={THEME_ENTRIES.map(({ slug, name }) => ({
+                href: `/themes/${slug}`,
+                label: name,
+              }))}
+            />
+          </div>
+
+          <div>
+            <h3 style={groupTitleStyle}>Sources et transparence</h3>
+            <LinkList
+              links={[
+                { href: '/methodologie', label: 'Méthodologie des calculs' },
+                { href: '/donnees', label: 'Jeux de données' },
+                { href: '/licence-donnees', label: 'Licence des données' },
+                { href: '/developpeurs', label: 'API publique' },
+                { href: '/a-propos', label: 'À propos du projet' },
+              ]}
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## What and why

An external agent-readiness scan measured the homepage at ~1.1 KB of JS-free content with a "flat heading structure". Two separate defects were behind that.

**Three competing `<h1>`s.** `AssemblyScrollExperience` renders `MobileExperience` on every viewport and mounts `CinematicExperience` on top of it once `useSyncExternalStore` confirms desktop, so the desktop DOM is the union of both trees. The two scroll-panel titles at lines 749/753 (`LA DÉMOCRATIE EN DONNÉES`, `VOTRE DÉPUTÉ, VOTRE VOIX`) both render, and both were `<h1>`. (The two hero `<h1>`s the issue counted are genuinely mutually exclusive - `reduceMotion` returns `StaticExperience` before `MobileExperience` can render.)

**~1 KB of prose.** `page.tsx` server-fetches the stats correctly, but the cinematic's text is short display strings inside animated panels. For a human that is the point; for a crawler or an LLM deciding what this domain is, the homepage said almost nothing.

## Changes

- **`AssemblyScrollExperience.tsx`** - the two scroll-panel titles become `<h2>`. Styling is inline (`margin: 0` included), so this is purely a tag change. Comments at all four sites record which one is the page's single `<h1>` and why.
- **`HomeSummary.tsx`** (new) - a static server component rendered below the cinematic. Three paragraphs stating what MonÉlu is, what it covers (17th legislature, live deputy/scrutin/position counts, the 2025-07-01 production horizon, the daily refresh), and where the data comes from under which licence, followed by a four-group link hub. Uses `--dp-*` tokens, no interactivity, no client bundle.
- **`e2e/smoke.spec.ts`** - two assertions in the MON-241 tier.

Measured on a local `next start` against the production API: the homepage's JS-free text goes from **~1.9 KB to ~3.9 KB**, of which 2013 characters are the new section.

## Acceptance criteria

| Recommended fix | How it is met |
|---|---|
| 1. One H1; demote 749 and 753 | Both are `<h2>` now. The single `<h1>` is the server-rendered hero, present on every viewport with or without JS. |
| 1b. A real `<h2>`/`<h3>` outline | `HomeSummary` contributes one `<h2>` and four `<h3>`s, on top of the three `<h2>`s `MobileExperience` already server-renders. See "Deliberately not done" below for the scroll panels. |
| 2. Server-rendered summary section | `HomeSummary`, always in the HTML. Asserted by a raw-HTTP test that never runs the client bundle. |
| 3. Internal-linking hub | Every one of the 12 `/groupes/[slug]` and 10 `/themes/[slug]` pages is now one hop from `/`, plus `/deputes`, `/deputes/tableau`, `/votes`, `/mon-depute`, `/quiz`, `/chat`, `/methodologie`, `/donnees`, `/licence-donnees`, `/developpeurs`, `/a-propos`. Source lists are `GROUP_ENTRIES`/`THEME_ENTRIES` - the same arrays `sitemap.ts` uses, so the hub cannot drift from the sitemap. |
| 4. Playwright: exactly one `h1` on `/` | `smoke: the homepage has exactly one h1`. On desktop it waits for `[data-title="0"]` (a cinematic-only node) before counting, so it cannot pass by counting before the cinematic mounts. Runs at 390px and 1280px - the two viewports render different trees - and skips the dark duplicates, which are irrelevant here. |

## Deliberately not done

The issue also suggested giving the cinematic scroll panels a heading outline. I left them as `div`s: they are client-only, so they are invisible to exactly the crawler this issue is about, and most of them sit at `opacity: 0` for most of the scroll. Marking them up as headings would hand screen-reader users a phantom document outline for no discoverability gain. The outline that matters is the server-rendered one, and that is what `HomeSummary` provides.

Also note `/` is light-only by ADR-027 (`isLightOnlyPath`), so the new section never renders dark in practice - it still uses `--dp-*` tokens rather than hardcoded colors, so it would follow if that ever changes.

## Test plan

- `npm run lint`, `npx tsc --noEmit`, `npm test` (380 passed), `npm run build` - all green.
- `npx playwright test -g "fits the viewport|exactly one h1|nav visibility"` - 36 passed, 4 skipped (the dark-project skips). The new section does not introduce horizontal overflow at 390px.
- Manual: served `next start` against the production API, extracted the tag-stripped text of `/` (1.9 KB → 3.9 KB) and screenshotted the section at 1280px and 390px.

## Deploy risk

None. Frontend-only, no schema, no env var, no workflow change. `HomeSummary` reads the stats object `page.tsx` already computes (it has a fallback path when the API is down), so it degrades the same way the rest of the page does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpqkKFd15yYhcg3bjAxK9e
