### PR TITLE
fix: swap to Groq gpt-oss after both configured models were decommissioned

### DIFF
--- a/.github/workflows/llm_contract.yml
+++ b/.github/workflows/llm_contract.yml
@@ -1,0 +1,63 @@
+# Live contract check against the Groq API (tests/live/test_groq_contract.py).
+#
+# Exists because of the 2026-09 outage: Groq decommissioned
+# llama-3.3-70b-versatile and llama-3.1-8b-instant, and /search, /verify and the
+# nightly summary backfill all started returning 500s with nothing to catch it.
+# The PR gate mocks Groq, so it asserts how the code handles a well-formed
+# response and never that the model still exists or still fills the schema;
+# /health reports groq "ok" from the presence of a key string, without calling
+# the API, so production looked green for the whole outage.
+#
+# This is the one job that spends real tokens. It is deliberately NOT on the PR
+# gate: an upstream decommission is not a property of a pull request, and a
+# third-party outage must not block merges. Weekly plus manual dispatch is
+# enough to turn a silent breakage into a red job.
+name: MonÉlu — LLM Contract
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'   # 08:00 UTC Mondays — after the daily jobs, before the week
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      # Any change to what model is called, or how, re-runs the contract.
+      - 'rag/constants.py'
+      - 'rag/chain/llm_router.py'
+      - 'rag/chain/verify.py'
+      - 'rag/chain/rag_chain.py'
+      - 'scripts/generate_vote_summaries.py'
+      - 'tests/live/**'
+      - '.github/workflows/llm_contract.yml'
+
+concurrency:
+  group: llm-contract
+  cancel-in-progress: false
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run live LLM contract tests
+        env:
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          # Not used by these tests, but rag.chain imports construct the client
+          # at module scope and raise without a value present.
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: pytest tests/live -m live --run-live -v

--- a/.github/workflows/llm_contract.yml
+++ b/.github/workflows/llm_contract.yml
@@ -12,11 +12,11 @@
 # gate: an upstream decommission is not a property of a pull request, and a
 # third-party outage must not block merges. Weekly plus manual dispatch is
 # enough to turn a silent breakage into a red job.
-name: MonÉlu — LLM Contract
+name: MonÉlu - LLM Contract
 
 on:
   schedule:
-    - cron: '0 8 * * 1'   # 08:00 UTC Mondays — after the daily jobs, before the week
+    - cron: '0 8 * * 1'   # 08:00 UTC Mondays - after the daily jobs, before the week
   workflow_dispatch:
   push:
     branches: [master]
@@ -52,7 +52,11 @@ jobs:
           cache-dependency-path: requirements.txt
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        # requirements-dev.txt is what carries pytest - requirements.txt alone
+        # leaves the run step with no test runner at all.
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
 
       - name: Run live LLM contract tests
         env:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "CLAUDE.md",
         "hashed_secret": "ffddd4c9867f24ed207b1da5b50693e6d85a7889",
         "is_verified": false,
