### PR TITLE
feat: llms.txt and an explicit AI-crawler policy (MON-261)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "CLAUDE.md",
         "hashed_secret": "ffddd4c9867f24ed207b1da5b50693e6d85a7889",
         "is_verified": false,
-        "line_number": 198
+        "line_number": 204
       }
     ],
     "README.md": [
@@ -171,5 +171,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-02T23:10:23Z"
+  "generated_at": "2026-09-02T23:21:22Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,12 @@ A new parser without such a guard ships a skeleton dataset on a green run - the 
 `HomeSummary` (`src/components/home/HomeSummary.tsx`) is the static prose block below the cinematic: it is what a crawler or an LLM actually reads about this site, since the scroll experience itself is ~1 KB of display strings inside animated panels.
 It is also the only place linking every `/groupes/[slug]` and `/themes/[slug]` from the homepage - keep it a server component with no interactivity.
 `e2e/smoke.spec.ts` asserts both halves at 390px and 1280px.
+- `/llms.txt` and `/llms-full.txt` are **route handlers**, not files in `public/` (MON-261).
+Every absolute URL in them derives from `SITE_URL`, and the section index is generated from `GROUP_ENTRIES`/`THEME_ENTRIES`, so a new group or theme cannot silently fall out of the file and a domain move carries them along.
+The body lives in `src/lib/llms.ts`; `__tests__/app/llms-txt.test.ts` fails if either file links a path with no matching `page.tsx` (`/verifier` is a 308 route handler, not a page - it is deliberately absent), drops a group or theme, or hardcodes a host.
+- `robots.ts` names GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, Claude-User, Claude-SearchBot, PerplexityBot, Perplexity-User, Google-Extended, Applebot-Extended, CCBot, Bytespider and meta-externalagent explicitly, all `allow: '/'` (MON-261).
+They are already covered by the `*` rule; listing them records the permissiveness as deliberate - this is Licence Ouverte 2.0 data whose purpose is reuse - so a later "tighten robots.txt" is a visible deletion rather than an inherited default.
+`Google-Extended` is the one entry with a distinct effect: it governs AI Overviews eligibility separately from Googlebot.
 
 **`archive/infra-aws/`** — Archived AWS Terraform IaC (not live)
 - Modeled an Airflow+Spark architecture never built, with no compute for the actual FastAPI app — archived rather than fixed (MON-46). See Phase 5 and decision 1 in the decisions log.
@@ -216,7 +222,7 @@ python scripts/migrate.py && uvicorn api.main:app --host 0.0.0.0 --port $PORT
 
 Health check: `GET /health` — returns DB status, record counts, `last_ingestion` timestamp, and dbt mart row counts (degrades gracefully if marts are absent).
 
-**Moving to a new domain** takes two environment variables, not one (MON-254, MON-274): `FRONTEND_BASE_URL` on Railway (backend — the `GET /` redirect and every share URL) and `NEXT_PUBLIC_SITE_URL` on Vercel (frontend — `metadataBase`, canonicals, sitemap, robots, OG cards). Same origin under two names; the Vercel one is inlined at build time, so it only takes effect on the next build. Every frontend route builds its `alternates.canonical` from `canonicalUrl()` in `frontend/src/lib/site.ts` (MON-269), so the move carries the canonicals with it; `frontend/__tests__/app/canonical.test.ts` fails if a new `page.tsx` ships without one or hardcodes the origin instead. The only allowlisted exceptions are `~offline` (service-worker fallback) and `embed/votes/[id]` (already `robots: noindex`).
+**Moving to a new domain** takes two environment variables, not one (MON-254, MON-274): `FRONTEND_BASE_URL` on Railway (backend — the `GET /` redirect and every share URL) and `NEXT_PUBLIC_SITE_URL` on Vercel (frontend — `metadataBase`, canonicals, sitemap, robots, OG cards). Same origin under two names; the Vercel one is inlined at build time, so it only takes effect on the next build. Every frontend route builds its `alternates.canonical` from `canonicalUrl()` in `frontend/src/lib/site.ts` (MON-269), so the move carries the canonicals with it; `frontend/__tests__/app/canonical.test.ts` fails if a new `page.tsx` ships without one or hardcodes the origin instead. The only allowlisted exceptions are `~offline` (service-worker fallback) and `embed/votes/[id]` (already `robots: noindex`). The reuse-attribution line that `/donnees`, `/licence-donnees` and `/llms.txt` all print is `DATA_ATTRIBUTION` in the same file (MON-261) - it is built from `SITE_HOST`, so the move cannot leave the site asking reusers to credit a host it no longer answers on.
 
 ---
 

--- a/frontend/__tests__/app/llms-txt.test.ts
+++ b/frontend/__tests__/app/llms-txt.test.ts
@@ -36,7 +36,8 @@ function routeExists(path: string): boolean {
 /** Every `SITE_URL`-rooted path the file links to. */
 function internalPaths(text: string): string[] {
   const paths = new Set<string>()
-  for (const match of text.matchAll(new RegExp(`${SITE_URL}(/[^)\\s\`]*)?`, 'g'))) {
+  const origin = SITE_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  for (const match of text.matchAll(new RegExp(`${origin}(/[^)\\s\`]*)?`, 'g'))) {
     const path = (match[1] ?? '/').replace(/\/+$/, '')
     if (path) paths.add(path)
   }
@@ -70,8 +71,10 @@ describe('llms.txt (MON-261)', () => {
     ['llms.txt', short],
     ['llms-full.txt', full],
   ])('%s only links pages that exist', (_name, text) => {
+    // Route handlers, not pages - they have no page.tsx to resolve to.
+    const NOT_PAGES = ['/sitemap.xml', '/llms.txt', '/llms-full.txt']
     const broken = internalPaths(text).filter(
-      path => path !== '/sitemap.xml' && path !== '/llms-full.txt' && !routeExists(path)
+      path => !NOT_PAGES.includes(path) && !routeExists(path)
     )
     expect(broken).toEqual([])
   })

--- a/frontend/__tests__/app/llms-txt.test.ts
+++ b/frontend/__tests__/app/llms-txt.test.ts
@@ -1,0 +1,113 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import robots from '@/app/robots'
+import { buildLlmsTxt, buildLlmsFullTxt } from '@/lib/llms'
+import { GROUP_ENTRIES } from '@/lib/groups'
+import { THEME_ENTRIES } from '@/lib/themes'
+import { SITE_URL, DATA_ATTRIBUTION } from '@/lib/site'
+
+const APP = join(__dirname, '..', '..', 'src', 'app')
+
+const short = buildLlmsTxt()
+const full = buildLlmsFullTxt()
+
+/**
+ * Does `path` resolve to an app-router page? Route groups (`(liste)`) are
+ * invisible in the URL, and a `[param]` segment matches any literal.
+ */
+function routeExists(path: string): boolean {
+  const segments = path.split('/').filter(Boolean)
+
+  function walk(dir: string, rest: string[]): boolean {
+    if (rest.length === 0 && existsSync(join(dir, 'page.tsx'))) return true
+    const entries = readdirSync(dir, { withFileTypes: true }).filter(e => e.isDirectory())
+    return entries.some(entry => {
+      if (entry.name.startsWith('(')) return walk(join(dir, entry.name), rest)
+      if (rest.length === 0) return false
+      const [head, ...tail] = rest
+      if (entry.name === head || entry.name.startsWith('[')) return walk(join(dir, entry.name), tail)
+      return false
+    })
+  }
+
+  return walk(APP, segments)
+}
+
+/** Every `SITE_URL`-rooted path the file links to. */
+function internalPaths(text: string): string[] {
+  const paths = new Set<string>()
+  for (const match of text.matchAll(new RegExp(`${SITE_URL}(/[^)\\s\`]*)?`, 'g'))) {
+    const path = (match[1] ?? '/').replace(/\/+$/, '')
+    if (path) paths.add(path)
+  }
+  return [...paths]
+}
+
+describe('llms.txt (MON-261)', () => {
+  it.each([
+    ['llms.txt', short],
+    ['llms-full.txt', full],
+  ])('%s states what the site is and how to attribute it', (_name, text) => {
+    expect(text.startsWith('# MonÉlu')).toBe(true)
+    expect(text).toContain('Licence Ouverte 2.0')
+    expect(text).toContain(DATA_ATTRIBUTION)
+    // The caveats a model would otherwise get wrong.
+    expect(text).toContain('nonVotant')
+    expect(text).toContain('1er juillet 2025')
+    expect(text).toContain('Braun-Pivet')
+  })
+
+  it.each([
+    ['llms.txt', short],
+    ['llms-full.txt', full],
+  ])('%s indexes every group and every theme', (_name, text) => {
+    for (const { slug } of GROUP_ENTRIES) expect(text).toContain(`/groupes/${slug}`)
+    for (const { slug } of THEME_ENTRIES) expect(text).toContain(`/themes/${slug}`)
+  })
+
+  // A file whose whole job is to orient a crawler must not point it at 404s.
+  it.each([
+    ['llms.txt', short],
+    ['llms-full.txt', full],
+  ])('%s only links pages that exist', (_name, text) => {
+    const broken = internalPaths(text).filter(
+      path => path !== '/sitemap.xml' && path !== '/llms-full.txt' && !routeExists(path)
+    )
+    expect(broken).toEqual([])
+  })
+
+  // Hardcoding the origin here would reintroduce MON-254 in a file nobody reads.
+  it('derives its own URLs rather than hardcoding a host', () => {
+    const source = readFileSync(join(__dirname, '..', '..', 'src', 'lib', 'llms.ts'), 'utf8')
+    expect(source).not.toMatch(/mon-elu\.vercel\.app|monelu\.fr/)
+  })
+
+  it('llms-full.txt inlines the calculation definitions llms.txt only links to', () => {
+    expect(full).toContain('mart_deputy_scorecard.sql')
+    expect(full).toContain('mart_party_alignment.sql')
+    expect(full.length).toBeGreaterThan(short.length)
+  })
+})
+
+describe('AI-crawler policy (MON-261)', () => {
+  const rules = robots().rules as Array<{ userAgent?: string | string[]; allow?: string | string[] }>
+
+  it('allows every crawler, named or not', () => {
+    for (const rule of rules) expect(rule.allow).toBe('/')
+  })
+
+  // Named entries exist so a later "tighten robots.txt" is a visible deletion
+  // rather than a silent inheritance change.
+  it.each(['GPTBot', 'OAI-SearchBot', 'ChatGPT-User', 'ClaudeBot', 'PerplexityBot', 'Google-Extended', 'CCBot'])(
+    'names %s explicitly',
+    agent => {
+      expect(rules.some(rule => rule.userAgent === agent)).toBe(true)
+    }
+  )
+
+  it('keeps the machine endpoints out for every agent', () => {
+    for (const rule of rules) {
+      expect((rule as { disallow?: string[] }).disallow).toEqual(['/partager', '/~offline'])
+    }
+  })
+})

--- a/frontend/src/app/donnees/page.tsx
+++ b/frontend/src/app/donnees/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { LegalPageLayout, LegalSection } from '@/components/LegalPageLayout'
 import { csvUrl } from '@/lib/api'
-import { canonicalUrl } from '@/lib/site'
+import { canonicalUrl, DATA_ATTRIBUTION } from '@/lib/site'
 
 export const metadata: Metadata = {
   title: 'Données ouvertes - MonÉlu',
@@ -107,7 +107,7 @@ export default function DonneesPage() {
           mentionner la source et la date. Attribution suggérée :
         </p>
         <div style={{ background: 'var(--dp-page-bg)', border: '1px solid var(--dp-border-subtle)', borderRadius: '8px', padding: '14px 18px', fontSize: '14px', color: 'var(--dp-text)', fontFamily: 'monospace' }}>
-          Données : Assemblée nationale, via monelu.fr - Licence Ouverte 2.0
+          {DATA_ATTRIBUTION}
         </div>
         <p style={{ fontSize: '15px', lineHeight: 1.75, color: 'var(--dp-text-secondary)', margin: '10px 0 0' }}>
           Conditions détaillées sur la page <Link href="/licence-donnees" style={{ color: 'var(--dp-text)' }}>Licence des données</Link>.

--- a/frontend/src/app/licence-donnees/page.tsx
+++ b/frontend/src/app/licence-donnees/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import { LegalPageLayout, LegalSection } from '@/components/LegalPageLayout'
-import { canonicalUrl } from '@/lib/site'
+import { canonicalUrl, DATA_ATTRIBUTION } from '@/lib/site'
 
 export const metadata: Metadata = {
   title: 'Licence des données - MonÉlu',
@@ -46,7 +46,7 @@ export default function LicenceDonneesPage() {
           suggérée :
         </p>
         <div style={{ background: 'var(--dp-page-bg)', border: '1px solid var(--dp-border-subtle)', borderRadius: '8px', padding: '14px 18px', fontSize: '14px', color: 'var(--dp-text)', fontFamily: 'monospace' }}>
-          Données : Assemblée nationale, via monelu.fr - Licence Ouverte 2.0
+          {DATA_ATTRIBUTION}
         </div>
       </LegalSection>
 

--- a/frontend/src/app/llms-full.txt/route.ts
+++ b/frontend/src/app/llms-full.txt/route.ts
@@ -1,0 +1,18 @@
+import { buildLlmsFullTxt } from '@/lib/llms'
+
+/**
+ * `/llms-full.txt` (MON-261) - `/llms.txt` with the calculation definitions
+ * from `/methodologie` inlined, so a model gets the formulas behind presence,
+ * alignment and the pour/contre percentages without a second fetch.
+ */
+export const dynamic = 'force-static'
+export const revalidate = 86400
+
+export function GET(): Response {
+  return new Response(buildLlmsFullTxt(), {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+    },
+  })
+}

--- a/frontend/src/app/llms.txt/route.ts
+++ b/frontend/src/app/llms.txt/route.ts
@@ -1,0 +1,19 @@
+import { buildLlmsTxt } from '@/lib/llms'
+
+/**
+ * `/llms.txt` (MON-261) - the orientation an LLM crawler gets before it reads
+ * any page. A route handler rather than a file in `public/` so every absolute
+ * URL in it derives from `SITE_URL`, and so the group/theme index cannot drift
+ * from the maps the rest of the site routes off.
+ */
+export const dynamic = 'force-static'
+export const revalidate = 86400
+
+export function GET(): Response {
+  return new Response(buildLlmsTxt(), {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+    },
+  })
+}

--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -1,11 +1,46 @@
 import type { MetadataRoute } from 'next'
 import { SITE_URL } from '@/lib/site'
 
+/**
+ * AI crawlers named explicitly (MON-261).
+ *
+ * They are already covered by the `*` rule, so listing them changes nothing
+ * today - which is the point. It records the policy as a deliberate yes
+ * instead of an inherited default, so a later "let's tighten robots.txt" does
+ * not silently delist a public-interest open-data site from AI answers. This
+ * is Licence Ouverte 2.0 data whose whole purpose is to be reused; being
+ * quotable by an assistant is distribution, not leakage.
+ *
+ * `Google-Extended` is the one with a distinct effect: it governs Gemini and
+ * AI Overviews eligibility separately from Googlebot, so it is worth an
+ * explicit entry rather than an inherited one.
+ */
+const AI_CRAWLERS = [
+  'GPTBot',
+  'OAI-SearchBot',
+  'ChatGPT-User',
+  'ClaudeBot',
+  'Claude-User',
+  'Claude-SearchBot',
+  'PerplexityBot',
+  'Perplexity-User',
+  'Google-Extended',
+  'Applebot-Extended',
+  'CCBot',
+  'Bytespider',
+  'meta-externalagent',
+]
+
+// /partager (share-target redirect) and /~offline (SW fallback) are
+// machine endpoints, not content pages.
+const DISALLOW = ['/partager', '/~offline']
+
 export default function robots(): MetadataRoute.Robots {
   return {
-    // /partager (share-target redirect) and /~offline (SW fallback) are
-    // machine endpoints, not content pages.
-    rules: { userAgent: '*', allow: '/', disallow: ['/partager', '/~offline'] },
+    rules: [
+      { userAgent: '*', allow: '/', disallow: DISALLOW },
+      ...AI_CRAWLERS.map(userAgent => ({ userAgent, allow: '/', disallow: DISALLOW })),
+    ],
     sitemap: `${SITE_URL}/sitemap.xml`,
   }
 }

--- a/frontend/src/lib/llms.ts
+++ b/frontend/src/lib/llms.ts
@@ -183,6 +183,7 @@ ${list([
 
   return [
     header(),
+    `*Version longue de [/llms.txt](${SITE_URL}/llms.txt) : le même fichier, avec les définitions de calcul de /methodologie inlinées.*`,
     caveats(),
     definitions,
     machineReadable(),

--- a/frontend/src/lib/llms.ts
+++ b/frontend/src/lib/llms.ts
@@ -1,0 +1,193 @@
+import { SITE_URL, DATA_ATTRIBUTION } from '@/lib/site'
+import { THEME_ENTRIES } from '@/lib/themes'
+import { GROUP_ENTRIES } from '@/lib/groups'
+
+/**
+ * `/llms.txt` and `/llms-full.txt` (MON-261).
+ *
+ * `robots.ts` lets every AI crawler in, but permission is not orientation: a
+ * model arriving on a deputy page has to infer from raw HTML which chamber,
+ * which legislature, what `nonVotant` means, and that the data is freely
+ * reusable. `llms.txt` is the emerging convention for saying it outright, in
+ * the one format a model reads first.
+ *
+ * Written in French, like the rest of the site - the corpus it describes is
+ * French, and the terms of art (`nonVotant`, "scrutin", "Licence Ouverte")
+ * have no lossless English equivalent.
+ *
+ * Everything absolute is derived: `SITE_URL` for our own pages,
+ * `API_BASE` for the REST surface, and the group/theme maps for the index,
+ * so a new group or theme cannot silently fall out of the file.
+ */
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'https://monelu-production.up.railway.app'
+
+const REPO = 'https://github.com/Walid-peach/MonElu'
+
+/** The caveats that change how a number should be read. Shared by both files. */
+const CAVEATS = [
+  '`nonVotant` n\'est pas `abstention`. Un non-votant était présent dans l\'hémicycle sans exprimer de vote ; une abstention est une position exprimée. Les pourcentages pour/contre/abstention se calculent sur les seules positions exprimées.',
+  'Le taux de présence compte le `nonVotant` comme présent, et son dénominateur est limité aux scrutins tenus pendant le mandat du député - un député élu en cours de législature n\'est pas pénalisé pour les votes antérieurs.',
+  'Yaël Braun-Pivet affiche 100 % de présence parce qu\'elle préside l\'Assemblée et figure sur chaque scrutin par construction des données source. Ce n\'est pas une performance, et ce n\'est pas une anomalie.',
+  'La base de production couvre les scrutins depuis le **1er juillet 2025**. La XVIIe législature a commencé le 7 juillet 2024 ; l\'historique antérieur existe en développement mais n\'est pas servi ici.',
+  'L\'alignement de groupe compare tout l\'historique d\'un député à son groupe **actuel**, même s\'il en a changé en cours de mandat.',
+  'Le résultat d\'un scrutin (adopté / rejeté) est repris tel quel de l\'Assemblée nationale, jamais recalculé.',
+  'Le compteur « députés suivis » dépasse 577 : il dénombre toutes les personnes ayant siégé depuis le début de la législature, remplacements compris.',
+  'Les résumés en langage clair et les réponses de l\'assistant sont générés par un LLM. Ce sont des aides à la lecture, pas des sources - le scrutin d\'origine fait foi.',
+]
+
+const SECTIONS: Array<{ path: string; what: string }> = [
+  { path: '/deputes', what: 'Annuaire des députés ; chaque fiche porte sa scorecard (présence, alignement, dissidence) et son historique de vote.' },
+  { path: '/deputes/tableau', what: 'Toutes les scorecards dans un tableau triable, sur un écran.' },
+  { path: '/deputes/comparer', what: 'Comparaison de deux députés scrutin par scrutin.' },
+  { path: '/votes', what: 'Tous les scrutins, filtrables par thème et par résultat ; chaque fiche liste les 577 positions.' },
+  { path: '/mon-depute', what: 'Trouver son député à partir de son code postal.' },
+  { path: '/quiz', what: 'Quiz de positionnement : vos réponses comparées aux votes réellement enregistrés.' },
+  { path: '/chat', what: 'Recherche sémantique (RAG) sur le corpus législatif, réponses sourcées par scrutin.' },
+  { path: '/methodologie', what: 'Comment chaque chiffre est calculé, avec le code source qui l\'implémente.' },
+  { path: '/donnees', what: 'Exports CSV, format des fichiers, fraîcheur.' },
+  { path: '/developpeurs', what: 'Documentation de l\'API REST.' },
+  { path: '/licence-donnees', what: 'Conditions de réutilisation.' },
+  { path: '/a-propos', what: 'Le projet, ses sources et ses partis pris.' },
+]
+
+function list(lines: string[]): string {
+  return lines.map(line => `- ${line}`).join('\n')
+}
+
+function header(): string {
+  return `# MonÉlu
+
+> Le registre complet des votes des députés de l'Assemblée nationale française, XVIIe législature (depuis le 7 juillet 2024). Chaque scrutin, chaque député, chaque position - en français clair, avec la méthode de calcul publiée et les données brutes téléchargeables. Site : ${SITE_URL}
+
+MonÉlu ingère quotidiennement l'open data de l'Assemblée nationale, en dérive des statistiques de présence et d'alignement de groupe, et les expose sur des pages publiques, via une API REST et en CSV. Le projet ne produit aucune donnée de vote : il structure et redistribue celle de l'Assemblée.`
+}
+
+function caveats(): string {
+  return `## À savoir avant de citer un chiffre
+
+${list(CAVEATS)}`
+}
+
+function machineReadable(): string {
+  return `## Surfaces lisibles par une machine
+
+- [Plan du site](${SITE_URL}/sitemap.xml) : toutes les URL indexables.
+- [Spécification OpenAPI](${API_BASE}/openapi.json) de l'API REST publique, et sa [documentation interactive](${API_BASE}/docs).
+- CSV - scorecard de tous les députés : \`GET ${API_BASE}/deputies/scorecard.csv\`
+- CSV - historique de vote d'un député : \`GET ${API_BASE}/deputies/{deputy_id}/votes.csv\`
+- CSV - positions des 577 députés sur un scrutin : \`GET ${API_BASE}/votes/{vote_id}/positions.csv\`
+- [Méthodologie](${SITE_URL}/methodologie) : la définition de chaque statistique.
+- [Lineage dbt](https://walid-peach.github.io/MonElu/dbt-docs/) : le graphe de transformation des données.
+- [Code source](${REPO}) : ingestion, transformations et API.
+
+L'API est soumise à un rate-limiting (30 req/min, 10 req/min sur la recherche et les scorecards). Les colonnes des exports CSV sont documentées sur [/donnees](${SITE_URL}/donnees).`
+}
+
+function licence(): string {
+  return `## Licence et attribution
+
+Données réutilisables librement, y compris commercialement, sous **Licence Ouverte 2.0 (Etalab)** - la même licence que les sources officielles. La seule obligation est de mentionner la source et la date. Attribution attendue :
+
+\`\`\`
+${DATA_ATTRIBUTION}
+\`\`\`
+
+Le code source de la plateforme est distribué séparément sur GitHub, sous sa propre licence.`
+}
+
+function sections(): string {
+  return `## Sections
+
+${list(SECTIONS.map(s => `[${s.path}](${SITE_URL}${s.path}) : ${s.what}`))}
+
+### Groupes parlementaires
+
+${list(GROUP_ENTRIES.map(g => `[${g.name}](${SITE_URL}/groupes/${g.slug})`))}
+
+### Thèmes
+
+${list(THEME_ENTRIES.map(t => `[${t.name}](${SITE_URL}/themes/${t.slug})`))}
+
+### Départements
+
+Une page par département ayant des députés en exercice, à \`${SITE_URL}/departements/{code INSEE}\` (ex. \`/departements/75\`, \`/departements/2A\`). La liste exhaustive est dans le [plan du site](${SITE_URL}/sitemap.xml).`
+}
+
+function contact(): string {
+  return `## Contact
+
+Une erreur ou une incohérence : walidelkhoukh99@gmail.com, en précisant le député, le scrutin ou la page concernée.`
+}
+
+/** The short orientation file served at `/llms.txt`. */
+export function buildLlmsTxt(): string {
+  return [
+    header(),
+    caveats(),
+    machineReadable(),
+    licence(),
+    sections(),
+    `## Aller plus loin\n\n[/llms-full.txt](${SITE_URL}/llms-full.txt) reprend ce fichier en y inlinant les définitions de calcul, pour éviter une seconde requête vers /methodologie.`,
+    contact(),
+  ].join('\n\n')
+}
+
+/**
+ * The long form served at `/llms-full.txt`: the same file with the
+ * calculation definitions inlined, so a model gets the formulas without a
+ * second fetch to `/methodologie`.
+ */
+export function buildLlmsFullTxt(): string {
+  const definitions = `## Définitions de calcul
+
+### Taux de présence
+
+Numérateur : les scrutins où une position du député est enregistrée, quelle qu'elle soit - \`pour\`, \`contre\`, \`abstention\` **ou** \`nonVotant\`. Dénominateur : les scrutins tenus entre la date de début et, le cas échéant, la date de fin de son mandat. C'est l'unique définition utilisée par le site, l'API et l'assistant.
+
+Source : \`transform/models/marts/mart_deputy_scorecard.sql\`.
+
+### Alignement de groupe et dissidence
+
+Pour chaque scrutin, la position majoritaire du groupe est calculée sur les positions exprimées (les \`nonVotant\` ne comptent pas). Un vote est dit dissident lorsque la position du député en diffère. En cas d'égalité stricte entre deux positions, le départage suit une règle déterministe écrite dans le code plutôt que l'ordre de retour de la base.
+
+Limite : la comparaison se fait avec le groupe **actuel** du député, pas celui auquel il appartenait au moment du vote.
+
+Source : \`transform/models/marts/mart_party_alignment.sql\`, \`transform/models/intermediate/int_party_vote_majority.sql\`.
+
+### Pourcentages pour / contre / abstention
+
+Calculés sur les seules positions exprimées, \`nonVotant\` exclu de ce calcul-là mais inclus dans la présence.
+
+### Résultat d'un scrutin
+
+Repris tel quel du champ officiel publié par l'Assemblée nationale. La XVIIe législature n'ayant pas de majorité stable, les scrutins rejetés y sont plus nombreux que les adoptés.
+
+Source : \`transform/models/staging/stg_votes.sql\`.
+
+### Quiz de positionnement
+
+Les réponses de l'utilisateur sont comparées aux positions réellement enregistrées des députés sur des scrutins réels. Le calcul est sans état : rien n'est conservé ni journalisé, sauf partage explicite, et un résultat partagé est recalculé côté serveur à partir des réponses soumises.
+
+### Fraîcheur
+
+Ingestion automatique chaque jour ouvré à 06h00 UTC : nouveaux scrutins et fiches de députés, reconstruction de l'index de recherche sémantique, puis recalcul des agrégats (présence, alignement, scorecards).
+
+### Limites connues
+
+${list([
+  'Deux députés sur 577 n\'ont pas de groupe parlementaire actif identifié dans les données source. Cas limite documenté, pas un défaut d\'ingestion.',
+  '`votes.dossier_id` est creux : l\'Assemblée n\'a commencé à renseigner le dossier législatif sur les scrutins qu\'en mars 2026. Les scrutins antérieurs ne sont pas rattachables à un dossier.',
+  'Les résumés en langage clair et les réponses de l\'assistant sont générés par un LLM à partir des données du scrutin. Ils aident à lire, ils ne font pas foi.',
+])}`
+
+  return [
+    header(),
+    caveats(),
+    definitions,
+    machineReadable(),
+    licence(),
+    sections(),
+    contact(),
+  ].join('\n\n')
+}

--- a/frontend/src/lib/site.ts
+++ b/frontend/src/lib/site.ts
@@ -36,3 +36,13 @@ export function canonicalUrl(path = '/'): string {
   if (!trimmed) return SITE_URL
   return `${SITE_URL}${trimmed.startsWith('/') ? trimmed : `/${trimmed}`}`
 }
+
+/**
+ * Attribution line the Licence Ouverte 2.0 asks reusers to print (MON-261).
+ *
+ * Derived from `SITE_HOST` rather than written out, because `/donnees`,
+ * `/licence-donnees` and `/llms.txt` all publish it and a domain move that
+ * updated only some of them would leave the site telling reusers to credit a
+ * host it no longer answers on.
+ */
+export const DATA_ATTRIBUTION = `Données : Assemblée nationale, via ${SITE_HOST} - Licence Ouverte 2.0`


### PR DESCRIPTION
## What and why

`robots.ts` already let every AI crawler in - the right policy for a civic open-data project, and it stays. But permission is not orientation. A model arriving on a deputy page had to infer from raw HTML which chamber this is, which legislature, what `nonVotant` means, that production data starts 2025-07-01, and that everything is Licence Ouverte 2.0. Nothing stated any of it in the form a model reads first.

This adds `/llms.txt` and `/llms-full.txt`, and makes the crawler policy explicit rather than inherited.

## Changes

**`/llms.txt`** (`frontend/src/app/llms.txt/route.ts`, body in `src/lib/llms.ts`)

- One-paragraph description: what MonÉlu is, which chamber, which legislature, since when.
- The caveats that change how a number should be read: `nonVotant` ≠ `abstention`; presence counts `nonVotant` as present and scopes the denominator to the mandate; the 2025-07-01 production horizon; Braun-Pivet's 100% is structural; group alignment compares to the *current* group; results are never recalculated.
- Licence Ouverte 2.0 (Etalab), commercial reuse permitted, attribution required, with the exact attribution string.
- Machine-readable surfaces: `/sitemap.xml`, the API's `/openapi.json` and `/docs`, the three CSV export patterns, `/methodologie`, the dbt lineage docs, the repo.
- An index of every section, all 12 groups, all 10 themes, and the `/departements/{code}` pattern.

**`/llms-full.txt`** - the same file with the calculation definitions from `/methodologie` inlined (presence formula, alignment/dissidence, expressed-positions percentages, result provenance, freshness, known limits), so a model gets the formulas without a second fetch.

Both are **route handlers, not files in `public/`**: every absolute URL derives from `SITE_URL`, and the group/theme index is generated from `GROUP_ENTRIES`/`THEME_ENTRIES`, so a new group or theme cannot silently fall out of the file and a domain move carries them along. Served `text/plain; charset=utf-8`, statically prerendered, `revalidate` 24 h.

**`robots.ts`** - keeps `allow: '/'` for `*` and adds named entries for GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, Claude-User, Claude-SearchBot, PerplexityBot, Perplexity-User, Google-Extended, Applebot-Extended, CCBot, Bytespider and meta-externalagent, all allowing `/` with the same two machine-endpoint disallows. They were already covered by `*`, so nothing changes today - that is the point: it records the permissiveness as deliberate, with the reason in a comment, so a later "let's tighten robots.txt" is a visible deletion rather than a silent delisting. `Google-Extended` is the one entry with a distinct effect - it governs AI Overviews eligibility separately from Googlebot.

**The `monelu.fr` mismatch** (the issue's Note) - `/donnees` and `/licence-donnees` both printed `Données : Assemblée nationale, via monelu.fr - Licence Ouverte 2.0`, a host the site does not serve from. `llms.txt` had to state one string and match them, so the line becomes `DATA_ATTRIBUTION` in `lib/site.ts`, built from `SITE_HOST`. All three now print the same thing, and a domain move carries it - the MON-254 shape.

## Acceptance criteria

| Asked for | How it is met |
|---|---|
| `llms.txt` with a one-paragraph description | `header()` in `src/lib/llms.ts` |
| The data caveats stated plainly | `CAVEATS`, in both files; covers all four the issue names plus three more |
| Licence + exact attribution string | `licence()`, using `DATA_ATTRIBUTION` |
| Links to machine-readable surfaces | `machineReadable()` - sitemap, OpenAPI, three CSVs, methodology, lineage, repo |
| Index of the main sections | `SECTIONS` + generated group/theme/department index |
| Companion `/llms-full.txt` with methodology inlined | `buildLlmsFullTxt()` |
| `robots.ts` keeps `allow: '/'` and names the AI crawlers, with a comment saying why | `AI_CRAWLERS` in `robots.ts` |
| Whatever `llms.txt` states must match the attribution on `/donnees` and `/licence-donnees` | All three read `DATA_ATTRIBUTION` |

The MCP endpoint link is deliberately deferred - MON-259 has not shipped, and pointing `llms.txt` at a 404 is worse than omitting it. It is one line in `machineReadable()` when it lands.

## Test plan

`frontend/__tests__/app/llms-txt.test.ts` (17 cases):

- Both files state what the site is, the licence, the attribution, and each caveat that would otherwise be misread.
- Both index every group and every theme, generated from the same maps the router uses.
- **Both only link pages that exist** - each `SITE_URL`-rooted path is resolved against `src/app`, handling route groups (`(liste)`) and `[param]` segments. This caught four links to hub pages that do not exist (`/groupes`, `/themes`, `/departements`, `/verifier` - the last is a 308 route handler, not a page) before they shipped.
- `src/lib/llms.ts` hardcodes no host (would reintroduce MON-254).
- `robots()` allows `/` on every rule, names the seven crawlers the issue calls out, and keeps `/partager` + `/~offline` disallowed for all of them.

Locally: `npm run lint`, `npm test` (40 suites / 397 tests), `npm run build` all green; `/llms.txt`, `/llms-full.txt` and `/robots.txt` verified in the build output (correct `content-type`, full crawler list, no broken links).

## Deploy risk

None. Three additive static routes, no schema, no env var, no workflow change. No Python touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpqkKFd15yYhcg3bjAxK9e
