### PR TITLE
docs: ADR-036 - the share-snapshot corpus is noindex, not merely unlisted (MON-264)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "CLAUDE.md",
         "hashed_secret": "ffddd4c9867f24ed207b1da5b50693e6d85a7889",
         "is_verified": false,
-        "line_number": 221
+        "line_number": 223
       }
     ],
     "README.md": [
@@ -171,5 +171,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-06T18:47:17Z"
+  "generated_at": "2026-09-06T19:14:36Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "CLAUDE.md",
         "hashed_secret": "ffddd4c9867f24ed207b1da5b50693e6d85a7889",
         "is_verified": false,
-        "line_number": 215
+        "line_number": 221
       }
     ],
     "README.md": [
@@ -171,5 +171,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-04T03:14:57Z"
+  "generated_at": "2026-09-06T18:47:17Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,12 @@ The body lives in `src/lib/llms.ts`; `__tests__/app/llms-txt.test.ts` fails if e
 - `robots.ts` names GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, Claude-User, Claude-SearchBot, PerplexityBot, Perplexity-User, Google-Extended, Applebot-Extended, CCBot, Bytespider and meta-externalagent explicitly, all `allow: '/'` (MON-261).
 They are already covered by the `*` rule; listing them records the permissiveness as deliberate - this is Licence Ouverte 2.0 data whose purpose is reuse - so a later "tighten robots.txt" is a visible deletion rather than an inherited default.
 `Google-Extended` is the one entry with a distinct effect: it governs AI Overviews eligibility separately from Googlebot.
+- The share-snapshot routes `/chat/s/[id]`, `/verifier/v/[id]` and `/quiz/s/[id]` are **`noindex`, not merely absent from the sitemap** (ADR-036, MON-264).
+The corpus is user-submitted and unmoderated - anyone can POST a claim or a question and get a permanent MonÉlu-branded URL - and `/quiz/s/*` can additionally carry the sharer's own answers via the ADR-028 `include_answers` opt-in.
+Since `robots.ts` allows every crawler on `/`, sitemap omission is only a discovery hint: one external link makes the page indexable, so each page declares `robots: { index: false, follow: true }` on **every** `generateMetadata` return path, including the early return taken when the snapshot fetch fails.
+Canonicals stay (a `noindex` page still claims its own URL across preview hosts).
+Never add these routes to `sitemap.ts`, and never add `ClaimReview`/`QAPage` or other rich-result markup to them - that is a request to be surfaced, which is what the ADR declines; MON-263 is closed as won't-do on those grounds.
+`frontend/__tests__/app/snapshot-noindex.test.ts` enforces all of it.
 
 **`archive/infra-aws/`** — Archived AWS Terraform IaC (not live)
 - Modeled an Airflow+Spark architecture never built, with no compute for the actual FastAPI app — archived rather than fixed (MON-46). See Phase 5 and decision 1 in the decisions log.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,9 @@ They are already covered by the `*` rule; listing them records the permissivenes
 `Google-Extended` is the one entry with a distinct effect: it governs AI Overviews eligibility separately from Googlebot.
 - The share-snapshot routes `/chat/s/[id]`, `/verifier/v/[id]` and `/quiz/s/[id]` are **`noindex`, not merely absent from the sitemap** (ADR-036, MON-264).
 The corpus is user-submitted and unmoderated - anyone can POST a claim or a question and get a permanent MonÉlu-branded URL - and `/quiz/s/*` can additionally carry the sharer's own answers via the ADR-028 `include_answers` opt-in.
-Since `robots.ts` allows every crawler on `/`, sitemap omission is only a discovery hint: one external link makes the page indexable, so each page declares `robots: { index: false, follow: true }` on **every** `generateMetadata` return path, including the early return taken when the snapshot fetch fails.
+Since `robots.ts` allows every crawler on `/`, sitemap omission is only a discovery hint: one external link makes the page indexable, so each page applies `SNAPSHOT_ROBOTS` (`{ index: false, follow: true }`) on **every** `generateMetadata` return path, including the early return taken when the snapshot fetch fails.
+`SNAPSHOT_ROBOTS` is defined once in `frontend/src/lib/seo.ts` - never re-declare it per route, the same rule `frontend_base_url()` follows on the backend.
+Social sharing is unaffected: unfurlers ignore `noindex`, and the `openGraph`/`twitter` metadata and `opengraph-image` routes are untouched.
 Canonicals stay (a `noindex` page still claims its own URL across preview hosts).
 Never add these routes to `sitemap.ts`, and never add `ClaimReview`/`QAPage` or other rich-result markup to them - that is a request to be surfaced, which is what the ADR declines; MON-263 is closed as won't-do on those grounds.
 `frontend/__tests__/app/snapshot-noindex.test.ts` enforces all of it.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1208,7 +1208,9 @@ The state this replaces was not a decision. `sitemap.ts` omitted the three snaps
 **What is given up:** this is genuinely the only content MonÉlu produces that is natively in the question→grounded-answer-with-citations shape LLM search rewards, and it grows for free as users share. That upside is real and is being declined, deliberately, because it is inseparable from putting unmoderated text under the site's name.
 
 **Impact:**
-- The three snapshot pages set `robots: { index: false, follow: true }` in `generateMetadata`, including on the early-return path taken when the snapshot fetch fails - a `noindex` that disappears when the API is down is not a policy.
+- `SNAPSHOT_ROBOTS` is defined once in `frontend/src/lib/seo.ts` and imported by the three routes, the same single-definition rule `frontend_base_url()` follows on the backend. It is a policy that must be identical everywhere it appears, so it must not be re-declared per route.
+- The three snapshot pages apply it in `generateMetadata`, including on the early-return path taken when the snapshot fetch fails - a `noindex` that disappears when the API is down is not a policy.
+- **Social sharing is unaffected.** `noindex` is a search-engine directive; link unfurlers do not honor it, and the `openGraph`/`twitter` metadata and the `opengraph-image` routes are untouched. A shared link still renders its preview card exactly as before - which is the entire point of these pages. The `opengraph-image.tsx` routes need no directive of their own: image routes carry no robots meta, and image indexing follows the parent page's.
 - `follow: true`, not `false`: the outbound links on these pages point at `/chat`, `/quiz` and vote pages that *should* be crawled. Only the snapshot document itself is withheld.
 - Canonicals stay. A `noindex` page still benefits from claiming its own URL across preview hosts (MON-269), and `canonical.test.ts` continues to require one.
 - `frontend/__tests__/app/snapshot-noindex.test.ts` enforces this: each of the three routes must declare `index: false`, and the list is checked against the real filesystem so a renamed route cannot silently drop out.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1183,6 +1183,42 @@ Building the page on the acte parcours instead costs one extra table and one ext
 
 ---
 
+## ADR-036 - The share-snapshot corpus is noindex, not merely unlisted (MON-264)
+
+**Date:** 2026-09-06
+**Status:** Final
+**Related:** ADR-022 (verification snapshots), ADR-024 (chat snapshots), ADR-025/ADR-028 (quiz snapshots and the `include_answers` opt-in), ADR-032 (snapshot retention)
+
+**Decision:** `/chat/s/[id]`, `/verifier/v/[id]` and `/quiz/s/[id]` declare `robots: { index: false, follow: true }`.
+They stay out of the sitemap, as they already were, and they are now out of the index as well.
+Share links keep working exactly as before - they are unguessable UUIDs meant to be sent to a person, not documents meant to be found by a stranger through a search engine.
+
+This closes MON-263 (`ClaimReview` JSON-LD on verdict pages) as won't-do: `ClaimReview` on a `noindex` page is inert, since Google's Fact Check ingestion needs a crawlable, indexable URL, and emitting it would in any case be MonÉlu formally publishing a fact-check rating over an unmoderated corpus.
+
+**Reason:**
+
+The state this replaces was not a decision. `sitemap.ts` omitted the three snapshot routes with an explanatory comment, but `robots.ts` allows every crawler on `/` with only `/partager` and `/~offline` disallowed, and none of the three pages set `noindex`. Absence from a sitemap is a discovery hint, not a directive: the moment anyone posts a share link on a forum or a social account, the page is fully indexable. So the corpus was already one external link away from being indexed, under a policy nobody had chosen. Writing the intent into the pages makes it enforced rather than merely documented.
+
+**Why not curate a subset** (the option MON-264 itself recommended): curation needs an editorial flag on `verifications`/`chat_shares`, someone to set it, and a `/questions` index page. This project has no admin surface at all - no auth, no CMS, no moderation queue - so the promotion step has no operator. A quality gate that nobody runs is a guarantee on paper only, which is the same objection ADR-033 raised against keeping a sandbox with no real owner, and the deferred-but-never-triggered pattern ADR-002 and ADR-014 already reject elsewhere. If a curation workflow ever acquires a real operator, lifting a `noindex` is a one-line change per route; building the flag now against a process that does not exist is not.
+
+**Why not index chat and verify wholesale:** the corpus is user-submitted questions and claims answered by a RAG chain that can be wrong. Indexing it means MonÉlu's domain hosts and ranks arbitrary third-party text under MonÉlu's authority - anyone can POST a defamatory claim to `/verify/` and get a permanent, MonÉlu-branded, search-visible URL for it. For a product whose entire premise is trustworthiness, a wrong answer ranking as MonÉlu's is worse than not ranking at all. The unbounded, thin, near-duplicate page count is a textbook index-bloat pattern on top of that.
+
+`/quiz/s/*` has an additional, independent reason: per ADR-028 its stored `result` can carry the sharer's own answers when they opt into friend comparison. That is personal political opinion, and it must not be search-indexable regardless of what is decided for the other two.
+
+**What is given up:** this is genuinely the only content MonÉlu produces that is natively in the question→grounded-answer-with-citations shape LLM search rewards, and it grows for free as users share. That upside is real and is being declined, deliberately, because it is inseparable from putting unmoderated text under the site's name.
+
+**Impact:**
+- The three snapshot pages set `robots: { index: false, follow: true }` in `generateMetadata`, including on the early-return path taken when the snapshot fetch fails - a `noindex` that disappears when the API is down is not a policy.
+- `follow: true`, not `false`: the outbound links on these pages point at `/chat`, `/quiz` and vote pages that *should* be crawled. Only the snapshot document itself is withheld.
+- Canonicals stay. A `noindex` page still benefits from claiming its own URL across preview hosts (MON-269), and `canonical.test.ts` continues to require one.
+- `frontend/__tests__/app/snapshot-noindex.test.ts` enforces this: each of the three routes must declare `index: false`, and the list is checked against the real filesystem so a renamed route cannot silently drop out.
+- Do NOT add these routes to `sitemap.ts`, and do NOT add `ClaimReview`, `QAPage` or any other rich-result markup to them - markup is a request to be surfaced, which is exactly what this ADR declines.
+- MON-263 is closed as won't-do under this ADR rather than deferred, since it is not waiting on a date or a threshold - it is waiting on a different answer to this question.
+
+**Trigger to revisit:** a real moderation operator exists for the snapshot corpus - a person or an automated gate that actually reviews a verdict before it is promoted - at which point option 2 (a curated `/questions` index carrying `QAPage`, and `ClaimReview` on promoted verdicts only) becomes buildable as filed, and this ADR is superseded rather than amended. Absent that, growth in share volume is not a trigger: more unmoderated pages is an argument for this decision, not against it.
+
+---
+
 ## Rules for future development sessions
 
 1. Read this file before writing any code
@@ -1204,3 +1240,4 @@ Building the page on the acte parcours instead costs one extra table and one ext
 17. The local Airflow/MinIO stack is archived, not live (ADR-033, MON-239) - do not resurrect `ingestion/dags/`, `quality/`, or the Makefile Airflow/MinIO targets without a new ADR; ADR-006 and ADR-011 still describe the design a promoted-to-production Airflow would use
 18. Group-majority position is one formula everywhere: plurality with an alphabetical tiebreak, defined in `int_party_vote_majority` and replicated exactly by `groups.py`'s `_majority_position` (ADR-034, MON-24, MON-228) - never invent a different tiebreak; quiz's skip-ties behavior in `compute_group_alignment` is a documented, deliberate exception, not a bug to "fix" into matching
 19. Bill timeline pages are built on the dossier acte parcours from `Dossiers_Legislatifs`, not on votes grouped by `dossier_id` (ADR-035, MON-105/MON-242) - the AN only began tagging scrutins with a dossier in March 2026, so a scrutin-only timeline misses the first four fifths of most bills; never fuzzy-match scrutin titles to bills, never publish a page for a dossier with no scrutins, and never list amendment scrutins inline by default
+20. The share-snapshot pages `/chat/s/*`, `/verifier/v/*` and `/quiz/s/*` are `noindex`, not merely absent from the sitemap (ADR-036, MON-264) - never add them to `sitemap.ts`, never drop the `robots: { index: false }` from their `generateMetadata` (including its early-return path), and never add `ClaimReview`/`QAPage` or other rich-result markup to them; MON-263 is closed as won't-do under this ADR, and the trigger to reopen is a real moderation operator, not share volume

--- a/frontend/__tests__/app/snapshot-noindex.test.ts
+++ b/frontend/__tests__/app/snapshot-noindex.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const APP = join(__dirname, '..', '..', 'src', 'app')
+
+/**
+ * The share-snapshot routes (ADR-036, MON-264).
+ *
+ * These pages render user-submitted, unmoderated content: a question and a
+ * RAG answer, a submitted claim and its verdict, or - via the ADR-028
+ * `include_answers` opt-in - the sharer's own political answers. They are
+ * shareable by unguessable UUID, but they are not documents a stranger should
+ * reach through a search engine.
+ *
+ * Absence from `sitemap.ts` does not achieve that on its own: `robots.ts`
+ * allows every crawler on `/`, so one external link to a share URL is enough
+ * to make the page indexable. The `noindex` on the page is the actual policy.
+ */
+const SNAPSHOT_ROUTES = [
+  'chat/s/[id]/page.tsx',
+  'verifier/v/[id]/page.tsx',
+  'quiz/s/[id]/page.tsx',
+]
+
+const sources = SNAPSHOT_ROUTES.map((route) => ({
+  route,
+  path: join(APP, route),
+  source: existsSync(join(APP, route)) ? readFileSync(join(APP, route), 'utf8') : '',
+}))
+
+describe('share snapshots are noindex (ADR-036, MON-264)', () => {
+  it.each(sources)('$route still exists, so this list stays honest', ({ source }) => {
+    expect(source).not.toBe('')
+  })
+
+  it.each(sources)('$route declares index: false', ({ source }) => {
+    expect(source).toMatch(/index:\s*false/)
+  })
+
+  // A noindex that vanishes when the API is down is not a policy. Both the
+  // early return taken on a failed snapshot fetch and the populated metadata
+  // object must carry it, so every generateMetadata return path is covered.
+  it.each(sources)('$route applies it on every generateMetadata return path', ({ source }) => {
+    const metadata = source.slice(source.indexOf('export async function generateMetadata'))
+    const body = metadata.slice(0, metadata.indexOf('\nexport default'))
+    const returns = body.match(/return\s*\{/g) ?? []
+    expect(returns.length).toBeGreaterThan(1)
+    expect([...body.matchAll(/robots:/g)].length).toBe(returns.length)
+  })
+
+  // Markup like ClaimReview or QAPage is a request to be surfaced as a rich
+  // result, which is exactly what ADR-036 declines for this corpus.
+  it.each(sources)('$route emits no rich-result markup', ({ source }) => {
+    expect(source).not.toMatch(/ClaimReview|QAPage|JsonLd/)
+  })
+})
+
+describe('sitemap excludes the snapshot corpus (ADR-036, MON-264)', () => {
+  const sitemap = readFileSync(join(APP, 'sitemap.ts'), 'utf8')
+
+  it.each(['/chat/s/', '/verifier/v/', '/quiz/s/'])('does not list %s', (prefix) => {
+    expect(sitemap).not.toContain(`${prefix}$`)
+    expect(sitemap).not.toMatch(new RegExp(`url:.*${prefix.replace(/\//g, '\\/')}`))
+  })
+})

--- a/frontend/__tests__/app/snapshot-noindex.test.ts
+++ b/frontend/__tests__/app/snapshot-noindex.test.ts
@@ -2,6 +2,7 @@ import { readFileSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
 
 const APP = join(__dirname, '..', '..', 'src', 'app')
+const SEO = join(__dirname, '..', '..', 'src', 'lib', 'seo.ts')
 
 /**
  * The share-snapshot routes (ADR-036, MON-264).
@@ -22,44 +23,66 @@ const SNAPSHOT_ROUTES = [
   'quiz/s/[id]/page.tsx',
 ]
 
-const sources = SNAPSHOT_ROUTES.map((route) => ({
-  route,
-  path: join(APP, route),
-  source: existsSync(join(APP, route)) ? readFileSync(join(APP, route), 'utf8') : '',
-}))
+/** Strip line and block comments so prose about the policy is not mistaken for it. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '')
+}
+
+const sources = SNAPSHOT_ROUTES.map((route) => {
+  const path = join(APP, route)
+  const source = existsSync(path) ? readFileSync(path, 'utf8') : ''
+  return { route, source, code: stripComments(source) }
+})
 
 describe('share snapshots are noindex (ADR-036, MON-264)', () => {
   it.each(sources)('$route still exists, so this list stays honest', ({ source }) => {
     expect(source).not.toBe('')
   })
 
-  it.each(sources)('$route declares index: false', ({ source }) => {
-    expect(source).toMatch(/index:\s*false/)
+  // One definition, in seo.ts, like frontend_base_url() on the backend. Three
+  // hand-maintained copies of the same literal are what drifts.
+  it('SNAPSHOT_ROBOTS is defined once, in lib/seo.ts', () => {
+    expect(readFileSync(SEO, 'utf8')).toMatch(
+      /export const SNAPSHOT_ROBOTS = \{ index: false, follow: true \} as const/
+    )
+  })
+
+  it.each(sources)('$route imports the shared SNAPSHOT_ROBOTS', ({ code }) => {
+    expect(code).toMatch(/import \{[^}]*\bSNAPSHOT_ROBOTS\b[^}]*\} from '@\/lib\/seo'/)
+    // A local redefinition would silently decouple this route from the policy.
+    expect(code).not.toMatch(/const SNAPSHOT_ROBOTS\s*=/)
   })
 
   // A noindex that vanishes when the API is down is not a policy. Both the
   // early return taken on a failed snapshot fetch and the populated metadata
   // object must carry it, so every generateMetadata return path is covered.
-  it.each(sources)('$route applies it on every generateMetadata return path', ({ source }) => {
-    const metadata = source.slice(source.indexOf('export async function generateMetadata'))
-    const body = metadata.slice(0, metadata.indexOf('\nexport default'))
+  it.each(sources)('$route applies it on every generateMetadata return path', ({ code }) => {
+    const start = code.indexOf('export async function generateMetadata')
+    expect(start).toBeGreaterThan(-1)
+    const end = code.indexOf('\nexport default', start)
+    // Slicing on a -1 here would silently trim one character and weaken the
+    // assertion instead of failing, so require the marker explicitly.
+    expect(end).toBeGreaterThan(start)
+
+    const body = code.slice(start, end)
     const returns = body.match(/return\s*\{/g) ?? []
     expect(returns.length).toBeGreaterThan(1)
-    expect([...body.matchAll(/robots:/g)].length).toBe(returns.length)
+    expect([...body.matchAll(/\brobots:/g)].length).toBe(returns.length)
   })
 
   // Markup like ClaimReview or QAPage is a request to be surfaced as a rich
-  // result, which is exactly what ADR-036 declines for this corpus.
-  it.each(sources)('$route emits no rich-result markup', ({ source }) => {
-    expect(source).not.toMatch(/ClaimReview|QAPage|JsonLd/)
+  // result, which is exactly what ADR-036 declines for this corpus. Checked
+  // against comment-stripped code so an explanatory comment naming the type
+  // (very natural under this ADR) does not fail the build.
+  it.each(sources)('$route emits no rich-result markup', ({ code }) => {
+    expect(code).not.toMatch(/ClaimReview|QAPage|JsonLd/)
   })
 })
 
 describe('sitemap excludes the snapshot corpus (ADR-036, MON-264)', () => {
-  const sitemap = readFileSync(join(APP, 'sitemap.ts'), 'utf8')
+  const sitemap = stripComments(readFileSync(join(APP, 'sitemap.ts'), 'utf8'))
 
   it.each(['/chat/s/', '/verifier/v/', '/quiz/s/'])('does not list %s', (prefix) => {
-    expect(sitemap).not.toContain(`${prefix}$`)
     expect(sitemap).not.toMatch(new RegExp(`url:.*${prefix.replace(/\//g, '\\/')}`))
   })
 })

--- a/frontend/src/app/chat/s/[id]/page.tsx
+++ b/frontend/src/app/chat/s/[id]/page.tsx
@@ -11,6 +11,11 @@ import { SITE_URL, canonicalUrl } from '@/lib/site'
 export const dynamicParams = true
 export const revalidate = 86400
 
+// Snapshot pages are noindex (ADR-036, MON-264): the corpus is user-submitted
+// and unmoderated, so it stays out of the index, not merely out of the sitemap.
+// `follow: true` - the outbound links here point at pages that should be crawled.
+const SNAPSHOT_ROBOTS = { index: false, follow: true } as const
+
 export async function generateMetadata({
   params,
 }: {
@@ -19,13 +24,14 @@ export async function generateMetadata({
   const { id } = await params
   const alternates = { canonical: canonicalUrl(`/chat/s/${id}`) }
   const share = await api.chatShare(id).catch(() => null)
-  if (!share) return { alternates }
+  if (!share) return { alternates, robots: SNAPSHOT_ROBOTS }
   const title = `« ${share.question} » - MonÉlu`
   const description = share.answer.length > 160 ? share.answer.slice(0, 160) + '…' : share.answer
   return {
     title,
     description,
     alternates,
+    robots: SNAPSHOT_ROBOTS,
     openGraph: { title, description, url: `${SITE_URL}/chat/s/${id}` },
     twitter: { card: 'summary_large_image', title, description },
   }

--- a/frontend/src/app/chat/s/[id]/page.tsx
+++ b/frontend/src/app/chat/s/[id]/page.tsx
@@ -4,17 +4,13 @@ import { notFound } from 'next/navigation'
 import { api, nullIfMissing } from '@/lib/api'
 import { ChatAnswerCard } from '@/components/ChatAnswerCard'
 import { SITE_URL, canonicalUrl } from '@/lib/site'
+import { SNAPSHOT_ROBOTS } from '@/lib/seo'
 
 // Chat shares are immutable snapshots (ADR-024, mirrors ADR-022 for
 // verifications): this page reads the stored answer via GET /search/share/{id}
 // — it must never re-run the RAG chain.
 export const dynamicParams = true
 export const revalidate = 86400
-
-// Snapshot pages are noindex (ADR-036, MON-264): the corpus is user-submitted
-// and unmoderated, so it stays out of the index, not merely out of the sitemap.
-// `follow: true` - the outbound links here point at pages that should be crawled.
-const SNAPSHOT_ROBOTS = { index: false, follow: true } as const
 
 export async function generateMetadata({
   params,

--- a/frontend/src/app/quiz/s/[id]/page.tsx
+++ b/frontend/src/app/quiz/s/[id]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { api, nullIfMissing } from '@/lib/api'
-import { SITE_URL } from '@/lib/seo'
+import { SITE_URL, SNAPSHOT_ROBOTS } from '@/lib/seo'
 import { canonicalUrl } from '@/lib/site'
 import { QuizResultCard } from '../../QuizResultCard'
 import { QuizResultSections } from '../../QuizResultSections'
@@ -22,11 +22,6 @@ function hookTitle(share: Awaited<ReturnType<typeof api.quiz.getShare>>): string
     ? `Je vote à ${best.agreement_pct}% comme ${best.full_name}`
     : 'Quel député vote comme vous ?'
 }
-
-// Snapshot pages are noindex (ADR-036, MON-264): the corpus is user-submitted
-// and unmoderated, so it stays out of the index, not merely out of the sitemap.
-// `follow: true` - the outbound links here point at pages that should be crawled.
-const SNAPSHOT_ROBOTS = { index: false, follow: true } as const
 
 export async function generateMetadata({
   params,

--- a/frontend/src/app/quiz/s/[id]/page.tsx
+++ b/frontend/src/app/quiz/s/[id]/page.tsx
@@ -23,6 +23,11 @@ function hookTitle(share: Awaited<ReturnType<typeof api.quiz.getShare>>): string
     : 'Quel député vote comme vous ?'
 }
 
+// Snapshot pages are noindex (ADR-036, MON-264): the corpus is user-submitted
+// and unmoderated, so it stays out of the index, not merely out of the sitemap.
+// `follow: true` - the outbound links here point at pages that should be crawled.
+const SNAPSHOT_ROBOTS = { index: false, follow: true } as const
+
 export async function generateMetadata({
   params,
 }: {
@@ -31,7 +36,7 @@ export async function generateMetadata({
   const { id } = await params
   const alternates = { canonical: canonicalUrl(`/quiz/s/${id}`) }
   const share = await api.quiz.getShare(id).catch(() => null)
-  if (!share) return { alternates }
+  if (!share) return { alternates, robots: SNAPSHOT_ROBOTS }
   const title = `${hookTitle(share)} — MonÉlu`
   const description =
     'Une dizaine de vrais scrutins de l’Assemblée nationale, comparés aux votes réels ' +
@@ -40,6 +45,7 @@ export async function generateMetadata({
     title,
     description,
     alternates,
+    robots: SNAPSHOT_ROBOTS,
     openGraph: { title, description, url: `${SITE_URL}/quiz/s/${id}` },
     twitter: { card: 'summary_large_image', title, description },
   }

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -95,8 +95,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.7,
     })),
     { url: `${SITE_URL}/chat`, changeFrequency: 'monthly', priority: 0.5 },
-    // /quiz only — /quiz/s/* share snapshots stay out of the sitemap, like
-    // the /chat/s/* and /verifier/v/* snapshot URLs.
+    // /quiz only. The /quiz/s/*, /chat/s/* and /verifier/v/* share snapshots
+    // stay out of the sitemap AND out of the index (ADR-036, MON-264): they
+    // are an unmoderated, user-submitted corpus, so each page declares
+    // `robots: { index: false }` rather than relying on this omission alone.
     { url: `${SITE_URL}/quiz`, changeFrequency: 'monthly', priority: 0.7 },
     { url: `${SITE_URL}/a-propos`, changeFrequency: 'monthly', priority: 0.4 },
     { url: `${SITE_URL}/developpeurs`, changeFrequency: 'monthly', priority: 0.4 },

--- a/frontend/src/app/verifier/v/[id]/page.tsx
+++ b/frontend/src/app/verifier/v/[id]/page.tsx
@@ -17,6 +17,11 @@ const VERDICT_LABELS: Record<string, string> = {
   inverifiable: 'Invérifiable',
 }
 
+// Snapshot pages are noindex (ADR-036, MON-264): the corpus is user-submitted
+// and unmoderated, so it stays out of the index, not merely out of the sitemap.
+// `follow: true` - the outbound links here point at pages that should be crawled.
+const SNAPSHOT_ROBOTS = { index: false, follow: true } as const
+
 export async function generateMetadata({
   params,
 }: {
@@ -25,7 +30,7 @@ export async function generateMetadata({
   const { id } = await params
   const alternates = { canonical: canonicalUrl(`/verifier/v/${id}`) }
   const v = await api.verification(id).catch(() => null)
-  if (!v) return { alternates }
+  if (!v) return { alternates, robots: SNAPSHOT_ROBOTS }
   const label = VERDICT_LABELS[v.verdict] ?? v.verdict
   const shortClaim = v.claim.length > 90 ? v.claim.slice(0, 90) + '…' : v.claim
   const title = `${label} - « ${shortClaim} » - MonÉlu Vérification`
@@ -34,6 +39,7 @@ export async function generateMetadata({
     title,
     description,
     alternates,
+    robots: SNAPSHOT_ROBOTS,
     openGraph: { title, description, url: `${SITE_URL}/verifier/v/${id}` },
     twitter: { card: 'summary_large_image', title, description },
   }

--- a/frontend/src/app/verifier/v/[id]/page.tsx
+++ b/frontend/src/app/verifier/v/[id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation'
 import { api, nullIfMissing } from '@/lib/api'
 import { VerdictCard } from '@/components/VerdictCard'
 import { SITE_URL, canonicalUrl } from '@/lib/site'
+import { SNAPSHOT_ROBOTS } from '@/lib/seo'
 
 // Verdicts are immutable snapshots (ADR-022): this page reads the stored
 // verdict via GET /verify/{id} — it must never trigger a new verification.
@@ -16,11 +17,6 @@ const VERDICT_LABELS: Record<string, string> = {
   trompeur: 'Trompeur',
   inverifiable: 'Invérifiable',
 }
-
-// Snapshot pages are noindex (ADR-036, MON-264): the corpus is user-submitted
-// and unmoderated, so it stays out of the index, not merely out of the sitemap.
-// `follow: true` - the outbound links here point at pages that should be crawled.
-const SNAPSHOT_ROBOTS = { index: false, follow: true } as const
 
 export async function generateMetadata({
   params,

--- a/frontend/src/lib/seo.ts
+++ b/frontend/src/lib/seo.ts
@@ -31,6 +31,29 @@ export const SITE_DESCRIPTION =
  */
 export const ORGANIZATION_ID = `${SITE_URL}/#organization`
 
+/**
+ * Robots directive for the share-snapshot routes: `/chat/s/[id]`,
+ * `/verifier/v/[id]` and `/quiz/s/[id]` (ADR-036, MON-264).
+ *
+ * That corpus is user-submitted and unmoderated - anyone can POST a question
+ * or a claim and get a permanent MonElu-branded URL - and `/quiz/s/*` can
+ * additionally carry the sharer's own answers via the ADR-028 opt-in. It stays
+ * out of the index, not merely out of the sitemap: `robots.ts` allows every
+ * crawler on `/`, so one external link to a share URL is otherwise enough to
+ * make the page indexable.
+ *
+ * `follow: true`, not `false` - the outbound links on these pages point at
+ * `/chat`, `/quiz` and vote pages that should be crawled. Only the snapshot
+ * document itself is withheld.
+ *
+ * Defined once here, like `frontend_base_url()` on the backend: it must be
+ * identical on all three routes, so it must not be re-declared per route.
+ * Apply it on EVERY `generateMetadata` return path, including the early return
+ * taken when the snapshot fetch fails - a noindex that vanishes when the API
+ * is down is not a policy.
+ */
+export const SNAPSHOT_ROBOTS = { index: false, follow: true } as const
+
 export type BreadcrumbItem = { name: string; url: string }
 
 /**


### PR DESCRIPTION
Resolves the MON-264 decision and, as a direct consequence, closes MON-263.

## The problem

`sitemap.ts` excluded `/chat/s/*`, `/verifier/v/*` and `/quiz/s/*` with an explanatory comment, so the intent looked settled. It wasn't enforced:

- `robots.ts` allows every crawler on `/`, disallowing only `/partager` and `/~offline`.
- None of the three pages set `noindex`.

Absence from a sitemap is a discovery hint, not a directive. One external link to a share URL - a forum post, a tweet - was enough to make an unmoderated, user-submitted page indexable under MonÉlu's authority. As MON-264 put it, "indexable in principle, invisible in practice" is the one position that is not a decision.

## The decision (ADR-036)

**Option 1: keep the whole corpus out, and enforce it on the page.** Share links keep working unchanged - they are unguessable UUIDs meant to be sent to a person, not documents meant to be found by a stranger.

**Why not curate a subset** (the option MON-264 itself recommended): curation needs an editorial flag, someone to set it, and a `/questions` index page. This project has no admin surface at all - no auth, no CMS, no moderation queue - so the promotion step has no operator. A quality gate nobody runs is a guarantee on paper only, which is the objection ADR-033 raised against keeping a sandbox with no owner. Lifting a `noindex` later is a one-line change per route; building the flag now against a process that doesn't exist is not.

**Why not index wholesale:** the corpus is user questions and claims answered by a RAG chain that can be wrong. Anyone can POST a defamatory claim to `/verify/` and get a permanent, MonÉlu-branded, search-visible URL. For a product whose premise is trustworthiness, a wrong answer ranking as MonÉlu's is worse than not ranking. `/quiz/s/*` has an independent reason: per ADR-028 its stored `result` can carry the sharer's own answers.

The upside being declined is real and is stated as such in the ADR: this is the only content MonÉlu produces natively in the question→grounded-answer-with-citations shape LLM search rewards, and it grows for free.

## Consequence for MON-263

Closed as **won't-do**, not deferred. `ClaimReview` on a `noindex` page is inert - Google's Fact Check ingestion needs a crawlable, indexable URL - and emitting it would be MonÉlu formally publishing a fact-check rating over an unmoderated corpus. It isn't waiting on a date or a threshold; it's waiting on a different answer to this question. The ADR's trigger to revisit is a real moderation operator, at which point option 2 becomes buildable as filed.

## What changed

| File | Change |
|---|---|
| `docs/decisions.md` | ADR-036 + rule 20 in the enforcement block |
| `frontend/src/lib/seo.ts` | `SNAPSHOT_ROBOTS` - the single definition of the directive |
| `chat/s/[id]`, `verifier/v/[id]`, `quiz/s/[id]` `page.tsx` | import it and apply it on **every** `generateMetadata` return path |
| `sitemap.ts` | comment now cites ADR-036 and says noindex, not just unlisted |
| `frontend/__tests__/app/snapshot-noindex.test.ts` | new, enforces all of it |
| `CLAUDE.md` | frontend section bullet |
| `.secrets.baseline` | hook re-recording CLAUDE.md line numbers, as in #354 |

Two details worth reviewing:

- **The early-return path carries the robots too.** A `noindex` that vanishes when the API is down is not a policy, so the `if (!share) return { alternates }` branch got it as well. The test asserts the `robots:` count equals the `return {` count inside `generateMetadata`, so a future fourth return path can't silently skip it.
- **`follow: true`, not `false`.** The outbound links on these pages point at `/chat`, `/quiz` and vote pages that *should* be crawled. Only the snapshot document itself is withheld. Canonicals stay - a `noindex` page still benefits from claiming its own URL across preview hosts (MON-269), and `canonical.test.ts` still requires one.

## Acceptance criteria

MON-264 asked for a decision, an ADR, and enforcement of whichever option won.

| Criterion | How it's met |
|---|---|
| Decide the question rather than leaving the status quo | ADR-036, status Final, option 1 |
| Write it up as an ADR | `docs/decisions.md` ADR-036 + rule 20 |
| Option 1 names `robots: { index: false }` on the three routes | Applied to all three, all return paths |
| `/quiz/s/*` stays out regardless (ADR-028 privacy) | Covered, and called out as an independent reason |
| Unblock or resolve MON-263 | Resolved: closed as won't-do, with the reopen trigger recorded |

## Test plan

- `npm run lint` - clean.
- `npm test` - 45 suites, 434 tests pass (that total already includes the 15 new ones).
- `npm run build` - succeeds; all three routes still render as dynamic (`ƒ`).
- **Mutation check**: removing `robots: SNAPSHOT_ROBOTS` from the chat page's populated return makes `snapshot-noindex.test.ts` fail. The test is not vacuous.
- **Live render check**: served the production build on :3987 and curled all three routes with a nonexistent UUID (the failure path, the one most at risk) - each returns `<meta name="robots" content="noindex"/>`. Control: `/votes` emits no robots meta.
- `ruff check .` / `ruff format --check .` - clean repo-wide. No Python changed.

**Populated-path check (added after review).** Rather than leave this to the unit test, I ran the three routes against a local stub API serving fake snapshots, so `generateMetadata` took its *populated* branch for real:

```
/chat/s/abc      200  robots="noindex, follow"  canonical=.../chat/s/abc  og:title present
/verifier/v/abc  200  robots="noindex, follow"  canonical=...             og:title present
/quiz/s/abc           robots="noindex, follow"  canonical=...             og:title present
```

That confirms three things at once: the directive is applied on the branch real share URLs actually take, the canonical survives it (MON-269), and **social unfurls are unaffected** - `og:title` is still emitted, so shared links keep their preview card. No production data was written to get this.

## Review fixes applied

Second commit (`04d6f01`) addresses both Should Fix findings from the review:

1. **`SNAPSHOT_ROBOTS` was declared three times**, comment and all. A policy constant that must be identical across three files is what drifts, and the project already rejects that shape for the backend equivalent (CLAUDE.md: "`frontend_base_url()` is the single definition ... never re-declare it per router"). It now lives in `lib/seo.ts`; the routes import it, and the test asserts both the shared import and the *absence* of a local redefinition.
2. **The test sliced on `indexOf('\nexport default')` without checking for `-1`.** A reordered file would have made `slice(0, -1)` drop one character rather than fail - a quietly weakened assertion instead of a red build. Both markers are now asserted before slicing.

Also applied, from Nice to Have: the test strips comments before matching (so a comment naming `ClaimReview` - very natural under this ADR - no longer breaks the build), and the near-vacuous `not.toContain('/chat/s/$')` line is dropped in favor of the regex that was doing the work. The ADR and CLAUDE.md gained the single-definition rule, the `opengraph-image` note, and the social-sharing clarification.

Both mutations re-verified as caught: dropping `robots:` from a populated return fails the suite, and so does re-declaring the constant locally.

## Deploy risk

None. No migration, no API change, no env var, no workflow change. Frontend-only metadata.

One thing to be aware of rather than a risk: if any of these URLs were already indexed, `noindex` will actively remove them from the index on the next crawl. That is the intended effect.