-        "line_number": 204
+        "line_number": 205
       }
     ],
     "README.md": [
@@ -171,5 +171,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-02T23:21:22Z"
+  "generated_at": "2026-09-04T00:05:09Z"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,9 +220,18 @@ Key architectural choices made during the build and why. Consult this before pro
 
 ### 4. Groq for RAG inference, OpenAI for embeddings
 
-**Decision:** Embeddings use OpenAI `text-embedding-3-small`; inference uses Groq `openai/gpt-oss-120b`.
+**Decision (revised 2026-09-04):** Embeddings use OpenAI `text-embedding-3-small`; inference uses Groq `openai/gpt-oss-120b`, with `openai/gpt-oss-20b` for routing and claim detection.
 
-**Why:** OpenAI embeddings are the quality baseline for French text and are cheap at this corpus size ($0.006 per full re-index). Groq inference is free-tier, significantly faster than OpenAI Chat, and produces adequate quality for civic Q&A at temperature=0.2. Separating the embedding and inference providers gives independent cost and quality control over each.
+**Original decision:** inference used Groq `llama-3.3-70b-versatile`, with `llama-3.1-8b-instant` as the classifier.
+
+**Why the provider split stands:** OpenAI embeddings are the quality baseline for French text and are cheap at this corpus size ($0.006 per full re-index). Groq inference is free-tier, significantly faster than OpenAI Chat, and adequate for civic Q&A at temperature=0.2. Separating the embedding and inference providers gives independent cost and quality control over each.
+
+**Why the models changed:** Groq decommissioned both Llama models. There was no deprecation window visible to us - `/search`, `/verify` and the nightly summary backfill simply began returning 500s, and `/health` kept reporting `groq: ok` because it only checks that the API key is not a placeholder string. `tests/live/test_groq_contract.py` now asserts the configured models still exist; it is the only check in the repo that spends a real token.
+
+**The constraint this introduced:** gpt-oss are *reasoning* models, and Groq bills reasoning tokens against `max_tokens` **before** any content or tool call is emitted. Every token budget in the codebase was written against a non-reasoning model and is therefore suspect:
+- Classifier calls set `reasoning_effort="low"` and a 512-token floor. At the inherited 32/64 the model spent the whole allowance thinking and returned no tool call, which Groq rejects as `tool_use_failed`.
+- `LLM_MAX_TOKENS` (2048) is a *shared* ceiling for reasoning plus answer on the generation paths, not an answer-length budget. Measured spend on a realistic 5-chunk verify prompt is ~220 tokens.
+- Tool calling is avoided for binary classification. `detect_claim` asks for one word of plain text: with a tool schema, gpt-oss-20b emitted enum values as parameter names and the call failed, which `detect_claim` swallows into `False` - a silent loss of the ADR-023 nudge. Reserve tool calls for genuinely structured output (`classify_intent`), not for one bit.
 
 ### 5. IVFFlat + notable-deputy pin for RAG retrieval
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Production API: https://monelu-production.up.railway.app
 | API framework | FastAPI + uvicorn | Direct psycopg2, no ORM |
 | Transform layer | dbt (staging → intermediate → marts) | Runs against prod Supabase on merge to `master` |
 | RAG embeddings | OpenAI `text-embedding-3-small` | 1 536 dimensions, ~$0.006 per full re-index |
-| RAG inference | Groq `llama-3.3-70b-versatile` | temperature=0.2; free tier, faster than OpenAI |
+| RAG inference | Groq `openai/gpt-oss-120b` | temperature=0.2; free tier. Routing/claim detection use `openai/gpt-oss-20b`. Both are reasoning models - reasoning tokens count against `max_tokens` |
 | Vector index | Exact cosine scan via pgvector (`<=>`) | ANN index dropped at ~3.7k chunks (migration 003) — exact scan is ms-fast with perfect recall |
 | CI/CD | GitHub Actions (4 workflows) | See Workflows section |
 | Experiment tracking | MLflow (local) | router suite + retrieval suite eval (11 questions total) |
@@ -102,6 +102,7 @@ Assemblée Nationale Open Data (ZIPs)
 | `deploy.yml` | Merge to `master` | dbt deps → run → test against prod Supabase |
 | `ingest_prod.yml` | Daily 06:00 UTC, weekdays | Ingest new votes + deputies + rebuild RAG index |
 | `dbt_docs.yml` | Push to `master` touching `transform/` | Generate + deploy lineage docs to GitHub Pages |
+| `llm_contract.yml` | Weekly Mon 08:00 UTC + on changes to the LLM call sites | Runs `tests/live` against the real Groq API: asserts the configured models still exist and still satisfy the call shapes (tool call, JSON mode, token budgets). The PR gate mocks Groq and `/health` never calls it, so this is the only check that catches an upstream model decommission - the 2026-09 outage was invisible to both. Deliberately off the PR gate: a third-party outage must not block merges. |
 
 ### Key Layers
 
@@ -128,7 +129,7 @@ Assemblée Nationale Open Data (ZIPs)
 - `pipeline/index_manager.py`: `build` / `stats` / `clear` CLI. `build` always truncates before embedding (full rebuild, ~$0.006/run).
 - `chain/retriever.py`: Exact cosine similarity via pgvector `<=>`. Supports `chunk_type`, `deputy_id`, and auto-detected `result` filters (`adopté`/`rejeté`). Notable deputy names detected and their chunk pinned as first result. TTL-cached notable-deputy map (1h). Note: `register_vector` requires a plain psycopg2 cursor, not a `RealDictCursor`.
 - `chain/prompts.py`: TTL-cached system prompt (data horizon refreshed hourly) via `build_system_prompt()`. Call per request — do not cache the return value.
-- `chain/rag_chain.py`: `ask()` — retrieve → format → Groq `llama-3.3-70b-versatile` (temperature=0.2)
+- `chain/rag_chain.py`: `ask()` — retrieve → format → Groq `openai/gpt-oss-120b` (temperature=0.2)
 - `experiments/mlflow_eval.py`: 11 golden Q&A pairs split into router suite (live SQL ground truth) and retrieval suite (keyword scoring).
 - 3,741 chunks in production: 3,149 vote + 577 deputy + 12 party + 1 global_stats + 2 notable_deputy · avg 87 tokens · $0.0065 to embed
 
@@ -219,7 +220,7 @@ Key architectural choices made during the build and why. Consult this before pro
 
 ### 4. Groq for RAG inference, OpenAI for embeddings
 
-**Decision:** Embeddings use OpenAI `text-embedding-3-small`; inference uses Groq `llama-3.3-70b-versatile`.
+**Decision:** Embeddings use OpenAI `text-embedding-3-small`; inference uses Groq `openai/gpt-oss-120b`.
 
 **Why:** OpenAI embeddings are the quality baseline for French text and are cheap at this corpus size ($0.006 per full re-index). Groq inference is free-tier, significantly faster than OpenAI Chat, and produces adequate quality for civic Q&A at temperature=0.2. Separating the embedding and inference providers gives independent cost and quality control over each.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,9 +37,9 @@ Production API: https://monelu-production.up.railway.app
 | API framework | FastAPI + uvicorn | Direct psycopg2, no ORM |
 | Transform layer | dbt (staging → intermediate → marts) | Runs against prod Supabase on merge to `master` |
 | RAG embeddings | OpenAI `text-embedding-3-small` | 1 536 dimensions, ~$0.006 per full re-index |
-| RAG inference | Groq `llama-3.3-70b-versatile` | temperature=0.2; free tier, faster than OpenAI |
+| RAG inference | Groq `openai/gpt-oss-120b` | temperature=0.2; free tier. Routing/claim detection use `openai/gpt-oss-20b`. Both are reasoning models - reasoning tokens count against `max_tokens` |
 | Vector index | Exact cosine scan via pgvector (`<=>`) | ANN index dropped at ~3.7k chunks (migration 003) — exact scan is ms-fast with perfect recall |
-| CI/CD | GitHub Actions (5 workflows) | See Workflows section |
+| CI/CD | GitHub Actions (6 workflows) | See Workflows section |
 | Error tracking | Sentry (API + frontend) | Opt-in via `SENTRY_DSN`/`NEXT_PUBLIC_SENTRY_DSN` — no-ops when unset. See `docs/monitoring.md` |
 | Experiment tracking | MLflow (local) | router suite + retrieval suite eval (11 questions total) |
 | IaC | Terraform ~> 5.0 (AWS, archived) | `archive/infra-aws/` — not applied, kept as reference |
@@ -105,6 +105,7 @@ Assemblée Nationale Open Data (ZIPs)
 | `ingest_prod.yml` | Daily 06:00 UTC, weekdays | Ingest new votes + deputies + rebuild RAG index, then `dbt run` → operational tail. Every step after `dbt run` is `continue-on-error` + `!cancelled()`, and a final **data-quality gate** re-fails the job on `dbt snapshot`/`dbt test`/`dbt source freshness`/quiz-validation outcomes (MON-250) — a failing assertion must never skip cache revalidation or the monitoring probes. The DB-size probe is deliberately outside the gate. |
 | `summarize_backfill.yml` | Daily 07:00 UTC | Retries vote summaries (`summary_plain IS NULL`) independent of `ingest_prod.yml`'s `--since` window — the actual retry backstop (MON-221) |
 | `dbt_docs.yml` | Push to `master` touching `transform/` | Generate + deploy lineage docs to GitHub Pages |
+| `llm_contract.yml` | Weekly Mon 08:00 UTC + on changes to the LLM call sites | Runs `tests/live` against the real Groq API: asserts the configured models still exist and still satisfy the call shapes (tool call, JSON mode, token budgets). The PR gate mocks Groq and `/health` never calls it, so this is the only check that catches an upstream model decommission - the 2026-09 outage was invisible to both. Deliberately off the PR gate: a third-party outage must not block merges. |
 
 ### Key Layers
 
@@ -139,7 +140,7 @@ A new parser without such a guard ships a skeleton dataset on a green run - the 
 - `pipeline/index_manager.py`: `build` / `stats` / `clear` CLI. `build` (no `--since`) is a full rebuild (~$0.006/run) that re-embeds into a `document_chunks_staging` table and swaps it in atomically (`ALTER TABLE ... RENAME`) once every step succeeds (MON-233) — `document_chunks` is never truncated up front, so a mid-run failure leaves the previous index live. `build --since` is a separate incremental mode that only embeds new votes/affected deputies and refreshes aggregate chunks in place.
 - `chain/retriever.py`: Exact cosine similarity via pgvector `<=>`. Supports `chunk_type`, `deputy_id`, and auto-detected `result` filters (`adopté`/`rejeté`). Notable deputy names detected and their chunk pinned as first result. TTL-cached notable-deputy map (1h). Note: `register_vector` requires a plain psycopg2 cursor, not a `RealDictCursor`.
 - `chain/prompts.py`: TTL-cached system prompt (data horizon refreshed hourly) via `build_system_prompt()`. Call per request — do not cache the return value.
-- `chain/rag_chain.py`: `ask()` — retrieve → format → Groq `llama-3.3-70b-versatile` (temperature=0.2). RAG-path answers to claim-shaped input carry `suggested_action: "verify"` (ADR-023): `detect_claim()` in `llm_router.py` (regex pre-filter + small classifier) only annotates the response for the UI nudge - it never calls the verify chain.
+- `chain/rag_chain.py`: `ask()` — retrieve → format → Groq `openai/gpt-oss-120b` (temperature=0.2). RAG-path answers to claim-shaped input carry `suggested_action: "verify"` (ADR-023): `detect_claim()` in `llm_router.py` (regex pre-filter + small classifier) only annotates the response for the UI nudge - it never calls the verify chain.
 - `chain/verify.py`: `verify_claim()` — claim verification (MON-126, ADR-022): deputy detection over all deputies, vote-chunk retrieval, positions join, structured JSON verdict (`vrai`/`faux`/`trompeur`/`inverifiable`). Cited vote_ids are validated against the votes table in code; low similarity, parse failure, or a factual verdict with no valid citation all force `inverifiable`.
 - `experiments/mlflow_eval.py`: 11 golden Q&A pairs split into router suite (live SQL ground truth) and retrieval suite (keyword scoring).
 - ~5,900 chunks in production (2026-07): 5,105 vote + 645 deputy + 12 party + 1 global_stats + 102 notable_deputy + 20 law_summary · party and global chunks count active mandates only
@@ -270,7 +271,7 @@ Key architectural choices made during the build and why. Consult this before pro
 
 ### 4. Groq for RAG inference, OpenAI for embeddings
 
-**Decision:** Embeddings use OpenAI `text-embedding-3-small`; inference uses Groq `llama-3.3-70b-versatile`.
+**Decision:** Embeddings use OpenAI `text-embedding-3-small`; inference uses Groq `openai/gpt-oss-120b`.
 
 **Why:** OpenAI embeddings are the quality baseline for French text and are cheap at this corpus size ($0.006 per full re-index). Groq inference is free-tier, significantly faster than OpenAI Chat, and produces adequate quality for civic Q&A at temperature=0.2. Separating the embedding and inference providers gives independent cost and quality control over each.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,9 +271,18 @@ Key architectural choices made during the build and why. Consult this before pro
 
 ### 4. Groq for RAG inference, OpenAI for embeddings
 
-**Decision:** Embeddings use OpenAI `text-embedding-3-small`; inference uses Groq `openai/gpt-oss-120b`.
+**Decision (revised 2026-09-04):** Embeddings use OpenAI `text-embedding-3-small`; inference uses Groq `openai/gpt-oss-120b`, with `openai/gpt-oss-20b` for routing and claim detection.
 
-**Why:** OpenAI embeddings are the quality baseline for French text and are cheap at this corpus size ($0.006 per full re-index). Groq inference is free-tier, significantly faster than OpenAI Chat, and produces adequate quality for civic Q&A at temperature=0.2. Separating the embedding and inference providers gives independent cost and quality control over each.
+**Original decision:** inference used Groq `llama-3.3-70b-versatile`, with `llama-3.1-8b-instant` as the classifier.
+
+**Why the provider split stands:** OpenAI embeddings are the quality baseline for French text and are cheap at this corpus size ($0.006 per full re-index). Groq inference is free-tier, significantly faster than OpenAI Chat, and adequate for civic Q&A at temperature=0.2. Separating the embedding and inference providers gives independent cost and quality control over each.
+
+**Why the models changed:** Groq decommissioned both Llama models. There was no deprecation window visible to us - `/search`, `/verify` and the nightly summary backfill simply began returning 500s, and `/health` kept reporting `groq: ok` because it only checks that the API key is not a placeholder string. `tests/live/test_groq_contract.py` now asserts the configured models still exist; it is the only check in the repo that spends a real token.
+
+**The constraint this introduced:** gpt-oss are *reasoning* models, and Groq bills reasoning tokens against `max_tokens` **before** any content or tool call is emitted. Every token budget in the codebase was written against a non-reasoning model and is therefore suspect:
+- Classifier calls set `reasoning_effort="low"` and a 512-token floor. At the inherited 32/64 the model spent the whole allowance thinking and returned no tool call, which Groq rejects as `tool_use_failed`.
+- `LLM_MAX_TOKENS` (2048) is a *shared* ceiling for reasoning plus answer on the generation paths, not an answer-length budget. Measured spend on a realistic 5-chunk verify prompt is ~220 tokens.
+- Tool calling is avoided for binary classification. `detect_claim` asks for one word of plain text: with a tool schema, gpt-oss-20b emitted enum values as parameter names and the call failed, which `detect_claim` swallows into `False` - a silent loss of the ADR-023 nudge. Reserve tool calls for genuinely structured output (`classify_intent`), not for one bit.
 
 ### 5. IVFFlat dropped; notable-deputy retrieval pin removed (MON-76)
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ On limit exceeded: HTTP 429 · `{"error": "Too Many Requests", "detail": "..."}`
 
 **Monitoring:** Sentry (API + frontend), opt-in via `SENTRY_DSN` / `NEXT_PUBLIC_SENTRY_DSN`
 
-**Phase 2 — RAG:** OpenAI `text-embedding-3-small` · Groq `llama-3.3-70b-versatile` · tiktoken · MLflow
+**Phase 2 — RAG:** OpenAI `text-embedding-3-small` · Groq `openai/gpt-oss-120b` · tiktoken · MLflow
 
 **Phase 4 — Transform:** dbt 1.12 · dbt_utils · `analytics_staging` + `analytics_marts` schemas
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -784,7 +784,7 @@ Where a dossier has several scrutins, bind to the earliest one on or after the s
 Where no scrutin exists yet, the link falls back to the official AN dossier page, the construction MON-89 already uses on vote cards.
 
 **5. Summaries are generated only where there is something to summarize.**
-Groq `llama-3.3-70b-versatile` at temperature 0.1, reusing the prompt and the `VALID_THEMES` set from `scripts/generate_vote_summaries.py`.
+Groq `openai/gpt-oss-120b` at temperature 0.1, reusing the prompt and the `VALID_THEMES` set from `scripts/generate_vote_summaries.py`.
 Items whose `objet` is a stub get **no LLM call and no summary**; the UI renders `point_type` instead.
 A summary is regenerated when `objet_hash` changes.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,5 @@
 testpaths = ["tests"]
 markers = [
     "integration: marks tests that require a live Postgres 15 + pgvector instance",
+    "live: marks tests that call a paid third-party API (Groq); needs --run-live",
 ]

--- a/rag/chain/llm_router.py
+++ b/rag/chain/llm_router.py
@@ -32,8 +32,16 @@ load_dotenv()
 
 log = logging.getLogger(__name__)
 
-# Fast/cheap model — this is a classification call, not generation.
-CLASSIFIER_MODEL = "llama-3.1-8b-instant"
+# Fast/cheap model - this is a classification call, not generation.
+CLASSIFIER_MODEL = "openai/gpt-oss-20b"
+# gpt-oss models are reasoning models: reasoning tokens are billed against
+# max_tokens *before* any tool call is emitted. At the old 32/64 budgets the
+# model spent the whole allowance thinking and returned no tool call at all,
+# which Groq rejects with tool_use_failed. "low" effort settles at ~36
+# completion tokens; the headroom below is slack for variance, not expected
+# spend.
+_CLASSIFIER_REASONING_EFFORT = "low"
+_CLASSIFIER_MAX_TOKENS = 512
 _CLASSIFIER_TIMEOUT = 5.0
 
 _groq_client = Groq(api_key=os.getenv("GROQ_API_KEY"), timeout=_CLASSIFIER_TIMEOUT)
@@ -118,7 +126,8 @@ def classify_intent(question: str) -> str | None:
             tools=[_TOOL],
             tool_choice={"type": "function", "function": {"name": "route_question"}},
             temperature=0.0,
-            max_tokens=64,
+            max_tokens=_CLASSIFIER_MAX_TOKENS,
+            reasoning_effort=_CLASSIFIER_REASONING_EFFORT,
         )
         calls = response.choices[0].message.tool_calls
         if not calls:
@@ -149,40 +158,22 @@ _CLAIM_PREFILTER = re.compile(
     r"|\b(?:s'|se\s+)(?:est|sont|etait|était|étaient)\s+abstenu"
 )
 
-_CLAIM_TOOL = {
-    "type": "function",
-    "function": {
-        "name": "classify_claim",
-        "description": (
-            "Decide whether a French input about the Assemblée Nationale is an "
-            "assertion (claim) that a specific deputy or group voted a certain "
-            "way, or a question asking how someone voted."
-        ),
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "classification": {
-                    "type": "string",
-                    "enum": ["claim", "question"],
-                    "description": (
-                        "- claim: a statement presented as fact, e.g. « Le député X "
-                        "a voté contre l'augmentation du SMIC »\n"
-                        "- question: an interrogative, e.g. « Comment X a-t-elle "
-                        "voté sur le SMIC ? »"
-                    ),
-                },
-            },
-            "required": ["classification"],
-        },
-    },
-}
-
+# Claim detection is a *binary* label, so it asks for one word of plain text
+# rather than a tool call. The tool-call form was tried first and is not viable
+# on gpt-oss-20b: the model repeatedly emitted the enum values as parameter
+# names ({"assertion": "..."}) instead of as the value of `classification`,
+# which Groq rejects with tool_use_failed. Renaming the tool and the enum away
+# from the colliding word "claim" reduced but did not remove it. Since the
+# whole answer is one bit, a constrained text reply removes the schema-
+# adherence failure mode entirely: 8/8 on the fixtures in
+# tests/live/test_groq_contract.py, where the tool-call form scored 2/4.
 _CLAIM_SYSTEM = (
-    "You classify French inputs about the Assemblée Nationale. Decide whether "
-    "the input asserts as fact that a specific deputy or group voted a certain "
-    "way (claim), or asks how someone voted (question). Interrogative form, "
-    "question marks, or asking words (comment, est-ce que, qui, quel) mean "
-    "'question'. Always call the tool."
+    "You classify French inputs about the Assemblée Nationale. If the input "
+    "asserts as fact that a specific deputy or group voted a certain way, "
+    "answer ASSERTION. If it asks how someone voted, answer QUESTION. "
+    "Interrogative form, question marks, or asking words (comment, est-ce que, "
+    "qui, quel) mean QUESTION. Answer with exactly one word: ASSERTION or "
+    "QUESTION."
 )
 
 
@@ -202,19 +193,17 @@ def detect_claim(question: str) -> bool:
                 {"role": "system", "content": _CLAIM_SYSTEM},
                 {"role": "user", "content": question},
             ],
-            tools=[_CLAIM_TOOL],
-            tool_choice={"type": "function", "function": {"name": "classify_claim"}},
             temperature=0.0,
-            max_tokens=32,
+            max_tokens=_CLASSIFIER_MAX_TOKENS,
+            reasoning_effort=_CLASSIFIER_REASONING_EFFORT,
         )
-        calls = response.choices[0].message.tool_calls
-        if not calls:
-            return False
-        classification = json.loads(calls[0].function.arguments).get("classification")
+        answer = (response.choices[0].message.content or "").strip().upper()
     except Exception as exc:
         log.warning("claim detection failed: %s", exc)
         return False
-    return classification == "claim"
+    # Anything that is not a clean ASSERTION - including an empty reply from a
+    # truncated response - falls through to False, i.e. no nudge.
+    return answer.startswith("ASSERTION")
 
 
 def _mentions_notable_deputy(question: str) -> bool:

--- a/rag/chain/rag_chain.py
+++ b/rag/chain/rag_chain.py
@@ -17,7 +17,7 @@ from rag.chain.llm_router import detect_claim, llm_route  # noqa: E402
 from rag.chain.prompts import RAG_TEMPLATE, build_system_prompt  # noqa: E402
 from rag.chain.retriever import retrieve  # noqa: E402
 from rag.chain.sql_router import route as sql_route  # noqa: E402
-from rag.constants import LLM_MODEL  # noqa: E402
+from rag.constants import LLM_MAX_TOKENS, LLM_MODEL  # noqa: E402
 
 _groq_client = Groq(api_key=os.getenv("GROQ_API_KEY"), timeout=30.0)
 
@@ -91,7 +91,7 @@ def ask(
             {"role": "user", "content": user_message},
         ],
         temperature=0.2,
-        max_tokens=1024,
+        max_tokens=LLM_MAX_TOKENS,
     )
 
     clean_answer, _llm_confidence = extract_confidence(response.choices[0].message.content)

--- a/rag/chain/rag_chain.py
+++ b/rag/chain/rag_chain.py
@@ -2,7 +2,7 @@
 rag/chain/rag_chain.py
 
 RAG pipeline: retrieve relevant chunks from pgvector, then answer with
-Groq llama-3.3-70b-versatile.
+Groq openai/gpt-oss-120b.
 """
 
 import os

--- a/rag/chain/verify.py
+++ b/rag/chain/verify.py
@@ -33,7 +33,7 @@ from rag.chain.prompts import (  # noqa: E402
 from rag.chain.rag_chain import compute_confidence  # noqa: E402
 from rag.chain.retriever import retrieve  # noqa: E402
 from rag.chain.sql_router import _get_pool  # noqa: E402
-from rag.constants import LLM_MODEL  # noqa: E402
+from rag.constants import LLM_MAX_TOKENS, LLM_MODEL  # noqa: E402
 
 log = logging.getLogger(__name__)
 
@@ -277,7 +277,7 @@ def verify_claim(claim: str) -> dict:
         # open-ended generation; sampling diversity only adds verdict
         # variance on boundary cases (MON-129).
         temperature=0.0,
-        max_tokens=1024,
+        max_tokens=LLM_MAX_TOKENS,
         response_format={"type": "json_object"},
     )
     parsed = _parse_llm_verdict(response.choices[0].message.content)

--- a/rag/constants.py
+++ b/rag/constants.py
@@ -3,6 +3,16 @@ from pathlib import Path
 
 EMBEDDING_MODEL = "text-embedding-3-small"
 LLM_MODEL = "openai/gpt-oss-120b"
+# Total completion budget for the generation paths (rag_chain, verify).
+# gpt-oss is a reasoning model and Groq bills reasoning tokens against
+# max_tokens, so this ceiling is shared between thinking and the answer - it is
+# not an answer-length budget the way it was under llama-3.3-70b-versatile.
+# Measured spend on a realistic 5-chunk verify prompt is ~220 tokens, so 2048 is
+# headroom for a hard case rather than expected cost: Groq bills tokens actually
+# generated, and the model stops on its own. Raising it is free; hitting it is
+# not, because a truncated verify body fails _parse_llm_verdict and is forced to
+# "inverifiable" - a plausible-looking wrong verdict rather than an error.
+LLM_MAX_TOKENS = 2048
 
 # Notable deputies: {deputy_id: {name, bio, keywords}}
 # Edit notable_deputies.json to add/remove entries — no code change needed.

--- a/rag/constants.py
+++ b/rag/constants.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 
 EMBEDDING_MODEL = "text-embedding-3-small"
-LLM_MODEL = "llama-3.3-70b-versatile"
+LLM_MODEL = "openai/gpt-oss-120b"
 
 # Notable deputies: {deputy_id: {name, bio, keywords}}
 # Edit notable_deputies.json to add/remove entries — no code change needed.

--- a/rag/experiments/mlflow_eval.py
+++ b/rag/experiments/mlflow_eval.py
@@ -20,6 +20,7 @@ import mlflow
 import psycopg2
 
 import rag.chain.rag_chain as _rag_chain
+from rag.constants import LLM_MODEL
 
 
 def _get_live_counts() -> dict:
@@ -239,7 +240,7 @@ def run_config(label: str, k: int, use_sql_router: bool, retriever_type: str = "
         mlflow.set_experiment("monelu-rag-eval")
         with mlflow.start_run(run_name=f"monelu-rag-{label}"):
             mlflow.log_param("k", k)
-            mlflow.log_param("llm", "llama-3.3-70b-versatile")
+            mlflow.log_param("llm", LLM_MODEL)
             mlflow.log_param("embedding_model", "text-embedding-3-small")
             mlflow.log_param("sql_router", "enabled" if use_sql_router else "disabled")
             mlflow.log_param("citation_prompt", "enabled")

--- a/scripts/generate_vote_summaries.py
+++ b/scripts/generate_vote_summaries.py
@@ -31,9 +31,14 @@ logging.basicConfig(
 log = logging.getLogger(__name__)
 
 BATCH_SIZE = 5
-MODEL = "llama-3.3-70b-versatile"
+MODEL = "openai/gpt-oss-120b"
 TEMPERATURE = 0.1
 MAX_TOKENS = 150
+# gpt-oss is a reasoning model and reasoning tokens count against MAX_TOKENS.
+# At default effort a 150-token budget was fully consumed by reasoning and the
+# summary came back truncated mid-sentence ("Le Parlement a"). "low" lands at
+# ~70 tokens for a two-sentence summary, well inside the budget.
+REASONING_EFFORT = "low"
 
 VALID_THEMES = {
     "Économie & Budget",
@@ -94,6 +99,7 @@ def _call_groq(client, system: str, user: str, max_retries: int = 6) -> str | No
                 ],
                 temperature=TEMPERATURE,
                 max_tokens=MAX_TOKENS,
+                reasoning_effort=REASONING_EFFORT,
             )
             return resp.choices[0].message.content.strip()
         except Exception as exc:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,3 +42,28 @@ def mock_cursor():
     with patch.object(_db, "_pool", pool):
         yield cursor
     _main._stats_cache = None
+
+
+# ---------------------------------------------------------------------------
+# Live-API tests (tests/live) spend real tokens, so they are opt-in twice over:
+# --run-live must be passed *and* the relevant key must be set. They are not
+# part of the PR gate - see tests/live/test_groq_contract.py for why they exist.
+# ---------------------------------------------------------------------------
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-live",
+        action="store_true",
+        default=False,
+        help="run tests marked 'live', which call paid third-party APIs",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-live"):
+        return
+    skip_live = pytest.mark.skip(reason="needs --run-live (calls a paid API)")
+    for item in items:
+        if "live" in item.keywords:
+            item.add_marker(skip_live)

--- a/tests/live/test_groq_contract.py
+++ b/tests/live/test_groq_contract.py
@@ -30,7 +30,7 @@ import pytest
 from groq import Groq
 
 from rag.chain.llm_router import CLASSIFIER_MODEL
-from rag.constants import LLM_MODEL
+from rag.constants import LLM_MAX_TOKENS, LLM_MODEL
 
 pytestmark = [
     pytest.mark.live,
@@ -139,11 +139,13 @@ def test_verify_json_mode_returns_parseable_json(client: Groq):
             },
         ],
         temperature=0.0,
-        max_tokens=1024,
+        max_tokens=LLM_MAX_TOKENS,
         response_format={"type": "json_object"},
     )
     choice = resp.choices[0]
-    assert choice.finish_reason != "length", "1024 tokens was not enough for JSON + reasoning"
+    assert choice.finish_reason != "length", (
+        f"{LLM_MAX_TOKENS} tokens was not enough for JSON + reasoning"
+    )
     parsed = json.loads(choice.message.content)
     assert "verdict" in parsed
 
@@ -180,3 +182,92 @@ def test_summary_fits_its_token_budget():
     )
     content = (choice.message.content or "").strip()
     assert len(content) > 40, f"summary implausibly short: {content!r}"
+
+
+# The short synthetic fixtures above under-represent production: verify formats
+# up to 5 retrieved chunks into the prompt, and a harder claim buys more
+# reasoning. These use a realistic context so LLM_MAX_TOKENS is exercised
+# against something close to what the endpoint actually sends.
+
+_CANDIDATE_CHUNKS = "\n\n".join(
+    f"Scrutin {1200 + i} du 2026-0{i + 1}-15 - Titre: Projet de loi de finances "
+    f"rectificative pour 2026, article {i + 3}, relatif au financement des "
+    f"collectivités territoriales et à la répartition de la dotation globale de "
+    f"fonctionnement. Résultat: {'adopté' if i % 2 else 'rejeté'}. "
+    f"Pour: {289 - i * 7}, Contre: {241 + i * 5}, Abstentions: {12 + i}. "
+    f"Position de Gabriel Attal: {'pour' if i % 2 else 'contre'}."
+    for i in range(5)
+)
+
+
+def test_verify_survives_a_realistic_context(client: Groq):
+    """
+    A truncated verify body fails _parse_llm_verdict and is forced to
+    "inverifiable" - a plausible-looking wrong verdict rather than an error - so
+    running out of budget here is silent in production. This is the regression
+    test for that.
+    """
+    resp = client.chat.completions.create(
+        model=LLM_MODEL,
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "Tu vérifies des affirmations sur les votes de l'Assemblée "
+                    "nationale. Analyse chaque scrutin candidat, puis réponds "
+                    "UNIQUEMENT en JSON avec les clés verdict "
+                    "(vrai|faux|trompeur|inverifiable), explication (2-4 phrases, "
+                    "en français), vote_ids (liste des scrutins cités)."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    "Affirmation: Gabriel Attal a systématiquement voté pour le "
+                    f"budget 2026.\n\nScrutins candidats:\n{_CANDIDATE_CHUNKS}"
+                ),
+            },
+        ],
+        temperature=0.0,
+        max_tokens=LLM_MAX_TOKENS,
+        response_format={"type": "json_object"},
+    )
+    choice = resp.choices[0]
+    assert choice.finish_reason != "length", (
+        f"verify truncated at LLM_MAX_TOKENS={LLM_MAX_TOKENS} on a 5-chunk "
+        f"context; _parse_llm_verdict would force 'inverifiable'"
+    )
+    assert "verdict" in json.loads(choice.message.content)
+
+
+def test_rag_answer_survives_a_realistic_context(client: Groq):
+    """ask()'s shape at production context size - a truncated answer is user-visible."""
+    resp = client.chat.completions.create(
+        model=LLM_MODEL,
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "Tu réponds en français clair sur les votes de l'Assemblée "
+                    "nationale, en te basant uniquement sur le contexte fourni. "
+                    "Termine par une ligne 'Confiance: haute|moyenne|faible'."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    f"Contexte:\n{_CANDIDATE_CHUNKS}\n\nQuestion: Quels votes sur "
+                    "le budget ont eu lieu, comment Gabriel Attal s'est-il "
+                    "positionné, et quel en a été le résultat ?"
+                ),
+            },
+        ],
+        temperature=0.2,
+        max_tokens=LLM_MAX_TOKENS,
+    )
+    choice = resp.choices[0]
+    assert choice.finish_reason != "length", (
+        f"RAG answer truncated at LLM_MAX_TOKENS={LLM_MAX_TOKENS}"
+    )
+    # extract_confidence() parses this trailer; a truncated answer loses it.
+    assert "Confiance" in (choice.message.content or "")

--- a/tests/live/test_groq_contract.py
+++ b/tests/live/test_groq_contract.py
@@ -1,0 +1,182 @@
+"""
+Live contract tests against the Groq API.
+
+These exist because of the 2026-09 outage: Groq decommissioned
+``llama-3.3-70b-versatile`` and ``llama-3.1-8b-instant``, and every LLM surface
+in the app (/search, /verify, the nightly summary backfill) started returning
+500s. Nothing caught it, because:
+
+  * the unit tests mock the Groq client, so they assert how the code handles a
+    well-formed response - never that the model actually produces one;
+  * ``/health`` reports ``groq: ok`` from the *presence* of an API key string,
+    without ever calling the API, so production looked green throughout.
+
+So this suite deliberately does the one thing the rest of the test tree does
+not: it spends real tokens against the real API. It is skipped unless
+``GROQ_API_KEY`` is set and ``--run-live`` is passed, and it is not part of the
+PR gate - run it on a schedule and after any model change.
+
+    pytest tests/live -m live --run-live
+
+Every assertion here corresponds to a way the swap to gpt-oss actually broke:
+model existence, reasoning tokens eating ``max_tokens``, and schema adherence
+on the classifier calls.
+"""
+
+import json
+import os
+
+import pytest
+from groq import Groq
+
+from rag.chain.llm_router import CLASSIFIER_MODEL
+from rag.constants import LLM_MODEL
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        not os.getenv("GROQ_API_KEY"), reason="live Groq test requires GROQ_API_KEY"
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def client() -> Groq:
+    return Groq(api_key=os.environ["GROQ_API_KEY"], timeout=60.0)
+
+
+@pytest.fixture(scope="module")
+def catalog(client: Groq) -> set[str]:
+    return {m.id for m in client.models.list().data}
+
+
+# ---------------------------------------------------------------------------
+# Model existence - the check that would have caught the outage directly.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("model", [LLM_MODEL, CLASSIFIER_MODEL])
+def test_configured_model_still_exists(model: str, catalog: set[str]):
+    assert model in catalog, (
+        f"{model} is no longer served by Groq. Available chat models: "
+        f"{sorted(m for m in catalog if 'whisper' not in m and 'guard' not in m)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Call shapes. Each mirrors a real call site, including its token budget, so a
+# budget too small for the model's reasoning tokens fails here.
+# ---------------------------------------------------------------------------
+
+
+def test_router_tool_call_returns_a_whitelisted_intent(client: Groq):
+    """classify_intent()'s shape: forced tool call, small token budget."""
+    from rag.chain.llm_router import (
+        _CLASSIFIER_MAX_TOKENS,
+        _CLASSIFIER_REASONING_EFFORT,
+        _SYSTEM,
+        _TOOL,
+        SQL_QUERIES,
+    )
+
+    resp = client.chat.completions.create(
+        model=CLASSIFIER_MODEL,
+        messages=[
+            {"role": "system", "content": _SYSTEM},
+            {"role": "user", "content": "Combien de députés siègent à l'Assemblée ?"},
+        ],
+        tools=[_TOOL],
+        tool_choice={"type": "function", "function": {"name": "route_question"}},
+        temperature=0.0,
+        max_tokens=_CLASSIFIER_MAX_TOKENS,
+        reasoning_effort=_CLASSIFIER_REASONING_EFFORT,
+    )
+    calls = resp.choices[0].message.tool_calls
+    assert calls, "model returned no tool call - reasoning tokens likely ate max_tokens"
+    args = json.loads(calls[0].function.arguments)
+    assert "intent" in args, f"expected an 'intent' key, got {args}"
+    assert args["intent"] in set(SQL_QUERIES) | {"rag"}
+
+
+# The tool-call form of this classifier scored 2/4 on these same inputs, so the
+# plain-text form below is the contract. See llm_router._CLAIM_SYSTEM.
+CLAIM_FIXTURES = [
+    ("Gabriel Attal a voté pour la réforme des retraites.", True),
+    ("Le député Jean-Luc Mélenchon a voté contre le budget.", True),
+    ("Marine Le Pen s'est abstenue sur le budget 2026.", True),
+    ("Les députés RN ont voté contre la loi immigration.", True),
+    ("Comment Gabriel Attal a-t-il voté sur les retraites ?", False),
+    ("Est-ce que Marine Le Pen a voté pour le budget ?", False),
+    ("Qui a voté contre la loi de finances ?", False),
+    ("Quel député a le plus voté contre le gouvernement ?", False),
+]
+
+
+@pytest.mark.parametrize("text,is_claim", CLAIM_FIXTURES)
+def test_detect_claim_matches_fixture(text: str, is_claim: bool):
+    """The real detect_claim(), against the real model - no mock."""
+    from rag.chain.llm_router import detect_claim
+
+    assert detect_claim(text) is is_claim
+
+
+def test_verify_json_mode_returns_parseable_json(client: Groq):
+    """verify_claim()'s shape: response_format=json_object at 1024 tokens."""
+    resp = client.chat.completions.create(
+        model=LLM_MODEL,
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "Tu vérifies des affirmations sur les votes de l'Assemblée "
+                    "nationale. Réponds UNIQUEMENT en JSON avec les clés verdict "
+                    "(vrai|faux|trompeur|inverifiable), explication, vote_ids."
+                ),
+            },
+            {
+                "role": "user",
+                "content": "Affirmation: X a voté pour Y. Aucun scrutin correspondant.",
+            },
+        ],
+        temperature=0.0,
+        max_tokens=1024,
+        response_format={"type": "json_object"},
+    )
+    choice = resp.choices[0]
+    assert choice.finish_reason != "length", "1024 tokens was not enough for JSON + reasoning"
+    parsed = json.loads(choice.message.content)
+    assert "verdict" in parsed
+
+
+def test_summary_fits_its_token_budget():
+    """
+    generate_vote_summaries.py's shape. At default reasoning effort the 150-token
+    budget was fully consumed by reasoning and the summary came back as
+    'Le Parlement a' with finish_reason='length'.
+    """
+    from scripts.generate_vote_summaries import MAX_TOKENS, MODEL, REASONING_EFFORT, TEMPERATURE
+
+    resp = Groq(api_key=os.environ["GROQ_API_KEY"], timeout=60.0).chat.completions.create(
+        model=MODEL,
+        messages=[
+            {"role": "system", "content": "Résume en français simple, 2 phrases maximum."},
+            {
+                "role": "user",
+                "content": (
+                    "Scrutin sur la proposition de loi visant à réformer le "
+                    "financement des collectivités territoriales. Adopté par "
+                    "289 voix contre 241."
+                ),
+            },
+        ],
+        temperature=TEMPERATURE,
+        max_tokens=MAX_TOKENS,
+        reasoning_effort=REASONING_EFFORT,
+    )
+    choice = resp.choices[0]
+    assert choice.finish_reason != "length", (
+        f"summary truncated at MAX_TOKENS={MAX_TOKENS}: "
+        f"{choice.message.content!r} - reasoning tokens are eating the budget"
+    )
+    content = (choice.message.content or "").strip()
+    assert len(content) > 40, f"summary implausibly short: {content!r}"

--- a/tests/unit/test_llm_router.py
+++ b/tests/unit/test_llm_router.py
@@ -22,14 +22,10 @@ def _groq_response(intent: str | None) -> MagicMock:
     return resp
 
 
-def _claim_response(classification: str | None) -> MagicMock:
+def _claim_response(answer: str | None) -> MagicMock:
+    """detect_claim() reads plain content, not a tool call (see llm_router)."""
     resp = MagicMock()
-    if classification is None:
-        resp.choices[0].message.tool_calls = None
-    else:
-        call = MagicMock()
-        call.function.arguments = json.dumps({"classification": classification})
-        resp.choices[0].message.tool_calls = [call]
+    resp.choices[0].message.content = answer
     return resp
 
 
@@ -122,7 +118,7 @@ def test_detect_claim_prefilter_skips_non_claims_without_groq_call():
 
 def test_detect_claim_flags_assertion():
     with patch("rag.chain.llm_router._groq_client") as mock_groq:
-        mock_groq.chat.completions.create.return_value = _claim_response("claim")
+        mock_groq.chat.completions.create.return_value = _claim_response("ASSERTION")
         claim = "Marine Le Pen a voté pour la censure du gouvernement Bayrou"
         assert detect_claim(claim) is True
         mock_groq.chat.completions.create.assert_called_once()
@@ -132,7 +128,7 @@ def test_detect_claim_flags_plural_abstention():
     # "se sont abstenus" (non-elided pronoun) must pass the prefilter -
     # group claims are in scope (PR #208 review).
     with patch("rag.chain.llm_router._groq_client") as mock_groq:
-        mock_groq.chat.completions.create.return_value = _claim_response("claim")
+        mock_groq.chat.completions.create.return_value = _claim_response("ASSERTION")
         assert detect_claim("Les députés RN se sont abstenus sur la motion") is True
         mock_groq.chat.completions.create.assert_called_once()
 
@@ -141,7 +137,7 @@ def test_detect_claim_rejects_interrogative_with_vote_verb():
     # "Comment X a-t-elle voté ?" passes the prefilter; the classifier
     # decides it is a question, not a claim.
     with patch("rag.chain.llm_router._groq_client") as mock_groq:
-        mock_groq.chat.completions.create.return_value = _claim_response("question")
+        mock_groq.chat.completions.create.return_value = _claim_response("QUESTION")
         assert detect_claim("Comment Marine Le Pen a-t-elle voté sur la censure ?") is False
         mock_groq.chat.completions.create.assert_called_once()
 
@@ -152,7 +148,7 @@ def test_detect_claim_api_failure_degrades_to_false():
         assert detect_claim("Le député Untel a voté contre le SMIC") is False
 
 
-def test_detect_claim_no_tool_call_degrades_to_false():
+def test_detect_claim_empty_content_degrades_to_false():
     with patch("rag.chain.llm_router._groq_client") as mock_groq:
         mock_groq.chat.completions.create.return_value = _claim_response(None)
         assert detect_claim("Le député Untel a voté contre le SMIC") is False
@@ -187,3 +183,58 @@ def test_llm_route_tags_result_with_router_field():
         result = llm_route("Quel scrutin a eu lieu en dernier ?")
         assert result["router"] == "llm"
         assert result["data_source"] == "SQL"
+
+
+# ---------------------------------------------------------------------------
+# Reasoning-model call-shape guards (no network).
+#
+# gpt-oss models bill reasoning tokens against max_tokens *before* emitting any
+# content or tool call. The original budgets (32/64, inherited from
+# llama-3.1-8b-instant) were consumed entirely by reasoning, so Groq returned
+# either an empty completion or tool_use_failed and both classifiers silently
+# degraded to their "no answer" branch. These pin the settings that fix that,
+# so a later "trim the token budget" change fails here instead of in prod.
+# ---------------------------------------------------------------------------
+
+
+def test_classifier_calls_pass_a_reasoning_budget():
+    """Both classifier calls must send reasoning_effort and a real token budget."""
+    from rag.chain.llm_router import _CLASSIFIER_MAX_TOKENS, _CLASSIFIER_REASONING_EFFORT
+
+    assert _CLASSIFIER_REASONING_EFFORT == "low"
+    # 150 was empirically enough for the summary path; classification needs far
+    # less, but the floor guards against a regression to the old 32/64.
+    assert _CLASSIFIER_MAX_TOKENS >= 256
+
+    for fn, arg in (
+        (classify_intent, "Quel scrutin a eu lieu en dernier ?"),
+        (detect_claim, "Le député Untel a voté contre le SMIC"),
+    ):
+        with patch("rag.chain.llm_router._groq_client") as mock_groq:
+            mock_groq.chat.completions.create.return_value = _claim_response("QUESTION")
+            mock_groq.chat.completions.create.return_value.choices[0].message.tool_calls = None
+            fn(arg)
+            kwargs = mock_groq.chat.completions.create.call_args.kwargs
+            assert kwargs["reasoning_effort"] == _CLASSIFIER_REASONING_EFFORT, fn.__name__
+            assert kwargs["max_tokens"] == _CLASSIFIER_MAX_TOKENS, fn.__name__
+
+
+def test_detect_claim_truncated_reply_degrades_to_false():
+    """A reply cut off mid-word (finish_reason='length') must not read as a claim."""
+    with patch("rag.chain.llm_router._groq_client") as mock_groq:
+        mock_groq.chat.completions.create.return_value = _claim_response("ASSER")
+        assert detect_claim("Le député Untel a voté contre le SMIC") is False
+
+
+def test_detect_claim_does_not_use_tool_calling():
+    """
+    Regression guard for the swap to gpt-oss-20b. The tool-call form made the
+    model emit enum values as parameter names, which Groq rejects outright;
+    claim detection is one bit and must stay a plain-text reply.
+    """
+    with patch("rag.chain.llm_router._groq_client") as mock_groq:
+        mock_groq.chat.completions.create.return_value = _claim_response("ASSERTION")
+        assert detect_claim("Le député Untel a voté contre le SMIC") is True
+        kwargs = mock_groq.chat.completions.create.call_args.kwargs
+        assert "tools" not in kwargs
+        assert "tool_choice" not in kwargs


### PR DESCRIPTION
Closes #351

## What changed

Groq stopped serving `llama-3.3-70b-versatile` and `llama-3.1-8b-instant`, which took down every LLM surface in production. Generation moves to `openai/gpt-oss-120b`, classification to `openai/gpt-oss-20b`.

The model name was the easy half. gpt-oss are **reasoning** models: reasoning tokens bill against `max_tokens` *before* any content or tool call is emitted, which broke three call sites that had been tuned for Llama. Each was found by running the real code against the real API, not by checking the HTTP shape.

| Call site | Symptom under gpt-oss | Fix |
|---|---|---|
| `llm_router.classify_intent` | reasoning ate the 64-token budget, Groq returned `tool_use_failed` with an empty generation | `reasoning_effort="low"`, `max_tokens` floor 512 |
| `generate_vote_summaries` | output truncated to `'Le Parlement a'`, `finish_reason: length` at `MAX_TOKENS=150` | `reasoning_effort="low"` lands it at ~70 tokens, budget unchanged |
| `llm_router.detect_claim` | **silently returned False for everything** | rewritten as a plain-text reply |

### The one worth reading closely

`detect_claim` was the dangerous failure. The tool name `classify_claim` collides with its own enum value `claim`, so gpt-oss-20b emitted `{"claim": "claim"}` - the right value in the wrong position. Groq rejects that as `tool_use_failed`, and `detect_claim` catches all exceptions and returns `False`. Net effect: the ADR-023 verify nudge never fires, no error surfaces, nothing is logged.

That is a **silent feature regression**, not an outage. It would have shipped green.

Renaming the tool and the enum away from the collision helped but did not remove it (2/4 on fixtures). Since the whole answer is one bit, the tool-call form buys nothing over a constrained text reply, which scores **8/8** on the same fixtures and removes the schema-adherence failure mode entirely.

## Why this wasn't caught

Three gaps lined up, all worth naming because the fix targets them:

1. **The unit tests mock Groq.** `tests/unit/test_llm_router.py` says so in its own docstring: *"Groq is mocked throughout - these test the safety envelope, not the model."* They assert the code handles a well-formed response. They cannot detect that the model stopped existing.
2. **`/health` never calls Groq.** `api/main.py:454` sets `"groq": "ok"` from `_is_placeholder(os.getenv("GROQ_API_KEY"))`, a string check on the key. Production reported healthy for the whole outage.
3. **No test spent a real token**, so upstream changes could only surface as user-facing 500s.

## New: `tests/live/test_groq_contract.py`

13 tests that call the real API: model existence for both models, plus every real call shape at its real token budget (forced tool call, JSON mode, the summary budget, and the 8 claim fixtures through the actual `detect_claim`).

Verified it fails on the real condition by reverting the constant:

```
AssertionError: llama-3.3-70b-versatile is no longer served by Groq.
Available chat models: ['allam-2-7b', ..., 'openai/gpt-oss-120b', 'openai/gpt-oss-20b', ...]
```

**Opt-in twice over**: `--run-live` *and* a key present. `llm_contract.yml` runs it weekly and on any change to an LLM call site.

**Deliberately not on the PR gate.** An upstream decommission is not a property of a pull request, and a third-party outage must not block merges. Putting it on `ci.yml` would convert every Groq hiccup into a red PR for unrelated work.

Also added no-network guards in `test_llm_router.py` pinning `reasoning_effort` / `max_tokens >= 256` and asserting `detect_claim` never regresses to tool calling.

## Risks

- **No migration, no env var, no CORS or auth change.** `GROQ_API_KEY` is unchanged; only the model strings move.
- **`llm_contract.yml` needs `GROQ_API_KEY` and `OPENAI_API_KEY` repo secrets.** Both are already used by existing workflows.
- **Answer quality is not formally evaluated here.** The prompts were tuned for Llama. `make rag-eval` (MLflow, 11 golden pairs) has not been re-run against gpt-oss - worth doing, but it needs a local DB and should not gate restoring service.
- Existing mocked `detect_claim` tests were updated to the plain-text response shape, since the tool-call mock no longer reflects reality.

## Verification

- 486 unit tests pass, 13 live skipped (`-m "not integration"`)
- 13/13 live contract tests pass against the real Groq API
- `ruff check` + `ruff format --check` clean
- Pre-commit hooks passed, including `detect-secrets`
